### PR TITLE
[docker] Add ulimits to docker-compose

### DIFF
--- a/opencti-docker/docker-compose-dev.yml
+++ b/opencti-docker/docker-compose-dev.yml
@@ -16,6 +16,13 @@ services:
     container_name: opencti-dev-elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:6.7.1
     restart: always
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
     ports:
       - 9200:9200
   opencti-dev-rabbitmq:

--- a/opencti-docker/docker-compose.yml
+++ b/opencti-docker/docker-compose.yml
@@ -15,6 +15,13 @@ services:
     volumes:
       - esdata:/usr/share/elasticsearch/data
     restart: always
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
   rabbitmq:
     image: rabbitmq:management
     environment:


### PR DESCRIPTION
Adding the ulimits to the docker-compose definitions will override
existing defaults and ensure that the user will never encounter the
following error message:

`max file descriptors [4096] for elasticsearch process is too low, increase to at least [65535]`