### PR TITLE
[doc] Fix position of "--compatibility" flag for docker-compose

### DIFF
--- a/opencti-docker/README.md
+++ b/opencti-docker/README.md
@@ -41,7 +41,7 @@ $ docker stack deploy -c docker-compose.yml opencti
 
 ### In standard Docker
 ```bash
-$ docker-compose up --compatibility
+$ docker-compose --compatibility up 
 ```
 
 You can now go to http://localhost:8080 and log in with the crendetials configured in your environement variables.

--- a/opencti-documentation/docs/installation/docker.md
+++ b/opencti-documentation/docs/installation/docker.md
@@ -47,7 +47,7 @@ $ docker stack deploy -c docker-compose.yml opencti
 
 ### In standard Docker
 ```bash
-$ docker-compose up --compatibility
+$ docker-compose --compatibility up
 ```
 
 You can now go to http://localhost:8080 and log in with the crendetials configured in your environement variables.

--- a/opencti-documentation/website/versioned_docs/version-1.1.0/installation/docker.md
+++ b/opencti-documentation/website/versioned_docs/version-1.1.0/installation/docker.md
@@ -48,7 +48,7 @@ $ docker stack deploy -c docker-compose.yml opencti
 
 ### In standard Docker
 ```bash
-$ docker-compose up --compatibility
+$ docker-compose --compatibility up
 ```
 
 You can now go to http://localhost:8080 and log in with the crendetials configured in your environement variables.


### PR DESCRIPTION
Minor fix:

```
$ docker-compose --version
docker-compose version 1.24.1, build 4667896b

$ docker-compose up --compatibility ; echo $?
Builds, (re)creates, starts, and attaches to containers for a service.
...
1

$ docker-compose --compatibility up
Creating network "opencti-docker_default" with the default driver
..
```
