### PR TITLE
Set LF line-ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
I opened `config/default.json` with vi and `^M` everywhere !  

```
$ find . -type f ! -path "./node_modules/*" -exec file "{}" ";" |grep CRLF
./babel.config.js: ASCII text, with CRLF line terminators
./.gitignore: ASCII text, with CRLF, LF line terminators
./package.json: ASCII text, with CRLF line terminators
./config/default.json: ASCII text, with CRLF line terminators
```