### PR TITLE
installing a worker should use an official release of pycti

### DIFF
--- a/opencti-worker/Dockerfile
+++ b/opencti-worker/Dockerfile
@@ -7,7 +7,7 @@ COPY src /opt/opencti-worker
 # hadolint ignore=DL3003
 RUN apk --no-cache add git build-base libmagic && \
     cd /opt/opencti-worker && \
-    pip3 install --no-cache-dir git+https://github.com/OpenCTI-Platform/client-python@master && \
+    pip3 install --no-cache-dir git+https://github.com/OpenCTI-Platform/client-python@4.0.3 && \
     pip3 install --no-cache-dir -r requirements.txt && \
     apk del git build-base
 

--- a/opencti-worker/src/requirements.txt
+++ b/opencti-worker/src/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.25.0
 PyYAML==5.3.1
 pika==1.1.0
-git+https://github.com/OpenCTI-Platform/client-python@master
+git+https://github.com/OpenCTI-Platform/client-python@4.0.3
 black==20.8b1


### PR DESCRIPTION
Outside of manually modifying every requirements.txt file for the worker (and connectors), there's no way to ensure reliable installs/reinstalls or building of docker images. 

I hope this doesn't negatively impact your development or release workflow.

fixes #964 