### PR TITLE
[docker] Improve docker build process with better layer caching & multi-stage builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build_platform:
     working_directory: ~/opencti
     docker:
-      - image: nikolaik/python-nodejs:python3.8-nodejs12
+      - image: nikolaik/python-nodejs:python3.8-nodejs15
     steps:
       - run:
           command: apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev
@@ -30,7 +30,7 @@ jobs:
   build_platform_musl:
     working_directory: ~/opencti_musl
     docker:
-      - image: nikolaik/python-nodejs:python3.8-nodejs12-alpine
+      - image: nikolaik/python-nodejs:python3.8-nodejs15-alpine
     steps:
       - run:
           command: apk update && apk upgrade && apk --no-cache add git build-base libmagic libffi-dev
@@ -56,7 +56,7 @@ jobs:
   package_rolling:
     working_directory: ~/opencti
     docker:
-      - image: circleci/node:12.21.0-stretch
+      - image: circleci/node:15.11.0-stretch
     steps:
       - attach_workspace:
           at: ~/
@@ -79,7 +79,7 @@ jobs:
   package_rolling_musl:
     working_directory: ~/opencti_musl
     docker:
-      - image: circleci/node:12.21.0-stretch
+      - image: circleci/node:15.11.0-stretch
     steps:
       - attach_workspace:
           at: ~/
@@ -102,7 +102,7 @@ jobs:
   deploy_demo:
     working_directory: ~/opencti
     docker:
-      - image: circleci/node:12.21.0-stretch
+      - image: circleci/node:15.11.0-stretch
     steps:
       - attach_workspace:
           at: ~/
@@ -139,7 +139,7 @@ jobs:
   deploy_reference:
     working_directory: ~/opencti
     docker:
-      - image: circleci/node:12.21.0-stretch
+      - image: circleci/node:15.11.0-stretch
     steps:
       - attach_workspace:
           at: ~/

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: opencti-tests
 
 steps:
 - name: api-tests
-  image: nikolaik/python-nodejs:python3.8-nodejs12-alpine
+  image: nikolaik/python-nodejs:python3.8-nodejs15-alpine
   environment:
     APP__ADMIN__PASSWORD: admin
     APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -27,7 +27,7 @@ steps:
       - opencti-platform/opencti-graphql/coverage
 
 - name: frontend-tests
-  image: nikolaik/python-nodejs:python3.8-nodejs12-alpine
+  image: nikolaik/python-nodejs:python3.8-nodejs15-alpine
   commands: 
   - cd opencti-platform/opencti-front
   - yarn install

--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -1,47 +1,52 @@
-FROM node:12.21.0-alpine
+FROM node:15.11.0-alpine3.13 AS base
 
-# Copy work files
-COPY opencti-front /opt/opencti-build/opencti-front
+
+FROM base AS graphql-deps-builder
+
+WORKDIR /opt/opencti-build/opencti-graphql
+COPY opencti-graphql/package.json opencti-graphql/yarn.lock ./
+RUN yarn install --frozen-lockfile --production && yarn cache clean --all
+
+
+FROM base AS graphql-builder
+
+WORKDIR /opt/opencti-build/opencti-graphql
+COPY opencti-graphql/package.json opencti-graphql/yarn.lock ./
+RUN yarn install --frozen-lockfile
 COPY opencti-graphql /opt/opencti-build/opencti-graphql
-COPY entrypoint.sh /
+RUN yarn run webpack --mode production
 
-# This hack is widely applied to avoid python printing issues in docker containers.
-# See: https://github.com/Docker-Hub-frolvlad/docker-alpine-python3/pull/13
+
+FROM base AS front-builder
+
+WORKDIR /opt/opencti-build/opencti-front
+COPY opencti-front/package.json opencti-front/yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY opencti-front /opt/opencti-build/opencti-front
+COPY opencti-graphql/config/schema/opencti.graphql /opt/opencti-build/opencti-graphql/config/schema/opencti.graphql
+RUN yarn relay && yarn generate
+
+
+FROM base AS app
+
+RUN set -ex; \
+    apk add --no-cache tini~=0.19 gcc~=10.2 musl-dev~=1.2 python3~=3.8 python3-dev~=3.8; \
+    python3 -m ensurepip; \
+    rm -rv /usr/lib/python*/ensurepip; \
+    pip3 install --no-cache-dir --upgrade pip setuptools wheel; \
+    ln -sf python3 /usr/bin/python;
+WORKDIR /opt/opencti
+COPY opencti-graphql/src/python/requirements.txt ./src/python/requirements.txt
+RUN pip3 install --no-cache-dir --requirement ./src/python/requirements.txt
+COPY --from=graphql-deps-builder /opt/opencti-build/opencti-graphql/node_modules ./node_modules
+COPY --from=graphql-builder /opt/opencti-build/opencti-graphql/build ./build
+COPY --from=front-builder /opt/opencti-build/opencti-front/build ./public
+COPY opencti-graphql/src ./src
+COPY opencti-graphql/config ./config
+COPY opencti-graphql/script ./script
 ENV PYTHONUNBUFFERED=1
+ENV NODE_OPTIONS=--max_old_space_size=8192
+ENV NODE_ENV=production
 
-# Install Python
-RUN apk add --update \
-    git \
-    python3 \
-    python3-dev \
-    py-pip \
-    build-base \
-    libffi-dev
-
-# Install Python
-RUN echo "**** install Python ****" && \
-    apk add --no-cache python3 && \
-    echo "**** install pip ****" && \
-    python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --no-cache --upgrade pip setuptools wheel
-
-# Build frontend && GraphQL API
-# hadolint ignore=DL3003
-RUN BUILD_OPENCTI=noninteractive \
-    echo "**** install opencti ****" && \
-    cd /opt/opencti-build/opencti-front && \
-	  yarn install && \
-	  yarn build && \
-	  yarn cache clean && \
-	  cd /opt/opencti-build/opencti-graphql && \
-	  yarn install && \
-	  yarn build && \
-	  yarn cache clean && \
-	  mv /opt/opencti-build/opencti-graphql /opt/opencti && \
-	  rm -rf /opt/opencti-build && \
-      apk del build-base python3-dev git
-
-# Expose and entrypoint
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "build/index.js"]

--- a/opencti-platform/entrypoint.sh
+++ b/opencti-platform/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Correct working directory
-cd /opt/opencti
-
-# Start
-yarn serv

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -82,7 +82,7 @@
     "relay": {}
   },
   "engines": {
-    "node": ">= 12.* < 13.0.0"
+    "node": ">= 12.* <= 15.*"
   },
   "scripts": {
     "start": "yarn relay && react-scripts start",


### PR DESCRIPTION
* better layer caching
  * copy only necessary assets before dependencies installation
* multi-stage builds
  * reduce image sizes from `751 MB` to `497 MB`
  * speedup build process
    * less layer cache dependencies
    * parallel build multi-stage layers with docker buildkit enabled
* use [`tini`](https://github.com/krallin/tini) as entrypoint
  * avoid to use `yarn start` because it's considered a [bad practice](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#cmd)
* use `--frozen-lockfile` with yarn
* install `opencti-graphql`'s production dependencies only with `yarn install --production` & remove cache with `yarn cache clean --all`
* use `--no-cache-dir` with pip3
  * originally it uses `--no-cache` option which does not actually exists
* remove unnecessary dependencies
  * originally `git`, `py-pip`, `build-base` & `libffi-dev` was installed
  * we only need `gcc` & `musl-dev` here
* set `ENV NODE_ENV=production` as default
* set `ENV NODE_OPTIONS=--max_old_space_size=${MAX_OLD_SPACE_SIZE}` as default 
