### PR TITLE
Solve the creation of an indicator from observable type text 

### DIFF
--- a/opencti-platform/opencti-graphql/src/python/stix2_create_pattern.py
+++ b/opencti-platform/opencti-graphql/src/python/stix2_create_pattern.py
@@ -20,6 +20,7 @@ PATTERN_MAPPING = {
     "IPv6-Addr": ["value"],
     "Mac-Addr": ["value"],
     "Mutex": ["name"],
+    "X-OpenCTI-Text": ["value"],
     "Network-Traffic": ["dst_port"],
     "Process": ["command_line"],
     "Process_pid": ["pid"],


### PR DESCRIPTION
added a missing line so when creating an observable type Text with the option of creating an indicator, the indicator is also created.