### PR TITLE
[api] Add CA for RabbitMQ

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -74,6 +74,7 @@
   "rabbitmq": {
     "hostname": "localhost",
     "use_ssl": false,
+    "ca": [],
     "port": 5672,
     "port_management": 15672,
     "management_ssl": false,

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -813,6 +813,7 @@ input RegisterConnectorInput {
 type RabbitMQConnection {
   host: String!
   use_ssl: Boolean!
+  ca: [String]
   port: Int!
   user: String!
   pass: String!


### PR DESCRIPTION
Add a configuration option to specify an array of CA certificates for RabbitMQ.

Note that to get this to work with the `opencti-worker` or various connectors, it may be necessary to set `SSL_CERT_FILE` or `SSL_CERT_DIR` in the environment as specified in [PEP 476](https://www.python.org/dev/peps/pep-0476/).

For example, a docker-compose snippet might look like:

```yaml
---
version: '3'
  services:
    opencti-worker-1:
      image: opencti/worker:4.4.0
      restart: always
      environment:
        OPENCTI_URL: https://cti.example.com
        OPENCTI_TOKEN: "${OPENCTI_ADMIN_TOKEN}"
        WORKER_LOG_LEVEL: info
        SSL_CERT_FILE: /etc/ssl/certs/selfsigned-ca.pem
      volumes:
      - ./ssl/ca.pem:/etc/ssl/certs/selfsigned-ca.pem:ro
      networks:
      - public
```

It may also be necessary to set `NODE_EXTRA_CA_CERTS` in the `opencti-platform` environment to make use of self-signed certificate authorities.