### PR TITLE
[api] Add native TLS support for redis

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -54,6 +54,8 @@
   },
   "redis": {
     "hostname": "localhost",
+    "use_ssl": false,
+    "ca": [],
     "port": 6379,
     "trimming": 0
   },

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -1,8 +1,8 @@
-import { lstatSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import amqp from 'amqplib';
 import axios from 'axios';
 import * as R from 'ramda';
-import conf from '../config/conf';
+import conf, { configureCA } from '../config/conf';
 import { DatabaseError } from '../config/errors';
 
 export const CONNECTOR_EXCHANGE = 'amqp.connector.exchange';
@@ -16,16 +16,6 @@ export const EVENT_TYPE_DELETE = 'delete';
 const USE_SSL = conf.get('rabbitmq:use_ssl');
 const RABBITMQ_CA = conf.get('rabbitmq:ca').map((path) => readFileSync(path));
 
-// https://golang.org/src/crypto/x509/root_linux.go
-const LINUX_CERTFILES = [
-  '/etc/ssl/certs/ca-certificates.crt', // Debian/Ubuntu/Gentoo etc.
-  '/etc/pki/tls/certs/ca-bundle.crt', // Fedora/RHEL 6
-  '/etc/ssl/ca-bundle.pem', // OpenSUSE
-  '/etc/pki/tls/cacert.pem', // OpenELEC
-  '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', // CentOS/RHEL 7
-  '/etc/ssl/cert.pem',
-];
-
 const amqpUri = () => {
   const host = conf.get('rabbitmq:hostname');
   const port = conf.get('rabbitmq:port');
@@ -36,26 +26,6 @@ const amqpCred = () => {
   const user = conf.get('rabbitmq:username');
   const pass = conf.get('rabbitmq:password');
   return { credentials: amqp.credentials.plain(user, pass) };
-};
-
-const amqpCA = () => {
-  if (RABBITMQ_CA.length) {
-    return { ca: RABBITMQ_CA };
-  } else {
-    for (const cert of LINUX_CERTFILES) {
-      try {
-        if (lstatSync(cert).isFile()) {
-          return { ca: [readFileSync(cert)] };
-        }
-      } catch (err) {
-        if (err.code === 'ENOENT') {
-          continue;
-        } else {
-          throw err;
-        }
-      }
-    }
-  }
 };
 
 export const config = () => {
@@ -71,7 +41,7 @@ export const config = () => {
 const amqpExecute = (execute) => {
   return new Promise((resolve, reject) => {
     amqp
-      .connect(amqpUri(), USE_SSL ? { ...amqpCred(), ...amqpCA() } : amqpCred())
+      .connect(amqpUri(), USE_SSL ? { ...amqpCred(), ...configureCA(RABBITMQ_CA) } : amqpCred())
       .then((connection) => {
         return connection
           .createConfirmChannel()

--- a/opencti-platform/opencti-graphql/src/database/redis.js
+++ b/opencti-platform/opencti-graphql/src/database/redis.js
@@ -1,8 +1,9 @@
+import { readFileSync } from 'fs';
 import Redis from 'ioredis';
 import Redlock from 'redlock';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import * as R from 'ramda';
-import conf, { logApp } from '../config/conf';
+import conf, { configureCA, logApp } from '../config/conf';
 import {
   generateLogMessage,
   isEmptyField,
@@ -24,16 +25,21 @@ import { now } from '../utils/format';
 import RedisStore from './sessionStore-redis';
 import SessionStoreMemory from './sessionStore-memory';
 
+const USE_SSL = conf.get('redis:use_ssl');
+const REDIS_CA = conf.get('redis:ca').map((path) => readFileSync(path));
+
 const BASE_DATABASE = 0; // works key for tracking / stream
 export const CONTEXT_DATABASE = 1; // locks / user context
 export const SESSION_DATABASE = 2; // locks / user context
 const OPENCTI_STREAM = 'stream.opencti';
 const REDIS_EXPIRE_TIME = 90;
+
 const redisOptions = (database) => ({
   lazyConnect: true,
   db: database,
   port: conf.get('redis:port'),
   host: conf.get('redis:hostname'),
+  tls: USE_SSL ? configureCA(REDIS_CA) : null,
   username: conf.get('redis:username'),
   password: conf.get('redis:password'),
   retryStrategy: /* istanbul ignore next */ (times) => Math.min(times * 50, 2000),


### PR DESCRIPTION
Add use_ssl, ca options to app JSON config for redis. Default to system certs if CA not specified.

* https://docs.redislabs.com/latest/rs/references/client_references/client_ioredis/
* Move LINUX_CERTFILES const to config/conf.js
* export configureCA() from config/conf.js