### PR TITLE
[frontend] Fix for StixDomainObjectDetectDuplicate.js prevents page reload when opening dialog

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.js
@@ -71,8 +71,9 @@ class StixDomainObjectDetectDuplicate extends Component {
     }
   }
 
-  handleOpen() {
+  handleOpen(e) {
     this.setState({ open: true });
+    e.preventDefault();
   }
 
   handleClose() {


### PR DESCRIPTION
Small fix that prevents the "potential duplicate entities" link from reloading the page when clicked to open the dialog.
Otherwise the anchor-tag's default behavior will trigger a page reload in the browser preventing the user from viewing the dialog and canceling the "Create an indicator" view.