### PR TITLE
[opencti-platform] Fixed belongs typo in Relationships

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Relation.js
+++ b/opencti-platform/opencti-front/src/utils/Relation.js
@@ -172,7 +172,7 @@ const stixCyberObservableRelationshipTypesMapping = {
   Directory_Directory: ['contains'],
   Directory_StixFile: ['contains'],
   Directory_Artifact: ['contains'],
-  'Email-Addr_User-Account': ['obs_belongsbelongs-to'],
+  'Email-Addr_User-Account': ['obs_belongs-to'],
   'Email-Message_Email-Addr': ['from', 'sender', 'to', 'bcc'],
   'Email-Message_Email-Mime-Part-Type': ['body-multipart'],
   'Email-Message_Artifact': ['raw-email'],


### PR DESCRIPTION
Side note: wouldn't it be maybe better to use constants to reduce the possibility of those typos?