### PR TITLE
Use claims to resolve roles

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -68,7 +68,6 @@
     "iterall": "1.3.0",
     "jsondiffpatch": "0.4.1",
     "jsonwebtoken": "8.5.1",
-    "jwt-decode": "3.1.2",
     "lru-cache": "6.0.0",
     "merge-graphql-schemas": "1.7.8",
     "migrate": "1.7.0",

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -1,7 +1,6 @@
 import * as R from 'ramda';
 import passport from 'passport/lib';
 import GitHub from 'github-api';
-import jwtDecode from 'jwt-decode';
 import FacebookStrategy from 'passport-facebook';
 import GithubStrategy from 'passport-github';
 import LocalStrategy from 'passport-local';

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -244,14 +244,13 @@ for (let i = 0; i < providerKeys.length; i += 1) {
         const openIdScope = `openid email profile ${R.uniq(additionalScope).join(' ')}`;
         const options = { client, passReqToCallback: true, params: { scope: openIdScope } };
         const openIDStrategy = new OpenIDStrategy(options, (req, tokenset, userinfo, done) => {
-          logApp.debug(`[OPENID] Successfully logged`, { userinfo });
+          logApp.debug(`[OPENID] Successfully logged`, { userinfo, claims: tokenset.claims() });
           // region roles mapping
           const isRoleBaseAccess = isNotEmptyField(mappedConfig.roles_management);
           const computeRolesMapping = () => {
-            const rolesPath = mappedConfig.roles_management?.roles_path || [];
+            const rolesPath = mappedConfig.roles_management?.roles_path || ['roles'];
             const rolesMapping = mappedConfig.roles_management?.roles_mapping || [];
-            const decodedUser = jwtDecode(tokenset.access_token);
-            const availableRoles = R.flatten(rolesPath.map((path) => R.path(path.split('.'), decodedUser) || []));
+            const availableRoles = R.flatten(rolesPath.map((path) => R.path(path.split('.'), tokenset.claims()) || []));
             const rolesMapper = genConfigMapper(rolesMapping);
             return availableRoles.map((a) => rolesMapper[a]).filter((r) => isNotEmptyField(r));
           };
@@ -259,10 +258,9 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           // endregion
           // region groups mapping
           const computeGroupsMapping = () => {
-            const groupsPath = mappedConfig.groups_management?.groups_path || [];
+            const groupsPath = mappedConfig.groups_management?.groups_path || ['groups'];
             const groupsMapping = mappedConfig.groups_management?.groups_mapping || [];
-            const decodedUser = jwtDecode(tokenset.access_token);
-            const availableGroups = R.flatten(groupsPath.map((path) => R.path(path.split('.'), decodedUser) || []));
+            const availableGroups = R.flatten(groupsPath.map((path) => R.path(path.split('.'), tokenset.claims()) || []));
             const groupsMapper = genConfigMapper(groupsMapping);
             return availableGroups.map((a) => groupsMapper[a]).filter((r) => isNotEmptyField(r));
           };

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -5842,11 +5842,6 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-jwt-decode@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
-  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
-
 keyv@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"


### PR DESCRIPTION
Use claims to resolve role/group instead of access_token.
Some services do not return all identity data in the access_token field, but rather in id_token/claims.