### PR TITLE
[api] Use claims to resolve roles (#1521)

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -68,7 +68,6 @@
     "iterall": "1.3.0",
     "jsondiffpatch": "0.4.1",
     "jsonwebtoken": "8.5.1",
-    "jwt-decode": "3.1.2",
     "lru-cache": "6.0.0",
     "merge-graphql-schemas": "1.7.8",
     "migrate": "1.7.0",

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -5842,11 +5842,6 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-jwt-decode@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
-  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
-
 keyv@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"


### PR DESCRIPTION
Use claims to resolve role/group instead of access_token.
Some services do not return all identity data in the access_token field, but rather in id_token/claims.
Remove jwt-decode dependency.