### PR TITLE
[GitHub] Removed Google link title from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Prerequisites
 
-- [ ] I read the [Deployment and Setup](https://www.notion.so/OpenCTI-Public-Knowledge-Base-d411e5e477734c59887dad3649f20518) section of the OpenCTI documentation as well as the [Troubleshooting](https://www.notion.so/Troubleshooting-ebc8fb04137d495aad917bc20340b9a6 "Google's Homepage") page and didn't find anything relevant to my problem.
+- [ ] I read the [Deployment and Setup](https://www.notion.so/OpenCTI-Public-Knowledge-Base-d411e5e477734c59887dad3649f20518) section of the OpenCTI documentation as well as the [Troubleshooting](https://www.notion.so/Troubleshooting-ebc8fb04137d495aad917bc20340b9a6) page and didn't find anything relevant to my problem.
 - [ ] I went through old GitHub issues and couldn't find anything relevant
 - [ ] I googled the issue and didn't find anything relevant
 


### PR DESCRIPTION
### Proposed changes

* Removed the Google link title as it was proposed in a markdown tutorial

### Related issues

* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
