### PR TITLE
[api] add missing relationship `resolves-to`

### DIFF
--- a/opencti-platform/opencti-graphql/src/schema/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/schema/stixCoreRelationship.js
@@ -42,6 +42,7 @@ export const RELATION_RELATED_TO = 'related-to';
 export const RELATION_DERIVED_FROM = 'derived-from';
 export const RELATION_DUPLICATE_OF = 'duplicate-of';
 export const RELATION_BELONGS_TO = 'belongs-to';
+export const RELATION_RESOLVES_TO = 'resolves-to';
 export const RELATION_PART_OF = 'part-of'; // Extension
 export const RELATION_SUBTECHNIQUE_OF = 'subtechnique-of'; // Extension
 export const RELATION_REVOKED_BY = 'revoked-by'; // Extension
@@ -83,6 +84,7 @@ export const STIX_CORE_RELATIONSHIPS = [
   RELATION_SUBTECHNIQUE_OF,
   RELATION_REVOKED_BY,
   RELATION_BELONGS_TO,
+  RELATION_RESOLVES_TO,
 ];
 schemaTypes.register(ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_CORE_RELATIONSHIPS);
 export const isStixCoreRelationship = (type) =>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

This PR adds a missing relationship: `resolves-to`

Currently, it is not possible to add a `resolves-to` relationship. A current alternative is to use the `resolves_to_refs` field. However, this is similar to the `belongs-to` relationship that do exist (which has a `belongs_to_refs` field as well).

### Proposed changes

* Add `resolves-to` relationship

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->