### PR TITLE
[worker] Implement dynamic timeout in thread dispatch loop

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -308,7 +308,13 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
 
     # Start the main loop
     def start(self) -> None:
+        sleep_delay = 60
         while True:
+            if sleep_delay == 0:
+                sleep_delay = 1
+            else:
+                sleep_delay <<= 1
+            sleep_delay = min(60, sleep_delay)
             try:
                 # Fetch queue configuration from API
                 self.connectors = self.api.connector.list()
@@ -336,6 +342,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                                 self.opencti_ssl_verify,
                                 self.opencti_json_logging,
                             )
+                            sleep_delay = 0
                             self.consumer_threads[queue].start()
                     else:
                         self.consumer_threads[queue] = Consumer(
@@ -346,6 +353,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             self.opencti_ssl_verify,
                             self.opencti_json_logging,
                         )
+                        sleep_delay = 0
                         self.consumer_threads[queue].start()
 
                 # Check if some threads must be stopped
@@ -358,6 +366,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                         try:
                             self.consumer_threads[thread].terminate()
                             self.consumer_threads.pop(thread, None)
+                            sleep_delay = 1
                         except:  # TODO: remove bare except
                             logging.info(
                                 "%s",
@@ -366,7 +375,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                                     ", an operation is running, keep trying..."
                                 ),
                             )
-                time.sleep(60)
+                time.sleep(sleep_delay)
             except KeyboardInterrupt:
                 # Graceful stop
                 for thread in self.consumer_threads:


### PR DESCRIPTION
### Proposed changes

The fixed timeout of 60s in the thread dispatch loop in Worker.start()
creates a situation where workers can stall up to 60s before requesting
more work from the queue under some circumstances. This change makes an
adaptive back-off that will loop quickly while work is being pulled off
the queues, but will gradually extend the delay period up to 60sec while
the queues are empty, resulting in comparable overhead during idle to
the current state.

### Related issues

* #1360
* #1772

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
