### PR TITLE
[frontend] Fix mui tooltip composition issue in ExportButtons (#1949)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ExportButtons.js
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.js
@@ -250,11 +250,11 @@ class ExportButtons extends Component {
         </Menu>
         {csvData && (
           <Tooltip title={t('Export to CSV')}>
-            <CSVLink data={csvData}>
-              <IconButton aria-haspopup="true" color="primary" size="large">
+            <IconButton aria-haspopup="true" color="primary" size="large">
+              <CSVLink data={csvData}>
                 <FileDelimitedOutline />
-              </IconButton>
-            </CSVLink>
+              </CSVLink>
+            </IconButton>
           </Tooltip>
         )}
         <Dialog

--- a/opencti-platform/opencti-front/src/components/ExportButtons.js
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.js
@@ -250,7 +250,7 @@ class ExportButtons extends Component {
         </Menu>
         {csvData && (
           <Tooltip title={t('Export to CSV')}>
-            <IconButton aria-haspopup="true" color="primary" size="large">
+            <IconButton aria-haspopup="true" color="primary" size="medium">
               <CSVLink data={csvData}>
                 <FileDelimitedOutline />
               </CSVLink>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change composition of the 'Export to CSV' button in the ExportButtons component to resolve issue preventing the Malware Courses of Action page from renderings.
* Change size of the IconButton for the Export to CSV button from large to medium to improve layout. (greater height compared to other icons used in ExportButtons was making it off center with other button icons in  the same row).

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/1949

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I didn't see any component level tests in the opencti-front module but if there are and I'm missing them, I can add coverage for this component.
