### PR TITLE
Support for IAM role usage when interacting with S3

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -117,7 +117,8 @@
     "use_ssl": false,
     "access_key": "ChangeMe",
     "secret_key": "ChangeMe",
-    "excluded_files": [".DS_Store"]
+    "excluded_files": [".DS_Store"],
+    "use_aws_role": false
   },
   "rabbitmq": {
     "hostname": "localhost",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -69,7 +69,7 @@
     "iterall": "1.3.0",
     "jsondiffpatch": "0.4.1",
     "jwt-decode": "3.1.2",
-    "lru-cache": "7.10.1",
+    "lru-cache": "^7.10.1",
     "merge-graphql-schemas": "1.7.8",
     "migrate": "1.8.0",
     "mime-types": "2.1.35",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -27,6 +27,7 @@
     "node": ">= 16.*"
   },
   "dependencies": {
+    "@aws-sdk/credential-providers": "^3.110.0",
     "@elastic/elasticsearch": "7.17.0",
     "@graphql-tools/schema": "8.3.14",
     "@graphql-tools/utils": "8.6.13",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -27,7 +27,7 @@
     "node": ">= 16.*"
   },
   "dependencies": {
-    "@aws-sdk/credential-providers": "^3.110.0",
+    "@aws-sdk/credential-providers": "3.110.0",
     "@elastic/elasticsearch": "7.17.0",
     "@graphql-tools/schema": "8.3.14",
     "@graphql-tools/utils": "8.6.13",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -69,7 +69,7 @@
     "iterall": "1.3.0",
     "jsondiffpatch": "0.4.1",
     "jwt-decode": "3.1.2",
-    "lru-cache": "^7.10.1",
+    "lru-cache": "7.10.1",
     "merge-graphql-schemas": "1.7.8",
     "migrate": "1.8.0",
     "mime-types": "2.1.35",

--- a/opencti-platform/opencti-graphql/src/database/minio.js
+++ b/opencti-platform/opencti-graphql/src/database/minio.js
@@ -2,6 +2,7 @@ import * as Minio from 'minio';
 import * as He from 'he';
 import * as R from 'ramda';
 import querystring from 'querystring';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import conf, { booleanConf, configureCA, logApp, logAudit } from '../config/conf';
 import { buildPagination } from './utils';
 import { loadExportWorksAsProgressFiles, deleteWorkForFile } from '../domain/work';
@@ -13,19 +14,39 @@ const bucketName = conf.get('minio:bucket_name') || 'opencti-bucket';
 const bucketRegion = conf.get('minio:bucket_region') || 'us-east-1';
 const excludedFiles = conf.get('minio:excluded_files') || ['.DS_Store'];
 
-const minioClient = new Minio.Client({
-  endPoint: conf.get('minio:endpoint'),
-  port: conf.get('minio:port') || 9000,
-  useSSL: booleanConf('minio:use_ssl', false),
-  accessKey: String(conf.get('minio:access_key')),
-  secretKey: String(conf.get('minio:secret_key')),
-  reqOptions: {
-    ...configureCA(conf.get('minio:ca')),
-    servername: conf.get('minio:endpoint'),
-  },
-});
+const getMinioClient = async () => {
+  const minioConfig = {
+    endPoint: conf.get('minio:endpoint'),
+    port: conf.get('minio:port') || 9000,
+    useSSL: booleanConf('minio:use_ssl', false),
+    accessKey: String(conf.get('minio:access_key')),
+    secretKey: String(conf.get('minio:secret_key')),
+    reqOptions: {
+      ...configureCA(conf.get('minio:ca')),
+      servername: conf.get('minio:endpoint'),
+    },
+  };
+
+  // Attempt to fetch AWS role for authentication if enabled
+  if (booleanConf('minio:use_aws_role', false)) {
+    try {
+      const credentialProvider = fromNodeProviderChain();
+      const awsCredentials = await credentialProvider();
+
+      minioConfig.accessKey = awsCredentials.accessKeyId;
+      minioConfig.secretKey = awsCredentials.secretAccessKey;
+      minioConfig.sessionToken = awsCredentials.sessionToken;
+    } catch (e) {
+      logApp.error('[MINIO] Failed to fetch AWS role credentials', { error: e });
+    }
+  }
+
+  return new Minio.Client(minioConfig);
+};
 
 export const initializeMinioBucket = async () => {
+  const minioClient = await getMinioClient();
+
   return new Promise((resolve, reject) => {
     try {
       minioClient.bucketExists(bucketName, (existErr, exists) => {
@@ -52,6 +73,8 @@ export const isStorageAlive = () => {
 };
 
 export const deleteFile = async (user, id) => {
+  const minioClient = await getMinioClient();
+
   logApp.debug(`[MINIO] delete file ${id} by ${user.user_email}`);
   await minioClient.removeObject(bucketName, id);
   await deleteWorkForFile(user, id);
@@ -67,7 +90,9 @@ export const deleteFiles = async (user, ids) => {
   return true;
 };
 
-export const downloadFile = (id) => {
+export const downloadFile = async (id) => {
+  const minioClient = await getMinioClient();
+
   try {
     return minioClient.getObject(bucketName, id);
   } catch (err) {
@@ -78,17 +103,22 @@ export const downloadFile = (id) => {
 
 export const getFileContent = (id) => {
   return new Promise((resolve, reject) => {
-    let str = '';
-    minioClient.getObject(bucketName, id, (err, stream) => {
-      stream.on('data', (data) => {
-        str += data.toString('utf-8');
+    getMinioClient().then((minioClient) => {
+      let str = '';
+
+      minioClient.getObject(bucketName, id, (err, stream) => {
+        stream.on('data', (data) => {
+          str += data.toString('utf-8');
+        });
+        stream.on('end', () => {
+          resolve(str);
+        });
+        stream.on('error', (error) => {
+          reject(error);
+        });
       });
-      stream.on('end', () => {
-        resolve(str);
-      });
-      stream.on('error', (error) => {
-        reject(error);
-      });
+    }).catch((err) => {
+      reject(err);
     });
   });
 };
@@ -103,6 +133,8 @@ export const storeFileConverter = (user, file) => {
 };
 
 export const loadFile = async (user, filename) => {
+  const minioClient = await getMinioClient();
+
   try {
     const stat = await minioClient.statObject(bucketName, filename);
     return {
@@ -126,19 +158,23 @@ const isFileObjectExcluded = (id) => {
 };
 export const rawFilesListing = (user, directory, recursive = false) => {
   return new Promise((resolve, reject) => {
-    const files = [];
-    const stream = minioClient.listObjectsV2(bucketName, directory, recursive);
-    stream.on('data', async (obj) => {
-      if (obj.name && !isFileObjectExcluded(obj.name)) {
-        files.push(R.assoc('id', obj.name, obj));
-      }
+    getMinioClient().then((minioClient) => {
+      const files = [];
+      const stream = minioClient.listObjectsV2(bucketName, directory, recursive);
+      stream.on('data', async (obj) => {
+        if (obj.name && !isFileObjectExcluded(obj.name)) {
+          files.push(R.assoc('id', obj.name, obj));
+        }
+      });
+      /* istanbul ignore next */
+      stream.on('error', (e) => {
+        logApp.error('[MINIO] Error listing files', { error: e });
+        reject(e);
+      });
+      stream.on('end', () => resolve(files));
+    }).catch((err) => {
+      reject(err);
     });
-    /* istanbul ignore next */
-    stream.on('error', (e) => {
-      logApp.error('[MINIO] Error listing files', { error: e });
-      reject(e);
-    });
-    stream.on('end', () => resolve(files));
   }).then((files) => {
     return Promise.all(
       R.map((elem) => {
@@ -150,6 +186,8 @@ export const rawFilesListing = (user, directory, recursive = false) => {
 };
 
 export const upload = async (user, path, fileUpload, metadata = {}) => {
+  const minioClient = await getMinioClient();
+
   const { createReadStream, filename, mimetype, encoding = '', version = now() } = await fileUpload;
   logAudit.info(user, UPLOAD_ACTION, { path, filename, metadata });
   const escapeName = querystring.escape(filename);

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -10541,19 +10541,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:7.10.1, lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
+  version: 7.10.1
+  resolution: "lru-cache@npm:7.10.1"
+  checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^6.0.0":
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
-  version: 7.10.1
-  resolution: "lru-cache@npm:7.10.1"
-  checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
   languageName: node
   linkType: hard
 
@@ -11634,7 +11634,7 @@ __metadata:
     jest-transform-graphql: 2.1.0
     jsondiffpatch: 0.4.1
     jwt-decode: 3.1.2
-    lru-cache: ^7.10.1
+    lru-cache: 7.10.1
     merge-graphql-schemas: 1.7.8
     migrate: 1.8.0
     mime-types: 2.1.35

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -10541,19 +10541,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:7.10.1, lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
-  version: 7.10.1
-  resolution: "lru-cache@npm:7.10.1"
-  checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^6.0.0":
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
+  version: 7.10.1
+  resolution: "lru-cache@npm:7.10.1"
+  checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
   languageName: node
   linkType: hard
 
@@ -11634,7 +11634,7 @@ __metadata:
     jest-transform-graphql: 2.1.0
     jsondiffpatch: 0.4.1
     jwt-decode: 3.1.2
-    lru-cache: 7.10.1
+    lru-cache: ^7.10.1
     merge-graphql-schemas: 1.7.8
     migrate: 1.8.0
     mime-types: 2.1.35

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -487,7 +487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.110.0":
+"@aws-sdk/credential-providers@npm:3.110.0":
   version: 3.110.0
   resolution: "@aws-sdk/credential-providers@npm:3.110.0"
   dependencies:
@@ -11560,7 +11560,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "opencti-graphql@workspace:."
   dependencies:
-    "@aws-sdk/credential-providers": ^3.110.0
+    "@aws-sdk/credential-providers": 3.110.0
     "@babel/preset-typescript": 7.16.7
     "@elastic/elasticsearch": 7.17.0
     "@graphql-codegen/cli": 2.6.2

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -48,6 +48,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/utils.keyvaluecache@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@apollo/utils.keyvaluecache@npm:1.0.1"
+  dependencies:
+    "@apollo/utils.logger": ^1.0.0
+    lru-cache: ^7.10.1
+  checksum: 1a5dbd2eae0575905e25d471430d431d145b767ee6f5e8efe3ba64ed44208db131f437e36cf17df6623ae6de97a87c4c8691b4a274510b52ab49f6afe9627a3b
+  languageName: node
+  linkType: hard
+
 "@apollo/utils.logger@npm:^1.0.0":
   version: 1.0.0
   resolution: "@apollo/utils.logger@npm:1.0.0"
@@ -153,6 +163,791 @@ __metadata:
   bin:
     relay-compiler: bin/relay-compiler
   checksum: f0cec120d02961ee8652e0dde72d9e425bc97cad5d0f767d8764cfd30952294eb2838432f33e4da8bb6999d0c13dcd1df128280666bfea373294d98aa8033ae7
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/ie11-detection@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:2.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: dd15daa1160ecdf28b9c930dcbd7f8bc96e74d7f791134974b672f5d36182274c76db4fff414385cdb8997a8b7ade991988a571aaac3184e226e2ed6428d895f
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/sha256-js": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@aws-crypto/sha256-js@npm:2.0.1"
+  dependencies:
+    "@aws-crypto/util": ^2.0.1
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: d5f07a5dde2cde277b63e781adc3fb0d04e202f56d159b50089f3bfd8bf657db1c35e18813e2ec6c3771dfdf0d0d6eb13f36a8ad021b5db7d2bb8fdc9f06dce3
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 77fad3813a5d3c495296fb836293184d32aeddacd436bf7d1b59b93d87de4cf7c0dbf862d4eaf915259edfb7b424ea05e2ceeddbaa1588a154d0c19df455c475
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@aws-crypto/util@npm:2.0.1"
+  dependencies:
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 83d7edea95336869854eb98bf53416a70ee824a03c8858779abcef7b7f35813ba3ba0aaa571d87c416bdcec78b620e825fe9e65769a15d2009af0ccb279ef981
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/abort-controller@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/abort-controller@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 4eb7fa7a93a8553a33d917b0566e72ee433d2b0fb011d3ce2e11e2e0c426da77cdeb19d9fa8ce144746d1e31e9e614ed2050af4512263f0de15ac62450407013
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-cognito-identity@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.110.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/client-sts": 3.110.0
+    "@aws-sdk/config-resolver": 3.110.0
+    "@aws-sdk/credential-provider-node": 3.110.0
+    "@aws-sdk/fetch-http-handler": 3.110.0
+    "@aws-sdk/hash-node": 3.110.0
+    "@aws-sdk/invalid-dependency": 3.110.0
+    "@aws-sdk/middleware-content-length": 3.110.0
+    "@aws-sdk/middleware-host-header": 3.110.0
+    "@aws-sdk/middleware-logger": 3.110.0
+    "@aws-sdk/middleware-recursion-detection": 3.110.0
+    "@aws-sdk/middleware-retry": 3.110.0
+    "@aws-sdk/middleware-serde": 3.110.0
+    "@aws-sdk/middleware-signing": 3.110.0
+    "@aws-sdk/middleware-stack": 3.110.0
+    "@aws-sdk/middleware-user-agent": 3.110.0
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/node-http-handler": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/smithy-client": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/url-parser": 3.110.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.55.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.110.0
+    "@aws-sdk/util-defaults-mode-node": 3.110.0
+    "@aws-sdk/util-user-agent-browser": 3.110.0
+    "@aws-sdk/util-user-agent-node": 3.110.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 05bddb3c93d2217e5c1bda20cf31c9bc19d623d6f65c8385b37ea64aa623cf4ca806b591d79c6fcf7457e77a7fa31b869ba60ee7157cf662db9ddaae649d94b1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/client-sso@npm:3.110.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.110.0
+    "@aws-sdk/fetch-http-handler": 3.110.0
+    "@aws-sdk/hash-node": 3.110.0
+    "@aws-sdk/invalid-dependency": 3.110.0
+    "@aws-sdk/middleware-content-length": 3.110.0
+    "@aws-sdk/middleware-host-header": 3.110.0
+    "@aws-sdk/middleware-logger": 3.110.0
+    "@aws-sdk/middleware-recursion-detection": 3.110.0
+    "@aws-sdk/middleware-retry": 3.110.0
+    "@aws-sdk/middleware-serde": 3.110.0
+    "@aws-sdk/middleware-stack": 3.110.0
+    "@aws-sdk/middleware-user-agent": 3.110.0
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/node-http-handler": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/smithy-client": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/url-parser": 3.110.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.55.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.110.0
+    "@aws-sdk/util-defaults-mode-node": 3.110.0
+    "@aws-sdk/util-user-agent-browser": 3.110.0
+    "@aws-sdk/util-user-agent-node": 3.110.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 1f6b9d2dfa2a3cc8c2ba87d26b51579039ec07d4e4c7c7c291566e9ccbe30538621e61aaed6f6703953ccd2bcff17e52e9df449aadbf02003b6486aa5955ef45
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/client-sts@npm:3.110.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.110.0
+    "@aws-sdk/credential-provider-node": 3.110.0
+    "@aws-sdk/fetch-http-handler": 3.110.0
+    "@aws-sdk/hash-node": 3.110.0
+    "@aws-sdk/invalid-dependency": 3.110.0
+    "@aws-sdk/middleware-content-length": 3.110.0
+    "@aws-sdk/middleware-host-header": 3.110.0
+    "@aws-sdk/middleware-logger": 3.110.0
+    "@aws-sdk/middleware-recursion-detection": 3.110.0
+    "@aws-sdk/middleware-retry": 3.110.0
+    "@aws-sdk/middleware-sdk-sts": 3.110.0
+    "@aws-sdk/middleware-serde": 3.110.0
+    "@aws-sdk/middleware-signing": 3.110.0
+    "@aws-sdk/middleware-stack": 3.110.0
+    "@aws-sdk/middleware-user-agent": 3.110.0
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/node-http-handler": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/smithy-client": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/url-parser": 3.110.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.55.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.110.0
+    "@aws-sdk/util-defaults-mode-node": 3.110.0
+    "@aws-sdk/util-user-agent-browser": 3.110.0
+    "@aws-sdk/util-user-agent-node": 3.110.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    entities: 2.2.0
+    fast-xml-parser: 3.19.0
+    tslib: ^2.3.1
+  checksum: d714f386a831c331c529ff6015815473222bc9b70bede0befeef0bb65f4967339cf327dba29127c95de3ef449cbc2f6dbe16102732af387d2781cc793c043d86
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/config-resolver@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/config-resolver@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/signature-v4": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-config-provider": 3.109.0
+    "@aws-sdk/util-middleware": 3.110.0
+    tslib: ^2.3.1
+  checksum: 0776e79d4d82b6ce31543ca92f5f8e8ef56049564ca4902239a9d387499a36a69eec7546bf2454f15834cd5b1857930624de44c4b5fe2660f08f9c905cfd74a0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-cognito-identity@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 279c8cc5b263cd1a9014518f90fd6f9c7ac4723c58e5305440f87334af2d0ed79de0efd6188dfbb2c46be87bb668ca7b68b3955363f153827cf8fc3e28b8e69f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 9d9cf1ec03792dcd68415f8e38d4dba2aa008aba297c6ccd7517b3620fc29c735e4b79c7057d5bbd33bf686b3997be21bdd9423667ee0a72fe369531b9579383
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-imds@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/url-parser": 3.110.0
+    tslib: ^2.3.1
+  checksum: 9b7f8a2af1d259b68130424994268c79f6bb5cef6aa1a584734ef465f6429c2a4e04e4003d4b404e26d74e258ad4578769f301285b5653cd82eebf35be673142
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.110.0
+    "@aws-sdk/credential-provider-imds": 3.110.0
+    "@aws-sdk/credential-provider-sso": 3.110.0
+    "@aws-sdk/credential-provider-web-identity": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: df9001d043fc9e1be662c2ad71e7c84a3c6a67344a979bbdeeea04463cdd41d9e10de094beeafe5183371def4799c6ef63bcb77f98ca4ba29ad5139b2e164a2f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.110.0
+    "@aws-sdk/credential-provider-imds": 3.110.0
+    "@aws-sdk/credential-provider-ini": 3.110.0
+    "@aws-sdk/credential-provider-process": 3.110.0
+    "@aws-sdk/credential-provider-sso": 3.110.0
+    "@aws-sdk/credential-provider-web-identity": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: f461cc7e3a2041a62ba2f2c4c8f56fa3803effe9ade37e7424b01152c3bceb28d6d4026356495269810e111b6e67ecc7876356e2e0c2595e9fe10bd737f47e0e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 8e4f7876d18dd6143f993cfd482485d43680e9dab25a1c8a2a9c24e74a20b68abc062c7b2420bc1557e07191cb67b568f400da4fac28a7cee1bc08e56adc96a3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 55a4500f74933d22574d6c3463973c7899277250b08bd2596aaf0d2983d6d6782b6529fedc86aebad646a7d33e9f545d4b1dfc5d9e80587955858e8481fea687
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 4d152a6c83d99ff2b5dc413572aa6cab4a5ac75aaaff7afda834713d7dcad963abac56ee2f19062f1a61205183e0d6be85f4db2824a19fd1957f8658f88748e8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-providers@npm:^3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/credential-providers@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.110.0
+    "@aws-sdk/client-sso": 3.110.0
+    "@aws-sdk/client-sts": 3.110.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.110.0
+    "@aws-sdk/credential-provider-env": 3.110.0
+    "@aws-sdk/credential-provider-imds": 3.110.0
+    "@aws-sdk/credential-provider-ini": 3.110.0
+    "@aws-sdk/credential-provider-node": 3.110.0
+    "@aws-sdk/credential-provider-process": 3.110.0
+    "@aws-sdk/credential-provider-sso": 3.110.0
+    "@aws-sdk/credential-provider-web-identity": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: c97d2dd7b2ab35cf0907b785cef7efea83ae0855299bdfb1cc9fcf46ad55e8a4deb12e3c94ba138a697280015c06e9c9e7191e1323770ac2be20d6c4838e5f91
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/fetch-http-handler@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/querystring-builder": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    tslib: ^2.3.1
+  checksum: 04d0005df578195be02289a8ac2f0ac7cca139ed8068e9d92cfa3d6929e494de2658ee2192723f3b58b27daaa1051f62a6d2dece1eabdea768f2d12db34d90e3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-node@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/hash-node@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: c373e8555b296c32ee17ce990823f57eecd2d2979c203eca74f3a880993e3454e28cb623e8b2c29aba4b0fd950ca3649dd61af4b0d4b1e6ca51fadc0fe1e4443
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/invalid-dependency@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 51bc4bdaa890abeb371c09bd21931e56e142a76afe0388ee269941d608f1c40895208da8a75915d54e3f664c8be8126fe2102591408c1888feaed5d617815e4d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/is-array-buffer@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 527481f024166197b84a2b4859b51df9b6da4396255c19832e8fdb2f6dfc914dab8ad89433602f8d797f3f8dacc312ab8a0073b2c8e20dc85a28ad9d27aceaa7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-content-length@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 1f32ca5071be185778b61f83a35c837071690e30480dbf172797382b0913189b7d36494879aa2cf904e57bbbb9623c3e3604939fca337292cdc2e10b20e34646
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: a642e46fb2c125f019b8b5ae2af8d7da8784d8ecf6b332fa11e6ce3c16ae877c3c09867a356db6a9592fe7902d9dd89b0e9fd52c18a582e0c4d3d7934573a33d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: b184f960b3a161beca9a40a95cba934acc3439e3a92951d0c7786ee77e2eff210552dc4b4c01a56fdf1824fc518db8724fa6b287a6cecaf28916ccb916203103
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 05f0b53b00d0ddb7fe296c4930488ace84a6980ea0492b6236fc32d3d091d90a83a1a3b94384777172f3b4b0df79beac852f1eb18c74eac9f1b78d5595fb96c1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-retry@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/service-error-classification": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-middleware": 3.110.0
+    tslib: ^2.3.1
+    uuid: ^8.3.2
+  checksum: 0f39dff9b8cd671661282c3f35179973c20f94fff95bd10d9f51e9b39110f4e2cd8f111f70c95b0babf4242d15978df78a2c35085b9de2377e70359758944d13
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-sts@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/signature-v4": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 1f6baa04494cec710cc63d6d46a824f059319aff3f62282152c0035b6355dc74dd2508b99d1af91d249d11c5dd13ab9e31f7fca9159e01bb3afa0b81e49442ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-serde@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 707c2bd25785830ef692b3621572ccd67885952b83eb740ad564ace2acd1b57324001bba88aed1fa94a33ee692dab6158582d0dd99a369d89ba41781559ac7da
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/signature-v4": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 32060f27229dac0b5c7946d6fefa3ad2dacaf6f93c9c695b89becc4d2b1509cfac0421ccc2b6372849981e11b20eac98071c42fd02d3976736abab8d15a8e293
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-stack@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.110.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 40ca4ece744e0bac98800aa1eb0936b3add8396e42835097abf558db8c7d98df98121529f0180dd10908d46e8624699b9579c8f4821ecc1b57023b9bc6592054
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 0186dad71b143f3281d2195e06f7770212ecdccfcbe1186e6aaa8102fa7878ae8be9b46c51647ffc29d6d42f10a7e3f90a7662b5ee1d93d4b55505b5a476f3ff
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-config-provider@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/shared-ini-file-loader": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 1e275a344259c218f006e142a289779572685ca284edbaf51a4c2191b9759801e1854f04ce38673b408edfc190d9f4e30239446eda6ba7b993171fbe7cb89ed9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-http-handler@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.110.0
+    "@aws-sdk/protocol-http": 3.110.0
+    "@aws-sdk/querystring-builder": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: f936c63e6570763ceaf02f1d4c24b414906805f05900c1c2ffc0ba736be67fc6a32b5d48278842b90aba2d3c7fce312978e5f1bc20321582da82de496a264857
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/property-provider@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/property-provider@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: ac15fc404d5c51b0c43a3f4180985cc13f179fc84603ece8efbeab51b5f304b00582d6a4a899ebd6e1abce829fc7f368fd64fc34e37505f2031e15059c09e0c6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/protocol-http@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 7c1812a2183cb2fd10dbe1e6132ce89f79939978e8cf3b4b62b2add16be06670d2bd662e4beb309dd5a7e9816b5b67d8253ed1af7f703980b128875b012878b9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-builder@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: 6fad6754b056ba9aec1ddf133113d966b6f3792497708571a6867cfd4dd8b78867fdcb45dda824726c26c64ea4d5e091d12b5c0951939a8b261389d17b29199f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-parser@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 232a50c9c331897ecd2fac74727019aac49a000845afc813a71e0ae39a4765a6b34f328b227f65749dc583f4ff342b9808c95bdae27960587a76435b9e25c7f7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/service-error-classification@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.110.0"
+  checksum: 7f32ad2d5de572abee63c9b15acc712809d7f5b868db09bc8a1dcc05cbf0d5591a22a7da0252ee0e9121ae8580fd374747cf27ed7af1330ee4a8006bb54671c0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.110.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: e791a02c34007b20504e8a702dc985e3bf36aae4371c3e60a9e44923130b4fe00ad204cc85816bd5598c3626aa6eb2c6fc91038e3c2042688dcc77f80ab59fff
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/signature-v4@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.55.0
+    "@aws-sdk/types": 3.110.0
+    "@aws-sdk/util-hex-encoding": 3.109.0
+    "@aws-sdk/util-middleware": 3.110.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: fb1a2cbd8632588b5aea4bc9587e2dd5c3f9124b2a14114b5dd1c82708c41f88f55955dddfc541613b35645758ca93924561ab07eff9a181bd8cb00600045270
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/smithy-client@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/smithy-client@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 2682b16440db5cbdba42c131930c0756660a1fa6ed5192bc56f1f71ca0c3607aaec4766a862429047e5c67ec32bc6ada4753d70ce4bb7b156e85c0d6267999ec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.110.0, @aws-sdk/types@npm:^3.1.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/types@npm:3.110.0"
+  checksum: a48ca2d0acfe98c851fc9205d7a4256bc4b16c242505f63ed7f7cecf3919e1d9e6ea365dc6177f2f831bc2b299f3b4b317a0146ad49b58c58b8cabad776fc0ec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/url-parser@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/url-parser@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/querystring-parser": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: b5786b1b4f089154f2cd3a90b0eb74110a2838af14a056afb480b230b284a9c5b55a6f595930e7704895331ab8c054cad298dff52e8a6238cab16baabb91e5ca
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64-browser@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: e4fb1dc0e5ac60320d4ba05dcf03b8e641c7a304f918df3134bf46c8ccf5b09d07ee283924a4cc4e9250fef582a2636bb4dac6ba71ee36662b2678dfe49d46b2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64-node@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-base64-node@npm:3.55.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: 4a2a58ae2e5d2d904271dd0433b9c15ca9a8e9d62e979c82159420ab8e1b573e96c8f223c951be2139cdfe49a09c478d165eff9468978883c4c5bcdfa7d9fd4b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-browser@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: f10c9e1f052da751e762e807f23b768052e5d375d7e048d596ee1d607065ff0c0ef7004bd4fd136848b6a5646c1c69e43860aa7a3da80d90023b749530faad59
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-node@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 35ae66271b7160c53b344a2bd933b5882e9fcef4a47c579a2a9e313657da8b896ca6c674489767f75d148ea5ffb8cbde2127eae55f5f39aaa4823a7c1d98ec69
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-buffer-from@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.55.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.55.0
+    tslib: ^2.3.1
+  checksum: 0c1d72cf2369c13a8bff7d990f8e8da7f5584dcbdf1965cf50674d531b42d80661eebdbbaf968d6932760fc3f5708374a676d05485a1d02347655ea5f2423f57
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-config-provider@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 99c9ef24faa555a317b46b782e211474dd9d666611e1aa76b963e93a6e7c54e32d5c20b87d9a601b9de68dfa1c7310d72667a74c335b31edb776e8494e2541af
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-browser@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: 3d5f73dce6442e85802df074bc77e1e4b77c48baaac883eb5d183632bb845e6e8e52eff7a10a30a64b014f675380e0c2c7629867d6e3940037a1ee7a1d6f0d61
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.110.0
+    "@aws-sdk/credential-provider-imds": 3.110.0
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/property-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: c4be1b9279f78c9dd83bb8a96e351690583ca1f975c2b5d4cee388852fedab9229b689d96f41e16491ffe33984292b2953ba3619e64f3ce5f55020bbc928f0f3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 1c166b53d7f84c0271cb71da8ac0ef4a9bfd78f2d2d70e4a903921dd3c355a79a446fa66ff64522d87aa9c738f445fdfd527043980bea642ae3acbc7dd758edf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 5bc79779a17ae4dd5cbcc221df6e85c976a149c0868745ae58075a3c51506aeeb087dfde4b3e5179004461243b11f3a458de720ee92866c6a1b65182326259ae
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-middleware@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/util-middleware@npm:3.110.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 19f820929368010d4f16004dd0884fbcb8054187e3a8cebe01f353534d48751ce211a5919913248a2c44a2eb5689e01993f8a9b7d0fb79b1cc7dac2cad804012
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-uri-escape@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: fad6780856f2b42a11ce7bb1e2ea5b7a966a8f564f3d09e83dca024291ae589a0cb2a1d294812cd626346addeb292c178f84867e40f8fab6fca067bc42ad360a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/types": 3.110.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: ff9df61ec7ec0bd2caba7a82ca50d765d0c1e015e32613895323cdbfb6a2875a98ba70ccfdbfbc9e17398fe3ec5dd29e659b5a4b58a8161bb51f7d7b5fbc098e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.110.0":
+  version: 3.110.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.110.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.110.0
+    "@aws-sdk/types": 3.110.0
+    tslib: ^2.3.1
+  checksum: 8ce1853270eb8be6885ade47c94ccb730edf7cd26d9a2ed33288223dcb0b35ca8c4ad2610881be2155ad4112fd52a8c3785ebf921b2db3c8bad74a58adc5452b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:3.109.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 8311763b04261dab5995ec67abf31795f41e9c4b1ad635ed305735e14c7e3bc48e9ae349a06aab485390358a6a58e97190144ea51190983cec4ae665887b219b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-node@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.109.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: ef706db8c0ceb014bc2fb9e5045b54369160648a9e919836132f98c5537eda82193f400fab607783ecf98a5df11b66c32256c4f2780bc689d7507ddaf2a0977b
   languageName: node
   linkType: hard
 
@@ -2546,9 +3341,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 17.0.43
-  resolution: "@types/node@npm:17.0.43"
-  checksum: 7fd84b1e37dc406c1c73a1461ccd6a1a38a5a335563788dd25e0aa75476d6948f815d0e9e4c2201f785a36a72269e6aaf0d851ca75c1e44b92e3a9d504e04a1e
+  version: 18.0.0
+  resolution: "@types/node@npm:18.0.0"
+  checksum: aab2b325727a2599f6d25ebe0dedf58c40fb66a51ce4ca9c0226ceb70fcda2d3afccdca29db5942eb48b158ee8585a274a1e3750c718bbd5399d7f41d62dfdcc
   languageName: node
   linkType: hard
 
@@ -3064,13 +3859,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-datasource@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "apollo-datasource@npm:3.3.1"
+"apollo-datasource@npm:^3.3.1, apollo-datasource@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "apollo-datasource@npm:3.3.2"
   dependencies:
-    apollo-server-caching: ^3.3.0
+    "@apollo/utils.keyvaluecache": ^1.0.1
     apollo-server-env: ^4.2.1
-  checksum: 5085c731afc45ea19198bad1fb59bfce779f5288802037e7681210b408bd3bc531dbe832236a91c72e084bc3ee5a8742440656a90e46b3f3939295159a2f62e2
+  checksum: 70244e792655b357213b92e9dd0e8ca553724857847c9bedb53a1dbf7a92fc0d8b05a60d77203d6c30331599b44c5d7cc5f4d94c934465fa05b146b681ed2293
   languageName: node
   linkType: hard
 
@@ -3129,7 +3924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-core@npm:3.8.2, apollo-server-core@npm:^3.8.2":
+"apollo-server-core@npm:3.8.2":
   version: 3.8.2
   resolution: "apollo-server-core@npm:3.8.2"
   dependencies:
@@ -3158,6 +3953,38 @@ __metadata:
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
   checksum: 2d5894f1e5636e59c518a4c10347d0c0d48eb4e7a5fee73dfd8baa352e9fc0c341bb9a25ce92609809bb2641c600e38db56e44eeb5650260b76eabe076560fd3
+  languageName: node
+  linkType: hard
+
+"apollo-server-core@npm:^3.8.2":
+  version: 3.9.0
+  resolution: "apollo-server-core@npm:3.9.0"
+  dependencies:
+    "@apollo/utils.keyvaluecache": ^1.0.1
+    "@apollo/utils.logger": ^1.0.0
+    "@apollo/utils.usagereporting": ^1.0.0
+    "@apollographql/apollo-tools": ^0.5.3
+    "@apollographql/graphql-playground-html": 1.6.29
+    "@graphql-tools/mock": ^8.1.2
+    "@graphql-tools/schema": ^8.0.0
+    "@josephg/resolvable": ^1.0.0
+    apollo-datasource: ^3.3.2
+    apollo-reporting-protobuf: ^3.3.1
+    apollo-server-env: ^4.2.1
+    apollo-server-errors: ^3.3.1
+    apollo-server-plugin-base: ^3.6.1
+    apollo-server-types: ^3.6.1
+    async-retry: ^1.2.1
+    fast-json-stable-stringify: ^2.1.0
+    graphql-tag: ^2.11.0
+    loglevel: ^1.6.8
+    lru-cache: ^6.0.0
+    sha.js: ^2.4.11
+    uuid: ^8.0.0
+    whatwg-mimetype: ^3.0.0
+  peerDependencies:
+    graphql: ^15.3.0 || ^16.0.0
+  checksum: 161401b7081ff69415999dcfb010d410ef8b1f8ee63368b54dddd0a24b8803b4c269dde0844e0a4fc5963169101f12749d9d9ae3c5cf4f0ac7fdd60b43eda43c
   languageName: node
   linkType: hard
 
@@ -3201,28 +4028,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-plugin-base@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "apollo-server-plugin-base@npm:3.6.0"
+"apollo-server-plugin-base@npm:^3.6.0, apollo-server-plugin-base@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "apollo-server-plugin-base@npm:3.6.1"
   dependencies:
-    apollo-server-types: ^3.6.0
+    apollo-server-types: ^3.6.1
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: ecb528ff9ccd7cf3acdb8b51ee17ad4de45511d47d5e8e42b581ffe88c7196ac28596d3d945178563fe75dfb6f9159a73db6d5e91f35e101bd0298734939d486
+  checksum: 66932834602e73b2df94057e37a98263990adb75cd76ab6b6d40af56f3e68591d02f3f2859036c9111898840f10ab59f6d06806607b562404deb86704cce386a
   languageName: node
   linkType: hard
 
-"apollo-server-types@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "apollo-server-types@npm:3.6.0"
+"apollo-server-types@npm:^3.6.0, apollo-server-types@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "apollo-server-types@npm:3.6.1"
   dependencies:
+    "@apollo/utils.keyvaluecache": ^1.0.1
     "@apollo/utils.logger": ^1.0.0
     apollo-reporting-protobuf: ^3.3.1
-    apollo-server-caching: ^3.3.0
     apollo-server-env: ^4.2.1
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: 4fafbaaae3699693fbb223f1b6532f70f9e7e90da3cc8bd50d2e35655af50ff984539553d6df4f668a6da40471ac86ac6af7ea0d212c8037c43d03f73e658f4d
+  checksum: b637c7d040f3c8bc1121918b441180999ea71e142e2ab9626e341015905d0b89be630bdf848fb0a4f39be71f12ac702f49e5b060eb0f13314f0a9e5183a759ab
   languageName: node
   linkType: hard
 
@@ -3869,6 +4696,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bowser@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "bowser@npm:2.11.0"
+  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -4220,9 +5054,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001349":
-  version: 1.0.30001354
-  resolution: "caniuse-lite@npm:1.0.30001354"
-  checksum: 3c4c213f98c7519474fcb110e8aa6857d724eb39a7c63ce46a558967cf355850f4cb67166afda33c460d91118a81d92679412e9c66abf7a72a0984a530153e66
+  version: 1.0.30001355
+  resolution: "caniuse-lite@npm:1.0.30001355"
+  checksum: 4154cabab0ae87d804007b1fc9109a532914dcd5dc4beeec8e1d3616f22971a0e96ed7fe0b00996c5104a4fe7ea7935c8e2878e06324c0ccfdcd6c69570e4ae1
   languageName: node
   linkType: hard
 
@@ -5408,9 +6242,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.147":
-  version: 1.4.155
-  resolution: "electron-to-chromium@npm:1.4.155"
-  checksum: 86f1152eb77711cb24cb08a984a986bf51e2d3d02d90209127f3781e4d771918d15a517e9903a78cd5cf40e06692074c13c7c55eb78b528bd69a0875854228b1
+  version: 1.4.158
+  resolution: "electron-to-chromium@npm:1.4.158"
+  checksum: cc23bf4172936122cf36084c2eeb68684170d32a2e0f4becb73fb9ab965a60a0e04e7b9e763858b24154b766ca851582d655209fb35479f04032394d926375c6
   languageName: node
   linkType: hard
 
@@ -5496,6 +6330,13 @@ __metadata:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
   checksum: 64c2dbbdd608d1a4df93b6e60786c603a1faf3b2e66dfd051d62cf4cfaeeb5e800166183685587208d62e9f7afff3f78f3d5978e32cd80125ba0c83b59a79d78
+  languageName: node
+  linkType: hard
+
+"entities@npm:2.2.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
   languageName: node
   linkType: hard
 
@@ -6521,6 +7362,15 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:3.19.0":
+  version: 3.19.0
+  resolution: "fast-xml-parser@npm:3.19.0"
+  bin:
+    xml2js: cli.js
+  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
   languageName: node
   linkType: hard
 
@@ -9691,7 +10541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:7.10.1, lru-cache@npm:^7.7.1":
+"lru-cache@npm:7.10.1, lru-cache@npm:^7.10.1, lru-cache@npm:^7.7.1":
   version: 7.10.1
   resolution: "lru-cache@npm:7.10.1"
   checksum: e8b190d71ed0fcd7b29c71a3e9b01f851c92d1ef8865ff06b5581ca991db1e5e006920ed4da8b56da1910664ed51abfd76c46fb55e82ac252ff6c970ff910d72
@@ -10710,6 +11560,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "opencti-graphql@workspace:."
   dependencies:
+    "@aws-sdk/credential-providers": ^3.110.0
     "@babel/preset-typescript": 7.16.7
     "@elastic/elasticsearch": 7.17.0
     "@graphql-codegen/cli": 2.6.2
@@ -13281,7 +14132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:~2.4.0":
+"tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:~2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Supporting IAM role access to interact with S3 instead of requiring IAM users when a user wishes to use AWS S3 instead of MinIO server.

### Related issues

* Resolves #2154
* Resolves #2024 (I recognise this issue suggests a native AWS SDK implementation, it is something that I will add in a future pull request)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

When using IAM credentials in AWS, the recommended practice is to use an attached role to an EC2 instance or ECS container rather than static credentials which do not expire. To solve this, I have used the AWS SDK to fetch the attached IAM role credentials which are then used in the MinIO client.

I have ensured this won't impact existing instances by adding a configuration option to opt-in to using this feature. For example, there may be an instance where a user is using an attached IAM role for logging but is interacting with MinIO through a set of static credentials. To ensure that IAM role credentials are not used in such a case, a default value is set to false which means the IAM role credentials won't be used by the MinIO client.

As IAM role credentials are temporary, a new MinIO client needs to be created every time.

This config option would require an update to the documentation as follows:

| Manual | Environment Variable | Default | Description |
| --- | --- | --- | --- |
| minio:use_aws_role | MINIO__USE_AWS_ROLE | false | Use attached IAM role for authentication for S3 |