### PR TITLE
Fix Correlation Graph bugs reported in Issue #2351

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeCorrelation.js
+++ b/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeCorrelation.js
@@ -1055,20 +1055,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
             }
           }
         }
-        objects(
-          types: [
-            "Threat-Actor"
-            "Intrusion-Set"
-            "Campaign"
-            "Incident"
-            "Malware"
-            "Tool"
-            "Vulnerability"
-            "Stix-Cyber-Observable"
-            "Indicator"
-          ]
-          first: 100
-        ) {
+        objects {
           edges {
             node {
               ... on BasicObject {
@@ -1093,7 +1080,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
                     }
                   }
                 }
-                reports(first: 10) {
+                reports {
                   edges {
                     node {
                       id
@@ -1196,7 +1183,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                reports(first: 10) {
+                reports {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -534,7 +534,7 @@ export const buildCorrelationData = (
     filterAdjust.selectedTimeRangeInterval,
   );
   const thisReportLinkNodes = R.filter(
-    (n) => n.reports && n.parent_types && n.reports.edges.length > 0,
+    (n) => n.reports && n.parent_types && n.reports.edges.length > 1,
     filteredObjects,
   );
   const relatedReportNodes = applyNodeFilters(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove the hard-coded node cap for traversal in the Correlation view
* Remove the hard-coded entity type limitations from the Correlation view code
* In correlation view, only display nodes from the current container that have 2 or more linked reports (eliminates leaves that show no correlation)

### Related issues

* #2351 
* This might also fix the bug where sometimes not all of the displayed entities would link to the current report node, in the graph

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] Where necessary I refactored code to improve the overall quality