### PR TITLE
Fix typo in 'agent' role

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Entity.js
+++ b/opencti-platform/opencti-front/src/utils/Entity.js
@@ -771,7 +771,7 @@ export const openVocabularies = {
   ],
   'threat-actor-role-ov': [
     {
-      key: 'gent',
+      key: 'agent',
       description:
         'Threat actor executes attacks either on behalf of themselves or at the direction of someone else.',
     },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* A minor change in the usage of the term `agent` which has a typo without the initial `a`

![image](https://user-images.githubusercontent.com/1590496/190904396-3b8852a2-b464-4ca6-847b-b9f24befbda2.png)


### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Note that the behaviour for systems that may be using the old `gent` term has not been tested. I'm not technically capable of addressing to what extent the DB consistency might be an issue here.