### PR TITLE
[api] Filters support multiples keys to search on (#2435)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ steps:
   - name: api-tests
     image: node:16.10.0-alpine
     environment:
-      APP__BASE_URL: http://api-tests:4000/
+      APP__BASE_URL: http://api-tests:4010/
       APP__ADMIN__PASSWORD: admin
       APP__SYNC_RAW_START_REMOTE_URI: http://opencti-raw-start:4100/graphql
       APP__SYNC_LIVE_START_REMOTE_URI: http://opencti-live-start:4200/graphql

--- a/opencti-platform/opencti-dev/Project.xml
+++ b/opencti-platform/opencti-dev/Project.xml
@@ -1,0 +1,27 @@
+<code_scheme name="Project" version="173">
+  <JSCodeStyleSettings version="0">
+    <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+    <option name="SPACES_WITHIN_IMPORTS" value="true" />
+  </JSCodeStyleSettings>
+  <TypeScriptCodeStyleSettings version="0">
+    <option name="USE_DOUBLE_QUOTES" value="false" />
+    <option name="FORCE_QUOTE_STYlE" value="true" />
+    <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+    <option name="SPACES_WITHIN_IMPORTS" value="true" />
+  </TypeScriptCodeStyleSettings>
+  <codeStyleSettings language="JavaScript">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="TypeScript">
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ChangeMe
+      MINIO_ROOT_PASSWORD: ChangeMe
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     restart: unless-stopped
   opencti-dev-rabbitmq:
     container_name: opencti-dev-rabbitmq
-    image: rabbitmq:3.10.7-management
+    image: rabbitmq:3.11-management
     restart: unless-stopped
     ports:
       - 5672:5672

--- a/opencti-platform/opencti-front/relay.schema.graphql
+++ b/opencti-platform/opencti-front/relay.schema.graphql
@@ -265,7 +265,7 @@ type LogConnection {
 }
 
 input LogsFiltering {
-  key: LogsFilter!
+  key: [LogsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -334,7 +334,7 @@ enum WorkspacesFilter {
 }
 
 input WorkspacesFiltering {
-  key: WorkspacesFilter!
+  key: [WorkspacesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -572,7 +572,7 @@ enum StatusFilter {
 }
 
 input StatusesFiltering {
-  key: StatusFilter!
+  key: [StatusFilter!]!
   values: [String!]
   operator: String
   filterMode: FilterMode
@@ -669,7 +669,7 @@ enum WorksFilter {
 }
 
 input WorksFiltering {
-  key: WorksFilter!
+  key: [WorksFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -791,7 +791,7 @@ enum TasksFilter {
 }
 
 input TasksFiltering {
-  key: TasksFilter!
+  key: [TasksFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1057,7 +1057,7 @@ enum UsersFilter {
 }
 
 input UsersFiltering {
-  key: UsersFilter!
+  key: [UsersFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1357,7 +1357,7 @@ enum MarkingDefinitionsFilter {
 }
 
 input MarkingDefinitionsFiltering {
-  key: MarkingDefinitionsFilter!
+  key: [MarkingDefinitionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1422,7 +1422,7 @@ enum LabelsFilter {
 }
 
 input LabelsFiltering {
-  key: LabelsFilter!
+  key: [LabelsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1487,7 +1487,7 @@ enum ExternalReferencesFilter {
 }
 
 input ExternalReferencesFiltering {
-  key: ExternalReferencesFilter!
+  key: [ExternalReferencesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1563,7 +1563,7 @@ enum KillChainPhasesFilter {
 }
 
 input KillChainPhasesFiltering {
-  key: KillChainPhasesFilter!
+  key: [KillChainPhasesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1641,7 +1641,7 @@ enum StixCoreObjectsFilter {
 }
 
 input StixCoreObjectsFiltering {
-  key: StixCoreObjectsFilter!
+  key: [StixCoreObjectsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1731,7 +1731,7 @@ enum StixDomainObjectsFilter {
 }
 
 input StixDomainObjectsFiltering {
-  key: StixDomainObjectsFilter!
+  key: [StixDomainObjectsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1834,7 +1834,7 @@ enum AttackPatternsFilter {
 }
 
 input AttackPatternsFiltering {
-  key: AttackPatternsFilter!
+  key: [AttackPatternsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1951,7 +1951,7 @@ enum CampaignsFilter {
 }
 
 input CampaignsFiltering {
-  key: CampaignsFilter!
+  key: [CampaignsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2064,7 +2064,7 @@ enum ContainersFilter {
 }
 
 input ContainersFiltering {
-  key: ContainersFilter!
+  key: [ContainersFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2139,7 +2139,7 @@ enum NotesFilter {
 }
 
 input NotesFiltering {
-  key: NotesFilter!
+  key: [NotesFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2250,7 +2250,7 @@ enum ObservedDatasFilter {
 }
 
 input ObservedDatasFiltering {
-  key: ObservedDatasFilter!
+  key: [ObservedDatasFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2358,7 +2358,7 @@ enum OpinionsFilter {
 }
 
 input OpinionsFiltering {
-  key: OpinionsFilter!
+  key: [OpinionsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2467,7 +2467,7 @@ enum ReportsFilter {
 }
 
 input ReportsFiltering {
-  key: ReportsFilter!
+  key: [ReportsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2574,7 +2574,7 @@ enum CoursesOfActionFilter {
 }
 
 input CoursesOfActionFiltering {
-  key: CoursesOfActionFilter!
+  key: [CoursesOfActionFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2668,7 +2668,7 @@ enum IdentitiesFilter {
   entity_type
   identity_class
   name
-  x_opencti_aliases
+  aliases
   confidence
   created
   modified
@@ -2682,7 +2682,7 @@ enum IdentitiesFilter {
 }
 
 input IdentitiesFiltering {
-  key: IdentitiesFilter!
+  key: [IdentitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2799,7 +2799,7 @@ enum IndividualsFilter {
 }
 
 input IndividualsFiltering {
-  key: IndividualsFilter!
+  key: [IndividualsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2913,7 +2913,7 @@ enum OrganizationsFilter {
 }
 
 input OrganizationsFiltering {
-  key: OrganizationsFilter!
+  key: [OrganizationsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3022,6 +3022,7 @@ enum SectorsOrdering {
 
 enum SectorsFilter {
   name
+  aliases
   confidence
   created
   modified
@@ -3036,7 +3037,7 @@ enum SectorsFilter {
 }
 
 input SectorsFiltering {
-  key: SectorsFilter!
+  key: [SectorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3146,7 +3147,7 @@ enum SystemsFilter {
 }
 
 input SystemsFiltering {
-  key: SystemsFilter!
+  key: [SystemsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3276,7 +3277,7 @@ enum IndicatorsFilter {
 }
 
 input IndicatorsFiltering {
-  key: IndicatorsFilter!
+  key: [IndicatorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3404,7 +3405,7 @@ enum InfrastructuresFilter {
 }
 
 input InfrastructuresFiltering {
-  key: InfrastructuresFilter!
+  key: [InfrastructuresFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3512,7 +3513,7 @@ enum IntrusionSetsFilter {
 }
 
 input IntrusionSetsFiltering {
-  key: IntrusionSetsFilter!
+  key: [IntrusionSetsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3615,7 +3616,7 @@ enum LocationsOrdering {
 enum LocationsFilter {
   entity_type
   name
-  x_opencti_aliases
+  aliases
   confidence
   created
   modified
@@ -3629,7 +3630,7 @@ enum LocationsFilter {
 }
 
 input LocationsFiltering {
-  key: LocationsFilter!
+  key: [LocationsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3730,6 +3731,8 @@ enum PositionsOrdering {
 }
 
 enum PositionsFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -3742,7 +3745,7 @@ enum PositionsFilter {
 }
 
 input PositionsFiltering {
-  key: PositionsFilter!
+  key: [PositionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3844,6 +3847,7 @@ enum CitiesOrdering {
 
 enum CitiesFilter {
   name
+  aliases
   created
   modified
   created_at
@@ -3856,7 +3860,7 @@ enum CitiesFilter {
 }
 
 input CitiesFiltering {
-  key: CitiesFilter!
+  key: [CitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3950,6 +3954,8 @@ enum CountriesOrdering {
 }
 
 enum CountriesFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -3960,7 +3966,7 @@ enum CountriesFilter {
 }
 
 input CountriesFiltering {
-  key: CountriesFilter!
+  key: [CountriesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4054,6 +4060,8 @@ enum RegionsOrdering {
 }
 
 enum RegionsFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -4064,7 +4072,7 @@ enum RegionsFilter {
 }
 
 input RegionsFiltering {
-  key: RegionsFilter!
+  key: [RegionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4182,7 +4190,7 @@ enum MalwaresFilter {
 }
 
 input MalwaresFiltering {
-  key: MalwaresFilter!
+  key: [MalwaresFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4297,7 +4305,7 @@ enum ThreatActorsFilter {
 }
 
 input ThreatActorsFiltering {
-  key: ThreatActorsFilter!
+  key: [ThreatActorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4416,7 +4424,7 @@ enum ToolsFilter {
 }
 
 input ToolsFiltering {
-  key: ToolsFilter!
+  key: [ToolsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4526,7 +4534,7 @@ enum VulnerabilitiesFilter {
 }
 
 input VulnerabilitiesFiltering {
-  key: VulnerabilitiesFilter!
+  key: [VulnerabilitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4640,7 +4648,7 @@ enum IncidentsFilter {
 }
 
 input IncidentsFiltering {
-  key: IncidentsFilter!
+  key: [IncidentsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4755,7 +4763,7 @@ enum StixCyberObservablesFilter {
 }
 
 input StixCyberObservablesFiltering {
-  key: StixCyberObservablesFilter!
+  key: [StixCyberObservablesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -6292,7 +6300,7 @@ enum StixObjectOrStixRelationshipsFilter {
 }
 
 input StixObjectOrStixRelationshipsFiltering {
-  key: StixObjectOrStixRelationshipsFilter!
+  key: [StixObjectOrStixRelationshipsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -6346,7 +6354,7 @@ enum StixRelationshipsFilter {
 }
 
 input StixRelationshipsFiltering {
-  key: StixRelationshipsFilter!
+  key: [StixRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -6420,7 +6428,7 @@ enum StixCoreRelationshipsFilter {
 }
 
 input StixCoreRelationshipsFiltering {
-  key: StixCoreRelationshipsFilter!
+  key: [StixCoreRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -6537,7 +6545,7 @@ enum StixSightingRelationshipsFilter {
 }
 
 input StixSightingRelationshipsFiltering {
-  key: StixSightingRelationshipsFilter!
+  key: [StixSightingRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -6634,7 +6642,7 @@ enum StixCyberObservableRelationshipsFilter {
 }
 
 input StixCyberObservableRelationshipsFiltering {
-  key: StixCyberObservableRelationshipsFilter!
+  key: [StixCyberObservableRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -6704,7 +6712,7 @@ enum StixMetaRelationshipsFilter {
 }
 
 input StixMetaRelationshipsFiltering {
-  key: StixMetaRelationshipsFilter!
+  key: [StixMetaRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -268,7 +268,7 @@ type LogConnection {
   edges: [LogEdge]
 }
 input LogsFiltering {
-  key: LogsFilter!
+  key: [LogsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -330,7 +330,7 @@ enum WorkspacesFilter {
   type
 }
 input WorkspacesFiltering {
-  key: WorkspacesFilter!
+  key: [WorkspacesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -559,7 +559,7 @@ enum StatusFilter {
   type
 }
 input StatusesFiltering {
-  key: StatusFilter!
+  key: [StatusFilter!]!
   values: [String!]
   operator: String
   filterMode: FilterMode
@@ -644,7 +644,7 @@ enum WorksFilter {
   completed_time
 }
 input WorksFiltering {
-  key: WorksFilter!
+  key: [WorksFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -752,7 +752,7 @@ enum TasksFilter {
   completed
 }
 input TasksFiltering {
-  key: TasksFilter!
+  key: [TasksFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1012,7 +1012,7 @@ enum UsersFilter {
   created_at
 }
 input UsersFiltering {
-  key: UsersFilter!
+  key: [UsersFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1305,7 +1305,7 @@ enum MarkingDefinitionsFilter {
   markedBy
 }
 input MarkingDefinitionsFiltering {
-  key: MarkingDefinitionsFilter!
+  key: [MarkingDefinitionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1370,7 +1370,7 @@ enum LabelsFilter {
   markedBy
 }
 input LabelsFiltering {
-  key: LabelsFilter!
+  key: [LabelsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1435,7 +1435,7 @@ enum ExternalReferencesFilter {
   external_id
 }
 input ExternalReferencesFiltering {
-  key: ExternalReferencesFilter!
+  key: [ExternalReferencesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1509,7 +1509,7 @@ enum KillChainPhasesFilter {
   phase_name
 }
 input KillChainPhasesFiltering {
-  key: KillChainPhasesFilter!
+  key: [KillChainPhasesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1588,7 +1588,7 @@ enum StixCoreObjectsFilter {
   confidence
 }
 input StixCoreObjectsFiltering {
-  key: StixCoreObjectsFilter!
+  key: [StixCoreObjectsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1699,7 +1699,7 @@ enum StixDomainObjectsFilter {
   x_opencti_workflow_id
 }
 input StixDomainObjectsFiltering {
-  key: StixDomainObjectsFilter!
+  key: [StixDomainObjectsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1823,7 +1823,7 @@ enum AttackPatternsFilter {
   x_opencti_workflow_id
 }
 input AttackPatternsFiltering {
-  key: AttackPatternsFilter!
+  key: [AttackPatternsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -1963,7 +1963,7 @@ enum CampaignsFilter {
   revoked
 }
 input CampaignsFiltering {
-  key: CampaignsFilter!
+  key: [CampaignsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2099,7 +2099,7 @@ enum ContainersFilter {
   revoked
 }
 input ContainersFiltering {
-  key: ContainersFilter!
+  key: [ContainersFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2217,7 +2217,7 @@ enum NotesFilter {
   revoked
 }
 input NotesFiltering {
-  key: NotesFilter!
+  key: [NotesFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2370,7 +2370,7 @@ enum ObservedDatasFilter {
   revoked
 }
 input ObservedDatasFiltering {
-  key: ObservedDatasFilter!
+  key: [ObservedDatasFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2522,7 +2522,7 @@ enum OpinionsFilter {
   revoked
 }
 input OpinionsFiltering {
-  key: OpinionsFilter!
+  key: [OpinionsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2675,7 +2675,7 @@ enum ReportsFilter {
   revoked
 }
 input ReportsFiltering {
-  key: ReportsFilter!
+  key: [ReportsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -2826,7 +2826,7 @@ enum CoursesOfActionFilter {
   x_mitre_id
 }
 input CoursesOfActionFiltering {
-  key: CoursesOfActionFilter!
+  key: [CoursesOfActionFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -2944,7 +2944,7 @@ enum IdentitiesFilter {
   entity_type
   identity_class
   name
-  x_opencti_aliases
+  aliases
   confidence
   created
   modified
@@ -2957,7 +2957,7 @@ enum IdentitiesFilter {
   revoked
 }
 input IdentitiesFiltering {
-  key: IdentitiesFilter!
+  key: [IdentitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3095,7 +3095,7 @@ enum IndividualsFilter {
   x_opencti_lastname
 }
 input IndividualsFiltering {
-  key: IndividualsFilter!
+  key: [IndividualsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3233,7 +3233,7 @@ enum OrganizationsFilter {
   revoked
 }
 input OrganizationsFiltering {
-  key: OrganizationsFilter!
+  key: [OrganizationsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3366,6 +3366,7 @@ enum SectorsOrdering {
 }
 enum SectorsFilter {
   name
+  aliases
   confidence
   created
   modified
@@ -3379,7 +3380,7 @@ enum SectorsFilter {
   revoked
 }
 input SectorsFiltering {
-  key: SectorsFilter!
+  key: [SectorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3513,7 +3514,7 @@ enum SystemsFilter {
   revoked
 }
 input SystemsFiltering {
-  key: SystemsFilter!
+  key: [SystemsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3667,7 +3668,7 @@ enum IndicatorsFilter {
   revoked
 }
 input IndicatorsFiltering {
-  key: IndicatorsFilter!
+  key: [IndicatorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3818,7 +3819,7 @@ enum InfrastructuresFilter {
   revoked
 }
 input InfrastructuresFiltering {
-  key: InfrastructuresFilter!
+  key: [InfrastructuresFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -3949,7 +3950,7 @@ enum IntrusionSetsFilter {
   revoked
 }
 input IntrusionSetsFiltering {
-  key: IntrusionSetsFilter!
+  key: [IntrusionSetsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4076,7 +4077,7 @@ enum LocationsOrdering {
 enum LocationsFilter {
   entity_type
   name
-  x_opencti_aliases
+  aliases
   confidence
   created
   modified
@@ -4089,7 +4090,7 @@ enum LocationsFilter {
   revoked
 }
 input LocationsFiltering {
-  key: LocationsFilter!
+  key: [LocationsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4212,6 +4213,8 @@ enum PositionsOrdering {
   x_opencti_workflow_id
 }
 enum PositionsFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -4223,7 +4226,7 @@ enum PositionsFilter {
   revoked
 }
 input PositionsFiltering {
-  key: PositionsFilter!
+  key: [PositionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4350,6 +4353,7 @@ enum CitiesOrdering {
 }
 enum CitiesFilter {
   name
+  aliases
   created
   modified
   created_at
@@ -4361,7 +4365,7 @@ enum CitiesFilter {
   revoked
 }
 input CitiesFiltering {
-  key: CitiesFilter!
+  key: [CitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4480,6 +4484,8 @@ enum CountriesOrdering {
   x_opencti_workflow_id
 }
 enum CountriesFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -4489,7 +4495,7 @@ enum CountriesFilter {
   x_opencti_workflow_id
 }
 input CountriesFiltering {
-  key: CountriesFilter!
+  key: [CountriesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4608,6 +4614,8 @@ enum RegionsOrdering {
   x_opencti_workflow_id
 }
 enum RegionsFilter {
+  name
+  aliases
   created
   modified
   created_at
@@ -4617,7 +4625,7 @@ enum RegionsFilter {
   x_opencti_workflow_id
 }
 input RegionsFiltering {
-  key: RegionsFilter!
+  key: [RegionsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4759,7 +4767,7 @@ enum MalwaresFilter {
   x_opencti_workflow_id
 }
 input MalwaresFiltering {
-  key: MalwaresFilter!
+  key: [MalwaresFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -4897,7 +4905,7 @@ enum ThreatActorsFilter {
   x_opencti_workflow_id
 }
 input ThreatActorsFiltering {
-  key: ThreatActorsFilter!
+  key: [ThreatActorsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -5039,7 +5047,7 @@ enum ToolsFilter {
   x_opencti_workflow_id
 }
 input ToolsFiltering {
-  key: ToolsFilter!
+  key: [ToolsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -5172,7 +5180,7 @@ enum VulnerabilitiesFilter {
   x_opencti_workflow_id
 }
 input VulnerabilitiesFiltering {
-  key: VulnerabilitiesFilter!
+  key: [VulnerabilitiesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -5309,7 +5317,7 @@ enum IncidentsFilter {
   x_opencti_workflow_id
 }
 input IncidentsFiltering {
-  key: IncidentsFilter!
+  key: [IncidentsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -5448,7 +5456,7 @@ enum StixCyberObservablesFilter {
   hashes_SHA256
 }
 input StixCyberObservablesFiltering {
-  key: StixCyberObservablesFilter!
+  key: [StixCyberObservablesFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -8473,7 +8481,7 @@ enum StixObjectOrStixRelationshipsFilter {
   hashes_SHA256
 }
 input StixObjectOrStixRelationshipsFiltering {
-  key: StixObjectOrStixRelationshipsFilter!
+  key: [StixObjectOrStixRelationshipsFilter!]!
   values: [String]!
   operator: String
   filterMode: FilterMode
@@ -8643,7 +8651,7 @@ enum StixRelationshipsFilter {
   toMainObservableType
 }
 input StixRelationshipsFiltering {
-  key: StixRelationshipsFilter!
+  key: [StixRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -8715,7 +8723,7 @@ enum StixCoreRelationshipsFilter {
   toTypes
 }
 input StixCoreRelationshipsFiltering {
-  key: StixCoreRelationshipsFilter!
+  key: [StixCoreRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -8853,7 +8861,7 @@ enum StixSightingRelationshipsFilter {
   x_opencti_workflow_id
 }
 input StixSightingRelationshipsFiltering {
-  key: StixSightingRelationshipsFilter!
+  key: [StixSightingRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -8949,7 +8957,7 @@ enum StixCyberObservableRelationshipsFilter {
   created_at
 }
 input StixCyberObservableRelationshipsFiltering {
-  key: StixCyberObservableRelationshipsFilter!
+  key: [StixCyberObservableRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode
@@ -9018,7 +9026,7 @@ enum StixMetaRelationshipsFilter {
   created_at
 }
 input StixMetaRelationshipsFiltering {
-  key: StixMetaRelationshipsFilter!
+  key: [StixMetaRelationshipsFilter!]!
   values: [String]
   operator: String
   filterMode: FilterMode

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -1,0 +1,73 @@
+{
+  "app": {
+    "port": 4010,
+    "logs_level": "info",
+    "performance_logger": false,
+    "sync_raw_start_remote_uri": "http://localhost:4200/graphql",
+    "sync_live_start_remote_uri": "http://localhost:4200/graphql",
+    "sync_direct_start_remote_uri": "http://localhost:4200/graphql",
+    "sync_restore_start_remote_uri": "http://localhost:4200/graphql",
+    "telemetry": {
+      "tracing": {
+        "enabled": false,
+        "exporter_otlp": "http://localhost:4318/v1/traces"
+      },
+      "metrics": {
+        "enabled": false,
+        "exporter_otlp": "",
+        "exporter_prometheus": 14269
+      }
+    },
+    "admin": {
+      "email": "admin@opencti.io",
+      "password": "admin",
+      "token": "d434ce02-e58e-4cac-8b4c-42bf16748e84"
+    }
+  },
+  "redis": {
+    "namespace": "test",
+    "hostname": "localhost",
+    "include_inferences": true
+  },
+  "elasticsearch": {
+    "index_prefix": "test",
+    "url": "http://localhost:9200"
+  },
+  "subscription_scheduler": {
+    "enabled": false
+  },
+  "rule_engine": {
+    "enabled": true
+  },
+  "history_manager": {
+    "enabled": true
+  },
+  "connector_manager": {
+    "enabled": true
+  },
+  "task_scheduler": {
+    "enabled": true
+  },
+  "expiration_scheduler": {
+    "enabled": true
+  },
+  "sync_manager": {
+    "enabled": true
+  },
+  "retention_manager": {
+    "enabled": true
+  },
+  "minio": {
+    "bucket_name": "test",
+    "endpoint": "localhost",
+    "port": 9000
+  },
+  "rabbitmq": {
+    "hostname": "localhost"
+  },
+  "providers": {
+    "local": {
+      "strategy": "LocalStrategy"
+    }
+  }
+}

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -320,6 +320,8 @@ export const ENABLED_HISTORY_MANAGER = booleanConf('history_manager:enabled', fa
 export const ENABLED_SUBSCRIPTION_MANAGER = booleanConf('subscription_scheduler:enabled', false);
 export const ENABLED_CACHING = booleanConf('redis:use_as_cache', false);
 
+export const ELASTIC_CREATION_PATTERN = nconf.get('elasticsearch:index_creation_pattern');
+
 const platformState = { stopping: false };
 export const getStoppingState = () => platformState.stopping;
 export const setStoppingState = (state) => {

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -305,6 +305,9 @@ export const configureCA = (certificates) => {
   return { ca: [] };
 };
 
+// App
+export const PORT = nconf.get('app:port');
+
 // Default activated managers
 export const ENABLED_API = booleanConf('app:enabled', true);
 export const ENABLED_TRACING = booleanConf('app:telemetry:tracing:enabled', false);

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -14,7 +14,7 @@ import { UnsupportedError } from '../config/errors';
 const MAX_SEARCH_SIZE = 5000;
 
 interface Filter {
-  key: string;
+  key: string | string[];
   operator?: string | null;
   filterMode?: 'and' | 'or' | null;
   values?: Array<unknown> | null;

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -43,7 +43,7 @@ export const getTypeStatuses = async (context: AuthContext, user: AuthUser, type
   const args = {
     orderBy: StatusOrdering.Order,
     orderMode: OrderingMode.Asc,
-    filters: [{ key: StatusFilter.Type, values: [type] }],
+    filters: [{ key: [StatusFilter.Type], values: [type] }],
   };
   return findAll(context, user, args);
 };

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -449,7 +449,7 @@ export enum AttackPatternsFilter {
 
 export type AttackPatternsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: AttackPatternsFilter;
+  key: Array<AttackPatternsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -1019,7 +1019,7 @@ export enum CampaignsFilter {
 
 export type CampaignsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: CampaignsFilter;
+  key: Array<CampaignsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -1268,6 +1268,7 @@ export enum ChannelsOrdering {
 }
 
 export enum CitiesFilter {
+  Aliases = 'aliases',
   Created = 'created',
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',
@@ -1282,7 +1283,7 @@ export enum CitiesFilter {
 
 export type CitiesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: CitiesFilter;
+  key: Array<CitiesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -1703,7 +1704,7 @@ export enum ContainersFilter {
 
 export type ContainersFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ContainersFilter;
+  key: Array<ContainersFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -1732,18 +1733,20 @@ export type ContextData = {
 };
 
 export enum CountriesFilter {
+  Aliases = 'aliases',
   Created = 'created',
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',
   LabelledBy = 'labelledBy',
   MarkedBy = 'markedBy',
   Modified = 'modified',
+  Name = 'name',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
 export type CountriesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: CountriesFilter;
+  key: Array<CountriesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -2148,7 +2151,7 @@ export enum CoursesOfActionFilter {
 
 export type CoursesOfActionFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: CoursesOfActionFilter;
+  key: Array<CoursesOfActionFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -3586,7 +3589,7 @@ export enum ExternalReferencesFilter {
 
 export type ExternalReferencesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ExternalReferencesFilter;
+  key: Array<ExternalReferencesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -4378,6 +4381,7 @@ export type IPv6AddrAddInput = {
 };
 
 export enum IdentitiesFilter {
+  Aliases = 'aliases',
   Confidence = 'confidence',
   Created = 'created',
   CreatedBy = 'createdBy',
@@ -4390,13 +4394,12 @@ export enum IdentitiesFilter {
   Name = 'name',
   Revoked = 'revoked',
   UpdatedAt = 'updated_at',
-  XOpenctiAliases = 'x_opencti_aliases',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
 export type IdentitiesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: IdentitiesFilter;
+  key: Array<IdentitiesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -4803,7 +4806,7 @@ export enum IncidentsFilter {
 
 export type IncidentsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: IncidentsFilter;
+  key: Array<IncidentsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5060,7 +5063,7 @@ export enum IndicatorsFilter {
 
 export type IndicatorsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: IndicatorsFilter;
+  key: Array<IndicatorsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5294,7 +5297,7 @@ export enum IndividualsFilter {
 
 export type IndividualsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: IndividualsFilter;
+  key: Array<IndividualsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5531,7 +5534,7 @@ export enum InfrastructuresFilter {
 
 export type InfrastructuresFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: InfrastructuresFilter;
+  key: Array<InfrastructuresFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5783,7 +5786,7 @@ export enum IntrusionSetsFilter {
 
 export type IntrusionSetsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: IntrusionSetsFilter;
+  key: Array<IntrusionSetsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5879,7 +5882,7 @@ export enum KillChainPhasesFilter {
 
 export type KillChainPhasesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: KillChainPhasesFilter;
+  key: Array<KillChainPhasesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -5962,7 +5965,7 @@ export enum LabelsFilter {
 
 export type LabelsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: LabelsFilter;
+  key: Array<LabelsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -6368,6 +6371,7 @@ export enum LocationType {
 }
 
 export enum LocationsFilter {
+  Aliases = 'aliases',
   Confidence = 'confidence',
   Created = 'created',
   CreatedBy = 'createdBy',
@@ -6379,13 +6383,12 @@ export enum LocationsFilter {
   Name = 'name',
   Revoked = 'revoked',
   UpdatedAt = 'updated_at',
-  XOpenctiAliases = 'x_opencti_aliases',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
 export type LocationsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: LocationsFilter;
+  key: Array<LocationsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -6433,7 +6436,7 @@ export enum LogsFilter {
 
 export type LogsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: LogsFilter;
+  key: Array<LogsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -6816,7 +6819,7 @@ export enum MalwaresFilter {
 
 export type MalwaresFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: MalwaresFilter;
+  key: Array<MalwaresFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -6908,7 +6911,7 @@ export enum MarkingDefinitionsFilter {
 
 export type MarkingDefinitionsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: MarkingDefinitionsFilter;
+  key: Array<MarkingDefinitionsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -8940,7 +8943,7 @@ export enum NotesFilter {
 
 export type NotesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: NotesFilter;
+  key: Array<NotesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -9198,7 +9201,7 @@ export enum ObservedDatasFilter {
 
 export type ObservedDatasFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ObservedDatasFilter;
+  key: Array<ObservedDatasFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -9444,7 +9447,7 @@ export enum OpinionsFilter {
 
 export type OpinionsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: OpinionsFilter;
+  key: Array<OpinionsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -9687,7 +9690,7 @@ export enum OrganizationsFilter {
 
 export type OrganizationsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: OrganizationsFilter;
+  key: Array<OrganizationsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -10215,12 +10218,14 @@ export type PositionEditMutationsRelationDeleteArgs = {
 };
 
 export enum PositionsFilter {
+  Aliases = 'aliases',
   Created = 'created',
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',
   LabelledBy = 'labelledBy',
   MarkedBy = 'markedBy',
   Modified = 'modified',
+  Name = 'name',
   Revoked = 'revoked',
   UpdatedAt = 'updated_at',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
@@ -10228,7 +10233,7 @@ export enum PositionsFilter {
 
 export type PositionsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: PositionsFilter;
+  key: Array<PositionsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -12353,18 +12358,20 @@ export type RegionEditMutationsRelationDeleteArgs = {
 };
 
 export enum RegionsFilter {
+  Aliases = 'aliases',
   Created = 'created',
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',
   LabelledBy = 'labelledBy',
   MarkedBy = 'markedBy',
   Modified = 'modified',
+  Name = 'name',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
 export type RegionsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: RegionsFilter;
+  key: Array<RegionsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -12619,7 +12626,7 @@ export enum ReportsFilter {
 
 export type ReportsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ReportsFilter;
+  key: Array<ReportsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -12984,6 +12991,7 @@ export type SectorEditMutationsRelationDeleteArgs = {
 };
 
 export enum SectorsFilter {
+  Aliases = 'aliases',
   Confidence = 'confidence',
   Created = 'created',
   CreatedBy = 'createdBy',
@@ -13000,7 +13008,7 @@ export enum SectorsFilter {
 
 export type SectorsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: SectorsFilter;
+  key: Array<SectorsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -13313,7 +13321,7 @@ export enum StatusTemplateOrdering {
 
 export type StatusesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StatusFilter;
+  key: Array<StatusFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -13512,7 +13520,7 @@ export enum StixCoreObjectsFilter {
 
 export type StixCoreObjectsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixCoreObjectsFilter;
+  key: Array<StixCoreObjectsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -13707,7 +13715,7 @@ export enum StixCoreRelationshipsFilter {
 
 export type StixCoreRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixCoreRelationshipsFilter;
+  key: Array<StixCoreRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14042,7 +14050,7 @@ export enum StixCyberObservableRelationshipsFilter {
 
 export type StixCyberObservableRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixCyberObservableRelationshipsFilter;
+  key: Array<StixCyberObservableRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14090,7 +14098,7 @@ export enum StixCyberObservablesFilter {
 
 export type StixCyberObservablesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixCyberObservablesFilter;
+  key: Array<StixCyberObservablesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14344,7 +14352,7 @@ export enum StixDomainObjectsFilter {
 
 export type StixDomainObjectsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixDomainObjectsFilter;
+  key: Array<StixDomainObjectsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14597,7 +14605,7 @@ export enum StixMetaRelationshipsFilter {
 
 export type StixMetaRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixMetaRelationshipsFilter;
+  key: Array<StixMetaRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14660,7 +14668,7 @@ export enum StixObjectOrStixRelationshipsFilter {
 
 export type StixObjectOrStixRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixObjectOrStixRelationshipsFilter;
+  key: Array<StixObjectOrStixRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values: Array<InputMaybe<Scalars['String']>>;
 };
@@ -14723,7 +14731,7 @@ export enum StixRelationshipsFilter {
 
 export type StixRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixRelationshipsFilter;
+  key: Array<StixRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -14891,7 +14899,7 @@ export enum StixSightingRelationshipsFilter {
 
 export type StixSightingRelationshipsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: StixSightingRelationshipsFilter;
+  key: Array<StixSightingRelationshipsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -15374,7 +15382,7 @@ export enum SystemsFilter {
 
 export type SystemsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: SystemsFilter;
+  key: Array<SystemsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -15476,7 +15484,7 @@ export enum TasksFilter {
 
 export type TasksFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: TasksFilter;
+  key: Array<TasksFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -15894,7 +15902,7 @@ export enum ThreatActorsFilter {
 
 export type ThreatActorsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ThreatActorsFilter;
+  key: Array<ThreatActorsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -16115,7 +16123,7 @@ export enum ToolsFilter {
 
 export type ToolsFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: ToolsFilter;
+  key: Array<ToolsFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -16761,7 +16769,7 @@ export enum UsersFilter {
 
 export type UsersFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: UsersFilter;
+  key: Array<UsersFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -16794,7 +16802,7 @@ export enum VulnerabilitiesFilter {
 
 export type VulnerabilitiesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: VulnerabilitiesFilter;
+  key: Array<VulnerabilitiesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -17395,7 +17403,7 @@ export enum WorksFilter {
 
 export type WorksFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: WorksFilter;
+  key: Array<WorksFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -17506,7 +17514,7 @@ export enum WorkspacesFilter {
 
 export type WorkspacesFiltering = {
   filterMode?: InputMaybe<FilterMode>;
-  key: WorkspacesFilter;
+  key: Array<WorkspacesFilter>;
   operator?: InputMaybe<Scalars['String']>;
   values?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -6,7 +6,7 @@ import { SubscriptionServer } from 'subscriptions-transport-ws';
 import { execute, subscribe } from 'graphql';
 import nconf from 'nconf';
 import express from 'express';
-import conf, { basePath, booleanConf, logApp } from '../config/conf';
+import conf, { basePath, booleanConf, logApp, PORT } from '../config/conf';
 import createApp from './httpPlatform';
 import createApolloServer from '../graphql/graphql';
 import { isStrategyActivated, STRATEGY_CERT } from '../config/providers';
@@ -16,7 +16,6 @@ import { getSettings } from '../domain/settings';
 import { executionContext } from '../utils/access';
 
 const MIN_20 = 20 * 60 * 1000;
-const PORT = conf.get('app:port');
 const REQ_TIMEOUT = conf.get('app:request_timeout');
 const CERT_KEY_PATH = conf.get('app:https_cert:key');
 const CERT_KEY_CERT = conf.get('app:https_cert:crt');

--- a/opencti-platform/opencti-graphql/tests/02-integration/00-inject/loader-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/00-inject/loader-test.js
@@ -1,13 +1,19 @@
-import platformInit from '../../../src/initialization';
-import { FIVE_MINUTES, PYTHON_PATH, API_TOKEN, API_URI, testContext, ADMIN_USER } from '../../utils/testQuery';
+import { ADMIN_USER, API_TOKEN, API_URI, FIVE_MINUTES, PYTHON_PATH, testContext } from '../../utils/testQuery';
 import { execTestingPython } from '../../../src/python/pythonBridge';
-import { startModules, shutdownModules } from '../../../src/modules';
+import { shutdownModules, startModules } from '../../../src/modules';
+import { elDeleteIndexes } from '../../../src/database/engine';
+import { ELASTIC_CREATION_PATTERN } from '../../../src/config/conf';
+import { WRITE_PLATFORM_INDICES } from '../../../src/database/utils';
+import platformInit from '../../../src/initialization';
+import { deleteStream } from '../../../src/database/redis';
 
 describe('Database provision', () => {
   const importOpts = [API_URI, API_TOKEN, './tests/data/DATA-TEST-STIX2_v2.json'];
   it(
     'should platform init',
-    () => {
+    async () => {
+      await elDeleteIndexes(WRITE_PLATFORM_INDICES.map((id) => `${id}${ELASTIC_CREATION_PATTERN}`));
+      await deleteStream();
       return expect(platformInit()).resolves.toBe(true);
     },
     FIVE_MINUTES

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -12,6 +12,7 @@ import {
   EVENT_TYPE_MERGE,
   EVENT_TYPE_UPDATE,
 } from '../../../src/database/rabbitmq';
+import { PORT } from '../../../src/config/conf';
 
 describe('Raw streams tests', () => {
   beforeAll(async () => {
@@ -26,7 +27,7 @@ describe('Raw streams tests', () => {
     'Should stream correctly formatted',
     async () => {
       // Read all events from the beginning.
-      const events = await fetchStreamEvents('http://localhost:4000/stream', { from: '0' });
+      const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });
       // Check the number of events
       expect(events.length).toBe(RAW_EVENTS_SIZE);
       // 01 - CHECK CREATE EVENTS
@@ -97,7 +98,7 @@ describe('Raw streams tests', () => {
   it(
     'Should events dependencies available',
     async () => {
-      const events = await fetchStreamEvents('http://localhost:4000/stream', { from: '0' });
+      const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });
       const contextWithDeletionEvents = events.filter(
         (e) => {
           const { context } = e.data;

--- a/opencti-platform/opencti-graphql/tests/03-streams/01-Live/live-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/01-Live/live-test.js
@@ -7,6 +7,7 @@ import { elAggregationCount } from '../../../src/database/engine';
 import { convertEntityTypeToStixType } from '../../../src/schema/schemaUtils';
 import { convertStoreToStix } from '../../../src/database/stix-converter';
 import { utcDate } from '../../../src/utils/format';
+import { PORT } from '../../../src/config/conf';
 
 describe('Live streams tests', () => {
   beforeAll(async () => {
@@ -53,7 +54,7 @@ describe('Live streams tests', () => {
       const report = await storeLoadByIdWithRefs(testContext, ADMIN_USER, 'report--f2b63e80-b523-4747-a069-35c002c690db');
       const stixReport = convertStoreToStix(report);
       const now = utcDate().toISOString();
-      const events = await fetchStreamEvents(`http://localhost:4000/stream/live?from=0&recover=${now}`);
+      const events = await fetchStreamEvents(`http://localhost:${PORT}/stream/live?from=0&recover=${now}`);
       expect(events.length).toBe(SYNC_LIVE_EVENTS_SIZE);
       await checkResultCounting(events);
       for (let index = 0; index < events.length; index += 1) {

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.js
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.js
@@ -1,7 +1,7 @@
 import { ApolloServer } from 'apollo-server-express';
 import axios from 'axios';
 import createSchema from '../../src/graphql/schema';
-import conf from '../../src/config/conf';
+import conf, { PORT } from '../../src/config/conf';
 import { BYPASS, executionContext, ROLE_ADMINISTRATOR } from '../../src/utils/access';
 
 // region static graphql modules
@@ -12,7 +12,7 @@ export const SYNC_RAW_START_REMOTE_URI = conf.get('app:sync_raw_start_remote_uri
 export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_uri');
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
-export const SYNC_TEST_REMOTE_URI = 'http://api-tests:4000';
+export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
 export const RAW_EVENTS_SIZE = 433;
 export const SYNC_LIVE_EVENTS_SIZE = 247;
 


### PR DESCRIPTION
We can query multiple keys in GraphQL, for example filters: [{ key: [name, aliases], values: ["Alias1"] }]