### PR TITLE
[api] Introduce impersonate capability for bypass role (#1755)

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/audit.ts
+++ b/opencti-platform/opencti-graphql/src/config/audit.ts
@@ -3,6 +3,7 @@ export const ACCESS_CONTROL = 'ACCESS_CONTROL';
 // endregion
 
 // region login
+export const IMPERSONATE_ACTION = 'IMPERSONATE';
 export const LOGIN_ACTION = 'LOGIN';
 export const LOGOUT_ACTION = 'LOGOUT';
 // endregion

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -262,7 +262,7 @@ export const logApp = {
 const LOG_AUDIT = 'AUDIT';
 export const logAudit = {
   _log: (level, user, operation, meta = {}) => {
-    if (!DEV_MODE && auditLogTransports.length > 0) {
+    if (auditLogTransports.length > 0) {
       const metaUser = { email: user.user_email, ...user.origin };
       const logMeta = isEmpty(meta) ? { auth: metaUser } : { resource: meta, auth: metaUser };
       auditLogger.log(level, operation, addBasicMetaInformation(LOG_AUDIT, logMeta));

--- a/opencti-platform/opencti-graphql/src/domain/label.js
+++ b/opencti-platform/opencti-graphql/src/domain/label.js
@@ -4,9 +4,17 @@ import { createEntity, deleteElementById, storeLoadById, updateAttribute } from 
 import { listEntities } from '../database/middleware-loader';
 import { BUS_TOPICS } from '../config/conf';
 import { ENTITY_TYPE_LABEL } from '../schema/stixMetaObject';
-import { normalizeName } from '../schema/identifier';
+import { generateStandardId, normalizeName } from '../schema/identifier';
+import { isAnId } from '../schema/schemaUtils';
 
-export const findById = (context, user, labelId) => {
+export const findById = (context, user, labelIdOrName) => {
+  // Could be internal_id (uuidV4)
+  if (isAnId(labelIdOrName)) {
+    return storeLoadById(context, user, labelIdOrName, ENTITY_TYPE_LABEL);
+  }
+  // Could be directly the label name
+  const labelName = normalizeName(labelIdOrName).toLowerCase();
+  const labelId = generateStandardId(ENTITY_TYPE_LABEL, { value: labelName });
   return storeLoadById(context, user, labelId, ENTITY_TYPE_LABEL);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -636,12 +636,13 @@ export const authenticateUser = async (context, req, user, provider, token = '')
     if (isBypassUser(logged)) {
       const applicantUser = await resolveUserById(context, applicantId);
       if (isEmptyField(applicantUser)) {
-        throw UnsupportedError(`User ${applicantId} cant be impersonate (not exists)`);
+        logApp.warn(`User ${applicantId} cant be impersonate (not exists)`);
+      } else {
+        logAudit.info(applicantUser, IMPERSONATE_ACTION, { from: user.id, to: applicantUser.id });
+        impersonate = applicantUser;
       }
-      logAudit.info(applicantUser, IMPERSONATE_ACTION, { from: user.id, to: applicantUser.id });
-      impersonate = applicantUser;
     } else {
-      throw ForbiddenAccess({ action: IMPERSONATE_ACTION, from: user.id, to: applicantId });
+      logAudit.error(user, IMPERSONATE_ACTION, { to: applicantId });
     }
   }
   const sessionUser = buildSessionUser(logged, impersonate, provider);

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -4,7 +4,7 @@ import { authenticator } from 'otplib';
 import bcrypt from 'bcryptjs';
 import { v4 as uuid } from 'uuid';
 import { delEditContext, delUserContext, notify, setEditContext } from '../database/redis';
-import { AuthenticationFailure, ForbiddenAccess, FunctionalError, UnsupportedError } from '../config/errors';
+import { AuthenticationFailure, ForbiddenAccess, FunctionalError } from '../config/errors';
 import { BUS_TOPICS, logApp, logAudit, OPENCTI_SESSION } from '../config/conf';
 import {
   batchListThroughGetTo,

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -53,7 +53,7 @@ export const ROLE_DEFAULT = 'Default';
 
 export const userWithOrigin = (req, user) => {
   // /!\ This metadata information is used in different ways
-  // - In audit logs to identified the user
+  // - In audit logs to identify the user
   // - In stream message to also identifier the user
   // - In logging system to know the level of the error message
   const origin = {

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -34,7 +34,11 @@ const createApolloServer = () => {
       executeContext.req = req;
       executeContext.res = res;
       executeContext.workId = req.headers['opencti-work-id'];
-      executeContext.user = connection ? connection.context.user : await authenticateUserFromRequest(executeContext, req, res);
+      if (connection) {
+        executeContext.user = connection.context.user;
+      } else {
+        executeContext.user = await authenticateUserFromRequest(executeContext, req, res);
+      }
       return executeContext;
     },
     tracing: DEV_MODE,


### PR DESCRIPTION
In the frame of "Be able to select labels to import #1755", the platform already have a capability to prevent a user to create labels.
The problem was more about a real impersonate of the user by the worker to fully respect the access rights of the connectors.