### PR TITLE
[build] fix front-builder in dockerfile

### DIFF
--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -35,6 +35,10 @@ WORKDIR /opt/opencti-build/opencti-front
 COPY opencti-front/package.json opencti-front/yarn.lock opencti-front/.yarnrc.yml ./
 COPY opencti-front/.yarn ./.yarn
 COPY opencti-front/patch ./patch
+RUN set -ex \
+    ; apk add --no-cache git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre \
+    && npm install -g node-gyp \
+&& yarn install
 
 RUN yarn install
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
There is an issue with node18 and node-sass, it seems to require a higher version of node-gpy (https://stackoverflow.com/questions/71119253/getting-errors-while-installing-node-sass)

IMO, the CI building the images and the Dockerfile should be aligned to avoid such issues. The build in the CI is not at all the same as the Dockerfile, even the base image is not the same. 


### Proposed changes

* Fix the Dockerfile that fails when building the `frontend-builder` by adding the same steps as in the `graphql-builder`

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
