### PR TITLE
[worker] set `isNumber` for prometheus telemetry port 

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -405,7 +405,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             "WORKER_PROMETHEUS_TELEMETRY_PORT",
             ["worker", "telemetry_prometheus_port"],
             config,
-            False,
+            True,
             14270,
         )
         self.telemetry_prometheus_host = get_config_variable(


### PR DESCRIPTION
The `WORKER_PROMETHEUS_TELEMETRY_PORT` is a number and needs to be handled as such to avoid crashing the initialization of the opencti worker.

Otherwise, when specifying another port than the default value, the following error occurs: `TypeError: an integer is required (got type str)` when initializing the http server. 

### Proposed changes

* Set `isNumber=true` when loading the `WORKER_PROMETHEUS_TELEMETRY_PORT` variable using the `get_config_variable` function.

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
