### PR TITLE
[api] Add received_time and processed_time to WorksFilter enum

### DIFF
--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -720,6 +720,7 @@ enum WorksFilter {
   completed_number
   completed_time
   received_time
+  processed_time
 }
 input WorksFiltering {
   key: [WorksFilter!]!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -719,6 +719,7 @@ enum WorksFilter {
   connector_id
   completed_number
   completed_time
+  received_time
 }
 input WorksFiltering {
   key: [WorksFilter!]!


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add received_time and processed_time to WorksFilter enum

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Adding these two fields will allow users to query the API for long running work tasks
