### PR TITLE
Engines / schedulers awareness across cluster of instances (#2709)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencti-front",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "private": true,
   "main": "src/index.tsx",
   "license": "Apache-2.0",

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -36,6 +36,7 @@ const rootPrivateQuery = graphql`
       platform_modules {
         id
         enable
+        running
       }
       ...AppThemeProvider_settings
       ...AppIntlProvider_settings

--- a/opencti-platform/opencti-front/src/private/components/Profile.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Profile.tsx
@@ -24,6 +24,7 @@ export const profileQuery = graphql`
       platform_modules {
         id
         enable
+        running
       }
       otp_mandatory
     }

--- a/opencti-platform/opencti-front/src/private/components/settings/RulesList.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/RulesList.js
@@ -725,6 +725,7 @@ export default createRefetchContainer(
           platform_modules {
             id
             enable
+            running
           }
         }
         stixDomainObjectsTimeSeries(

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.js
@@ -122,6 +122,7 @@ const settingsQuery = graphql`
       platform_modules {
         id
         enable
+        running
       }
       editContext {
         name

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1043,6 +1043,7 @@ interface InternalObject {
 type Module {
   id: ID!
   enable: Boolean!
+  running: Boolean!
 }
 
 type Provider {

--- a/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
+++ b/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import { RootPrivateQuery$data } from '../private/__generated__/RootPrivateQuery.graphql';
 
 export interface ModuleHelper {
@@ -14,7 +13,7 @@ const isFeatureEnable = (
   id: string,
 ) => {
   const flags = settings.platform_feature_flags ?? [];
-  const feature = R.find((f) => f.id === id, flags);
+  const feature = flags.find((f) => f.id === id);
   return feature !== undefined && feature.enable === true;
 };
 
@@ -23,7 +22,7 @@ const isModuleEnable = (
   id: string,
 ) => {
   const modules = settings.platform_modules || [];
-  const module = R.find((f) => f.id === id, modules);
+  const module = modules.find((f) => f.id === id);
   return module !== undefined && module.enable === true;
 };
 

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -990,6 +990,7 @@ interface InternalObject {
 type Module {
   id: ID!
   enable: Boolean!
+  running: Boolean!
 }
 type Provider {
   name: String!

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencti-graphql",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "main": "src/back.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -16,6 +16,7 @@
     "lint": "cross-env DEBUG=eslint:cli-engine TIMING=1 eslint --max-warnings 0 --cache -c .eslintrc.json src",
     "build": "yarn install:python && yarn build:prod",
     "start": "NODE_ENV=dev yarn build:dev && node build/back.js",
+    "start-cluster": "NODE_ENV=cluster node build/back.js",
     "serv": "node build/back.js",
     "insert:dev": "node build/script-insert-dataset.js",
     "test:dev": "vitest --threads false run -c ./builder/dev/vitest.config.ts",

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -708,4 +708,12 @@ export const registerClusterInstance = async (instanceId: string, instanceConfig
     tx.zremrangebyscore('platform_cluster', '-inf', time - 120000);
   });
 };
+export const getClusterInstances = async () => {
+  const instances = await clientBase.zrange('platform_cluster', 0, -1);
+  if (instances) {
+    const instancesConfig = await clientBase.mget(...instances);
+    return (instancesConfig.filter((n) => n !== null) as string[]).map((n) => JSON.parse(n));
+  }
+  return [];
+};
 // endregion

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -10192,6 +10192,7 @@ export type Module = {
   __typename?: 'Module';
   enable: Scalars['Boolean'];
   id: Scalars['ID'];
+  running: Scalars['Boolean'];
 };
 
 export type MultiDistribution = {
@@ -27792,6 +27793,7 @@ export type MessagesStatsResolvers<ContextType = any, ParentType extends Resolve
 export type ModuleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Module'] = ResolversParentTypes['Module']> = ResolversObject<{
   enable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  running?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -3,15 +3,11 @@ import { logApp } from '../config/conf';
 import historyManager from './historyManager';
 import ruleEngine from './ruleManager';
 import subscriptionManager from './subscriptionManager';
-import connectorManager from './connectorManager';
 import taskManager from './taskManager';
 import expiredManager from './expiredManager';
 import syncManager from './syncManager';
 import retentionManager from './retentionManager';
 import { registerClusterInstance } from '../database/redis';
-import { loadEntity } from '../database/middleware';
-import { executionContext, SYSTEM_USER } from '../utils/access';
-import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 
 const SCHEDULE_TIME = 30000;
 
@@ -23,42 +19,38 @@ export type Config = {
 
 const initClusterManager = () => {
   let scheduler: SetIntervalAsyncTimer<[]>;
-  let config_subscription = {};
-  let config_rule = {};
-  let config_history = {};
-  let config_connector = {};
-  let config_task = {};
-  let config_expiration = {};
-  let config_sync = {};
-  let config_retention = {};
+  let configSubscription = {};
+  let configRule = {};
+  let configHistory = {};
+  let configTask = {};
+  let configExpiration = {};
+  let configSync = {};
+  let configRetention = {};
 
   const clusterHandler = async (platform_id: string) => {
     try {
       // receive information from the managers every 30s
-      config_subscription = await subscriptionManager.status();
-      config_rule = await ruleEngine.status();
-      config_history = await historyManager.status();
-      config_connector = await connectorManager.status();
-      config_task = await taskManager.status();
-      config_expiration = await expiredManager.status();
-      config_sync = await syncManager.status();
-      config_retention = await retentionManager.status();
+      configSubscription = await subscriptionManager.status();
+      configRule = await ruleEngine.status();
+      configHistory = await historyManager.status();
+      configTask = await taskManager.status();
+      configExpiration = await expiredManager.status();
+      configSync = await syncManager.status();
+      configRetention = await retentionManager.status();
     } finally {
       const config_managers = [
-        config_subscription,
-        config_rule,
-        config_history,
-        config_connector,
-        config_task,
-        config_expiration,
-        config_sync,
-        config_retention,
+        configSubscription,
+        configRule,
+        configHistory,
+        configTask,
+        configExpiration,
+        configSync,
+        configRetention,
       ];
       const config_data = {
         platform_id,
         managers: config_managers,
       };
-      logApp.info('config_managers = ', config_managers);
       await registerClusterInstance(platform_id, config_data);
     }
   };

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -1,0 +1,35 @@
+import { clearIntervalAsync, setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/fixed';
+import { logApp } from '../config/conf';
+import historyManager from './historyManager';
+
+const SCHEDULE_TIME = 30000;
+
+const initClusterManager = () => {
+  let scheduler: SetIntervalAsyncTimer<[]>;
+  let syncListening = true;
+  const clusterHandler = async () => {
+    try {
+      logApp.info('[OPENCTI-MODULE] hello'); // printing Hello every 30s
+    } finally { /* empty */ }
+  };
+  return {
+    start: async () => {
+      logApp.info('[OPENCTI-MODULE] Starting cluster manager');
+      await historyManager.declare();
+      scheduler = setIntervalAsync(async () => {
+        await clusterHandler();
+      }, SCHEDULE_TIME);
+    },
+    shutdown: async () => {
+      syncListening = false;
+      logApp.info('[OPENCTI-MODULE] Stopping cluster manager');
+      if (scheduler) {
+        await clearIntervalAsync(scheduler);
+      }
+      return true;
+    },
+  };
+};
+const clusterManager = initClusterManager();
+
+export default clusterManager;

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -1,27 +1,67 @@
 import { clearIntervalAsync, setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import { logApp } from '../config/conf';
 import historyManager from './historyManager';
+import ruleEngine from './ruleManager';
+import subscriptionManager from './subscriptionManager';
+import connectorManager from './connectorManager';
+import taskManager from './taskManager';
+import expiredManager from './expiredManager';
+import syncManager from './syncManager';
+import retentionManager from './retentionManager';
 
 const SCHEDULE_TIME = 30000;
 
+export type Config = {
+  key: string,
+  enabled: boolean,
+  running: boolean,
+};
+
 const initClusterManager = () => {
   let scheduler: SetIntervalAsyncTimer<[]>;
-  let syncListening = true;
+  let config_subscription = {};
+  let config_rule = {};
+  let config_history = {};
+  let config_connector = {};
+  let config_task = {};
+  let config_expiration = {};
+  let config_sync = {};
+  let config_retention = {};
+
   const clusterHandler = async () => {
     try {
       logApp.info('[OPENCTI-MODULE] hello'); // printing Hello every 30s
-    } finally { /* empty */ }
+      config_subscription = await subscriptionManager.status();
+      config_rule = await ruleEngine.status();
+      config_history = await historyManager.status();
+      config_connector = await connectorManager.status();
+      config_task = await taskManager.status();
+      config_expiration = await expiredManager.status();
+      config_sync = await syncManager.status();
+      config_retention = await retentionManager.status();
+    } finally {
+      const config_managers = [
+        config_subscription,
+        config_rule,
+        config_history,
+        config_connector,
+        config_task,
+        config_expiration,
+        config_sync,
+        config_retention,
+      ];
+      logApp.info('config_managers = ', config_managers);
+    }
   };
+
   return {
     start: async () => {
       logApp.info('[OPENCTI-MODULE] Starting cluster manager');
-      await historyManager.declare();
       scheduler = setIntervalAsync(async () => {
         await clusterHandler();
       }, SCHEDULE_TIME);
     },
     shutdown: async () => {
-      syncListening = false;
       logApp.info('[OPENCTI-MODULE] Stopping cluster manager');
       if (scheduler) {
         await clearIntervalAsync(scheduler);
@@ -30,6 +70,7 @@ const initClusterManager = () => {
     },
   };
 };
+
 const clusterManager = initClusterManager();
 
 export default clusterManager;

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -129,7 +129,6 @@ const initConnectorManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Connector manager declares itself');
       return {
         id: 'connector_manager',
         enabled: booleanConf('connector_manager:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -130,8 +130,8 @@ const initConnectorManager = () => {
     },
     status: async () => {
       return {
-        id: 'connector_manager',
-        enabled: booleanConf('connector_manager:enabled', false),
+        id: 'CONNECTOR_MANAGER',
+        enable: booleanConf('connector_manager:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -1,6 +1,6 @@
 import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
 import { lockResource, redisDeleteWorks, redisGetConnectorStatus, redisGetWork } from '../database/redis';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { connectors } from '../database/repository';
 import { elDeleteInstances, elUpdate } from '../database/engine';
@@ -16,6 +16,7 @@ import { now, sinceNowInDays } from '../utils/format';
 const SCHEDULE_TIME = conf.get('connector_manager:interval');
 const CONNECTOR_MANAGER_KEY = conf.get('connector_manager:lock_key');
 const CONNECTOR_WORK_RANGE = conf.get('connector_manager:works_day_range');
+let running = false;
 
 const closeOldWorks = async (context, connector) => {
   // Get current status from Redis
@@ -94,6 +95,7 @@ const connectorHandler = async () => {
   try {
     // Lock the manager
     lock = await lockResource([CONNECTOR_MANAGER_KEY]);
+    running = true;
     const context = executionContext('connector_manager');
     // Execute the cleaning
     const platformConnectors = await connectors(context, SYSTEM_USER);
@@ -111,6 +113,7 @@ const connectorHandler = async () => {
       logApp.error('[OPENCTI-MODULE] Connector manager failed to start', { error: e });
     }
   } finally {
+    running = false;
     logApp.debug('[OPENCTI-MODULE] Connector manager done');
     if (lock) await lock.unlock();
   }
@@ -124,6 +127,14 @@ const initConnectorManager = () => {
       scheduler = setIntervalAsync(async () => {
         await connectorHandler();
       }, SCHEDULE_TIME);
+    },
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] Connector manager declares itself');
+      return {
+        id: 'connector_manager',
+        enabled: booleanConf('connector_manager:enabled', false),
+        running,
+      };
     },
     shutdown: async () => {
       if (scheduler) {

--- a/opencti-platform/opencti-graphql/src/manager/expiredManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/expiredManager.js
@@ -67,7 +67,6 @@ const initExpiredManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Expiration manager declares itself');
       return {
         id: 'expiration_scheduler',
         enabled: booleanConf('expiration_scheduler:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/expiredManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/expiredManager.js
@@ -5,7 +5,7 @@ import { elList, ES_MAX_CONCURRENCY } from '../database/engine';
 import { READ_DATA_INDICES } from '../database/utils';
 import { prepareDate } from '../utils/format';
 import { patchAttribute } from '../database/middleware';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { ENTITY_TYPE_INDICATOR } from '../schema/stixDomainObject';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { TYPE_LOCK_ERROR } from '../config/errors';
@@ -16,12 +16,14 @@ import { TYPE_LOCK_ERROR } from '../config/errors';
 // If the lock is free, every API as the right to take it.
 const SCHEDULE_TIME = conf.get('expiration_scheduler:interval');
 const EXPIRED_MANAGER_KEY = conf.get('expiration_scheduler:lock_key');
+let running = false;
 
 const expireHandler = async () => {
   let lock;
   try {
     // Lock the manager
     lock = await lockResource([EXPIRED_MANAGER_KEY]);
+    running = true;
     const context = executionContext('expiration_manager');
     // Execute the cleaning
     const callback = async (elements) => {
@@ -49,6 +51,7 @@ const expireHandler = async () => {
       logApp.error('[OPENCTI-MODULE] Expiration manager failed to start', { error: e });
     }
   } finally {
+    running = false;
     logApp.debug('[OPENCTI-MODULE] Expiration manager done');
     if (lock) await lock.unlock();
   }
@@ -62,6 +65,14 @@ const initExpiredManager = () => {
       scheduler = setIntervalAsync(async () => {
         await expireHandler();
       }, SCHEDULE_TIME);
+    },
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] Expiration manager declares itself');
+      return {
+        id: 'expiration_scheduler',
+        enabled: booleanConf('expiration_scheduler:enabled', false),
+        running,
+      };
     },
     shutdown: async () => {
       if (scheduler) {

--- a/opencti-platform/opencti-graphql/src/manager/expiredManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/expiredManager.js
@@ -68,8 +68,8 @@ const initExpiredManager = () => {
     },
     status: async () => {
       return {
-        id: 'expiration_scheduler',
-        enabled: booleanConf('expiration_scheduler:enabled', false),
+        id: 'EXPIRATION_SCHEDULER',
+        enable: booleanConf('expiration_scheduler:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -197,8 +197,8 @@ const initHistoryManager = () => {
     },
     status: async () => {
       return {
-        id: 'history_manager',
-        enabled: booleanConf('history_manager:enabled', false),
+        id: 'HISTORY_MANAGER',
+        enable: booleanConf('history_manager:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { clearIntervalAsync, setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import { createStreamProcessor, lockResource, StreamProcessor } from '../database/redis';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { EVENT_TYPE_UPDATE, INDEX_HISTORY, isEmptyField, isNotEmptyField } from '../database/utils';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { executionContext, SYSTEM_USER } from '../utils/access';
@@ -141,6 +141,7 @@ const initHistoryManager = () => {
   let scheduler: SetIntervalAsyncTimer<[]>;
   let streamProcessor: StreamProcessor;
   let syncListening = true;
+  let running = false;
   const wait = (ms: number) => {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -151,6 +152,7 @@ const initHistoryManager = () => {
     try {
       // Lock the manager
       lock = await lockResource([HISTORY_ENGINE_KEY]);
+      running = true;
       logApp.info('[OPENCTI-MODULE] Running history manager');
       streamProcessor = createStreamProcessor(SYSTEM_USER, 'History manager', false, historyStreamHandler);
       await streamProcessor.start(lastEventId);
@@ -164,6 +166,7 @@ const initHistoryManager = () => {
         logApp.error('[OPENCTI-MODULE] history manager failed to start', { error: e });
       }
     } finally {
+      running = false;
       if (streamProcessor) await streamProcessor.shutdown();
       if (lock) await lock.unlock();
     }
@@ -192,10 +195,13 @@ const initHistoryManager = () => {
         }
       }, SCHEDULE_TIME);
     },
-    declare: async () => {
-      if (syncListening) {
-        logApp.info(`[OPENCTI-MODULE] History manager declares itself as ${HISTORY_ENGINE_KEY}`);
-      }
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] History manager declares itself');
+      return {
+        id: 'history_manager',
+        enabled: booleanConf('history_manager:enabled', false),
+        running,
+      };
     },
     shutdown: async () => {
       syncListening = false;

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -196,7 +196,6 @@ const initHistoryManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] History manager declares itself');
       return {
         id: 'history_manager',
         enabled: booleanConf('history_manager:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -192,6 +192,11 @@ const initHistoryManager = () => {
         }
       }, SCHEDULE_TIME);
     },
+    declare: async () => {
+      if (syncListening) {
+        logApp.info(`[OPENCTI-MODULE] History manager declares itself as ${HISTORY_ENGINE_KEY}`);
+      }
+    },
     shutdown: async () => {
       syncListening = false;
       if (scheduler) {

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.js
@@ -91,7 +91,6 @@ const initRetentionManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Retention manager declares itself');
       return {
         id: 'retention_manager',
         enabled: booleanConf('retention_manager:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.js
@@ -92,8 +92,8 @@ const initRetentionManager = () => {
     },
     status: async () => {
       return {
-        id: 'retention_manager',
-        enabled: booleanConf('retention_manager:enabled', false),
+        id: 'RETENTION_MANAGER',
+        enable: booleanConf('retention_manager:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.js
@@ -2,7 +2,7 @@ import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/dynamic
 import moment from 'moment';
 import { lockResource } from '../database/redis';
 import { findAll as findRetentionRulesToExecute } from '../domain/retentionRule';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { deleteElementById, patchAttribute } from '../database/middleware';
 import { executionContext, RETENTION_MANAGER_USER } from '../utils/access';
@@ -19,6 +19,7 @@ const SCHEDULE_TIME = conf.get('retention_manager:interval') || 60000;
 const RETENTION_MANAGER_KEY = conf.get('retention_manager:lock_key') || 'retention_manager_lock';
 const RETENTION_BATCH_SIZE = conf.get('retention_manager:batch_size') || 100;
 const RETENTION_INDICES = [...READ_STIX_INDICES, READ_INDEX_STIX_META_OBJECTS, READ_INDEX_STIX_META_RELATIONSHIPS];
+let running = false;
 
 const executeProcessing = async (context, retentionRule) => {
   const { id, name, max_retention: maxDays, filters } = retentionRule;
@@ -57,6 +58,7 @@ const retentionHandler = async () => {
   try {
     // Lock the manager
     lock = await lockResource([RETENTION_MANAGER_KEY]);
+    running = true;
     const context = executionContext('retention_manager');
     const retentionRules = await findRetentionRulesToExecute(context, RETENTION_MANAGER_USER, { connectionFormat: false });
     logApp.debug(`[OPENCTI] Retention manager execution for ${retentionRules.length} rules`);
@@ -75,6 +77,7 @@ const retentionHandler = async () => {
       logApp.error('[OPENCTI-MODULE] Retention manager fail to execute', { error: e });
     }
   } finally {
+    running = false;
     if (lock) await lock.unlock();
   }
 };
@@ -86,6 +89,14 @@ const initRetentionManager = () => {
       scheduler = setIntervalAsync(async () => {
         await retentionHandler();
       }, SCHEDULE_TIME);
+    },
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] Retention manager declares itself');
+      return {
+        id: 'retention_manager',
+        enabled: booleanConf('retention_manager:enabled', false),
+        running,
+      };
     },
     shutdown: async () => {
       if (scheduler) {

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -366,8 +366,8 @@ const initRuleManager = () => {
     },
     status: async () => {
       return {
-        id: 'rule_engine',
-        enabled: booleanConf('rule_engine:enabled', false),
+        id: 'RULE_ENGINE',
+        enable: booleanConf('rule_engine:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -365,7 +365,6 @@ const initRuleManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Rule engine declares itself');
       return {
         id: 'rule_engine',
         enabled: booleanConf('rule_engine:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
@@ -4,7 +4,7 @@ import { lockResource } from '../database/redis';
 import { elList, ES_MAX_CONCURRENCY } from '../database/engine';
 import { READ_PLATFORM_INDICES } from '../database/utils';
 import { hoursAgo, minutesAgo, now, prepareDate, utcDate } from '../utils/format';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { ENTITY_TYPE_USER_SUBSCRIPTION } from '../schema/internalObject';
 import { generateDigestForSubscription } from '../domain/userSubscription';
@@ -20,12 +20,14 @@ const SCHEDULE_TIME = conf.get('subscription_scheduler:interval');
 const SUBSCRIPTION_MANAGER_KEY = conf.get('subscription_scheduler:lock_key');
 
 const defaultCrons = ['5-minutes', '1-hours', '24-hours', '1-weeks', '1-months'];
+let running = false;
 
 const subscriptionHandler = async () => {
   let lock;
   try {
     // Lock the manager
     lock = await lockResource([SUBSCRIPTION_MANAGER_KEY]);
+    running = true;
     const context = executionContext('subscription_manager');
     // Execute the cleaning
     const callback = async (elements) => {
@@ -74,6 +76,7 @@ const subscriptionHandler = async () => {
       logApp.error('[OPENCTI-MODULE] Subscription manager failed to start', { error: e });
     }
   } finally {
+    running = false;
     logApp.debug('[OPENCTI-MODULE] Subscription manager done');
     if (lock) await lock.unlock();
   }
@@ -87,6 +90,14 @@ const initSubscriptionManager = () => {
       scheduler = setIntervalAsync(async () => {
         await subscriptionHandler();
       }, SCHEDULE_TIME);
+    },
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] Subscription manager declares itself');
+      return {
+        id: 'subscription_scheduler',
+        enabled: booleanConf('subscription_scheduler:enabled', false),
+        running,
+      };
     },
     shutdown: async () => {
       if (scheduler) {

--- a/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
@@ -92,7 +92,6 @@ const initSubscriptionManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Subscription manager declares itself');
       return {
         id: 'subscription_scheduler',
         enabled: booleanConf('subscription_scheduler:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/subscriptionManager.js
@@ -93,8 +93,8 @@ const initSubscriptionManager = () => {
     },
     status: async () => {
       return {
-        id: 'subscription_scheduler',
-        enabled: booleanConf('subscription_scheduler:enabled', false),
+        id: 'SUBSCRIPTION_MANAGER',
+        enable: booleanConf('subscription_scheduler:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -239,8 +239,8 @@ const initSyncManager = () => {
     },
     status: async () => {
       return {
-        id: 'sync_manager',
-        enabled: booleanConf('sync_manager:enabled', false),
+        id: 'SYNC_MANAGER',
+        enable: booleanConf('sync_manager:enabled', false),
         running: managerRunning,
       };
     },

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
 import * as jsonpatch from 'fast-json-patch';
 import https from 'node:https';
-import conf, { logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import Queue from '../utils/queue';
@@ -161,6 +161,7 @@ const syncManagerInstance = (syncId) => {
 const initSyncManager = () => {
   let scheduler;
   let syncListening = true;
+  let managerRunning = false;
   const syncManagers = new Map();
   const processStep = async () => {
     // Get syncs definition
@@ -215,6 +216,7 @@ const initSyncManager = () => {
     try {
       logApp.debug('[OPENCTI-MODULE] Running sync manager');
       lock = await lockResource([SYNC_MANAGER_KEY]);
+      managerRunning = true;
       await processingLoop();
     } catch (e) {
       if (e.name === TYPE_LOCK_ERROR) {
@@ -223,6 +225,7 @@ const initSyncManager = () => {
         logApp.error('[OPENCTI-MODULE] Sync manager failed to start', { error: e });
       }
     } finally {
+      managerRunning = false;
       logApp.debug('[OPENCTI-MODULE] Sync manager done');
       if (lock) await lock.unlock();
     }
@@ -233,6 +236,14 @@ const initSyncManager = () => {
       scheduler = setIntervalAsync(async () => {
         await syncManagerHandler();
       }, WAIT_TIME_ACTION);
+    },
+    status: async () => {
+      logApp.info('[OPENCTI-MODULE] Sync manager declares itself');
+      return {
+        id: 'sync_manager',
+        enabled: booleanConf('sync_manager:enabled', false),
+        running: managerRunning,
+      };
     },
     shutdown: async () => {
       syncListening = false;

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -238,7 +238,6 @@ const initSyncManager = () => {
       }, WAIT_TIME_ACTION);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Sync manager declares itself');
       return {
         id: 'sync_manager',
         enabled: booleanConf('sync_manager:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -490,7 +490,6 @@ const initTaskManager = () => {
       }, SCHEDULE_TIME);
     },
     status: async () => {
-      logApp.info('[OPENCTI-MODULE] Task manager declares itself');
       return {
         id: 'task_scheduler',
         enabled: booleanConf('task_scheduler:enabled', false),

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -491,8 +491,8 @@ const initTaskManager = () => {
     },
     status: async () => {
       return {
-        id: 'task_scheduler',
-        enabled: booleanConf('task_scheduler:enabled', false),
+        id: 'TASK_MANAGER',
+        enable: booleanConf('task_scheduler:enabled', false),
         running,
       };
     },

--- a/opencti-platform/opencti-graphql/src/modules.js
+++ b/opencti-platform/opencti-graphql/src/modules.js
@@ -19,6 +19,7 @@ import syncManager from './manager/syncManager';
 import retentionManager from './manager/retentionManager';
 import httpServer from './http/httpServer';
 import connectorManager from './manager/connectorManager';
+import clusterManager from './manager/clusterManager';
 
 // region static graphql modules
 import './modules/index';
@@ -90,6 +91,9 @@ export const startModules = async () => {
     logApp.info('[OPENCTI-MODULE] History manager not started (disabled by configuration)');
   }
   // endregion
+  // region Cluster manager
+  await clusterManager.start();
+  // endregion
 };
 
 export const shutdownModules = async () => {
@@ -149,6 +153,11 @@ export const shutdownModules = async () => {
     await historyManager.shutdown();
     logApp.info(`[OPENCTI-MODULE] History manager stopped in ${new Date().getTime() - stopTime} ms`);
   }
+  // endregion
+  // region Cluster manager
+  stopTime = new Date().getTime();
+  await clusterManager.shutdown();
+  logApp.info(`[OPENCTI-MODULE] Cluster manager stopped in ${new Date().getTime() - stopTime} ms`);
   // endregion
 };
 // endregion


### PR DESCRIPTION
### Use case

Engines/Schedulers/Managers can be enable or disabled. This information is reported in Settings > Tools (green or red icon).

However, if several instances are turned on, it is not taking into account (the front take the information of the front instance in a static manner).
—>We should have an Enabled button if one of the instances have the manager.

The fact that cluster of instances are not taking into account has consequences since the user has or not access to different panels according to these Enabled/disabled buttons :
- the ‘rules engine’ tab (in Settings) content is accessible if the Rules engine is enabled,
- the ‘Subscriptions & Digests’ part content is accessible if the Subscriptions manager is enabled.

Example : disable the rule engine on the "frontend instance" and enable it on the "ingestion instance" should not prevent a user to manage the rules in the settings

### Implemented solution (technical)

- each manager declares its configuration (if it is enable or not and if it is running or not)
- creation of a 'cluster manager' that
       - fetches manager information from each instance every 30s
       - stores/updates these information in Redis every 30s
       - maintain a list of the running instances (an instance is deleted from the list if we have no information from it since 2min or more)
- in graphql, getModules() now returns for each manager, if it is enable or not in at least one instance, and if it is running or not in at least one instance.

### Points that are opened to discussion

- The period for updating an instance config is 30s
- An instance is considered as down if we have no information from it since 2min or more
--> these 2 numbers can be modified --> open to discussion

### Related issues

https://github.com/OpenCTI-Platform/opencti/issues/2709

### Notion page

https://www.notion.so/filigran/Engines-schedulers-awareness-across-cluster-of-instances-2709-f1f2a031f6fa43ef935d27b5a9535fd3

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
