### PR TITLE
[back] Protect the platform from missing resolution due to shard failure

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/errors.js
+++ b/opencti-platform/opencti-graphql/src/config/errors.js
@@ -87,9 +87,17 @@ export const FunctionalError = (reason, data) => error('FunctionalError', 'Busin
   ...data,
 });
 
+const TYPE_LOCK = 'LockError';
 export const TYPE_LOCK_ERROR = 'ExecutionError';
-export const LockTimeoutError = (data, reason) => error('LockError', 'Lock timeout', {
+export const LockTimeoutError = (data, reason) => error(TYPE_LOCK, 'Lock timeout', {
   reason: reason ?? 'Execution timeout, too many concurrent call on the same entities',
+  http_status: 500,
+  category: CATEGORY_BUSINESS,
+  ...data,
+});
+
+export const EngineShardsError = (data) => error(TYPE_LOCK, 'Engine shards failure', {
+  reason: 'Engine execution fail, some shards are not available, please check your engine status',
   http_status: 500,
   category: CATEGORY_BUSINESS,
   ...data,


### PR DESCRIPTION
In Opensearch / Elasticsearch the data is splitted into different shards that will be located on different physical nodes.
When a query is made on a index, every shard will be consulted to know if the information is availble. In some case the shard is not in capacity to answer, but elastic doesnt fail the query, he simply answer the result with metadata of the shards that fail and succeed.

This situation in OpenCTI when the cluster answer a search with possible missing information could be highly problematic depending of the situation. The most problematic is data duplication on highly use elements, like marking definition.

See https://github.com/OpenCTI-Platform/opencti/issues/2781