### PR TITLE
[Front] bug fix: limitation of observable bulk copy from the tool bar when doing a SelectAll (#2807)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.js
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.js
@@ -241,7 +241,7 @@ const toolBarConnectorsQuery = graphql`
   }
 `;
 
-const maxNumberOfObservablesToCopy = 1000;
+export const maxNumberOfObservablesToCopy = 1000;
 
 const toolBarContainersQuery = graphql`
   query ToolBarContainersQuery($search: String) {

--- a/opencti-platform/opencti-front/src/utils/hooks/useCopy.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useCopy.tsx
@@ -3,6 +3,7 @@ import { fetchQuery, MESSAGING$ } from '../../relay/environment';
 import { convertFilters } from '../ListParameters';
 import { Filters } from '../../components/list_lines';
 import { useFormatter } from '../../components/i18n';
+import { maxNumberOfObservablesToCopy } from '../../private/components/data/ToolBar';
 
 interface UseCopyProps<T> {
   filters?: Filters;
@@ -35,10 +36,12 @@ const useCopy = <T extends OperationType['response']>(
           id: elementId,
           search: searchTerm,
           filters: convertFilters(filters ?? {}),
+          count: maxNumberOfObservablesToCopy,
         })
         : fetchQuery(query, {
           search: searchTerm,
           filters: convertFilters(filters ?? {}),
+          count: maxNumberOfObservablesToCopy,
         })
       )
         .toPromise()


### PR DESCRIPTION
## Related issue
https://github.com/OpenCTI-Platform/opencti/issues/2807

## Description

When we bulk copy observables in the clipboard (button copy of the tool bar), only the 10 first elements are copied if the selection was made via SelectAll. 

## Reproducible Steps

Go to a report > Observables OR to Observables.
The list of observables should have more than 10 elements.
Select all the elements.
Copy them (copy button of the tool bar).
Paste them somewhere: there are only the 10 first ones.

## Expected Output

We should be able to copy all the elements of the list under the limitation of 1000.

## Explanation
If we select more than 10 elements by clicking on every checkbox: no problem, all the elements are copied.
If we do a 'select all' : only the 10 first are copied

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
