### PR TITLE
List exports bug fixes for contained data (#2804)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.js
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.js
@@ -242,7 +242,7 @@ class StixCoreObjectOrStixCoreRelationshipContainers extends Component {
             handleChangeView={this.handleChangeView.bind(this)}
             openExports={openExports}
             noPadding={typeof this.props.onChangeOpenExports === 'function'}
-            exportEntityType="Report"
+            exportEntityType="Analysis"
             exportContext={exportContext}
             keyword={searchTerm}
             handleSwitchRedirectionMode={this.handleSwitchRedirectionMode.bind(this)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
-import * as R from 'ramda';
-import { graphql, createRefetchContainer } from 'react-relay';
+import { createRefetchContainer, graphql } from 'react-relay';
 import List from '@mui/material/List';
 import { interval } from 'rxjs';
 import ListSubheader from '@mui/material/ListSubheader';
@@ -57,11 +56,17 @@ const StixCoreObjectsExportsContentComponent = ({
       subscription.unsubscribe();
     };
   });
-  const stixCoreObjectsExportFiles = R.pathOr(
-    [],
-    ['stixCoreObjectsExportFiles', 'edges'],
-    data,
-  );
+  const stixCoreObjectsExportFiles = data?.stixCoreObjectsExportFiles?.edges ?? [];
+
+  let paginationOptionsForExport = paginationOptions; // paginationsOptions with correct types filters
+  if (paginationOptions?.types && paginationOptions.types.length > 0) {
+    const filtersForExport = [...paginationOptionsForExport.filters, { key: 'entity_type', values: paginationOptions.types }];
+    paginationOptionsForExport = {
+      ...paginationOptions,
+      filters: filtersForExport,
+    };
+  }
+
   return (
     <List
       subheader={
@@ -71,7 +76,7 @@ const StixCoreObjectsExportsContentComponent = ({
             <StixCoreObjectsExportCreation
               data={data}
               exportEntityType={exportEntityType}
-              paginationOptions={paginationOptions}
+              paginationOptions={paginationOptionsForExport}
               context={context}
               onExportAsk={() => relay.refetch({
                 type: exportEntityType,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.js
@@ -645,9 +645,7 @@ class EntityStixCoreRelationships extends Component {
     }
     let selectedRelationshipTypes;
     if (filters.relationship_type && filters.relationship_type.length > 0) {
-      if (
-        filters.relationship_type.filter((o) => o.id === 'all').length > 0
-      ) {
+      if (filters.relationship_type.filter((o) => o.id === 'all').length > 0) {
         selectedRelationshipTypes = [];
       } else {
         selectedRelationshipTypes = filters.relationship_type.map((o) => o.id);
@@ -763,30 +761,30 @@ class EntityStixCoreRelationships extends Component {
       : stixCoreObjectTypesWithoutObservables;
     return (
       <ExportContextProvider>
-      <div className={classes.container}>
-        {finalView === 'relationships'
-          && this.renderRelationships(paginationOptions, backgroundTaskFilters)}
-        {finalView === 'entities'
-          && this.renderEntities(paginationOptions, backgroundTaskFilters)}
-        <Security needs={[KNOWLEDGE_KNUPDATE]}>
-          <StixCoreRelationshipCreationFromEntity
-            entityId={entityId}
-            isRelationReversed={isRelationReversed}
-            paddingRight={220}
-            targetStixDomainObjectTypes={targetStixDomainObjectTypes}
-            targetStixCyberObservableTypes={targetStixCyberObservableTypes}
-            allowedRelationshipTypes={relationshipTypes}
-            paginationOptions={paginationOptions}
-            defaultStartTime={defaultStartTime}
-            defaultStopTime={defaultStopTime}
-            connectionKey={
-              finalView === 'entities'
-                ? 'Pagination_stixCoreObjects'
-                : undefined
-            }
-          />
-        </Security>
-      </div>
+        <div className={classes.container}>
+          {finalView === 'relationships'
+            && this.renderRelationships(paginationOptions, backgroundTaskFilters)}
+          {finalView === 'entities'
+            && this.renderEntities(paginationOptions, backgroundTaskFilters)}
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <StixCoreRelationshipCreationFromEntity
+              entityId={entityId}
+              isRelationReversed={isRelationReversed}
+              paddingRight={220}
+              targetStixDomainObjectTypes={targetStixDomainObjectTypes}
+              targetStixCyberObservableTypes={targetStixCyberObservableTypes}
+              allowedRelationshipTypes={relationshipTypes}
+              paginationOptions={paginationOptions}
+              defaultStartTime={defaultStartTime}
+              defaultStopTime={defaultStopTime}
+              connectionKey={
+                finalView === 'entities'
+                  ? 'Pagination_stixCoreObjects'
+                  : undefined
+              }
+            />
+          </Security>
+        </div>
       </ExportContextProvider>
     );
   }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsEntities.tsx
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery } from 'react-relay';
 import ListLinesContent from '../../../../components/list_lines/ListLinesContent';
@@ -16,6 +15,9 @@ import {
   EntityStixCoreRelationshipsEntitiesPaginationQuery$variables,
 } from './__generated__/EntityStixCoreRelationshipsEntitiesPaginationQuery.graphql';
 import { UseLocalStorageHelpers } from '../../../../utils/hooks/useLocalStorage';
+import {
+  EntityStixCoreRelationshipsEntities_data$key,
+} from './__generated__/EntityStixCoreRelationshipsEntities_data.graphql';
 
 const nbOfRowsToLoad = 50;
 
@@ -115,7 +117,8 @@ EntityStixCoreRelationshipsEntitiesProps
   selectAll,
   setNumberOfElements,
 }) => {
-  const { data, loadMore, hasMore, isLoadingMore } = usePreloadedPaginationFragment({
+  const { data, loadMore, hasMore, isLoadingMore } = usePreloadedPaginationFragment<
+  EntityStixCoreRelationshipsEntitiesPaginationQuery, EntityStixCoreRelationshipsEntities_data$key>({
     queryRef,
     linesQuery: entityStixCoreRelationshipsEntitiesQuery,
     linesFragment: entityStixCoreRelationshipsEntitiesFragment,
@@ -128,12 +131,8 @@ EntityStixCoreRelationshipsEntitiesProps
       loadMore={loadMore}
       hasMore={hasMore}
       isLoading={isLoadingMore}
-      dataList={R.pathOr([], ['stixCoreObjects', 'edges'], data)}
-      globalCount={R.pathOr(
-        nbOfRowsToLoad,
-        ['stixCoreObjects', 'pageInfo', 'globalCount'],
-        data,
-      )}
+      dataList={data?.stixCoreObjects?.edges ?? []}
+      globalCount={data?.stixCoreObjects?.pageInfo?.globalCount ?? nbOfRowsToLoad}
       LineComponent={EntityStixCoreRelationshipsEntitiesLine}
       DummyLineComponent={EntityStixCoreRelationshipsEntitiesLineDummy}
       dataColumns={dataColumns}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
@@ -67,9 +67,9 @@ class StixDomainObjectsExportsContentComponent extends Component {
       context,
     } = this.props;
     const stixDomainObjectsExportFiles = data?.stixDomainObjectsExportFiles?.edges ?? [];
-
+    console.log('paginationOptions', paginationOptions);
     let paginationOptionsForExport = paginationOptions; // paginationsOptions with correct elementId
-    if (paginationOptions?.filters && Object.values(paginationOptions.filters).map((o) => o.key).includes('objectContains')) { // for reports contained in entity>Analysis
+    if (paginationOptions?.filters && Object.values(paginationOptions.filters).map((o) => o.key).includes('objectContains')) { // for elements contained in entity>Analysis
       const filtersValues = Object.values(paginationOptions.filters);
       const [elementId] = filtersValues.filter((o) => o.key === 'objectContains')[0].values;
       const filtersForExport = filtersValues.filter((o) => o.key !== 'objectContains');
@@ -79,6 +79,14 @@ class StixDomainObjectsExportsContentComponent extends Component {
         elementId,
       };
     }
+    if (paginationOptions?.fromId) { // for relationships contained in entity>Knowledge>Sightings
+      const filtersForExport = [...paginationOptionsForExport.filters, { key: 'fromId', values: [paginationOptions.fromId] }];
+      paginationOptionsForExport = {
+        ...paginationOptions,
+        filters: filtersForExport,
+      };
+    }
+    console.log('paginationOptionsForExport', paginationOptionsForExport);
 
     return (
       <List

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
@@ -67,27 +67,38 @@ class StixDomainObjectsExportsContentComponent extends Component {
       context,
     } = this.props;
     const stixDomainObjectsExportFiles = data?.stixDomainObjectsExportFiles?.edges ?? [];
-    console.log('paginationOptions', paginationOptions);
     let paginationOptionsForExport = paginationOptions; // paginationsOptions with correct elementId
-    if (paginationOptions?.filters && Object.values(paginationOptions.filters).map((o) => o.key).includes('objectContains')) { // for elements contained in entity>Analysis
+    if (
+      paginationOptions?.filters
+      && Object.values(paginationOptions.filters)
+        .map((o) => o.key)
+        .includes('objectContains')
+    ) {
+      // for elements contained in entity>Analysis
       const filtersValues = Object.values(paginationOptions.filters);
-      const [elementId] = filtersValues.filter((o) => o.key === 'objectContains')[0].values;
-      const filtersForExport = filtersValues.filter((o) => o.key !== 'objectContains');
+      const [elementId] = filtersValues.filter(
+        (o) => o.key === 'objectContains',
+      )[0].values;
+      const filtersForExport = filtersValues.filter(
+        (o) => o.key !== 'objectContains',
+      );
       paginationOptionsForExport = {
         ...paginationOptions,
         filters: filtersForExport,
         elementId,
       };
     }
-    if (paginationOptions?.fromId) { // for relationships contained in entity>Knowledge>Sightings
-      const filtersForExport = [...paginationOptionsForExport.filters, { key: 'fromId', values: [paginationOptions.fromId] }];
+    if (paginationOptions?.fromId) {
+      // for relationships contained in entity>Knowledge>Sightings
+      const filtersForExport = [
+        ...paginationOptionsForExport.filters,
+        { key: 'fromId', values: [paginationOptions.fromId] },
+      ];
       paginationOptionsForExport = {
         ...paginationOptions,
         filters: filtersForExport,
       };
     }
-    console.log('paginationOptionsForExport', paginationOptionsForExport);
-
     return (
       <List
         subheader={

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.js
@@ -72,10 +72,10 @@ class StixDomainObjectsExportsContentComponent extends Component {
     if (paginationOptions?.filters && Object.values(paginationOptions.filters).map((o) => o.key).includes('objectContains')) { // for reports contained in entity>Analysis
       const filtersValues = Object.values(paginationOptions.filters);
       const [elementId] = filtersValues.filter((o) => o.key === 'objectContains')[0].values;
-      const newFilters = filtersValues.filter((o) => o.key !== 'objectContains');
+      const filtersForExport = filtersValues.filter((o) => o.key !== 'objectContains');
       paginationOptionsForExport = {
         ...paginationOptions,
-        filters: newFilters,
+        filters: filtersForExport,
         elementId,
       };
     }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1946,6 +1946,7 @@ enum StixDomainObjectsFilter {
   published
   creator
   x_opencti_workflow_id
+  fromId
 }
 
 input StixDomainObjectsFiltering {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1934,6 +1934,7 @@ enum StixDomainObjectsFilter {
   published
   creator
   x_opencti_workflow_id
+  fromId
 }
 input StixDomainObjectsFiltering {
   key: [StixDomainObjectsFilter!]!

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -117,6 +117,10 @@ export const stixDomainObjectsExportAsk = async (context, user, args) => {
       initialParams.elementId = R.head(R.head(argsFilters.filters.filter((n) => n.key.includes('elementId'))).values);
       newArgsFiltersFilters = newArgsFiltersFilters.filter((n) => !n.key.includes('elementId'));
     }
+    if (argsFilters.filters.filter((n) => n.key.includes('fromId')).length > 0) {
+      initialParams.fromId = R.head(R.head(argsFilters.filters.filter((n) => n.key.includes('fromId'))).values);
+      newArgsFiltersFilters = newArgsFiltersFilters.filter((n) => !n.key.includes('fromId'));
+    }
   }
   const finalArgsFilter = {
     ...argsFilters,

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19710,6 +19710,7 @@ export enum StixDomainObjectsFilter {
   CreatedAt = 'created_at',
   Creator = 'creator',
   EntityType = 'entity_type',
+  FromId = 'fromId',
   HasExternalReference = 'hasExternalReference',
   Indicates = 'indicates',
   IndicatorTypes = 'indicator_types',


### PR DESCRIPTION
- exports of data contained in entity>Knowledge -->more data than expected are often exported
example: go to Malware > Knowledge > Tool > export in csv : tool + other objects are exported

- stix core relationship --> nothing exported for txt files (no field 'name')
solution: indicate with an error message that no export is possible instead of creating an empty file

- exports of data in entity>Knowledge>Observables --> entity_type filters don't work
example: go to Malware > Knowledge > Observables > filter only the observables with the entity_type 'domain-name' > export in csv --> all the observables are exported (not only the one of type 'domain-name')

- export of data in the Analysis tab of an entity: only the reports are exported

- ...

### Associated PR in client-python
https://github.com/OpenCTI-Platform/client-python/pull/326

### Associated PR in connectors
https://github.com/OpenCTI-Platform/connectors/pull/1010

### Related issue

https://github.com/OpenCTI-Platform/opencti/issues/2804

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
