### PR TITLE
[Front] FIlter "relatedTo" not take into account the entity types palette (#2842)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 interface OptionValue extends Option {
   type: string;
+  parentTypes: string[];
   group?: string;
 }
 
@@ -105,7 +106,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = ({
   if (isStixObjectTypes) {
     if (searchScope[filterKey] && searchScope[filterKey].length > 0) {
       options = (entities[filterKey] || [])
-        .filter((n) => searchScope[filterKey].includes(n.type))
+        .filter((n) => searchScope[filterKey].some((s) => (n.parentTypes ?? []).concat(n.type).includes(s)))
         .sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
     } else {
       options = (entities[filterKey] || []).sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.js
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.js
@@ -65,6 +65,7 @@ const filtersStixCoreObjectsSearchQuery = graphql`
         node {
           id
           entity_type
+          parent_types
           ... on AttackPattern {
             name
             description
@@ -360,7 +361,7 @@ const useSearchEntities = ({
         break;
       case 'elementId':
         fetchQuery(filtersStixCoreObjectsSearchQuery, {
-          types: (searchScope && searchScope.fromId) || ['Stix-Core-Object'],
+          types: (searchScope && searchScope.elementId) || ['Stix-Core-Object'],
           search: event.target.value !== 0 ? event.target.value : '',
           count: 50,
         })
@@ -372,6 +373,7 @@ const useSearchEntities = ({
                 label: defaultValue(n.node),
                 value: n.node.id,
                 type: n.node.entity_type,
+                parentTypes: n.node.parent_types,
               })),
             )(data);
             unionSetEntities('elementId', elementIdEntities);
@@ -391,6 +393,7 @@ const useSearchEntities = ({
                 label: defaultValue(n.node),
                 value: n.node.id,
                 type: n.node.entity_type,
+                parentTypes: n.node.parent_types,
               })),
             )(data);
             unionSetEntities('fromId', fromIdEntities);
@@ -410,6 +413,7 @@ const useSearchEntities = ({
                 label: defaultValue(n.node),
                 value: n.node.id,
                 type: n.node.entity_type,
+                parentTypes: n.node.parent_types,
               })),
             )(data);
             unionSetEntities('toId', toIdEntities);
@@ -429,6 +433,7 @@ const useSearchEntities = ({
                 label: defaultValue(n.node),
                 value: n.node.id,
                 type: n.node.entity_type,
+                parentTypes: n.node.parent_types,
               })),
             )(data);
             unionSetEntities('targets', toIdEntities);
@@ -450,6 +455,7 @@ const useSearchEntities = ({
                 label: defaultValue(n.node),
                 value: n.node.id,
                 type: n.node.entity_type,
+                parentTypes: n.node.parent_types,
               })),
             )(data);
             unionSetEntities('objectContains', objectContainsEntities);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

* [issues 2842](https://github.com/OpenCTI-Platform/opencti/issues/2842)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
