### PR TITLE
[back] Disable cache for dataloader (#2878)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -258,7 +258,7 @@ export const batchLoader = (loader) => {
       const ids = objects.map((i) => i.id);
       return loader(context, user, ids, args);
     },
-    { maxBatchSize: MAX_BATCH_SIZE }
+    { maxBatchSize: MAX_BATCH_SIZE, cache: false }
   );
   return {
     load: (id, context, user, args = {}) => {


### PR DESCRIPTION
Because dataloader use a simple Map as cache.
Cache is not needed as we always fetch a list of uniq ids