### PR TITLE
[backend] Fix rule inferred relations updates to save only supported attributes (#3011)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1989,7 +1989,11 @@ const createRuleDataPatch = (instance) => {
   if (isBasicRelationship(instance.entity_type)) {
     patch.i_inference_weight = weight;
   }
-  const attributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes();
+  let attributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes();
+  if (instance.entity_type) { // keep only supported attributes
+    const entityAttributes = schemaAttributesDefinition.getAttributeNames(instance.entity_type);
+    attributes = attributes.filter((attr) => entityAttributes.includes(attr));
+  }
   for (let index = 0; index < attributes.length; index += 1) {
     const attribute = attributes[index];
     const values = getAllRulesField(instance, attribute);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1989,16 +1989,14 @@ const createRuleDataPatch = (instance) => {
   if (isBasicRelationship(instance.entity_type)) {
     patch.i_inference_weight = weight;
   }
-  let attributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes();
-  if (instance.entity_type) { // keep only supported attributes
-    const entityAttributes = schemaAttributesDefinition.getAttributeNames(instance.entity_type);
-    attributes = attributes.filter((attr) => entityAttributes.includes(attr));
-  }
-  for (let index = 0; index < attributes.length; index += 1) {
-    const attribute = attributes[index];
+  // list supported attributes [{name: string, operation: string}] by entity type
+  const supportedAttributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes(instance.entity_type);
+  for (let index = 0; index < supportedAttributes.length; index += 1) {
+    const supportedAttribute = supportedAttributes[index];
+    const attribute = supportedAttribute.name;
     const values = getAllRulesField(instance, attribute);
     if (values.length > 0) {
-      const operation = RULES_ATTRIBUTES_BEHAVIOR.getOperation(attribute);
+      const { operation } = supportedAttribute;
       if (operation === RULES_ATTRIBUTES_BEHAVIOR.OPERATIONS.AVG) {
         if (!isNumericAttribute(attribute)) {
           throw UnsupportedError('Can apply avg on non numeric attribute');
@@ -3165,7 +3163,7 @@ export const createInferredEntity = async (context, input, ruleContent, type) =>
   };
   // Inferred entity have a specific standardId generated from dependencies data.
   const standardId = idGenFromData(type, ruleContent.content.dependencies.sort());
-  const instance = { standard_id: standardId, ...input, [ruleContent.field]: [ruleContent.content] };
+  const instance = { standard_id: standardId, entity_type: type, ...input, [ruleContent.field]: [ruleContent.content] };
   const patch = createRuleDataPatch(instance);
   const inputEntity = { ...instance, ...patch };
   logApp.info('Create inferred entity', { entity: inputEntity });

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -24,7 +24,6 @@ import {
 import { RULE_PREFIX } from '../schema/general';
 import { ENTITY_TYPE_RULE_MANAGER } from '../schema/internalObject';
 import { ALREADY_DELETED_ERROR, TYPE_LOCK_ERROR } from '../config/errors';
-import { RULES_ATTRIBUTES_BEHAVIOR } from '../rules/rules';
 import { getParentTypes } from '../schema/schemaUtils';
 import { isBasicRelationship } from '../schema/stixRelationship';
 import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
@@ -55,14 +54,6 @@ const MIN_LIVE_STREAM_EVENT_VERSION = 4;
 const RULE_ENGINE_ID = 'rule_engine_settings';
 const RULE_ENGINE_KEY = conf.get('rule_engine:lock_key');
 const SCHEDULE_TIME = 10000;
-
-// region rules registration
-const ruleBehaviors = RULES_DECLARATION.map((d) => d.behaviors ?? []).flat();
-for (let index = 0; index < ruleBehaviors.length; index += 1) {
-  const ruleBehavior = ruleBehaviors[index];
-  RULES_ATTRIBUTES_BEHAVIOR.register(ruleBehavior);
-}
-// endregion
 
 export const getManagerInfo = async (context: AuthContext, user: AuthUser): Promise<RuleManager> => {
   const isRuleEngineActivated = await isModuleActivated('RULE_ENGINE');

--- a/opencti-platform/opencti-graphql/src/rules/attributed-to-attributed/AttributedToAttributedDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/attributed-to-attributed/AttributedToAttributedDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_ATTRIBUTED_TO } from '../../schema/stixCoreRelationship';
-import type { RuleBehavior, RuleDefinition } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'attribution_attribution';
 const name = 'Attribution propagation';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/attribution-targets/AttributionTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/attribution-targets/AttributionTargetsDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_ATTRIBUTED_TO, RELATION_TARGETS } from '../../schema/stixCoreRelationship';
-import type { RuleBehavior, RuleDefinition } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'attribution_targets';
 const name = 'Targeting propagation via attribution';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/attribution-use/AttributionUseDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/attribution-use/AttributionUseDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_ATTRIBUTED_TO, RELATION_USES } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'attribution_use';
 const name = 'Usage propagation via attribution';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/indicate-sighted/IndicateSightedDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/indicate-sighted/IndicateSightedDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_INDICATES } from '../../schema/stixCoreRelationship';
-import type { RuleBehavior, RuleDefinition } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
 import {
   ENTITY_TYPE_CAMPAIGN,
@@ -54,11 +54,10 @@ const filtersIndicates = {
   fromTypes: [ENTITY_TYPE_INDICATOR],
   toTypes: [ENTITY_TYPE_MALWARE, ENTITY_TYPE_THREAT_ACTOR, ENTITY_TYPE_INTRUSION_SET, ENTITY_TYPE_CAMPAIGN, ENTITY_TYPE_INCIDENT]
 };
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [
   { filters: filtersSighting, attributes: [] },
   { filters: filtersIndicates, attributes: [] }
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_LOCATED_AT } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'localization_of_targets';
 const name = 'Targeting propagation when located';
@@ -54,8 +54,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/located-at-located/LocatedAtLocatedDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/located-at-located/LocatedAtLocatedDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_LOCATED_AT } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'location_location';
 const name = 'Location propagation';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/location-targets/LocationTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/location-targets/LocationTargetsDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_LOCATED_AT, RELATION_TARGETS } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'location_targets';
 const name = 'Targeting propagation via location';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/observable-related/ObservableRelatedDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/observable-related/ObservableRelatedDefinition.ts
@@ -7,7 +7,7 @@ import {
   ENTITY_TYPE_MALWARE,
   ENTITY_TYPE_THREAT_ACTOR,
 } from '../../schema/stixDomainObject';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'observable_related';
 const name = 'Relation propagation via an observable';
@@ -73,8 +73,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/observed-sighting/ObserveSightingDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/observed-sighting/ObserveSightingDefinition.ts
@@ -1,13 +1,11 @@
 import { RELATION_BASED_ON } from '../../schema/stixCoreRelationship';
 import { ABSTRACT_STIX_CYBER_OBSERVABLE } from '../../schema/general';
 import { ENTITY_TYPE_CONTAINER_OBSERVED_DATA, ENTITY_TYPE_INDICATOR } from '../../schema/stixDomainObject';
-import { RULES_ATTRIBUTES_BEHAVIOR } from '../rules';
 import type { RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
 
 const id = 'observe_sighting';
 const name = 'Sightings of observables via observed data';
 const description = 'Infer sightings based on observed data and indicators.';
-const behaviors = [{ ruleId: id, attribute: 'attribute_count', operation: RULES_ATTRIBUTES_BEHAVIOR.OPERATIONS.SUM }];
 const category = 'Alerting';
 const display = {
   if: [
@@ -75,5 +73,5 @@ const scopes: Array<RuleScope> = [
   },
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/part-of-part/PartOfPartDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/part-of-part/PartOfPartDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_PART_OF } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'part_part';
 const name = 'Belonging propagation';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/part-of-targets/PartOfTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/part-of-targets/PartOfTargetsDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_PART_OF, RELATION_TARGETS } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'part-of_targets';
 const name = 'Targeting propagation via belonging';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/participate-to-parts/ParticipateToPartsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/participate-to-parts/ParticipateToPartsDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_PART_OF } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 import { RELATION_PARTICIPATE_TO } from '../../schema/internalRelationship';
 import { ENTITY_TYPE_USER } from '../../schema/internalObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../schema/stixDomainObject';
@@ -53,11 +53,10 @@ const filterPartOf = {
   toTypes: [ENTITY_TYPE_IDENTITY_ORGANIZATION]
 };
 
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [
   { filters: filterParticipateTo, attributes: [] },
   { filters: filterPartOf, attributes: [] }
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/related-to-related/RelatedToRelatedDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/related-to-related/RelatedToRelatedDefinition.ts
@@ -1,5 +1,5 @@
 import { RELATION_RELATED_TO } from '../../schema/stixCoreRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'related_related';
 const name = 'Relation propagation testing rule';
@@ -45,8 +45,7 @@ const attributes = [
   { name: 'confidence' },
   { name: 'object_marking_refs' },
 ];
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [{ filters, attributes }];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/report-refs-identity-part-of/ReportRefIdentityPartOfDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/report-refs-identity-part-of/ReportRefIdentityPartOfDefinition.ts
@@ -1,7 +1,7 @@
 import { RELATION_PART_OF } from '../../schema/stixCoreRelationship';
 import { ENTITY_TYPE_IDENTITY } from '../../schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../schema/stixDomainObject';
-import type { RuleBehavior, RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
+import type { RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
 
 const id = 'report_ref_identity_part_of';
 const name = 'Identities propagation in reports';
@@ -61,6 +61,5 @@ const scopes: Array<RuleScope> = [
   },
 ];
 
-const behaviors: Array<RuleBehavior> = [];
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/report-refs-indicator-based-on/ReportRefIndicatorBasedOnDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/report-refs-indicator-based-on/ReportRefIndicatorBasedOnDefinition.ts
@@ -1,7 +1,7 @@
 import { RELATION_BASED_ON } from '../../schema/stixCoreRelationship';
 import { ABSTRACT_STIX_CYBER_OBSERVABLE } from '../../schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_INDICATOR } from '../../schema/stixDomainObject';
-import type { RuleBehavior, RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
+import type { RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
 
 const id = 'report_ref_indicator_based_on';
 const name = 'Observables propagation in reports';
@@ -61,6 +61,5 @@ const scopes: Array<RuleScope> = [
   },
 ];
 
-const behaviors: Array<RuleBehavior> = [];
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/report-refs-location-located-at/ReportRefLocationLocatedAtDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/report-refs-location-located-at/ReportRefLocationLocatedAtDefinition.ts
@@ -1,7 +1,7 @@
 import { RELATION_LOCATED_AT } from '../../schema/stixCoreRelationship';
 import { ENTITY_TYPE_LOCATION } from '../../schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../schema/stixDomainObject';
-import type { RuleBehavior, RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
+import type { RuleDefinition, RuleFilters, RuleScope } from '../../types/rules';
 
 const id = 'report_ref_location_located_at';
 const name = 'Locations propagation in reports';
@@ -61,6 +61,5 @@ const scopes: Array<RuleScope> = [
   },
 ];
 
-const behaviors: Array<RuleBehavior> = [];
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/rules.js
+++ b/opencti-platform/opencti-graphql/src/rules/rules.js
@@ -4,10 +4,9 @@ import { isInternalId, shortHash } from '../schema/schemaUtils';
 import { RULE_PREFIX } from '../schema/general';
 import { RULE_MANAGER_USER_UUID } from '../utils/access';
 import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
-import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 import { isStixCoreObject } from '../schema/stixCoreObject';
-import {isBasicRelationship} from "../schema/stixRelationship";
-import {ENTITY_TYPE_INCIDENT} from "../schema/stixDomainObject";
+import { isBasicRelationship } from '../schema/stixRelationship';
+import { ENTITY_TYPE_INCIDENT } from '../schema/stixDomainObject';
 
 // region definition
 export const RULES_ATTRIBUTES_BEHAVIOR = {

--- a/opencti-platform/opencti-graphql/src/rules/rules.js
+++ b/opencti-platform/opencti-graphql/src/rules/rules.js
@@ -2,37 +2,46 @@ import * as R from 'ramda';
 import { UnsupportedError } from '../config/errors';
 import { isInternalId, shortHash } from '../schema/schemaUtils';
 import { RULE_PREFIX } from '../schema/general';
-import { isEmptyField, isNotEmptyField } from '../database/utils';
-import { logApp } from '../config/conf';
 import { RULE_MANAGER_USER_UUID } from '../utils/access';
+import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
+import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
+import { isStixCoreObject } from '../schema/stixCoreObject';
+import {isBasicRelationship} from "../schema/stixRelationship";
+import {ENTITY_TYPE_INCIDENT} from "../schema/stixDomainObject";
 
 // region definition
 export const RULES_ATTRIBUTES_BEHAVIOR = {
   OPERATIONS: { MIN: 'MIN', MAX: 'MAX', AVG: 'AVG', SUM: 'SUM', AGG: 'AGG' },
-  _attributes: {
-    start_time: 'MIN',
-    first_seen: 'MIN',
-    stop_time: 'MAX',
-    last_seen: 'MAX',
-    confidence: 'AVG',
-    objectMarking: 'AGG',
-  },
-  register({ ruleId, attribute, operation }) {
-    const meta = { ruleId, attribute, operation };
-    if (isEmptyField(this.OPERATIONS[operation])) {
-      throw UnsupportedError('Try to register an unsupported operation', meta);
+  supportedAttributes(entityType) {
+    if (isStixSightingRelationship(entityType)) {
+      return [
+        { name: 'first_seen', operation: 'MIN' },
+        { name: 'last_seen', operation: 'MAX' },
+        { name: 'confidence', operation: 'AVG' },
+        { name: 'attribute_count', operation: 'SUM' },
+        { name: 'objectMarking', operation: 'AGG' },
+      ];
     }
-    const declaredOperation = this._attributes[attribute];
-    if (isNotEmptyField(declaredOperation) && declaredOperation !== operation) {
-      logApp.warn('Overriding attribute rule operation', meta);
+    if (isBasicRelationship(entityType)) {
+      return [
+        { name: 'start_time', operation: 'MIN' },
+        { name: 'stop_time', operation: 'MAX' },
+        { name: 'confidence', operation: 'AVG' },
+        { name: 'objectMarking', operation: 'AGG' },
+      ];
     }
-    this._attributes[attribute] = operation;
-  },
-  getOperation(name) {
-    return this._attributes[name];
-  },
-  supportedAttributes() {
-    return Object.keys(this._attributes);
+    if (entityType === ENTITY_TYPE_INCIDENT) { // RuleSightingIncident
+      return [
+        { name: 'first_seen', operation: 'MIN' },
+        { name: 'last_seen', operation: 'MAX' },
+        { name: 'confidence', operation: 'AVG' },
+        { name: 'objectMarking', operation: 'AGG' },
+      ];
+    }
+    if (isStixCoreObject(entityType)) {
+      return [{ name: 'objectMarking', operation: 'AGG' }];
+    }
+    return [];
   },
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/rules/sighting-incident/SightingIncidentDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-incident/SightingIncidentDefinition.ts
@@ -1,7 +1,7 @@
 import { ENTITY_TYPE_IDENTITY } from '../../schema/general';
 import { ENTITY_TYPE_INDICATOR } from '../../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 
 const id = 'sighting_incident';
 const name = 'Raise incident based on sighting';
@@ -53,7 +53,6 @@ const display = {
 const scan = { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ENTITY_TYPE_INDICATOR], toTypes: [ENTITY_TYPE_IDENTITY] };
 
 // For live
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [
   {
     filters: { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ENTITY_TYPE_INDICATOR], toTypes: [ENTITY_TYPE_IDENTITY] },
@@ -70,5 +69,5 @@ const scopes = [
   },
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorDefinition.ts
@@ -1,7 +1,7 @@
 import { ABSTRACT_STIX_CYBER_OBSERVABLE, ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION } from '../../schema/general';
 import { ENTITY_TYPE_INDICATOR } from '../../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 import { RELATION_BASED_ON } from '../../schema/stixCoreRelationship';
 
 const id = 'sighting_indicator';
@@ -41,7 +41,6 @@ const display = {
 const scan = { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ENTITY_TYPE_INDICATOR], toTypes: [ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION] };
 
 // For live
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [
   {
     filters: { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ENTITY_TYPE_INDICATOR], toTypes: [ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION] },
@@ -53,5 +52,5 @@ const scopes = [
   },
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
@@ -92,7 +92,7 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
         const input = { fromId: toObservable, toId: toSightingIdentityOrLocation, relationship_type: STIX_SIGHTING_RELATIONSHIP };
         const ruleContent = createRuleContent(def.id, dependencies, explanation, {
           confidence: computedConfidence,
-          start_time: range.start,
+          start_time: range.start, // TODO should be first_seen and last_seen
           stop_time: range.end,
           objectMarking: elementMarkings
         });

--- a/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
@@ -92,8 +92,8 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
         const input = { fromId: toObservable, toId: toSightingIdentityOrLocation, relationship_type: STIX_SIGHTING_RELATIONSHIP };
         const ruleContent = createRuleContent(def.id, dependencies, explanation, {
           confidence: computedConfidence,
-          start_time: range.start, // TODO should be first_seen and last_seen
-          stop_time: range.end,
+          first_seen: range.start,
+          last_seen: range.end,
           objectMarking: elementMarkings
         });
         await createInferredRelation(context, input, ruleContent);

--- a/opencti-platform/opencti-graphql/src/rules/sighting-observable/SightingObservableDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-observable/SightingObservableDefinition.ts
@@ -1,7 +1,7 @@
 import { ABSTRACT_STIX_CYBER_OBSERVABLE, ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION } from '../../schema/general';
 import { ENTITY_TYPE_INDICATOR } from '../../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
-import type { RuleDefinition, RuleBehavior } from '../../types/rules';
+import type { RuleDefinition } from '../../types/rules';
 import { RELATION_BASED_ON } from '../../schema/stixCoreRelationship';
 
 const id = 'sighting_observable';
@@ -41,7 +41,6 @@ const display = {
 const scan = { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ABSTRACT_STIX_CYBER_OBSERVABLE], toTypes: [ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION] };
 
 // For live
-const behaviors: Array<RuleBehavior> = [];
 const scopes = [
   {
     filters: { types: [STIX_SIGHTING_RELATIONSHIP], fromTypes: [ABSTRACT_STIX_CYBER_OBSERVABLE], toTypes: [ENTITY_TYPE_IDENTITY, ENTITY_TYPE_LOCATION] },
@@ -53,5 +52,5 @@ const scopes = [
   },
 ];
 
-const definition: RuleDefinition = { id, name, description, scan, scopes, behaviors, category, display };
+const definition: RuleDefinition = { id, name, description, scan, scopes, category, display };
 export default definition;

--- a/opencti-platform/opencti-graphql/src/types/rules.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/rules.d.ts
@@ -19,12 +19,6 @@ interface RuleScope {
   attributes: Array<RuleScanAttribute>;
 }
 
-interface RuleBehavior {
-  ruleId: string;
-  attribute: string;
-  operation: string;
-}
-
 interface RelationTypes {
   leftType: string;
   rightType: string;
@@ -55,7 +49,6 @@ interface RuleDefinition {
   display: DisplayDefinition;
   scan: RuleFilters;
   scopes: Array<RuleScope>;
-  behaviors: Array<RuleBehavior>; // TODO remove ?
 }
 
 interface RuleRuntime extends RuleDefinition {

--- a/opencti-platform/opencti-graphql/src/types/rules.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/rules.d.ts
@@ -55,7 +55,7 @@ interface RuleDefinition {
   display: DisplayDefinition;
   scan: RuleFilters;
   scopes: Array<RuleScope>;
-  behaviors: Array<RuleBehavior>;
+  behaviors: Array<RuleBehavior>; // TODO remove ?
 }
 
 interface RuleRuntime extends RuleDefinition {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Keep only schema attributes definition when updating an inferred relationship from rule (entity type "targets")

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3011

The issue is due to existing saved relationships with unsuported attributes such as "first_seen" and when a rule is applied on these entities and tries to update them, it will check the entity attributes and throws an error.
I'm not completely sure about how these entities were saved with "first_seen" attributes, but the fix should work (I reproduced the case)

How I reproduced the bug : 
- Enable "INFERENCE OF TARGETING VIA A SIGHTING" rule (under Victimology")
- The rule was applied on my existing test data (intrusion_sets/fe16663c-6b94-4857-9640-e53573560f02)
- I changed the code in IndicateSightedRule.applyFromStixSighting to add first_seen to ruleContent data. (commit 373ff7bc 1/20/2023)
- When changing the relationship confidence, the rule is applied and tries to upsert the entity

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
