### PR TITLE
[Front] event end_date edition bug fix (#3033)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.js
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.js
@@ -95,17 +95,12 @@ const MalwareEditionDetailsComponent = (props) => {
 
   const handleSubmitField = (name, value) => {
     if (!enableReferences) {
-      malwareValidation(t)
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          commitFieldPatch({
-            variables: {
-              id: malware.id,
-              input: { key: name, value: value || '' },
-            },
-          });
-        })
-        .catch(() => false);
+      commitFieldPatch({
+        variables: {
+          id: malware.id,
+          input: { key: name, value: value || '' },
+        },
+      });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.js
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.js
@@ -82,8 +82,9 @@ const EventEditionOverviewComponent = (props) => {
     event_types: Yup.array().nullable(),
     start_time: Yup.date().typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')).nullable(),
     stop_time: Yup.date()
+      .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .min(Yup.ref('start_time'), "The end date can't be before start date")
-      .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')).nullable(),
+      .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
   };
@@ -134,17 +135,12 @@ const EventEditionOverviewComponent = (props) => {
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      eventValidator
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          editor.fieldPatch({
-            variables: {
-              id: event.id,
-              input: { key: name, value: finalValue ?? '' },
-            },
-          });
-        })
-        .catch(() => false);
+      editor.fieldPatch({
+        variables: {
+          id: event.id,
+          input: { key: name, value: finalValue ?? '' },
+        },
+      });
     }
   };
 


### PR DESCRIPTION
Can't update end date of an event.

Not: idem for Last seen of a Malware

Reproductible steps:

Go to an event. Edit the field 'end date'. The modification is not saved.

### Related issues

https://github.com/OpenCTI-Platform/opencti/issues/3033