### PR TITLE
[back] Patch Weakness CWE-843

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -468,7 +468,7 @@ const createSseMiddleware = () => {
     }
   };
   const convertParameterToDate = (param) => {
-    if (!param) {
+    if (!param || typeof param !== 'string') {
       return undefined;
     }
     if (param === '0' || param === '0-0') {
@@ -486,7 +486,7 @@ const createSseMiddleware = () => {
     return undefined;
   };
   const convertParameterToStreamId = (param) => {
-    if (!param) {
+    if (!param || typeof param !== 'string') {
       return undefined;
     }
     if (param === '0' || param === '0-0') {


### PR DESCRIPTION
### Proposed changes

* found some critical weaknesses in CodeQL scanning
* Potential type confusion as this HTTP request parameter  may be either an array or a string.

### Related issues

* [CWE-843](https://cwe.mitre.org/data/definitions/843.html)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Path of the type confusion through parameter tampering

[opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js:191](https://github.com/rtkwlf/srsd-opencti/blob/546fb66590c386722d5543c90227a0523890874f/opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js#L191-L191)
```js
    return new Promise((resolve) => setTimeout(() => resolve(), ms));
  };
  const extractQueryParameter = (req, param) => {
    const paramData = req.query[param];
    if (paramData && Array.isArray(paramData) && paramData.length > 0) {
      return paramData.at(0);
    }
```

[opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js:195](https://github.com/rtkwlf/srsd-opencti/blob/546fb66590c386722d5543c90227a0523890874f/opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js#L195-L195)
```js
    if (paramData && Array.isArray(paramData) && paramData.length > 0) {
      return paramData.at(0);
    }
    return paramData;
  };
  const resolveMissingReferences = async (context, req, missingRefs, cache) => {
    const refsToResolve = missingRefs.filter((m) => !cache.has(m));
```

[opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js:304](https://github.com/rtkwlf/srsd-opencti/blob/546fb66590c386722d5543c90227a0523890874f/opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js#L304-L304)
```js
      const sessionUser = req.user;
      const context = executionContext('raw_stream');
      const paramStartFrom = extractQueryParameter(req, 'from') || req.headers.from || req.headers['last-event-id'];
      const startStreamId = convertParameterToStreamId(paramStartFrom);
      if (!isUserGlobalCapabilityGranted(sessionUser)) {
        res.statusMessage = 'You are not authorized, please check your credentials';
        res.status(401).end();
```

https://github.com/rtkwlf/srsd-opencti/blob/546fb66590c386722d5543c90227a0523890874f/opencti/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js#L488-L488
```js
    }
    return undefined;
  };
  const convertParameterToStreamId = (param) => {
    if (!param) {
      return undefined;
    }
```






