### PR TITLE
[frontend] enable Valid Until date modification (#3148)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
@@ -147,17 +147,12 @@ IncidentEditionDetailsProps
   const handleSubmitField = (name: string, value: string | string[] | null) => {
     if (!enableReferences) {
       const finalValue: string = value as string;
-      incidentEditionDetailsValidation(t)
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          commitFieldPatch({
-            variables: {
-              id: incident.id,
-              input: [{ key: name, value: [finalValue ?? ''] }],
-            },
-          });
-        })
-        .catch(() => false);
+      commitFieldPatch({
+        variables: {
+          id: incident.id,
+          input: [{ key: name, value: [finalValue ?? ''] }],
+        },
+      });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.js
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.js
@@ -185,20 +185,15 @@ const IndicatorEditionOverviewComponent = ({
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      indicatorValidator
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          editor.fieldPatch({
-            variables: {
-              id: indicator.id,
-              input: {
-                key: name,
-                value: finalValue ?? '',
-              },
-            },
-          });
-        })
-        .catch(() => false);
+      editor.fieldPatch({
+        variables: {
+          id: indicator.id,
+          input: {
+            key: name,
+            value: finalValue ?? '',
+          },
+        },
+      });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.js
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.js
@@ -172,17 +172,12 @@ const InfrastructureEditionOverviewComponent = (props) => {
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      infrastructureValidator
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          editor.fieldPatch({
-            variables: {
-              id: infrastructure.id,
-              input: { key: name, value: finalValue ?? '' },
-            },
-          });
-        })
-        .catch(() => false);
+      editor.fieldPatch({
+        variables: {
+          id: infrastructure.id,
+          input: { key: name, value: finalValue ?? '' },
+        },
+      });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.js
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.js
@@ -123,18 +123,13 @@ const IntrusionSetEditionDetailsComponent = (props) => {
       if (name === 'goals') {
         finalValue = value && value.length > 0 ? R.split('\n', value) : [];
       }
-      intrusionSetValidation(t)
-        .validateAt(name, { [name]: value })
-        .then(() => {
-          commitMutation({
-            mutation: intrusionSetMutationFieldPatch,
-            variables: {
-              id: intrusionSet.id,
-              input: { key: name, value: finalValue || '' },
-            },
-          });
-        })
-        .catch(() => false);
+      commitMutation({
+        mutation: intrusionSetMutationFieldPatch,
+        variables: {
+          id: intrusionSet.id,
+          input: { key: name, value: finalValue || '' },
+        },
+      });
     }
   };
 


### PR DESCRIPTION
## Related issue
https://github.com/OpenCTI-Platform/opencti/issues/3148

## Notion page
same principle as : https://www.notion.so/filigran/Can-t-update-end-date-of-an-event-3033-ae8c2ab25c564973b974dfb3c980c90d