### PR TITLE
[frontend/backend] Group default membership and auto marking must be initialized (#3116)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -54,19 +54,11 @@ export const batchRoles = async (context, user, groupIds) => {
 };
 
 export const addGroup = async (context, user, group) => {
-  let groupWithDefaultValues = group;
-  if (groupWithDefaultValues.default_assignation === undefined) {
-    groupWithDefaultValues = {
-      ...groupWithDefaultValues,
-      default_assignation: false,
-    };
-  }
-  if (groupWithDefaultValues.auto_new_marking === undefined) {
-    groupWithDefaultValues = {
-      ...groupWithDefaultValues,
-      auto_new_marking: false,
-    };
-  }
+  const groupWithDefaultValues = {
+    ...group,
+    default_assignation: group.default_assignation ?? false,
+    auto_new_marking: group.auto_new_marking ?? false
+  };
   const created = await createEntity(context, user, groupWithDefaultValues, ENTITY_TYPE_GROUP);
   return notify(BUS_TOPICS[ENTITY_TYPE_GROUP].ADDED_TOPIC, created, user);
 };

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -54,7 +54,20 @@ export const batchRoles = async (context, user, groupIds) => {
 };
 
 export const addGroup = async (context, user, group) => {
-  const created = await createEntity(context, user, group, ENTITY_TYPE_GROUP);
+  let groupWithDefaultValues = group;
+  if (groupWithDefaultValues.default_assignation === undefined) {
+    groupWithDefaultValues = {
+      ...groupWithDefaultValues,
+      default_assignation: false,
+    };
+  }
+  if (groupWithDefaultValues.auto_new_marking === undefined) {
+    groupWithDefaultValues = {
+      ...groupWithDefaultValues,
+      auto_new_marking: false,
+    };
+  }
+  const created = await createEntity(context, user, groupWithDefaultValues, ENTITY_TYPE_GROUP);
   return notify(BUS_TOPICS[ENTITY_TYPE_GROUP].ADDED_TOPIC, created, user);
 };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
@@ -1,0 +1,26 @@
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { logApp } from '../config/conf';
+import { findAll, groupEditField } from '../domain/group';
+
+export const up = async (next) => {
+  const context = executionContext('migration');
+  const groupsEdges = await findAll(context, SYSTEM_USER);
+  const groups = groupsEdges.edges.map((n) => n.node);
+  const groupEditionPromises = groups.map((group) => {
+    const updateInput = [];
+    if (group.auto_new_marking === undefined) {
+      updateInput.push({ key: 'auto_new_marking', value: ['false'] });
+    }
+    if (group.default_assignation === undefined) {
+      updateInput.push({ key: 'default_assignation', value: ['false'] });
+    }
+    return updateInput.length > 0 ? groupEditField(context, SYSTEM_USER, group.id, updateInput) : null;
+  }).filter((promise) => promise !== null);
+  await Promise.all(groupEditionPromises);
+  logApp.info('[MIGRATION] Refacto group initialization done.');
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
@@ -1,13 +1,19 @@
+import { Promise } from 'bluebird';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { logApp } from '../config/conf';
 import { groupEditField } from '../domain/group';
 import { ENTITY_TYPE_GROUP } from '../schema/internalObject';
 import { listAllEntities } from '../database/middleware-loader';
+import { ES_MAX_CONCURRENCY } from '../database/engine';
 
 export const up = async (next) => {
   const context = executionContext('migration');
+  logApp.info('[MIGRATION] Group initialization migration');
   const groups = await listAllEntities(context, SYSTEM_USER, [ENTITY_TYPE_GROUP]);
-  const groupEditionPromises = groups.map((group) => {
+  const patchingGroups = groups.filter((g) => g.auto_new_marking === undefined || g.default_assignation === undefined);
+  logApp.info(`[MIGRATION] Group initialization patching ${patchingGroups.length} groups`);
+  let currentProcessing = 0;
+  const concurrentUpdate = async (group) => {
     const updateInput = [];
     if (group.auto_new_marking === undefined) {
       updateInput.push({ key: 'auto_new_marking', value: ['false'] });
@@ -15,10 +21,12 @@ export const up = async (next) => {
     if (group.default_assignation === undefined) {
       updateInput.push({ key: 'default_assignation', value: ['false'] });
     }
-    return updateInput.length > 0 ? groupEditField(context, SYSTEM_USER, group.id, updateInput) : null;
-  }).filter((promise) => promise !== null);
-  await Promise.all(groupEditionPromises);
-  logApp.info('[MIGRATION] Refacto group initialization done.');
+    await groupEditField(context, SYSTEM_USER, group.id, updateInput);
+    currentProcessing += 1;
+    logApp.info(`[OPENCTI] Group initialization patching : ${currentProcessing} / ${patchingGroups.length}`);
+  };
+  await Promise.map(patchingGroups, concurrentUpdate, { concurrency: ES_MAX_CONCURRENCY });
+  logApp.info('[MIGRATION] Group initialization done.');
   next();
 };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1681825498443-group-initialization.js
@@ -1,11 +1,12 @@
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { logApp } from '../config/conf';
-import { findAll, groupEditField } from '../domain/group';
+import { groupEditField } from '../domain/group';
+import { ENTITY_TYPE_GROUP } from '../schema/internalObject';
+import { listAllEntities } from '../database/middleware-loader';
 
 export const up = async (next) => {
   const context = executionContext('migration');
-  const groupsEdges = await findAll(context, SYSTEM_USER);
-  const groups = groupsEdges.edges.map((n) => n.node);
+  const groups = await listAllEntities(context, SYSTEM_USER, [ENTITY_TYPE_GROUP]);
   const groupEditionPromises = groups.map((group) => {
     const updateInput = [];
     if (group.auto_new_marking === undefined) {


### PR DESCRIPTION
## Related issue
https://github.com/OpenCTI-Platform/opencti/issues/3116

## Notion page
https://www.notion.so/filigran/Group-default-membership-and-auto-marking-must-be-initialized-to-allow-correct-sorting-filtering-3-9e54df103a2448ffa0dd95166fbbeda2