### PR TITLE
[frontend/backend] Adding password complexity to user create/edit/profile edit by self

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -33,6 +33,7 @@
     "mdi-material-ui": "7.6.0",
     "moment": "2.29.4",
     "moment-timezone": "0.5.41",
+    "password-validator": "^5.3.0",
     "pdfmake": "0.2.7*",
     "prop-types": "15.8.1",
     "qrcode": "1.5.1",

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -27,6 +27,12 @@ const rootPrivateQuery = graphql`
       platform_map_tile_server_dark
       platform_map_tile_server_light
       platform_theme
+      password_config_min_length
+      password_config_max_length
+      password_config_uppercase
+      password_config_lowercase
+      password_config_digits
+      password_config_special_char
       platform_feature_flags {
         id
         enable

--- a/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.js
+++ b/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.js
@@ -31,6 +31,7 @@ import Loader from '../../../components/Loader';
 import { convertOrganizations } from '../../../utils/edition';
 import ObjectOrganizationField from '../common/form/ObjectOrganizationField';
 import { OTP_CODE_SIZE } from '../../../public/components/OtpActivation';
+import { passwordValidate } from '../../../utils/PasswordValidate';
 
 const styles = () => ({
   container: {
@@ -105,13 +106,15 @@ const userValidation = (t) => Yup.object().shape({
   otp_activated: Yup.boolean(),
 });
 
-const passwordValidation = (t) => Yup.object().shape({
-  current_password: Yup.string().required(t('This field is required')),
-  password: Yup.string().required(t('This field is required')),
-  confirmation: Yup.string()
-    .oneOf([Yup.ref('password'), null], t('The values do not match'))
-    .required(t('This field is required')),
-});
+function passwordValidation(t) {
+  Yup.addMethod(Yup.string, "password", passwordValidate);
+  return Yup.object().shape({
+    password: Yup.string().password(t("Password does not meet criteria")).required(t("Required")),
+    confirmation: Yup.string()
+      .oneOf([Yup.ref('password'), null], t('The values do not match'))
+      .required(t('This field is required')),
+  });
+}
 
 const Otp = ({ closeFunction, secret, uri }) => {
   const { t } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionPassword.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionPassword.js
@@ -9,6 +9,7 @@ import Button from '@mui/material/Button';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
 import inject18n from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
+import { passwordValidate } from '../../../../utils/PasswordValidate';
 
 const styles = (theme) => ({
   buttons: {
@@ -33,12 +34,15 @@ const userMutationFieldPatch = graphql`
   }
 `;
 
-const userValidation = (t) => Yup.object().shape({
-  password: Yup.string().required(t('This field is required')),
-  confirmation: Yup.string()
-    .oneOf([Yup.ref('password'), null], t('The values do not match'))
-    .required(t('This field is required')),
-});
+function passwordValidation(t) {
+  Yup.addMethod(Yup.string, "password", passwordValidate);
+  return Yup.object().shape({
+    password: Yup.string().password(t("Password does not meet criteria")).required(t("Required")),
+    confirmation: Yup.string()
+      .oneOf([Yup.ref('password'), null], t('The values do not match'))
+      .required(t('This field is required')),
+  });
+}
 
 class UserEditionPasswordComponent extends Component {
   onSubmit(values, { setSubmitting, resetForm }) {
@@ -66,7 +70,7 @@ class UserEditionPasswordComponent extends Component {
         <Formik
           enableReinitialize={true}
           initialValues={initialValues}
-          validationSchema={userValidation(t)}
+          validationSchema={passwordValidation.bind(this)(t)}
           onSubmit={this.onSubmit.bind(this)}
         >
           {({ submitForm, isSubmitting }) => (

--- a/opencti-platform/opencti-front/src/public/LoginRoot.tsx
+++ b/opencti-platform/opencti-front/src/public/LoginRoot.tsx
@@ -15,6 +15,12 @@ export const rootPublicQuery = graphql`
       platform_login_message
       platform_theme_dark_logo_login
       platform_theme_light_logo_login
+      password_config_min_length
+      password_config_max_length
+      password_config_uppercase
+      password_config_lowercase
+      password_config_digits
+      password_config_special_char
       platform_providers {
         name
         type

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1093,6 +1093,12 @@ type Settings implements InternalObject & BasicObject {
   created_at: DateTime!
   updated_at: DateTime!
   otp_mandatory: Boolean
+  password_config_min_length: Int
+  password_config_max_length: Int
+  password_config_uppercase: Int
+  password_config_lowercase: Int
+  password_config_digits: Int
+  password_config_special_char: Int
   editContext: [EditUserContext!]
 }
 

--- a/opencti-platform/opencti-front/src/utils/PasswordValidate.js
+++ b/opencti-platform/opencti-front/src/utils/PasswordValidate.js
@@ -1,0 +1,52 @@
+import * as Yup from 'yup';
+import PasswordValidator from 'password-validator';
+import { fetchQuery } from '../relay/environment';
+
+const fetchDefaultSettings = graphql`
+  query PasswordValidateSettingsQuery {
+    settings {
+      password_config_min_length
+      password_config_max_length
+      password_config_uppercase
+      password_config_lowercase
+      password_config_digits
+      password_config_special_char
+    }
+  }
+`;
+
+export const passwordValidate = (errorMessage) => Yup.string()
+  .test('test-password', errorMessage, async function (value) {
+    let d;
+    await fetchQuery(fetchDefaultSettings, {}).toPromise().then(data => d = {
+      min_length: data?.settings?.password_config_min_length ?? 10,
+      max_length: data?.settings?.password_config_max_length ?? 50,
+      digits: data?.settings?.password_config_digits ?? 1,
+      uppercase: data?.settings?.password_config_uppercase ?? 1,
+      symbols:data?.settings?.password_config_special_char ?? 1,
+    });
+    const { path, createError } = this;
+    const schema = new PasswordValidator();
+    schema.is().min(d.min_length, `minimum of ${d.min_length} characters`);
+    schema.is().max(d.max_length, `maximum of ${d.max_length} characters`);
+    schema.has().digits(d.digits, `minimum of ${d.digits} number`);
+    schema.has().uppercase(d.uppercase,`minimum of ${d.uppercase} capitalized letter`);
+    schema.has().symbols(d.symbols, `minimum of ${d.symbols} special character`);
+    // ####################################################################################
+    // TODO: Should read in a static JSON list of known bad passwords
+    // schema.is().not().oneOf(['opencti','p@ssw0rd','Password','password','P@ssword','P@ssword1'], 'password not allowed');
+    // ####################################################################################
+    // TODO: Improvement - check for repeating pattern like qwertyqwerty
+    // const pattern = /^([a-z])\2+$/;
+    // schema.is().not([pattern], 'pattern is not allowed');
+    // ####################################################################################
+    const errors = schema.validate(value, { details: true }).map(({ message }) => message);
+    let message = `${errorMessage}:`;
+    for (const error of errors) {
+      message += `\n - ${error}`
+    }
+      return (
+        (value && schema.validate(value))||
+        createError({ path, message })
+      );
+  });

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -12577,6 +12577,7 @@ __metadata:
     mdi-material-ui: 7.6.0
     moment: 2.29.4
     moment-timezone: 0.5.41
+    password-validator: ^5.3.0
     pdfmake: 0.2.7*
     prettier: 2.8.4
     prop-types: 15.8.1
@@ -12804,6 +12805,13 @@ __metadata:
   version: 0.1.1
   resolution: "pascalcase@npm:0.1.1"
   checksum: f83681c3c8ff75fa473a2bb2b113289952f802ff895d435edd717e7cb898b0408cbdb247117a938edcbc5d141020909846cc2b92c47213d764e2a94d2ad2b925
+  languageName: node
+  linkType: hard
+
+"password-validator@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "password-validator@npm:5.3.0"
+  checksum: 4ffd5e6aa24cd262a136a5d338cff0396a45d129e688768e66aa19ad2ff536c65be12c1289e26901859ac1a04eff58aa3c49e3f1196dc5790e45c36aa7b66b4b
   languageName: node
   linkType: hard
 

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -44,6 +44,12 @@
         "exporter_prometheus": 14269
       }
     },
+    "password_config_min_length":10,
+    "password_config_max_length":50,
+    "password_config_uppercase":1,
+    "password_config_lowercase":1,
+    "password_config_digits":1,
+    "password_config_special_char":1,
     "request_timeout": 1200000,
     "session_timeout": 1200000,
     "session_manager": "shared",

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1040,6 +1040,12 @@ type Settings implements InternalObject & BasicObject {
   created_at: DateTime! @auth
   updated_at: DateTime! @auth
   otp_mandatory: Boolean @auth
+  password_config_min_length: Int
+  password_config_max_length: Int
+  password_config_uppercase: Int
+  password_config_lowercase: Int
+  password_config_digits: Int
+  password_config_special_char: Int
   # Technical
   editContext: [EditUserContext!] @auth(for: [SETTINGS])
 }

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19084,6 +19084,12 @@ export type Settings = BasicObject & InternalObject & {
   id: Scalars['ID'];
   otp_mandatory?: Maybe<Scalars['Boolean']>;
   parent_types: Array<Scalars['String']>;
+  password_config_digits?: Maybe<Scalars['Int']>;
+  password_config_lowercase?: Maybe<Scalars['Int']>;
+  password_config_max_length?: Maybe<Scalars['Int']>;
+  password_config_min_length?: Maybe<Scalars['Int']>;
+  password_config_special_char?: Maybe<Scalars['Int']>;
+  password_config_uppercase?: Maybe<Scalars['Int']>;
   platform_cluster: Cluster;
   platform_email?: Maybe<Scalars['String']>;
   platform_favicon?: Maybe<Scalars['String']>;
@@ -31202,6 +31208,12 @@ export type SettingsResolvers<ContextType = any, ParentType extends ResolversPar
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   otp_mandatory?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   parent_types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  password_config_digits?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  password_config_lowercase?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  password_config_max_length?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  password_config_min_length?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  password_config_special_char?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  password_config_uppercase?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   platform_cluster?: Resolver<ResolversTypes['Cluster'], ParentType, ContextType>;
   platform_email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_favicon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -49,6 +49,13 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'platform_theme_light_logo_login', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_language', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_login_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'platform_consent_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'password_config_min_length', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
+    { name: 'password_config_max_length', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
+    { name: 'password_config_uppercase', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
+    { name: 'password_config_lowercase', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
+    { name: 'password_config_digits', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
+    { name: 'password_config_special_char', type: 'numeric', mandatoryType: 'external', multiple: false, upsert: false },
     { name: 'otp_mandatory', type: 'boolean', mandatoryType: 'no', multiple: false, upsert: false },
   ],
   [ENTITY_TYPE_MIGRATION_STATUS]: [

--- a/opencti-platform/opencti-graphql/src/resolvers/settings.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/settings.js
@@ -1,4 +1,5 @@
 import { withFilter } from 'graphql-subscriptions';
+import nconf from 'nconf';
 import { BUS_TOPICS } from '../config/conf';
 import {
   getApplicationInfo,
@@ -24,6 +25,12 @@ const settingsResolvers = {
     relationships: (_, __, context) => elAggregationCount(context, context.user, READ_DATA_INDICES, { types: ['stix-relationship'], field: 'entity_type' }),
   },
   Settings: {
+    password_config_digits: () => Number(nconf.get('app:password_config_digits')),
+    password_config_lowercase: () => Number(nconf.get('app:password_config_lowercase')),
+    password_config_max_length: () => Number(nconf.get('app:password_config_max_length')),
+    password_config_min_length: () => Number(nconf.get('app:password_config_min_length')),
+    password_config_special_char: () => Number(nconf.get('app:password_config_special_char')),
+    password_config_uppercase: () => Number(nconf.get('app:password_config_uppercase')),
     platform_organization: (settings, __, context) => findById(context, context.user, settings.platform_organization),
     otp_mandatory: (settings) => settings.otp_mandatory ?? false,
     editContext: (settings) => fetchEditContext(settings.id),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Related to or completes an existing PR - https://github.com/OpenCTI-Platform/opencti/issues/3262

Added password complexity to the user create, edit, and self profile edit form. 

Implemented checking of:

- Min Length (password_config_min_length)
- Max Length (password_config_max_length)
- Upper Chars (password_config_uppercase)
- Lower Chars (password_config_lowercase)
- Special Char Count (password_config_digits)
- Digit Count (password_config_special_char)

These configuration options are controlled in the config/default.json file at startup.

    "password_config_min_length":10,
    "password_config_max_length":50,
    "password_config_uppercase":1,
    "password_config_lowercase":1,
    "password_config_digits":1,
    "password_config_special_char":1,

### Related issues

There are placeholder TODOs in the code to possibly expand for checking of repeated strings like 'qwertyqwerty' and to check from a known list of "compromised" or "bad passwords" to reject those - but that was not implemented in this initial change request. 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ X ] I consider the submitted work as finished
- [ X ] I tested the code for its functionality
- [ X ] I wrote test cases for the relevant uses case
-          (Manual texts done via GUI - however - Selenium based tests will be submitted in a future PR)
- [ ] I added/update the relevant documentation (either on github or on notion)
-          No - not done - suppose the above configuration options need to be added to the Notion Configuration Options pages? 
- [ X ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None.
