### PR TITLE
[frontend/backend] outcomes attribute not mandatory in trigger (#3256)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
@@ -137,7 +137,11 @@ TriggerEditionOverviewProps
         trigger.trigger_type === 'live'
           ? Yup.array().required(t('This field is required'))
           : Yup.array().nullable(),
-    outcomes: Yup.array().required(t('This field is required')),
+    outcomes: trigger.trigger_type === 'digest'
+      ? Yup.array()
+        .min(1, t('Minimum one trigger'))
+        .required(t('This field is required'))
+      : Yup.array().nullable(),
     period:
         trigger.trigger_type === 'digest'
           ? Yup.string().required(t('This field is required'))
@@ -259,8 +263,8 @@ TriggerEditionOverviewProps
   const initialValues = {
     name: trigger.name,
     description: trigger.description,
-    event_types: trigger.event_types,
-    outcomes: trigger.outcomes,
+    event_types: trigger.event_types ?? [],
+    outcomes: trigger.outcomes ?? [],
     period: trigger.period,
     trigger_ids: convertTriggers(trigger),
     day: currentTime.length > 1 ? currentTime[0] : '1',
@@ -437,8 +441,8 @@ TriggerEditionOverviewProps
           >
             <MenuItem value="f4ee7b33-006a-4b0d-b57d-411ad288653d">
               <Checkbox
-                checked={
-                  values.outcomes.indexOf(
+                checked={values.outcomes
+                  && values.outcomes.indexOf(
                     'f4ee7b33-006a-4b0d-b57d-411ad288653d',
                   ) > -1
                 }
@@ -451,8 +455,8 @@ TriggerEditionOverviewProps
             </MenuItem>
             <MenuItem value="44fcf1f4-8e31-4b31-8dbc-cd6993e1b822">
               <Checkbox
-                checked={
-                  values.outcomes.indexOf(
+                checked={values.outcomes
+                  && values.outcomes.indexOf(
                     '44fcf1f4-8e31-4b31-8dbc-cd6993e1b822',
                   ) > -1
                 }
@@ -464,7 +468,8 @@ TriggerEditionOverviewProps
               />
             </MenuItem>
             <MenuItem value="webhook" disabled={true}>
-              <Checkbox checked={values.outcomes.indexOf('webhook') > -1} />
+              <Checkbox checked={values.outcomes
+                && values.outcomes.indexOf('webhook') > -1} />
               <ListItemText primary={outcomesOptions.webhook} />
             </MenuItem>
           </Field>

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -169,7 +169,7 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.outcomes.width }}
             >
-              {data.outcomes?.length > 0
+              {data.outcomes && data.outcomes.length > 0
                 && data.outcomes
                   .map<React.ReactNode>((n) => (
                     <code>{outcomesOptions[n]}</code>

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -169,7 +169,7 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.outcomes.width }}
             >
-              {data.outcomes.length > 0
+              {data.outcomes?.length > 0
                 && data.outcomes
                   .map<React.ReactNode>((n) => (
                     <code>{outcomesOptions[n]}</code>

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
@@ -126,7 +126,7 @@ const liveTriggerValidation = (t: (message: string) => string) => Yup.object().s
   name: Yup.string().required(t('This field is required')),
   description: Yup.string().nullable(),
   event_types: Yup.array().required(t('This field is required')),
-  outcomes: Yup.array().required(t('This field is required')),
+  outcomes: Yup.array().nullable(),
 });
 
 interface TriggerLiveAddInput {

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerPopover.tsx
@@ -132,7 +132,7 @@ const TriggerPopover = ({
       >
         {queryRef && (
           <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
-            <TriggerEditionContainer queryRef={queryRef} handleClose={handleClose} paginationOptions={paginationOptions}/>
+            <TriggerEditionContainer queryRef={queryRef} handleClose={handleCloseEdit} paginationOptions={paginationOptions}/>
           </React.Suspense>
         )}
       </Drawer>

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9074,7 +9074,7 @@ type Trigger implements InternalObject & BasicObject {
   trigger_type: TriggerType!
   event_types: [TriggerEventType!]
   filters: String
-  outcomes: [StixRef!]!
+  outcomes: [StixRef]
   trigger_ids: [String]
   triggers: [Trigger]
   period: DigestPeriod
@@ -9155,7 +9155,7 @@ input TriggerLiveAddInput {
   name: name_String_NotNull_minLength_1!
   description: String
   event_types: [TriggerEventType!]!
-  outcomes: [StixRef!]!
+  outcomes: [StixRef]
   filters: String
 }
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -22872,7 +22872,7 @@ export type Trigger = BasicObject & InternalObject & {
   id: Scalars['ID'];
   modified?: Maybe<Scalars['DateTime']>;
   name: Scalars['String'];
-  outcomes: Array<Scalars['StixRef']>;
+  outcomes?: Maybe<Array<Maybe<Scalars['StixRef']>>>;
   parent_types: Array<Maybe<Scalars['String']>>;
   period?: Maybe<DigestPeriod>;
   standard_id: Scalars['String'];
@@ -22921,7 +22921,7 @@ export type TriggerLiveAddInput = {
   event_types: Array<TriggerEventType>;
   filters?: InputMaybe<Scalars['String']>;
   name: Scalars['String'];
-  outcomes: Array<Scalars['StixRef']>;
+  outcomes?: InputMaybe<Array<InputMaybe<Scalars['StixRef']>>>;
 };
 
 export enum TriggerType {
@@ -32380,7 +32380,7 @@ export type TriggerResolvers<ContextType = any, ParentType extends ResolversPare
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  outcomes?: Resolver<Array<ResolversTypes['StixRef']>, ParentType, ContextType>;
+  outcomes?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixRef']>>>, ParentType, ContextType>;
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   period?: Resolver<Maybe<ResolversTypes['DigestPeriod']>, ParentType, ContextType>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
@@ -41,7 +41,7 @@ type Trigger implements InternalObject & BasicObject {
     trigger_type: TriggerType! # live or digest
     event_types: [TriggerEventType!]
     filters: String
-    outcomes: [StixRef!]!
+    outcomes: [StixRef]
     trigger_ids: [String]
     triggers: [Trigger]
     period: DigestPeriod
@@ -169,7 +169,7 @@ input TriggerLiveAddInput {
     name: String! @constraint(minLength: 1)
     description: String
     event_types: [TriggerEventType!]!
-    outcomes: [StixRef!]!
+    outcomes: [StixRef]
     filters: String
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -35,7 +35,7 @@ const TRIGGER_DEFINITION: ModuleDefinition<StoreEntityTrigger, StixTrigger> = {
     { name: 'name', type: 'string', mandatoryType: 'internal', multiple: false, upsert: false },
     { name: 'description', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'event_types', type: 'string', mandatoryType: 'no', multiple: true, upsert: false },
-    { name: 'outcomes', type: 'string', mandatoryType: 'internal', multiple: true, upsert: false },
+    { name: 'outcomes', type: 'string', mandatoryType: 'no', multiple: true, upsert: false },
     { name: 'filters', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'trigger_ids', type: 'string', mandatoryType: 'no', multiple: true, upsert: false },
     { name: 'period', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },


### PR DESCRIPTION
PR content:
- schema validator for multiple attributes
- trigger edition bug fix of issue 3256 (https://github.com/OpenCTI-Platform/opencti/issues/3256)
- 'outcomes' is not mandatory in type trigger
- close trigger edition form with close button bug fix