### PR TITLE
[backend] add missing assigneeTo filter (#3255)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1810,6 +1810,7 @@ enum StixCoreObjectsFilter {
   created_at
   createdBy
   markedBy
+  assigneeTo
   labelledBy
   killChainPhase
   hasExternalReference

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1744,6 +1744,7 @@ enum StixCoreObjectsFilter {
   created_at
   createdBy
   markedBy
+  assigneeTo
   labelledBy
   killChainPhase
   hasExternalReference

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19660,6 +19660,7 @@ export type StixCoreObjectsDistributionParameters = {
 export enum StixCoreObjectsFilter {
   Abstract = 'abstract',
   Aliases = 'aliases',
+  AssigneeTo = 'assigneeTo',
   Confidence = 'confidence',
   Context = 'context',
   Created = 'created',

--- a/opencti-platform/opencti-graphql/src/schema/stixCoreObject.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixCoreObject.ts
@@ -4,7 +4,7 @@ import { isStixMetaObject } from './stixMetaObject';
 import { isInternalObject } from './internalObject';
 import { ABSTRACT_BASIC_OBJECT, ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_OBJECT, buildRefRelationKey } from './general';
 import { isStixRelationshipExceptRef } from './stixRelationship';
-import { RELATION_CREATED_BY, RELATION_EXTERNAL_REFERENCE, RELATION_KILL_CHAIN_PHASE, RELATION_OBJECT, RELATION_OBJECT_LABEL, RELATION_OBJECT_MARKING } from './stixRefRelationship';
+import { RELATION_CREATED_BY, RELATION_EXTERNAL_REFERENCE, RELATION_KILL_CHAIN_PHASE, RELATION_OBJECT, RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_LABEL, RELATION_OBJECT_MARKING } from './stixRefRelationship';
 import { RELATION_INDICATES, RELATION_RELATED_TO, RELATION_TARGETS } from './stixCoreRelationship';
 import { RELATION_PARTICIPATE_TO } from './internalRelationship';
 import type { StoreObject } from '../types/store';
@@ -21,6 +21,7 @@ export const stixCoreObjectOptions = {
   StixCoreObjectsFilter: {
     createdBy: buildRefRelationKey(RELATION_CREATED_BY),
     markedBy: buildRefRelationKey(RELATION_OBJECT_MARKING),
+    assigneeTo: buildRefRelationKey(RELATION_OBJECT_ASSIGNEE),
     labelledBy: buildRefRelationKey(RELATION_OBJECT_LABEL),
     objectContains: buildRefRelationKey(RELATION_OBJECT),
     hasExternalReference: buildRefRelationKey(RELATION_EXTERNAL_REFERENCE),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `assigneeTo` filter was not supported.
When trying to create a dashboard with entitites filter "Assignee", we get this error : 
```"Variable \"$filters\" got invalid value \"assigneeTo\" at \"filters[0].key\"; Value \"assigneeTo\" does not exist in \"StixCoreObjectsFilter\" enum."```

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3255

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

