### PR TITLE
[backend/frontend] Added support for Consent Message on Login Page

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
@@ -81,6 +81,8 @@ const settingsQuery = graphql`
       platform_theme
       platform_language
       platform_login_message
+      platform_consent_message
+      platform_consent_confirm_text
       platform_theme_dark_background
       platform_theme_dark_paper
       platform_theme_dark_nav
@@ -153,6 +155,8 @@ export const settingsMutationFieldPatch = graphql`
         platform_theme_light_logo_login
         platform_language
         platform_login_message
+        platform_consent_message
+        platform_consent_confirm_text
       }
     }
   }
@@ -207,6 +211,8 @@ const settingsValidation = (t) => Yup.object().shape({
   platform_theme_light_logo_login: Yup.string().nullable(),
   platform_language: Yup.string().nullable(),
   platform_login_message: Yup.string().nullable(),
+  platform_consent_message: Yup.string().nullable(),
+  platform_consent_confirm_text: Yup.string().nullable(),
 });
 
 const Settings = () => {
@@ -279,6 +285,8 @@ const Settings = () => {
                 'platform_theme',
                 'platform_language',
                 'platform_login_message',
+                'platform_consent_message',
+                'platform_consent_confirm_text',
                 'platform_theme_dark_background',
                 'platform_theme_dark_paper',
                 'platform_theme_dark_nav',
@@ -319,7 +327,7 @@ const Settings = () => {
                               variant="standard"
                               name="platform_title"
                               label={t('Platform title')}
-                              fullWidth={true}
+                              fullWidth
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)}
                               helperText={<SubscriptionFocus context={editContext} fieldName="platform_title"/>}
@@ -328,7 +336,7 @@ const Settings = () => {
                               variant="standard"
                               name="platform_favicon"
                               label={t('Platform favicon URL')}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)}
@@ -338,7 +346,7 @@ const Settings = () => {
                               variant="standard"
                               name="platform_email"
                               label={t('Sender email address')}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)}
@@ -348,7 +356,7 @@ const Settings = () => {
                               variant="standard"
                               name="platform_theme"
                               label={t('Theme')}
-                              fullWidth={true}
+                              fullWidth
                               containerstyle={fieldSpacingContainerStyle}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onChange={(name, value) => handleSubmitField(id, name, value)}
@@ -360,7 +368,7 @@ const Settings = () => {
                               variant="standard"
                               name="platform_language"
                               label={t('Language')}
-                              fullWidth={true}
+                              fullWidth
                               containerstyle={fieldSpacingContainerStyle}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onChange={(name, value) => handleSubmitField(id, name, value)}
@@ -404,11 +412,17 @@ const Settings = () => {
                         validationSchema={settingsValidation(t)}>
                         {() => (
                           <Form>
+                            <Typography variant="h1" gutterBottom={true} style={{ marginTop: '20px' }}>
+                            {t('Platform Message Configuration')}
+                            </Typography>
+                            <Typography variant="h4" gutterBottom={true} style={{ marginTop: '20px' }}>
+                              {t('Platform Login Message')}
+                            </Typography>
                             <Field
                               component={MarkDownField}
                               name="platform_login_message"
                               label={t('Platform login message')}
-                              fullWidth={true}
+                              fullWidth
                               multiline={true}
                               rows="3"
                               style={{ marginTop: 20 }}
@@ -416,6 +430,53 @@ const Settings = () => {
                               onSubmit={(name, value) => handleSubmitField(id, name, value)}
                               variant="standard"
                               helperText={<SubscriptionFocus context={editContext} fieldName="platform_login_message"/>}
+                            />
+                            <Typography variant="h4" gutterBottom={true} style={{ marginTop: '20px' }}>
+                              {t('Platform Consent Message')}
+                            </Typography>
+                            <Field
+                              component={MarkDownField}
+                              name="platform_consent_message"
+                              label={t('Platform Consent Message - requires acceptance to enable login form when set')}
+                              fullWidth
+                              multiline={true}
+                              rows="3"
+                              style={{ marginTop: 20 }}
+                              onFocus={(name) => handleChangeFocus(id, name)}
+                              onSubmit={(name, value) => handleSubmitField(id, name, value)
+                              }
+                              variant="standard"
+                              helperText={
+                                <SubscriptionFocus
+                                  context={editContext}
+                                  fieldName="platform_consent_message"
+                                />
+                              }
+                            />
+                            <Typography variant="h4" gutterBottom={true} style={{ marginTop: '20px' }}>
+                              {t('Platform Consent Confirm Text')}
+                            </Typography>
+                            <Field
+                              component={MarkDownField}
+                              name="platform_consent_confirm_text"
+                              label={`${t('Platform Consent Confirm Text - confirm label next to confirm checkbox')
+                              }. ${t('Default')}: ${
+                                t('I have read and comply with the above statement')}`
+                                    }
+                              fullWidth
+                              multiline={true}
+                              rows="3"
+                              style={{ marginTop: 20 }}
+                              onFocus={(name) => handleChangeFocus(id, name)}
+                              onSubmit={(name, value) => handleSubmitField(id, name, value)
+                              }
+                              variant="standard"
+                              helperText={
+                                <SubscriptionFocus
+                                  context={editContext}
+                                  fieldName="platform_consent_confirm_text"
+                                />
+                              }
                             />
                           </Form>
                         )}
@@ -443,7 +504,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
                               }
@@ -463,7 +524,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -484,7 +545,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -505,7 +566,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -526,7 +587,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -547,7 +608,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -569,7 +630,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -590,7 +651,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -611,7 +672,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -650,7 +711,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
                               }
@@ -670,7 +731,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -691,7 +752,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -712,7 +773,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -733,7 +794,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -754,7 +815,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -776,7 +837,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -797,7 +858,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)
@@ -818,7 +879,7 @@ const Settings = () => {
                               InputLabelProps={{
                                 shrink: true,
                               }}
-                              fullWidth={true}
+                              fullWidth
                               style={{ marginTop: 20 }}
                               onFocus={(name) => handleChangeFocus(id, name)}
                               onSubmit={(name, value) => handleSubmitField(id, name, value)

--- a/opencti-platform/opencti-front/src/public/LoginRoot.tsx
+++ b/opencti-platform/opencti-front/src/public/LoginRoot.tsx
@@ -13,6 +13,8 @@ export const rootPublicQuery = graphql`
     settings {
       platform_theme
       platform_login_message
+      platform_consent_message
+      platform_consent_confirm_text
       platform_theme_dark_logo_login
       platform_theme_light_logo_login
       platform_providers {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1035,6 +1035,8 @@ type Settings implements InternalObject & BasicObject {
   platform_map_tile_server_dark: String
   platform_map_tile_server_light: String
   platform_login_message: String
+  platform_consent_message: String
+  platform_consent_confirm_text: String
   platform_reference_attachment: Boolean
   platform_feature_flags: [Module!]
   created_at: DateTime!

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -1863,6 +1863,12 @@ const i18n = {
       'suggestion_threats-indicators':
         'La acción de crear `indica` reñacopmes emtre los indicadores y la amenaza seleccionada, después añade todas las relaciones al contenedor.',
       Collapse: 'Colapso',
+      'Platform Message Configuration': 'Configuración de mensajes de la plataforma',
+      'Platform Consent Message': 'Mensaje de consentimiento de la plataforma',
+      'Platform Consent Message - requires acceptance to enable login form when set':
+        'Mensaje de consentimiento de la plataforma: requiere aceptación para habilitar el formulario de inicio de sesión cuando se establece',
+      'I have read and comply with the above statement': 'He leído y cumplo con la declaración anterior',
+      'Platform Consent Confirm Text - confirm label next to confirm checkbox': 'Texto de confirmación de consentimiento de la plataforma: etiqueta de confirmación junto a la casilla de verificación de confirmación',
     },
     'fr-fr': {
       // Titles
@@ -3736,6 +3742,12 @@ const i18n = {
       'suggestion_threats-indicators':
         'Create `indicates` relationships between indicators and the selected threat, then add all relations to the container.',
       Collapse: 'Réduire',
+      'Platform Message Configuration': 'Configuration des messages de la plate-forme',
+      'Platform Consent Message': 'Message de consentement de la plate-forme',
+      'Platform Consent Message - requires acceptance to enable login form when set':
+        "Message de consentement de la plate-forme - nécessite une acceptation pour activer le formulaire de connexion lorsqu'il est défini",
+      'I have read and comply with the above statement': "J'ai lu et respecte la déclaration ci-dessus",
+      'Platform Consent Confirm Text - confirm label next to confirm checkbox': "Texte de confirmation du consentement de la plate-forme - confirmez l'étiquette à côté de la case à cocher de confirmation",
     },
     'ja-jp': {
       // Titles
@@ -5561,6 +5573,12 @@ const i18n = {
       'suggestion_threats-indicators':
         'インジケータと脅威に `指し示す` のリレーションシップを作成したあと、全てのリレーションシップをコンテナに追加する。',
       Collapse: '崩壊',
+      'Platform Message Configuration': 'プラットフォームメッセージの構成',
+      'Platform Consent Message': 'プラットフォーム同意メッセージ',
+      'Platform Consent Message - requires acceptance to enable login form when set':
+        'プラットフォーム同意メッセージ - 設定時にログインフォームを有効にするには同意が必要です',
+      'I have read and comply with the above statement': '上記の声明を読み、遵守します',
+      'Platform Consent Confirm Text - confirm label next to confirm checkbox': 'プラットフォーム同意確認テキスト - 確認チェックボックスの横にある確認ラベル',
     },
     'zh-cn': {
       // Titles
@@ -7288,6 +7306,13 @@ const i18n = {
       'suggestion_threats-indicators':
         '在指标和所选威胁之间创建“指示”关系，然后将所有关系添加到容器中',
       Collapse: '坍塌',
+      'Platform Message Configuration': '平台消息配置',
+      'Platform Consent Message': '我已阅读并遵守以上声明',
+      'Platform Consent Message - requires acceptance to enable login form when set':
+        '平台同意消息 - 需要接受才能在设置时启用登录表单',
+      'I have read and comply with the above statement': '我已阅读并遵守以上声明',
+      'Platform Consent Confirm Text - confirm label next to confirm checkbox':
+        '平台同意确认文本 - 确认复选框旁边的确认标签',
     },
     'en-us': {
       gt: 'Greater than',

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -978,6 +978,8 @@ type Settings implements InternalObject & BasicObject {
   platform_map_tile_server_dark: String
   platform_map_tile_server_light: String
   platform_login_message: String
+  platform_consent_message: String
+  platform_consent_confirm_text: String
   platform_reference_attachment: Boolean @auth
   platform_feature_flags: [Module!] @auth
   created_at: DateTime! @auth

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19466,6 +19466,8 @@ export type Settings = BasicObject & InternalObject & {
   password_policy_min_uppercase?: Maybe<Scalars['Int']>;
   password_policy_min_words?: Maybe<Scalars['Int']>;
   platform_cluster: Cluster;
+  platform_consent_confirm_text?: Maybe<Scalars['String']>;
+  platform_consent_message?: Maybe<Scalars['String']>;
   platform_email?: Maybe<Scalars['String']>;
   platform_favicon?: Maybe<Scalars['String']>;
   platform_feature_flags?: Maybe<Array<Module>>;
@@ -31786,6 +31788,8 @@ export type SettingsResolvers<ContextType = any, ParentType extends ResolversPar
   password_policy_min_uppercase?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   password_policy_min_words?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   platform_cluster?: Resolver<ResolversTypes['Cluster'], ParentType, ContextType>;
+  platform_consent_confirm_text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  platform_consent_message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_favicon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_feature_flags?: Resolver<Maybe<Array<ResolversTypes['Module']>>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -48,6 +48,8 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'platform_theme_light_logo_login', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_language', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_login_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'platform_consent_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'platform_consent_confirm_text', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'otp_mandatory', type: 'boolean', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'password_policy_min_length', type: 'numeric', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'password_policy_max_length', type: 'numeric', mandatoryType: 'no', multiple: false, upsert: false },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR allows for a customizable (off settings GUI by Admin) "Consent to Monitor" or "Legal Notice" message ('platform_consent_message') that is displayed beneath the 'platform_login_message' (if configured) on the Login Page. If the new ('platform_consent_message') is configured, the message will be displayed on the login page, and the user will be required to click a consent check box agreeing to the displayed terms, before the Login Form is displayed.

If the new ('platform_consent_message') is blank in the configuration, the login page will ignore this field and display nothing.

### Related issues

This PR has been tested with LDAP configuration, standard internal OpenCTI authentication, and SSO SAML authentication. 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ X ] I consider the submitted work as finished
- [ X ] I tested the code for its functionality
- [ X ] I wrote test cases for the relevant uses case
-          Tested manually within the GUI. A future PR will have Selenium autotest to supplement this capability automatically.
- [ ] I added/update the relevant documentation (either on github or on notion)
-          This has not been done, suspect the ('platform_consent_message')  option needs to be added to Notion page documentation.
- [ X ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None.
