### PR TITLE
[frontend/backend] Added Customizable Header/Footer banner and Idle Time Screen Masking then Logout

### DIFF
--- a/opencti-platform/opencti-front/src/private/Index.jsx
+++ b/opencti-platform/opencti-front/src/private/Index.jsx
@@ -27,6 +27,7 @@ import StixObjectOrStixRelationship from './components/StixObjectOrStixRelations
 import SearchBulk from './components/SearchBulk';
 import TopBar from './components/nav/TopBar';
 import RootCases from './components/cases/Root';
+import { useBannerSettings } from '../utils/SystemBanners';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: theme.mixins.toolbar,
@@ -38,8 +39,9 @@ const Index = () => {
   const location = useLocation();
   const theme = useTheme();
   const classes = useStyles();
+  const { bannerHeight } = useBannerSettings();
   return (
-    <Box sx={{ display: 'flex', minWidth: 1400 }}>
+    <Box sx={{ display: 'flex', minWidth: 1400, marginTop: bannerHeight, marginBottom: bannerHeight }}>
       <CssBaseline />
       {!noTopBarLocations.includes(location.pathname) && <TopBar />}
       <LeftBar />

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -35,6 +35,8 @@ const rootPrivateQuery = graphql`
       platform_map_tile_server_dark
       platform_map_tile_server_light
       platform_theme
+      platform_session_idle_timeout
+      platform_session_timeout
       platform_feature_flags {
         id
         enable

--- a/opencti-platform/opencti-front/src/private/components/IdleTimeoutLockscreen.tsx
+++ b/opencti-platform/opencti-front/src/private/components/IdleTimeoutLockscreen.tsx
@@ -1,0 +1,289 @@
+import React, { useEffect, useReducer, useRef, useState } from 'react';
+import { compose } from 'ramda';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+import { RecordSourceSelectorProxy } from 'relay-runtime';
+import inject18n, { useFormatter } from '../../components/i18n';
+import { commitLocalUpdate } from '../../relay/environment';
+import { ONE_SECOND, formatSeconds, secondsBetweenDates } from '../../utils/Time';
+import { SYSTEM_BANNER_HEIGHT } from '../../utils/SystemBanners';
+
+// NOTE: This is a hack that can go away once <TopBar> has been refactored in 5.9.0
+// See https://github.com/OpenCTI-Platform/opencti/issues/2796
+/**
+ * This semaphore creates a lock that prevents multiple IdleTimeoutLockscreen components
+ * from creating additional timeout intervals. There are some views in the application
+ * that use the TopBar component twice, which then creates two separate instances of this
+ * component. Using an incrementing semaphore like this ensures that only one timeout
+ * interval is set at any given moment.
+ */
+let timeoutSemaphore = 0;
+
+/**
+ * Gets timeout and banner settings from react relay and return those values.
+ */
+export function getSettings(callback: (settings: { idleLimit: number, sessionLimit: number, bannerText: string }) => void) {
+  commitLocalUpdate((store: RecordSourceSelectorProxy) => {
+    const settings = store.getRoot().getLinkedRecord('settings');
+    const bannerText = settings ? String(settings.getValue('platform_banner_text')) : '';
+    const timeoutMS = settings ? Number(settings.getValue('platform_session_idle_timeout')) : 0; // Default to 0: Disabled
+    const sessionMS = settings ? Number(settings.getValue('platform_session_timeout')) : 1200000;
+    const idleLimit = timeoutMS ? Math.floor(timeoutMS / ONE_SECOND) : 0;
+    const sessionLimit = sessionMS ? Math.floor(sessionMS / ONE_SECOND) : 0;
+    if (typeof callback === 'function') {
+      callback({ idleLimit, sessionLimit, bannerText });
+    }
+  });
+}
+
+interface TimeoutState {
+  idleLimit: number;
+  sessionLimit: number;
+  idleCount: number | null;
+  startDate: Date;
+}
+
+type Action =
+  | { type: 'count down' }
+  | { type: 'set limits', idleLimit: number, sessionLimit: number }
+  | { type: 'reset timeout' }
+  | { type: 'disable timeout' };
+
+/**
+ * Handles various state changes for the timeout counting functionality.
+ */
+function timeoutReducer(state: TimeoutState, action: Action): TimeoutState {
+  const { idleLimit, sessionLimit, idleCount, startDate } = state;
+  switch (action.type) {
+    case 'count down':
+      if (idleCount) {
+        return { idleLimit, sessionLimit, idleCount: idleCount - 1, startDate };
+      }
+      return state;
+
+    case 'set limits':
+      return { idleLimit: action.idleLimit, sessionLimit: action.sessionLimit, idleCount, startDate };
+
+    case 'reset timeout':
+      return { idleLimit, sessionLimit, idleCount: sessionLimit, startDate: new Date() };
+
+    case 'disable timeout':
+      return { idleLimit: 0, sessionLimit: 0, idleCount: null, startDate: new Date() };
+
+    default:
+      return state;
+  }
+}
+
+/**
+ * Redirects to the Dashboard Homepage, flagging the user as being expired.
+ */
+function redirectToDashboard(handleLogout:(url?: string) => void) {
+  const getUrl = window.location;
+  handleLogout(`${getUrl.protocol}//${getUrl.host}/dashboard?ExpiredSession=1`);
+}
+
+interface IdleTimeoutLockscreenProps {
+  handleLogout: (url?: string) => void;
+}
+
+const IdleTimeoutLockscreen: React.FunctionComponent<IdleTimeoutLockscreenProps> = ({
+  handleLogout,
+}) => {
+  const { t } = useFormatter();
+  const [systemBannersOffset, setSystemBannersOffset] = useState(0);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [state, dispatch] = useReducer(timeoutReducer, { idleLimit: 0, sessionLimit: 0, idleCount: null, startDate: new Date() });
+  const [resetCounter, triggerReset] = useState(false);
+  const interval = useRef<NodeJS.Timer | null>(null);
+
+  /**
+   * Decrements the idle timeout counter by one until it is zero.
+   */
+  function onCountdown() {
+    dispatch({ type: 'count down' });
+  }
+
+  /**
+   * Clears the timeout interval when restarting a count or unmounting the component.
+   */
+  function clearTimeoutInterval() {
+    if (interval.current) {
+      clearInterval(interval.current);
+      interval.current = null;
+    }
+  }
+
+  /**
+   * Resets the idle timeout counter, but only if the dialog has been closed.
+   */
+  function resetIdleTimeout() {
+    if (dialogOpen) return; // Don't touch the timeout counter if the dialog is still open
+    if (state.sessionLimit > 0) {
+      dispatch({ type: 'reset timeout' });
+    }
+  }
+
+  /**
+   * Locks the application screen by opening a dialog which blurs the current application view.
+   */
+  function lockScreen() {
+    setDialogOpen(true);
+  }
+
+  /**
+   * Unlocks the application screen by closing the dialog and refreshes the session.
+   */
+  function unlockScreen() {
+    setDialogOpen(false);
+  }
+
+  /**
+   * Disables timeout functionality on this page.
+   */
+  function disableTimeout() {
+    clearTimeoutInterval();
+    dispatch({ type: 'disable timeout' });
+    unlockScreen();
+  }
+
+  /**
+   * Triggers a reset of the idle timeout counter, usually when a click event occurs.
+   */
+  function resetTimeout() {
+    triggerReset(true);
+  }
+
+  /**
+   * Watches dialogOpen state to reset the idle counter when the dialog closes.
+   */
+  useEffect(() => {
+    if (!dialogOpen && state.idleCount) {
+      resetIdleTimeout();
+    }
+  }, [dialogOpen]);
+
+  /**
+   * Detects the mounting of the component, similar to componentWillMount() in class component.
+   */
+  useEffect(() => {
+    // NOTE: This is a hack that can go away once <TopBar> has been refactored in 5.9.0
+    timeoutSemaphore += 1;
+    if (timeoutSemaphore > 1) {
+      return;
+    }
+
+    // Update state from settings values stored in react relay
+    getSettings(({ idleLimit, sessionLimit, bannerText }) => {
+      setSystemBannersOffset(bannerText ? SYSTEM_BANNER_HEIGHT : 0);
+      dispatch({ type: 'set limits', idleLimit, sessionLimit });
+    });
+
+    // Reset the timeout counter every time the user clicks anything in the application
+    document.body.addEventListener('click', resetTimeout);
+
+    // Cleanup of this component, similar to componentWillUnmount() in class component
+    // eslint-disable-next-line consistent-return
+    return () => {
+      clearTimeoutInterval();
+      // Removing event listeners when the component unmounts is good practice
+      document.body.removeEventListener('click', resetTimeout);
+      // NOTE: This is a hack that can go away once <TopBar> has been refactored in 5.9.0
+      timeoutSemaphore -= 1;
+    };
+  }, []);
+
+  /**
+   * Watches resetCounter trigger state, should only be called by the document.body click listener.
+   */
+  useEffect(() => {
+    if (resetCounter === true) {
+      resetIdleTimeout();
+      triggerReset(false);
+    }
+  }, [resetCounter]);
+
+  /**
+   * Watches for sessionLimit state change, should only change once when the component loads.
+   */
+  useEffect(() => {
+    if (state.sessionLimit > 0) {
+      resetIdleTimeout();
+      interval.current = setInterval(onCountdown, ONE_SECOND);
+    }
+  }, [state.sessionLimit]);
+
+  /**
+   * Watches for idleCount change and takes action if timeout limits have been reached.
+   */
+  useEffect(() => {
+    if (state.idleCount === null) return; // Skip further processing of idleCount if it is unset
+
+    const secondsBetween = secondsBetweenDates(state.startDate, new Date());
+    // Ensure that the user is logged out if the page has been open longer than the session allows
+    if (
+      secondsBetween >= state.sessionLimit
+      || (state.idleCount !== null && state.idleCount !== undefined && state.idleCount <= 0 && dialogOpen)
+    ) {
+      redirectToDashboard(handleLogout);
+    }
+    // Lock the screen for the remaining session time
+    if (!dialogOpen && secondsBetween >= state.idleLimit && secondsBetween < state.sessionLimit) {
+      lockScreen();
+    }
+  }, [state.idleCount]);
+
+  // NOTE: The timeout semaphore is a hack that can go away once <TopBar> has been refactored in 5.9.0
+  return timeoutSemaphore === 1 ? (
+    <Dialog
+      open={dialogOpen}
+      onClose={() => { }}
+      disableEscapeKeyDown={true}
+      maxWidth='sm'
+      PaperProps={{ elevation: 1 }}
+      sx={{
+        backdropFilter: 'blur(15px)',
+        marginTop: `${systemBannersOffset}px`,
+        height: `calc(100% - ${systemBannersOffset * 2}px)`,
+      }}
+    >
+      <DialogTitle sx={{ textAlign: 'center' }}>
+        {t('Session Timeout')}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant='body1'>
+          {t('You will be automatically logged out in')}
+        </Typography>
+        <Typography variant='h6' sx={{ width: '100%', textAlign: 'center' }}>
+          {formatSeconds(state.idleCount ?? 0)}
+        </Typography>
+        <Typography variant='body1'>
+          {t('Select CONTINUE to keep working or select lOGOUT to terminate your session.')}
+        </Typography>
+      </DialogContent>
+      <DialogActions
+        sx={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Button color='secondary' onClick={() => handleLogout()}>
+          {t('Logout')}
+        </Button>
+        <Button size='small' onClick={() => disableTimeout()}>
+          {t('Disable timeout on this page')}
+        </Button>
+        <Button color='primary' onClick={() => unlockScreen()}>
+          {t('Continue')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  ) : null;
+};
+
+export default compose(inject18n)(IdleTimeoutLockscreen);

--- a/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraphBar.jsx
@@ -67,6 +67,7 @@ import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relat
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -112,6 +113,9 @@ class GroupingKnowledgeGraphBar extends Component {
       openEditObservable: false,
       displayRemove: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -422,7 +426,11 @@ class GroupingKnowledgeGraphBar extends Component {
         anchor="bottom"
         variant="permanent"
         classes={{ paper: classes.bottomNav }}
-        PaperProps={{ variant: 'elevation', elevation: 1 }}
+        PaperProps={{
+          variant: 'elevation',
+          elevation: 1,
+          style: { bottom: this.bannerHeight },
+        }}
       >
         <div
           style={{

--- a/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraphBar.jsx
@@ -71,6 +71,7 @@ import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relat
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -117,6 +118,9 @@ class ReportKnowledgeGraphBar extends Component {
       displayRemove: false,
       deleteObject: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -438,6 +442,7 @@ class ReportKnowledgeGraphBar extends Component {
         PaperProps={{
           variant: 'elevation',
           elevation: 1,
+          style: { bottom: this.bannerHeight },
         }}
       >
         <div

--- a/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
@@ -166,6 +166,7 @@ const Feedbacks: FunctionComponent<FeedbacksProps> = () => {
               filters={{
                 entity_type: [{ id: 'Feedback', value: 'Feedback' }],
               }}
+              rightOffset={0}
             />
           </Suspense>
         )}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -71,6 +71,7 @@ import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relat
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -117,6 +118,9 @@ class IncidentKnowledgeGraphBar extends Component {
       displayRemove: false,
       deleteObject: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -438,6 +442,7 @@ class IncidentKnowledgeGraphBar extends Component {
         PaperProps={{
           variant: 'elevation',
           elevation: 1,
+          style: { bottom: this.bannerHeight },
         }}
       >
         <div

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -70,6 +70,7 @@ import StixCyberObservableEdition from '../../observations/stix_cyber_observable
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -116,6 +117,9 @@ class CaseRfiKnowledgeGraphBar extends Component {
       displayRemove: false,
       deleteObject: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -438,6 +442,7 @@ class CaseRfiKnowledgeGraphBar extends Component {
         PaperProps={{
           variant: 'elevation',
           elevation: 1,
+          style: { bottom: this.bannerHeight },
         }}
       >
         <div

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -70,6 +70,7 @@ import StixCyberObservableEdition from '../../observations/stix_cyber_observable
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -116,6 +117,9 @@ class CaseRftKnowledgeGraphBar extends Component {
       displayRemove: false,
       deleteObject: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -438,6 +442,7 @@ class CaseRftKnowledgeGraphBar extends Component {
         PaperProps={{
           variant: 'elevation',
           elevation: 1,
+          style: { bottom: this.bannerHeight },
         }}
       >
         <div

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -361,6 +361,7 @@ ContainerStixCyberObservablesComponentProps
               container={container}
               handleCopy={handleCopy}
               warning={true}
+              rightOffset={250 + 85}
             />
             <StixCyberObservablesRightBar
               types={types}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.jsx
@@ -327,6 +327,7 @@ class ContainerStixDomainObjectsComponent extends Component {
                 variant="large"
                 container={container}
                 warning={true}
+                rightOffset={250 + 85}
               />
               <StixDomainObjectsRightBar
                 types={types}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraphBar.jsx
@@ -43,6 +43,7 @@ import { dateFormat } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import { resolveLink } from '../../../../utils/Entity';
 import { parseDomain } from '../../../../utils/Graph';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -81,6 +82,9 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
       openEditEntity: false,
       displayRemove: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenStixCoreObjectsTypes(event) {
@@ -191,7 +195,7 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
           anchor="bottom"
           variant="permanent"
           classes={{ paper: classes.bottomNav }}
-          PaperProps={{ variant: 'elevation', elevation: 1 }}
+          PaperProps={{ variant: 'elevation', elevation: 1, style: { bottom: this.bannerHeight } }}
         >
           <div
             style={{
@@ -392,7 +396,7 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
         anchor="bottom"
         variant="permanent"
         classes={{ paper: classes.bottomNav }}
-        PaperProps={{ variant: 'elevation', elevation: 1 }}
+        PaperProps={{ variant: 'elevation', elevation: 1, style: { bottom: this.bannerHeight } }}
       >
         <div
           style={{

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileToolbar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileToolbar.jsx
@@ -22,6 +22,7 @@ import { Form, Formik } from 'formik';
 import DialogTitle from '@mui/material/DialogTitle';
 import inject18n from '../../../../../components/i18n';
 import ObjectMarkingField from '../../form/ObjectMarkingField';
+import { getBannerSettings } from '../../../../../utils/SystemBanners';
 
 const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
@@ -30,7 +31,7 @@ Transition.displayName = 'TransitionSlide';
 
 const styles = (theme) => ({
   bottomNav: {
-    zIndex: 1100,
+    zIndex: 1040,
     padding: '0 0 0 180px',
     display: 'flex',
     height: 50,
@@ -107,6 +108,9 @@ class WorkbenchFileToolbar extends Component {
       displayDelete: false,
       displayApplyMarking: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenApplyMarking() {
@@ -146,6 +150,7 @@ class WorkbenchFileToolbar extends Component {
       handleClearSelectedElements,
       submitDelete,
       theme,
+      rightOffset,
     } = this.props;
     const { displayDelete, displayApplyMarking } = this.state;
     const isOpen = numberOfSelectedElements > 0;
@@ -159,7 +164,7 @@ class WorkbenchFileToolbar extends Component {
           paper: classes.bottomNav,
         }}
         open={isOpen}
-        PaperProps={{ variant: 'elevation', elevation: 1 }}
+        PaperProps={{ variant: 'elevation', elevation: 1, style: { bottom: this.bannerHeight, paddingRight: rightOffset ?? 85 } }}
       >
         <Toolbar style={{ minHeight: 54 }}>
           <Typography
@@ -289,6 +294,7 @@ WorkbenchFileToolbar.propTypes = {
   handleClearSelectedElements: PropTypes.func,
   submitDelete: PropTypes.func,
   submitApplyMarking: PropTypes.func,
+  rightOffset: PropTypes.number,
 };
 
 export default R.compose(

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement } from 'react';
+import React, { FunctionComponent, ReactElement, useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Drawer from '@mui/material/Drawer';
 import MenuList from '@mui/material/MenuList';
@@ -8,6 +8,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import { Theme } from '../../../../components/Theme';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   drawer: {
@@ -33,6 +34,10 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({
   const classes = useStyles();
   const { t } = useFormatter();
   const location = useLocation();
+  const [bannerHeight, setBannerHeight] = useState('');
+  useEffect(() => {
+    getBannerSettings(({ bannerHeight: bH }) => setBannerHeight(bH));
+  }, []);
 
   return (
     <Drawer
@@ -41,7 +46,7 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({
       classes={{ paper: classes.drawer }}
     >
       <div className={classes.toolbar} />
-      <MenuList component="nav">
+      <MenuList component="nav" style={{ marginTop: bannerHeight, marginBottom: bannerHeight }}>
         {entries.map((entry, idx) => {
           return (
             <MenuItem

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -44,6 +44,7 @@ import {
   GlobeModel,
 } from 'mdi-material-ui';
 import inject18n from '../../../../components/i18n';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = (theme) => ({
   drawer: {
@@ -61,6 +62,13 @@ const styles = (theme) => ({
 });
 
 class StixCoreObjectKnowledgeBar extends Component {
+  constructor(props) {
+    super(props);
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
+  }
+
   render() {
     const { t, location, classes, stixCoreObjectLink, availableSections } = this.props;
     // eslint-disable-next-line max-len
@@ -72,7 +80,7 @@ class StixCoreObjectKnowledgeBar extends Component {
         classes={{ paper: classes.drawer }}
       >
         <div className={classes.toolbar} />
-        <MenuList style={{ paddingBottom: 0 }} component="nav">
+        <MenuList style={{ paddingBottom: 0 }} sx={{ marginTop: this.bannerHeight }} component="nav">
           <MenuItem
             component={Link}
             to={`${stixCoreObjectLink}/overview`}
@@ -766,6 +774,7 @@ class StixCoreObjectKnowledgeBar extends Component {
         )}
         <MenuList
           style={{ paddingBottom: 0 }}
+          sx={{ marginBottom: this.bannerHeight }}
           component="nav"
           subheader={
             <ListSubheader style={{ height: 35 }}>{t('Other')}</ListSubheader>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.jsx
@@ -432,6 +432,7 @@ class EntityStixCoreRelationships extends Component {
                 this,
               )}
               variant="medium"
+              rightOffset={200 + 85}
             />
           </div>
         )}
@@ -625,6 +626,7 @@ class EntityStixCoreRelationships extends Component {
               warningMessage={t(
                 'Be careful, you are about to delete the selected entities (not the relationships!).',
               )}
+              rightOffset={200 + 85}
             />
           </div>
         )}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsRightBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsRightBar.jsx
@@ -14,6 +14,7 @@ import { FilterOffOutline } from 'mdi-material-ui';
 import inject18n from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import { stixDomainObjectsLinesSubTypesQuery } from './StixDomainObjectsLines';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -36,6 +37,13 @@ const styles = (theme) => ({
 });
 
 class StixDomainObjectsRightBar extends Component {
+  constructor(props) {
+    super(props);
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
+  }
+
   render() {
     const { classes, t, types = [], handleToggle, handleClear } = this.props;
     return (
@@ -61,6 +69,7 @@ class StixDomainObjectsRightBar extends Component {
               )(subTypesEdges);
               return (
                 <List
+                  sx={{ marginTop: this.bannerHeight, marginBottom: this.bannerHeight }}
                   subheader={
                     <ListSubheader component="div">
                       {t('Entity types')}

--- a/opencti-platform/opencti-front/src/private/components/data/Entities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Entities.jsx
@@ -349,6 +349,7 @@ class Entities extends Component {
                 this,
               )}
               variant="large"
+              rightOffset={250}
             />
           </div>
         )}

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionMenu.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionMenu.jsx
@@ -6,6 +6,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../components/i18n';
+import { useBannerSettings } from '../../../utils/SystemBanners';
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
@@ -22,6 +23,7 @@ const SharingMenu = () => {
   const location = useLocation();
   const classes = useStyles();
   const { t } = useFormatter();
+  const { bannerHeight } = useBannerSettings();
   return (
     <Drawer
       variant="permanent"
@@ -29,7 +31,7 @@ const SharingMenu = () => {
       classes={{ paper: classes.drawer }}
     >
       <div className={classes.toolbar} />
-      <MenuList component="nav">
+      <MenuList component="nav" sx={{ marginTop: bannerHeight, marginBottom: bannerHeight }}>
         <MenuItem
           component={Link}
           to={'/dashboard/data/ingestion/sync'}

--- a/opencti-platform/opencti-front/src/private/components/data/Relationships.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Relationships.jsx
@@ -323,6 +323,7 @@ class Relationships extends Component {
               handleClearSelectedElements={this.handleClearSelectedElements.bind(
                 this,
               )}
+              rightOffset={0}
             />
           </div>
         )}

--- a/opencti-platform/opencti-front/src/private/components/data/SharingMenu.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/SharingMenu.jsx
@@ -6,6 +6,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../components/i18n';
+import { useBannerSettings } from '../../../utils/SystemBanners';
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
@@ -22,6 +23,8 @@ const SharingMenu = () => {
   const location = useLocation();
   const classes = useStyles();
   const { t } = useFormatter();
+  const { bannerHeight } = useBannerSettings();
+
   return (
     <Drawer
       variant="permanent"
@@ -29,7 +32,7 @@ const SharingMenu = () => {
       classes={{ paper: classes.drawer }}
     >
       <div className={classes.toolbar} />
-      <MenuList component="nav">
+      <MenuList component="nav" sx={{ marginTop: bannerHeight, marginBottom: bannerHeight }}>
         <MenuItem
           component={Link}
           to={'/dashboard/data/sharing/streams'}

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -80,31 +80,32 @@ import { hexToRGB } from '../../../utils/Colors';
 import { externalReferencesQueriesSearchQuery } from '../analysis/external_references/ExternalReferencesQueries';
 import StixDomainObjectCreation from '../common/stix_domain_objects/StixDomainObjectCreation';
 import ItemMarkings from '../../../components/ItemMarkings';
+import { getBannerSettings } from '../../../utils/SystemBanners';
 
 const styles = (theme) => ({
   bottomNav: {
     padding: 0,
-    zIndex: 1100,
+    zIndex: 1000,
     display: 'flex',
     height: 50,
     overflow: 'hidden',
   },
   bottomNavWithLargePadding: {
-    zIndex: 1100,
+    zIndex: 1000,
     padding: '0 230px 0 0',
     display: 'flex',
     height: 50,
     overflow: 'hidden',
   },
   bottomNavWithMediumPadding: {
-    zIndex: 1100,
+    zIndex: 1000,
     padding: '0 200px 0 0',
     display: 'flex',
     height: 50,
     overflow: 'hidden',
   },
   bottomNavWithSmallPadding: {
-    zIndex: 1100,
+    zIndex: 1000,
     padding: '0 180px 0 0',
     display: 'flex',
     height: 50,
@@ -295,6 +296,9 @@ class ToolBar extends Component {
       enrichSelected: [],
       navOpen: localStorage.getItem('navOpen') === 'true',
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   componentDidMount() {
@@ -1190,6 +1194,7 @@ class ToolBar extends Component {
       deleteDisable,
       warning,
       warningMessage,
+      rightOffset,
     } = this.props;
     const { actions, keptEntityId, mergingElement, actionsInputs, navOpen } = this.state;
     const isOpen = numberOfSelectedElements > 0;
@@ -1303,7 +1308,7 @@ class ToolBar extends Component {
         PaperProps={{
           variant: 'elevation',
           elevation: 1,
-          style: { paddingLeft: navOpen ? 185 : 60 },
+          style: { paddingLeft: navOpen ? 185 : 60, bottom: this.bannerHeight, paddingRight: rightOffset ?? 85 },
         }}
       >
         <Toolbar style={{ minHeight: 54 }}>
@@ -2281,6 +2286,7 @@ ToolBar.propTypes = {
   handleCopy: PropTypes.func,
   warning: PropTypes.bool,
   warningMessage: PropTypes.string,
+  rightOffset: PropTypes.number,
 };
 
 export default R.compose(inject18n, withTheme, withStyles(styles))(ToolBar);

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -39,6 +39,7 @@ import { MESSAGING$ } from '../../../relay/environment';
 import {
   useIsHiddenEntities,
 } from '../../../utils/hooks/useEntitySettings';
+import { useBannerSettings } from '../../../utils/SystemBanners';
 
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
@@ -160,6 +161,7 @@ const LeftBar = () => {
     'City',
     'Position',
   );
+  const { bannerHeight } = useBannerSettings();
   return (
     <Drawer
       variant="permanent"
@@ -175,7 +177,7 @@ const LeftBar = () => {
       }}
     >
       <Toolbar />
-      <MenuList component="nav">
+      <MenuList component="nav" sx={{ marginTop: bannerHeight }}>
         <StyledTooltip title={!navOpen && t('Dashboard')} placement="right">
           <MenuItem
             component={Link}
@@ -443,6 +445,7 @@ const LeftBar = () => {
       </Security>
       <MenuItem
         dense={true}
+        sx={{ marginBottom: bannerHeight }}
         classes={{
           root: navOpen ? classes.menuCollapseOpen : classes.menuCollapse,
         }}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -96,6 +96,8 @@ import TopMenuCaseRfi from './TopMenuCaseRfi';
 import TopMenuCaseRft from './TopMenuCaseRft';
 import TopMenuTask from './TopMenuTask';
 import TopMenuAudits from './TopMenuAudits';
+import SystemBanners from '../../../public/components/SystemBanners';
+import IdleTimeoutLockscreen, { getSettings } from '../IdleTimeoutLockscreen';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   appBar: {
@@ -231,15 +233,19 @@ const TopBar: FunctionComponent<TopBarProps> = ({
   const handleCloseMenu = () => {
     setMenuOpen({ open: false, anchorEl: null });
   };
-  const handleLogout = () => {
+  const handleLogout = (redirect = '') => {
+    function redirectWindow() {
+      if (redirect === '' || redirect.length === undefined) window.location.reload();
+      else window.location.replace(redirect);
+    }
     commitMutation({
       mutation: logoutMutation,
       variables: {},
-      onCompleted: () => window.location.reload(),
+      onCompleted: redirectWindow,
       updater: undefined,
       optimisticUpdater: undefined,
       optimisticResponse: undefined,
-      onError: undefined,
+      onError: redirectWindow,
       setSubmitting: undefined,
     });
   };
@@ -259,6 +265,15 @@ const TopBar: FunctionComponent<TopBarProps> = ({
     setOpenDrawer(false);
     handleCloseMenu();
   };
+  const [bannerHeight, setBannerHeight] = useState('');
+  const [idleTimeoutLimit, setIdleTimeoutLimit] = useState(0);
+  useEffect(() => {
+    getSettings(({ idleLimit }) => {
+      if (idleLimit > 0) {
+        setIdleTimeoutLimit(idleLimit);
+      }
+    });
+  }, []);
 
   return (
     <AppBar
@@ -267,7 +282,9 @@ const TopBar: FunctionComponent<TopBarProps> = ({
       variant="elevation"
       elevation={1}
     >
-      <Toolbar>
+      {/* Header and Footer Banners containing classification level of system */}
+      <SystemBanners handleBannerChange={setBannerHeight} handleLogout={handleLogout} />
+      <Toolbar style={{ marginTop: bannerHeight }}>
         <div className={classes.logoContainer}>
           <Link to="/dashboard">
             <img
@@ -290,7 +307,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           {location.pathname.includes('/dashboard/import') && <TopMenuImport />}
           {(location.pathname === '/dashboard/analysis'
             || location.pathname.match('/dashboard/analysis/[a-z_]+$')) && (
-            <TopMenuAnalysis />
+              <TopMenuAnalysis />
           )}
           {location.pathname === '/dashboard/profile/me' && <TopMenuProfile />}
           {location.pathname !== '/dashboard/profile/me'
@@ -299,7 +316,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/cases'
             || location.pathname.match('/dashboard/cases/[a-z_]+$')) && (
-            <TopMenuCases />
+              <TopMenuCases />
           )}
           {location.pathname.includes('/dashboard/cases/incidents/') && (
             <TopMenuCaseIncident />
@@ -336,7 +353,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           ) && <TopMenuExternalReference />}
           {(location.pathname === '/dashboard/events'
             || location.pathname.match('/dashboard/events/[a-z_]+$')) && (
-            <TopMenuEvents />
+              <TopMenuEvents />
           )}
           {location.pathname.includes('/dashboard/events/incidents/') && (
             <TopMenuIncident />
@@ -349,7 +366,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/observations'
             || location.pathname.match('/dashboard/observations/[a-z_]+$')) && (
-            <TopMenuObservations />
+              <TopMenuObservations />
           )}
           {location.pathname.includes(
             '/dashboard/observations/indicators/',
@@ -365,7 +382,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/threats'
             || location.pathname.match('/dashboard/threats/[a-z_]+$')) && (
-            <TopMenuThreats />
+              <TopMenuThreats />
           )}
           {location.pathname.includes('/dashboard/threats/threat_actors/') && (
             <TopMenuThreatActor />
@@ -378,7 +395,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/arsenal'
             || location.pathname.match('/dashboard/arsenal/[a-z_]+$')) && (
-            <TopMenuArsenal />
+              <TopMenuArsenal />
           )}
           {location.pathname.includes('/dashboard/arsenal/malwares/') && (
             <TopMenuMalware />
@@ -394,7 +411,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           ) && <TopMenuVulnerability />}
           {(location.pathname === '/dashboard/entities'
             || location.pathname.match('/dashboard/entities/[a-z_]+$')) && (
-            <TopMenuEntities />
+              <TopMenuEntities />
           )}
           {location.pathname.includes('/dashboard/entities/sectors/') && (
             <TopMenuSector />
@@ -413,7 +430,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/locations'
             || location.pathname.match('/dashboard/locations/[a-z_]+$')) && (
-            <TopMenuLocation />
+              <TopMenuLocation />
           )}
           {location.pathname.includes('/dashboard/locations/countries/') && (
             <TopMenuCountry />
@@ -432,7 +449,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
           )}
           {(location.pathname === '/dashboard/techniques'
             || location.pathname.match('/dashboard/techniques/[a-z_]+$')) && (
-            <TopMenuTechniques />
+              <TopMenuTechniques />
           )}
           {location.pathname.includes(
             '/dashboard/techniques/attack_patterns/',
@@ -597,6 +614,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
               classes={{ root: classes.button }}
               aria-owns={menuOpen.open ? 'menu-appbar' : undefined}
               aria-haspopup="true"
+              id="profile-menu-button"
               onClick={handleOpenMenu}
               color={
                 location.pathname === '/dashboard/profile/me'
@@ -620,7 +638,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
                 {t('Profile')}
               </MenuItem>
               <MenuItem onClick={handleOpenDrawer}>{t('Feedback')}</MenuItem>
-              <MenuItem onClick={handleLogout}>{t('Logout')}</MenuItem>
+              <MenuItem id="logout-button" onClick={() => handleLogout()}>{t('Logout')}</MenuItem>
             </Menu>
           </div>
         </div>
@@ -629,6 +647,7 @@ const TopBar: FunctionComponent<TopBarProps> = ({
         openDrawer={openDrawer}
         handleCloseDrawer={handleCloseDrawer}
       />
+      {idleTimeoutLimit > 0 && <IdleTimeoutLockscreen handleLogout={handleLogout} />}
     </AppBar>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -222,6 +222,7 @@ const Indicators = () => {
               handleClearSelectedElements={handleClearSelectedElements}
               variant="large"
               type="Indicator"
+              rightOffset={250 + 85}
             />
           </div>
     );

--- a/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
@@ -228,6 +228,7 @@ const StixCyberObservables: FunctionComponent = () => {
           handleClearSelectedElements={handleClearSelectedElements}
           variant="large"
           handleCopy={handleCopy}
+          rightOffset={250 + 85}
         />
       </div>
     );

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorsRightBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorsRightBar.tsx
@@ -17,6 +17,7 @@ import { Theme } from '../../../../components/Theme';
 import { StixCyberObservablesLinesSubTypesQuery$data } from '../stix_cyber_observables/__generated__/StixCyberObservablesLinesSubTypesQuery.graphql';
 import { vocabularyQuery } from '../../common/form/OpenVocabField';
 import { OpenVocabFieldQuery$data } from '../../common/form/__generated__/OpenVocabFieldQuery.graphql';
+import { useBannerSettings } from '../../../../utils/SystemBanners';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
@@ -70,6 +71,7 @@ const IndicatorsRightBar: FunctionComponent<IndicatorsRightBarProps> = ({
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
+  const { bannerHeight } = useBannerSettings();
   return (
     <Drawer
       variant="permanent"
@@ -90,6 +92,7 @@ const IndicatorsRightBar: FunctionComponent<IndicatorsRightBarProps> = ({
           const patternTypes = props?.vocabularies?.edges;
           return (
             <List
+              sx={{ marginTop: bannerHeight, marginBottom: bannerHeight }}
               subheader={
                 <ListSubheader component="div">
                   {t('Pattern type')}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicators.jsx
@@ -363,6 +363,7 @@ class StixDomainObjectIndicators extends Component {
               search={searchTerm}
               handleClearSelectedElements={this.handleClearSelectedElements.bind(this)}
               variant="large"
+              rightOffset={250 + 85}
             />
           </div>
         )}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesRightBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesRightBar.jsx
@@ -14,6 +14,7 @@ import { FilterOffOutline } from 'mdi-material-ui';
 import inject18n from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import { stixCyberObservablesLinesSubTypesQuery } from './StixCyberObservablesLines';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -36,6 +37,13 @@ const styles = (theme) => ({
 });
 
 class StixCyberObservablesRightBar extends Component {
+  constructor(props) {
+    super(props);
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
+  }
+
   render() {
     const { classes, t, types = [], handleToggle, handleClear } = this.props;
     return (
@@ -59,6 +67,7 @@ class StixCyberObservablesRightBar extends Component {
               )(subTypesEdges);
               return (
                 <List
+                  sx={{ marginTop: this.bannerHeight, marginBottom: this.bannerHeight }}
                   subheader={
                     <ListSubheader component="div">
                       {t('Observable types')}

--- a/opencti-platform/opencti-front/src/private/components/profile/notifications/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/notifications/ToolBar.jsx
@@ -1,0 +1,698 @@
+import React, { Component } from 'react';
+import * as PropTypes from 'prop-types';
+import * as R from 'ramda';
+import { Link } from 'react-router-dom';
+import { graphql } from 'react-relay';
+import withTheme from '@mui/styles/withTheme';
+import withStyles from '@mui/styles/withStyles';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import Table from '@mui/material/Table';
+import TableHead from '@mui/material/TableHead';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableRow from '@mui/material/TableRow';
+import IconButton from '@mui/material/IconButton';
+import {
+  CheckCircleOutlined,
+  ClearOutlined,
+  DeleteOutlined,
+  UnpublishedOutlined,
+} from '@mui/icons-material';
+import Drawer from '@mui/material/Drawer';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Slide from '@mui/material/Slide';
+import Chip from '@mui/material/Chip';
+import DialogTitle from '@mui/material/DialogTitle';
+import Alert from '@mui/material/Alert';
+import inject18n from '../../../../components/i18n';
+import { truncate } from '../../../../utils/String';
+import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
+import { defaultValue } from '../../../../utils/Graph';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
+
+const styles = (theme) => ({
+  bottomNav: {
+    padding: 0,
+    zIndex: 1040,
+    display: 'flex',
+    height: 50,
+    overflow: 'hidden',
+  },
+  bottomNavWithLargePadding: {
+    zIndex: 1040,
+    padding: '0 230px 0 0',
+    display: 'flex',
+    height: 50,
+    overflow: 'hidden',
+  },
+  bottomNavWithMediumPadding: {
+    zIndex: 1040,
+    padding: '0 200px 0 0',
+    display: 'flex',
+    height: 50,
+    overflow: 'hidden',
+  },
+  bottomNavWithSmallPadding: {
+    zIndex: 1040,
+    padding: '0 180px 0 0',
+    display: 'flex',
+    height: 50,
+    overflow: 'hidden',
+  },
+  drawerPaper: {
+    minHeight: '100vh',
+    width: '50%',
+    position: 'fixed',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    padding: 0,
+  },
+  header: {
+    backgroundColor: theme.palette.background.nav,
+    padding: '20px 20px 20px 60px',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 12,
+    left: 5,
+    color: 'inherit',
+  },
+  buttons: {
+    marginTop: 20,
+    textAlign: 'right',
+  },
+  button: {
+    marginLeft: theme.spacing(2),
+  },
+  buttonAdd: {
+    width: '100%',
+    height: 20,
+  },
+  container: {
+    padding: '10px 20px 20px 20px',
+  },
+  aliases: {
+    margin: '0 7px 7px 0',
+  },
+  title: {
+    flex: '1 1 100%',
+    fontSize: '12px',
+  },
+  chipValue: {
+    margin: 0,
+  },
+  filter: {
+    margin: '5px 10px 5px 0',
+  },
+  operator: {
+    fontFamily: 'Consolas, monaco, monospace',
+    backgroundColor: theme.palette.background.accent,
+    margin: '5px 10px 5px 0',
+  },
+  step: {
+    position: 'relative',
+    width: '100%',
+    margin: '0 0 20px 0',
+    padding: 15,
+    verticalAlign: 'middle',
+    border: `1px solid ${theme.palette.background.accent}`,
+    borderRadius: 5,
+    display: 'flex',
+  },
+  formControl: {
+    width: '100%',
+  },
+  stepType: {
+    margin: 0,
+    paddingRight: 20,
+    width: '30%',
+  },
+  stepField: {
+    margin: 0,
+    paddingRight: 20,
+    width: '30%',
+  },
+  stepValues: {
+    paddingRight: 20,
+    margin: 0,
+  },
+  stepCloseButton: {
+    position: 'absolute',
+    top: -20,
+    right: -20,
+  },
+  icon: {
+    paddingTop: 4,
+    display: 'inline-block',
+  },
+  text: {
+    display: 'inline-block',
+    flexGrow: 1,
+    marginLeft: 10,
+  },
+  autoCompleteIndicator: {
+    display: 'none',
+  },
+});
+
+const Transition = React.forwardRef((props, ref) => (
+  <Slide direction="up" ref={ref} {...props} />
+));
+Transition.displayName = 'TransitionSlide';
+
+const toolBarListTaskAddMutation = graphql`
+  mutation ToolBarNotificationsListTaskAddMutation($input: ListTaskAddInput!) {
+    listTaskAdd(input: $input) {
+      id
+      type
+    }
+  }
+`;
+
+const toolBarQueryTaskAddMutation = graphql`
+  mutation ToolBarNotificationsQueryTaskAddMutation($input: QueryTaskAddInput!) {
+    queryTaskAdd(input: $input) {
+      id
+      type
+    }
+  }
+`;
+
+class ToolBar extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayTask: false,
+      actions: [],
+      actionsInputs: [{}],
+      processing: false,
+      navOpen: localStorage.getItem('navOpen') === 'true',
+    };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
+  }
+
+  componentDidMount() {
+    this.subscription = MESSAGING$.toggleNav.subscribe({
+      next: () => this.setState({ navOpen: localStorage.getItem('navOpen') === 'true' }),
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription.unsubscribe();
+  }
+
+  handleOpenTask() {
+    this.setState({ displayTask: true });
+  }
+
+  handleCloseTask() {
+    this.setState({
+      displayTask: false,
+      actions: [],
+      keptEntityId: null,
+      mergingElement: null,
+      processing: false,
+    });
+  }
+
+  handleLaunchRead(read) {
+    const actions = [
+      {
+        type: 'REPLACE',
+        context: { field: 'is_read', type: 'ATTRIBUTE', values: [read ? 'true' : 'false'] },
+      },
+    ];
+    this.setState({ actions }, () => {
+      this.handleOpenTask();
+    });
+  }
+
+  handleLaunchDelete() {
+    const actions = [{ type: 'DELETE', context: null }];
+    this.setState({ actions }, () => {
+      this.handleOpenTask();
+    });
+  }
+
+  submitTask() {
+    this.setState({ processing: true });
+    const { actions, mergingElement } = this.state;
+    const {
+      filters,
+      search,
+      selectAll,
+      selectedElements,
+      deSelectedElements,
+      numberOfSelectedElements,
+      handleClearSelectedElements,
+      t,
+    } = this.props;
+    if (numberOfSelectedElements === 0) return;
+    const jsonFilters = JSON.stringify(filters);
+    const finalActions = R.map(
+      (n) => ({
+        type: n.type,
+        context: n.context
+          ? {
+            ...n.context,
+            values: R.map((o) => o.id || o.value || o, n.context.values),
+          }
+          : null,
+      }),
+      actions,
+    );
+    if (selectAll) {
+      commitMutation({
+        mutation: toolBarQueryTaskAddMutation,
+        variables: {
+          input: {
+            filters: jsonFilters,
+            search,
+            actions: finalActions,
+            excluded_ids: Object.keys(deSelectedElements || {}),
+          },
+        },
+        onCompleted: () => {
+          handleClearSelectedElements();
+          MESSAGING$.notifySuccess(
+            <span>
+              {t(
+                'The background task has been executed. You can monitor it on',
+              )}{' '}
+              <Link to="/dashboard/data/tasks">{t('the dedicated page')}</Link>.
+            </span>,
+          );
+          this.setState({ processing: false });
+          this.handleCloseTask();
+        },
+      });
+    } else {
+      commitMutation({
+        mutation: toolBarListTaskAddMutation,
+        variables: {
+          input: {
+            ids: mergingElement
+              ? [mergingElement.id]
+              : Object.keys(selectedElements),
+            actions: finalActions,
+          },
+        },
+        onCompleted: () => {
+          handleClearSelectedElements();
+          MESSAGING$.notifySuccess(
+            <span>
+              {t(
+                'The background task has been executed. You can monitor it on',
+              )}{' '}
+              <Link to="/dashboard/data/tasks">{t('the dedicated page')}</Link>.
+            </span>,
+          );
+          this.setState({ processing: false });
+          this.handleCloseTask();
+        },
+      });
+    }
+  }
+
+  render() {
+    const {
+      t,
+      n,
+      classes,
+      numberOfSelectedElements,
+      handleClearSelectedElements,
+      selectedElements,
+      selectAll,
+      filters,
+      search,
+      theme,
+      variant,
+      deleteDisable,
+      rightOffset,
+    } = this.props;
+    const { actions, mergingElement, navOpen } = this.state;
+    const isOpen = numberOfSelectedElements > 0;
+    let paperClass;
+    switch (variant) {
+      case 'large':
+        paperClass = classes.bottomNavWithLargePadding;
+        break;
+      case 'medium':
+        paperClass = classes.bottomNavWithMediumPadding;
+        break;
+      case 'small':
+        paperClass = classes.bottomNavWithSmallPadding;
+        break;
+      default:
+        paperClass = classes.bottomNav;
+    }
+    return (
+      <Drawer
+        anchor="bottom"
+        variant="persistent"
+        classes={{ paper: paperClass }}
+        open={isOpen}
+        PaperProps={{
+          variant: 'elevation',
+          elevation: 1,
+          style: { paddingLeft: navOpen ? 185 : 60, bottom: this.bannerHeight, paddingRight: rightOffset ?? 85 },
+        }}
+      >
+        <Toolbar style={{ minHeight: 54 }}>
+          <Typography
+            className={classes.title}
+            color="inherit"
+            variant="subtitle1"
+          >
+            <span
+              style={{
+                padding: '2px 5px 2px 5px',
+                marginRight: 5,
+                backgroundColor: theme.palette.secondary.main,
+                color: '#ffffff',
+              }}
+            >
+              {numberOfSelectedElements}
+            </span>{' '}
+            {t('selected')}{' '}
+            <IconButton
+              aria-label="clear"
+              disabled={numberOfSelectedElements === 0 || this.state.processing}
+              onClick={handleClearSelectedElements.bind(this)}
+              size="small"
+            >
+              <ClearOutlined fontSize="small" />
+            </IconButton>
+          </Typography>
+          <Tooltip title={t('Mark as read')}>
+            <span>
+              <IconButton
+                aria-label="ack"
+                disabled={
+                  numberOfSelectedElements === 0 || this.state.processing
+                }
+                onClick={this.handleLaunchRead.bind(this, true)}
+                color="success"
+                size="small"
+              >
+                <CheckCircleOutlined fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title={t('Mark as unread')}>
+            <span>
+              <IconButton
+                aria-label="ack"
+                disabled={
+                  numberOfSelectedElements === 0 || this.state.processing
+                }
+                onClick={this.handleLaunchRead.bind(this, false)}
+                color="warning"
+                size="small"
+              >
+                <UnpublishedOutlined fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          {deleteDisable !== true && (
+            <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+              <Tooltip title={t('Delete')}>
+                <span>
+                  <IconButton
+                    aria-label="delete"
+                    disabled={
+                      numberOfSelectedElements === 0 || this.state.processing
+                    }
+                    onClick={this.handleLaunchDelete.bind(this)}
+                    color="primary"
+                    size="small"
+                  >
+                    <DeleteOutlined fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Security>
+          )}
+        </Toolbar>
+        <Dialog
+          PaperProps={{ elevation: 1 }}
+          open={this.state.displayTask}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          onClose={this.handleCloseTask.bind(this)}
+          fullWidth={true}
+          maxWidth="md"
+        >
+          <DialogTitle>
+            <div style={{ float: 'left' }}>{t('Launch a background task')}</div>
+            <div style={{ float: 'right' }}>
+              <span
+                style={{
+                  padding: '2px 5px 2px 5px',
+                  marginRight: 5,
+                  backgroundColor: theme.palette.secondary.main,
+                  color: '#ffffff',
+                }}
+              >
+                {n(numberOfSelectedElements)}
+              </span>{' '}
+              {t('selected element(s)')}
+            </div>
+          </DialogTitle>
+          <DialogContent>
+            {numberOfSelectedElements > 1000 && (
+              <Alert severity="warning">
+                {t(
+                  "You're targeting more than 1000 entities with this background task, be sure of what you're doing!",
+                )}
+              </Alert>
+            )}
+            <TableContainer>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>#</TableCell>
+                    <TableCell>{t('Step')}</TableCell>
+                    <TableCell>{t('Field')}</TableCell>
+                    <TableCell>{t('Values')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow>
+                    <TableCell>
+                      {' '}
+                      <span
+                        style={{
+                          padding: '2px 5px 2px 5px',
+                          marginRight: 5,
+                          color:
+                            theme.palette.mode === 'dark'
+                              ? '#000000'
+                              : '#ffffff',
+                          backgroundColor: theme.palette.primary.main,
+                        }}
+                      >
+                        1
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <Chip label="SCOPE" />
+                    </TableCell>
+                    <TableCell>{t('N/A')}</TableCell>
+                    <TableCell>
+                      {selectAll ? (
+                        <div className={classes.filters}>
+                          {search && search.length > 0 && (
+                            <span>
+                              <Chip
+                                classes={{ root: classes.filter }}
+                                label={
+                                  <div>
+                                    <strong>{t('Search')}</strong>: {search}
+                                  </div>
+                                }
+                              />
+                              <Chip
+                                classes={{ root: classes.operator }}
+                                label={t('AND')}
+                              />
+                            </span>
+                          )}
+                          {R.map((currentFilter) => {
+                            const label = `${truncate(
+                              currentFilter[0].startsWith('rel_')
+                                ? t(
+                                  `relationship_${currentFilter[0]
+                                    .replace('rel_', '')
+                                    .replace('.*', '')}`,
+                                )
+                                : t(`filter_${currentFilter[0]}`),
+                              20,
+                            )}`;
+                            const localFilterMode = currentFilter[0].endsWith(
+                              'not_eq',
+                            )
+                              ? t('AND')
+                              : t('OR');
+                            const values = (
+                              <span>
+                                {R.map(
+                                  (o) => (
+                                    <span
+                                      key={typeof o === 'string' ? o : o.value}
+                                    >
+                                      {/* eslint-disable-next-line no-nested-ternary */}
+                                      {typeof o === 'string'
+                                        ? o
+                                        : o.value && o.value.length > 0
+                                          ? truncate(o.value, 15)
+                                          : t('No label')}{' '}
+                                      {R.last(currentFilter[1]).value
+                                        !== o.value && (
+                                        <code>{localFilterMode}</code>
+                                      )}{' '}
+                                    </span>
+                                  ),
+                                  currentFilter[1],
+                                )}
+                              </span>
+                            );
+                            return (
+                              <span key={currentFilter[0]}>
+                                <Chip
+                                  classes={{ root: classes.filter }}
+                                  label={
+                                    <div>
+                                      <strong>{label}</strong>: {values}
+                                    </div>
+                                  }
+                                />
+                                {R.last(R.toPairs(filters))[0]
+                                  !== currentFilter[0] && (
+                                  <Chip
+                                    classes={{ root: classes.operator }}
+                                    label={t('AND')}
+                                  />
+                                )}
+                              </span>
+                            );
+                          }, R.toPairs(filters))}
+                        </div>
+                      ) : (
+                        <span>
+                          {mergingElement
+                            ? truncate(
+                              R.join(', ', [defaultValue(mergingElement)]),
+                              80,
+                            )
+                            : truncate(
+                              R.join(
+                                ', ',
+                                R.map(
+                                  (o) => defaultValue(o),
+                                  R.values(selectedElements || {}),
+                                ),
+                              ),
+                              80,
+                            )}
+                        </span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                  {R.map((o) => {
+                    const number = actions.indexOf(o);
+                    return (
+                      <TableRow key={o.type}>
+                        <TableCell>
+                          {' '}
+                          <span
+                            style={{
+                              padding: '2px 5px 2px 5px',
+                              marginRight: 5,
+                              color:
+                                theme.palette.mode === 'dark'
+                                  ? '#000000'
+                                  : '#ffffff',
+                              backgroundColor: theme.palette.primary.main,
+                            }}
+                          >
+                            {number + 2}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <Chip label={o.type} />
+                        </TableCell>
+                        <TableCell>
+                          {R.pathOr(t('N/A'), ['context', 'field'], o)}
+                        </TableCell>
+                        <TableCell>
+                          {truncate(
+                            R.join(
+                              ', ',
+                              R.map(
+                                (p) => (typeof p === 'string' ? p : defaultValue(p)),
+                                R.pathOr([], ['context', 'values'], o),
+                              ),
+                            ),
+                            80,
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  }, actions)}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={this.handleCloseTask.bind(this)}
+              disabled={this.state.processing}
+            >
+              {t('Cancel')}
+            </Button>
+            <Button
+              onClick={this.submitTask.bind(this)}
+              color="secondary"
+              disabled={this.state.processing}
+            >
+              {t('Launch')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Drawer>
+    );
+  }
+}
+
+ToolBar.propTypes = {
+  classes: PropTypes.object,
+  theme: PropTypes.object,
+  t: PropTypes.func,
+  numberOfSelectedElements: PropTypes.number,
+  selectedElements: PropTypes.object,
+  deSelectedElements: PropTypes.object,
+  selectAll: PropTypes.bool,
+  filters: PropTypes.object,
+  search: PropTypes.string,
+  handleClearSelectedElements: PropTypes.func,
+  variant: PropTypes.string,
+  container: PropTypes.object,
+  type: PropTypes.string,
+  handleCopy: PropTypes.func,
+  rightOffset: PropTypes.number,
+};
+
+export default R.compose(inject18n, withTheme, withStyles(styles))(ToolBar);

--- a/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
@@ -216,6 +216,7 @@ class Labels extends Component {
           )}
           type="Label"
           variant="small"
+          rightOffset={200 + 85}
         />
       </div>
     );

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
@@ -26,6 +26,7 @@ import Alert from '@mui/material/Alert';
 import { SubscriptionFocus } from '../../../components/Subscription';
 import { commitMutation, QueryRenderer } from '../../../relay/environment';
 import { useFormatter } from '../../../components/i18n';
+import MarkDownField from '../../../components/MarkdownField';
 import TextField from '../../../components/TextField';
 import SelectField from '../../../components/SelectField';
 import Loader from '../../../components/Loader';
@@ -89,6 +90,9 @@ const settingsQuery = graphql`
       platform_email
       platform_theme
       platform_language
+      platform_login_message
+      platform_banner_text
+      platform_banner_level
       platform_theme_dark_background
       platform_theme_dark_paper
       platform_theme_dark_nav
@@ -165,6 +169,9 @@ export const settingsMutationFieldPatch = graphql`
         platform_theme_light_logo_login
         platform_language
         enterprise_edition
+        platform_login_message
+        platform_banner_text
+        platform_banner_level
       }
     }
   }
@@ -207,6 +214,9 @@ const settingsValidation = (t) => Yup.object().shape({
   platform_theme_light_logo_login: Yup.string().nullable(),
   platform_language: Yup.string().nullable(),
   enterprise_edition: Yup.string().nullable(),
+  platform_login_message: Yup.string().nullable(),
+  platform_banner_text: Yup.string().nullable(),
+  platform_banner_level: Yup.string().nullable(),
 });
 
 const Settings = () => {
@@ -277,6 +287,9 @@ const Settings = () => {
                 'platform_email',
                 'platform_theme',
                 'platform_language',
+                'platform_login_message',
+                'platform_banner_text',
+                'platform_banner_level',
                 'platform_theme_dark_background',
                 'platform_theme_dark_paper',
                 'platform_theme_dark_nav',
@@ -425,6 +438,56 @@ const Settings = () => {
                               <MenuItem value="zh-cn">简化字</MenuItem>
                             </Field>
                             <HiddenTypesList />
+
+                            <Typography variant="h4" gutterBottom={true} style={{ marginTop: '30px' }}>
+                            {t('Platform Banner Configuration')}
+                            </Typography>
+
+                            <Field
+                              component={SelectField}
+                              variant="standard"
+                              name="platform_banner_level"
+                              label={t('Platform Banner Level')}
+                              fullWidth={true}
+                              containerstyle={{
+                                marginTop: 5,
+                                width: '100%',
+                              }}
+                              onFocus={(name) => handleChangeFocus(id, name)}
+                              onChange={(name, value) => handleSubmitField(id, name, value)}
+                              helpertext={
+                                <SubscriptionFocus
+                                  context={editContext}
+                                  fieldName="platform_banner_level"
+                                />
+                              }
+                            >
+                              <MenuItem value="auto">
+                                <em>{t('Automatic')}</em>
+                              </MenuItem>
+                              <MenuItem value="OFF">{t('OFF')}</MenuItem>
+                              <MenuItem value="GREEN">{t('GREEN')}</MenuItem>
+                              <MenuItem value="RED">{t('RED')}</MenuItem>
+                              <MenuItem value="YELLOW">{t('YELLOW')}</MenuItem>
+                            </Field>
+                            <Field
+                              component={MarkDownField}
+                              name="platform_banner_text"
+                              label={t('Platform Banner Text')}
+                              fullWidth={true}
+                              multiline={true}
+                              rows="3"
+                              style={{ marginTop: 20 }}
+                              onFocus={(name) => handleChangeFocus(id, name)}
+                              onSubmit={(name, value) => handleSubmitField(id, name, value)}
+                              variant="standard"
+                              helperText={
+                                <SubscriptionFocus
+                                  context={editContext}
+                                  fieldName="platform_banner_text"
+                                />
+                              }
+                            />
                           </Form>
                         )}
                       </Formik>

--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -152,6 +152,7 @@ const Vocabularies = () => {
               deleteDisable={true}
               filters={{ entity_type: [{ id: 'Vocabulary' }] }}
               variant="small"
+              rightOffset={200 + 85}
             />
           </>
         )}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/ToolBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/ToolBar.tsx
@@ -28,10 +28,11 @@ import { entitySettingPatch } from './entitySetting/EntitySettingSettings';
 import useEntitySettings from '../../../../utils/hooks/useEntitySettings';
 import type { EntitySetting } from '../../../../utils/hooks/useEntitySettings';
 import { MESSAGING$ } from '../../../../relay/environment';
+import { useBannerSettings } from '../../../../utils/SystemBanners';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   bottomNav: {
-    zIndex: 1100,
+    zIndex: 1040,
     display: 'flex',
     height: 50,
     overflow: 'hidden',
@@ -191,6 +192,9 @@ const ToolBar: FunctionComponent<{
     });
     handleClose();
   };
+
+  const { bannerHeight } = useBannerSettings();
+
   return (
     <Drawer
       anchor="bottom"
@@ -200,7 +204,7 @@ const ToolBar: FunctionComponent<{
       PaperProps={{
         variant: 'elevation',
         elevation: 1,
-        style: { paddingLeft: navOpen ? 185 : 60 },
+        style: { paddingLeft: navOpen ? 185 : 60, bottom: bannerHeight },
       }}
     >
       <Toolbar style={{ minHeight: 54 }}>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
@@ -21,6 +21,10 @@ const subscription = graphql`
 
 const dashboardQuery = graphql`
   query RootDashboardQuery($id: String!) {
+    settings {
+      platform_banner_text
+      platform_banner_level
+    }  
     workspace(id: $id) {
       id
       name
@@ -72,6 +76,7 @@ class RootDashboard extends Component {
                         <Dashboard
                           {...routeProps}
                           workspace={props.workspace}
+                          settings={props.settings}
                         />
                       )}
                     />

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
@@ -63,6 +63,7 @@ import StixCoreRelationshipEdition from '../../common/stix_core_relationships/St
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import InvestigationAddStixCoreObjects from './InvestigationAddStixCoreObjects';
+import { getBannerSettings } from '../../../../utils/SystemBanners';
 
 const styles = () => ({
   bottomNav: {
@@ -103,6 +104,9 @@ class InvestigationGraphBar extends Component {
       relationReversed: false,
       openCreatedRelation: false,
     };
+    getBannerSettings(({ bannerHeight }) => {
+      this.bannerHeight = bannerHeight;
+    });
   }
 
   handleOpenRemove() {
@@ -340,7 +344,11 @@ class InvestigationGraphBar extends Component {
         anchor="bottom"
         variant="permanent"
         classes={{ paper: classes.bottomNav }}
-        PaperProps={{ variant: 'elevation', elevation: 1 }}
+        PaperProps={{
+          variant: 'elevation',
+          elevation: 1,
+          style: { bottom: this.bannerHeight },
+        }}
       >
         <div
           style={{

--- a/opencti-platform/opencti-front/src/public/Root.js
+++ b/opencti-platform/opencti-front/src/public/Root.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { graphql } from 'react-relay';
+import { StyledEngineProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import { QueryRenderer } from '../relay/environment';
+import { ConnectedThemeProvider } from '../components/AppThemeProvider';
+import { ConnectedIntlProvider } from '../components/AppIntlProvider';
+import Login from './components/Login';
+
+const rootPublicQuery = graphql`
+  query RootPublicQuery {
+    settings {
+      platform_theme
+      platform_login_message
+      platform_banner_text
+      platform_banner_level
+      platform_theme_dark_logo_login
+      platform_theme_light_logo_login
+      platform_providers {
+        name
+        type
+        provider
+      }
+      ...AppThemeProvider_settings
+      ...AppIntlProvider_settings
+    }
+  }
+`;
+
+const Root = ({ type }) => (
+  <QueryRenderer
+    query={rootPublicQuery}
+    variables={{}}
+    render={({ props }) => {
+      if (props && props.settings) {
+        return (
+          <StyledEngineProvider injectFirst={true}>
+            <ConnectedThemeProvider settings={props.settings}>
+              <CssBaseline />
+              <ConnectedIntlProvider settings={props.settings}>
+                <Login settings={props.settings} type={type} />
+              </ConnectedIntlProvider>
+            </ConnectedThemeProvider>
+          </StyledEngineProvider>
+        );
+      }
+      return <div />;
+    }}
+  />
+);
+
+export default Root;

--- a/opencti-platform/opencti-front/src/public/components/SystemBanners.js
+++ b/opencti-platform/opencti-front/src/public/components/SystemBanners.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import * as R from 'ramda';
+import withStyles from '@mui/styles/withStyles';
+import inject18n from '../../components/i18n';
+import { SYSTEM_BANNER_HEIGHT, getBannerSettings, bannerColorClassName } from '../../utils/SystemBanners';
+import { commitLocalUpdate } from '../../relay/environment';
+
+const BANNER_Z_INDEX = 2000;
+
+const styles = () => ({
+  banner: {
+    textAlign: 'center',
+    height: `${SYSTEM_BANNER_HEIGHT}px`,
+    width: '100%',
+    position: 'fixed',
+    zIndex: BANNER_Z_INDEX,
+  },
+  bannerTop: {
+    top: 0,
+  },
+  bannerBottom: {
+    bottom: 0,
+  },
+  bannerGreen: {
+    background: '#00840C',
+  },
+  bannerRed: {
+    background: '#ef0000',
+  },
+  bannerYellow: {
+    background: '#ffff00',
+  },
+  classificationText: {
+    height: `${SYSTEM_BANNER_HEIGHT - 4}px`,
+    fontFamily: 'Arial,Helvetica,Geneva,Swiss,sans-serif',
+    fontWeight: 'bold',
+    padding: '2px 0',
+    position: 'relative',
+  },
+  classificationTextGreen: {
+    color: '#ffff00',
+  },
+  classificationTextRed: {
+    color: '#ffffff',
+  },
+  classificationTextYellow: {
+    color: '#000000',
+  },
+});
+
+class SystemBanners extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleLogout = props.handleLogout;
+    commitLocalUpdate((store) => {
+      // Handles NoAuth error when not logged in
+      if (store.getRoot().getLinkedRecord('me')) {
+        const me = store.getRoot().getLinkedRecord('me');
+        this.accountStatus = me.getValue('account_status');
+      }
+    });
+    this.state = {
+      bannerMessage: '',
+      bannerLevel: '',
+    };
+    // These local versions of the state variables are necessary to control state updates
+    this.bannerLevel = '';
+    this.bannerMessage = '';
+  }
+
+  updateBanners = (bannerSettings) => {
+    const { bannerLevel, bannerText: bannerMessage, bannerHeight } = bannerSettings;
+    this.bannerLevel = bannerLevel;
+    this.bannerMessage = bannerMessage;
+    this.setState({ bannerLevel, bannerMessage });
+    if (R.is(Function, this.props.handleBannerChange)) {
+      this.props.handleBannerChange(bannerHeight);
+    }
+  };
+
+  componentDidMount() {
+    getBannerSettings(this.updateBanners);
+  }
+
+  componentDidUpdate() {
+    getBannerSettings((settings) => {
+      const { bannerLevel, bannerText } = settings;
+      if (this.bannerLevel !== bannerLevel || this.bannerMessage !== bannerText) {
+        this.updateBanners(settings);
+      }
+    });
+  }
+
+  checkAccountStatus(accountStatus) {
+    if (accountStatus === 'Inactive') {
+      const getUrl = window.location;
+      // var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
+      // Redirect to the Dashboard Homepage flagging your account Inactive
+      this.handleLogout(`${getUrl.protocol}//${getUrl.host}/dashboard?AccountInactive=1`);
+    } else if (accountStatus === 'Locked') {
+      const getUrl = window.location;
+      // var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
+      // Redirect to the Dashboard Homepage flagging your account Locked
+      this.handleLogout(`${getUrl.protocol}//${getUrl.host}/dashboard?AccountLocked=1`);
+    } else if (accountStatus === 'LockedTraining') {
+      const getUrl = window.location;
+      // var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
+      // Redirect to the Dashboard Homepage flagging your account Locked
+      this.handleLogout(`${getUrl.protocol}//${getUrl.host}/dashboard?AccountLocked=2`);
+    } else if (accountStatus === 'Active') {
+      // Do nothing
+    }
+  }
+
+  render() {
+    // Check Account Status
+    this.checkAccountStatus(this.accountStatus);
+
+    const { classes } = this.props;
+    const { bannerMessage, bannerLevel } = this.state;
+
+    const bannerColor = bannerColorClassName(bannerLevel);
+    const bannerTextColor = bannerColorClassName(bannerLevel, 'classificationText');
+
+    const topBannerClasses = [
+      classes.banner, classes.bannerTop, classes[bannerColor],
+    ].join(' ');
+    const bottomBannerClasses = [
+      classes.banner, classes.bannerBottom, classes[bannerColor],
+    ].join(' ');
+    const bannerTextClasses = [
+      classes.classificationText, classes[bannerTextColor],
+    ].join(' ');
+
+    return bannerLevel && (
+      <div>
+        <div className={topBannerClasses}>
+          <span className={bannerTextClasses}>
+            {bannerMessage}
+          </span>
+        </div>
+        <div className={bottomBannerClasses}>
+          <span className={bannerTextClasses}>
+            {bannerMessage}
+          </span>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default R.compose(inject18n, withStyles(styles))(SystemBanners);

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1055,6 +1055,10 @@ type Settings implements InternalObject & BasicObject {
   platform_login_message: String
   platform_consent_message: String
   platform_consent_confirm_text: String
+  platform_banner_text: String
+  platform_banner_level: String
+  platform_session_idle_timeout: Int
+  platform_session_timeout: Int
   platform_demo: Boolean
   platform_reference_attachment: Boolean
   platform_feature_flags: [Module!]

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -301,6 +301,10 @@ const i18n = {
       Registration: 'Registro',
       'are updating...': 'se están modificando...',
       'is updating...': 'se está modificando...',
+      'You will be automatically logged out in': 'Se cerrará la sesión automáticamente',
+      'Select CONTINUE to keep working or select LOGOUT to terminate your session.':
+        'Seleccione CONTINUAR para seguir trabajando o seleccione CERRAR SESIÓN para terminar su sesión.',
+      'Disable timeout on this page': 'Deshabilitar el tiempo de espera en esta página',
       // Form
       Yes: 'Sí',
       No: 'No',
@@ -1987,6 +1991,13 @@ const i18n = {
         'Requiere aceptación para habilitar el formulario de inicio de sesión cuando se establece',
       'One line confirm label next to confirm checkbox':
         'Etiqueta de confirmación de una línea junto a la casilla de verificación de confirmación',
+      OFF: 'APAGADO',
+      GREEN: 'VERDE',
+      RED: 'ROJO',
+      YELLOW: 'AMARILLO',
+      'Platform Banner Level': 'Nivel de banner de plataforma',
+      'Platform Banner Text': 'Texto de la pancarta de la plataforma',
+      'System Banner Configuration': 'Configuración de la pancarta del sistema',
     },
     'fr-fr': {
       // Titles
@@ -2305,6 +2316,10 @@ const i18n = {
       Registration: 'Inscription',
       'are updating...': 'modifient actuellement...',
       'is updating...': 'modifie actuellement...',
+      'You will be automatically logged out in': 'Vous serez automatiquement déconnecté',
+      'Select CONTINUE to keep working or select LOGOUT to terminate your session.':
+        'Sélectionnez CONTINUER pour continuer à travailler ou sélectionnez DÉCONNEXION pour mettre fin à votre session.',
+      'Disable timeout on this page': 'Désactiver le délai d\'attente sur cette page',
       // Form
       Yes: 'Oui',
       No: 'Non',
@@ -3975,6 +3990,13 @@ const i18n = {
         "Nécessite une acceptation pour activer le formulaire de connexion lorsqu'il est défini",
       'One line confirm label next to confirm checkbox':
         'Texte monoligne de confirmation à côté de la case à cocher de confirmation',
+      OFF: 'DÉSACTIVÉ',
+      GREEN: 'VERT',
+      RED: 'ROUGE',
+      YELLOW: 'JAUNE',
+      'Platform Banner Level': 'Niveau de la bannière de la plate-forme',
+      'Platform Banner Text': 'Texte de la bannière de la plate-forme',
+      'System Banner Configuration': 'Configuration de la bannière système',
     },
     'ja-jp': {
       // Titles
@@ -4258,6 +4280,10 @@ const i18n = {
       Registration: '登録',
       'are updating...': 'がアップデート中',
       'is updating...': 'がアップデート中',
+      'You will be automatically logged out in': '自動的にログアウトされます',
+      'Select CONTINUE to keep working or select LOGOUT to terminate your session.':
+        '[続行] を選択して作業を続行するか、[ログアウト] を選択してセッションを終了します。',
+      'Disable timeout on this page': 'このページでタイムアウトを無効にする',
       // Form
       Yes: 'はい',
       No: 'いいえ',
@@ -5892,6 +5918,13 @@ const i18n = {
         '設定時にログインフォームを有効にするには同意が必要です',
       'One line confirm label next to confirm checkbox':
         '確認チェックボックスの横にある 1 行の確認ラベル',
+      OFF: 'オフ',
+      GREEN: '緑',
+      RED: '赤',
+      YELLOW: '黄色',
+      'Platform Banner Level': 'プラットフォーム バナー レベル',
+      'Platform Banner Text': 'プラットフォームのバナーテキスト',
+      'System Banner Configuration': 'システムバナーの設定',
     },
     'zh-cn': {
       // Titles
@@ -6133,6 +6166,10 @@ const i18n = {
       Registration: '注册',
       'are updating...': '正在更新...',
       'is updating...': '正在更新...',
+      'You will be automatically logged out in': '您将自动注销',
+      'Select CONTINUE to keep working or select LOGOUT to terminate your session.':
+        '选择继续以继续工作或选择注销以终止您的会话。',
+      'Disable timeout on this page': '在此页面上禁用超时',
       // Form
       Yes: '是',
       No: '否',
@@ -7706,6 +7743,13 @@ const i18n = {
         '設置後需要接受才能啟用登錄表單',
       'One line confirm label next to confirm checkbox':
         '確認複選框旁邊的一行確認標籤',
+      OFF: '离开',
+      GREEN: '绿色的',
+      RED: '红色的',
+      YELLOW: '黄色的',
+      'Platform Banner Level': '平台横幅级别',
+      'Platform Banner Text': '平台横幅文本',
+      'System Banner Configuration': '系统横幅配置',
     },
     'en-us': {
       gt: 'Greater than',

--- a/opencti-platform/opencti-front/src/utils/SystemBanners.tsx
+++ b/opencti-platform/opencti-front/src/utils/SystemBanners.tsx
@@ -1,0 +1,68 @@
+import * as R from 'ramda';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { RecordSourceProxy } from 'relay-runtime';
+import { commitLocalUpdate } from '../relay/environment';
+import { SystemBannersQuery } from './__generated__/SystemBannersQuery.graphql';
+
+const settingsQuery = graphql`
+  query SystemBannersQuery {
+    settings {
+      platform_banner_text
+      platform_banner_level
+    }
+  }
+`;
+
+/** Height in pixels for the top and bottom system banners */
+export const SYSTEM_BANNER_HEIGHT = 20;
+
+export const classificationLevels = ['GREEN', 'RED', 'YELLOW'];
+
+interface BannerSettings {
+  bannerLevel?: string | null;
+  bannerText?: string | null;
+  bannerHeight: string;
+}
+
+export function validateBannerLevel(bannerLevel?: string | null) {
+  return (bannerLevel
+    && classificationLevels.find((level) => level === bannerLevel)) || null;
+}
+
+type SettingsOptions = {
+  platform_banner_level: string;
+  platform_banner_text: string;
+};
+
+export function useBannerSettings(settingsOptions: SettingsOptions | null = null): BannerSettings {
+  const settings = settingsOptions || useLazyLoadQuery<SystemBannersQuery>(settingsQuery, {})?.settings;
+  const bannerLevel = settings && validateBannerLevel(settings.platform_banner_level);
+  const bannerText = (bannerLevel && settings && settings.platform_banner_text) || null;
+  const bannerHeight = bannerLevel ? `${SYSTEM_BANNER_HEIGHT}px` : '0';
+  return { bannerText, bannerLevel, bannerHeight };
+}
+
+export function getBannerSettings(callback: (bannerSettings: BannerSettings) => void) {
+  commitLocalUpdate((store: RecordSourceProxy) => {
+    const settings = store.getRoot().getLinkedRecord('settings');
+
+    const bannerLevel = settings && validateBannerLevel(
+      settings.getValue('platform_banner_level') as string,
+    );
+    const bannerText = (bannerLevel && settings
+      && settings.getValue('platform_banner_text')) as string
+      || null;
+    const bannerHeight = bannerLevel ? `${SYSTEM_BANNER_HEIGHT}px` : '0';
+
+    if (R.is(Function, callback)) {
+      callback({ bannerText, bannerLevel, bannerHeight });
+    }
+  });
+}
+
+export function bannerColorClassName(color: string, prefix = 'banner') {
+  if (!R.is(String, color)) return '';
+  let colorName = color.toLowerCase();
+  colorName = colorName.substring(0, 1).toUpperCase() + colorName.substring(1);
+  return `${prefix}${colorName}`;
+}

--- a/opencti-platform/opencti-front/src/utils/Time.js
+++ b/opencti-platform/opencti-front/src/utils/Time.js
@@ -4,6 +4,7 @@ import { isNone } from '../components/i18n';
 const defaultDateFormat = 'YYYY-MM-DD';
 const yearDateFormat = 'YYYY';
 
+export const ONE_SECOND = 1000;
 export const FIVE_SECONDS = 5000;
 export const TEN_SECONDS = FIVE_SECONDS * 2;
 
@@ -85,4 +86,34 @@ export const minutesBetweenDates = (startDate, endDate) => {
   const start = parse(startDate);
   const end = parse(endDate);
   return end.diff(start, 'minutes') + 1;
+};
+
+export const secondsBetweenDates = (startDate, endDate) => {
+  const start = parse(startDate);
+  const end = parse(endDate);
+  return end.diff(start, 'seconds') + 1;
+};
+
+/**
+ * Returns a string of the format "hh:MM:ss" from a given number of seconds.
+ *
+ * @param {number} seconds
+ */
+export const formatSeconds = (seconds) => {
+  const ONE_MINUTE = 60;
+  const ONE_HOUR = ONE_MINUTE * ONE_MINUTE;
+
+  const leadingZero = (value) => {
+    return value < 10 ? `0${value}` : String(value);
+  };
+
+  const hours = Math.floor(seconds / ONE_HOUR);
+  let secondsLeft = seconds % ONE_HOUR;
+  const minutes = Math.floor(secondsLeft / ONE_MINUTE);
+  secondsLeft = Math.floor(secondsLeft % ONE_MINUTE);
+
+  const formattedHours = hours ? `${leadingZero(hours)}:` : '';
+  const formattedMins = (minutes || hours) ? `${leadingZero(minutes)}:` : '';
+  const formattedSecs = `${leadingZero(secondsLeft)}`;
+  return `${formattedHours}${formattedMins}${formattedSecs}`;
 };

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -46,6 +46,7 @@
     },
     "request_timeout": 1200000,
     "session_timeout": 1200000,
+    "session_idle_timeout": 0,
     "session_manager": "shared",
     "rate_protection": {
       "time_window": 1,

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -997,6 +997,10 @@ type Settings implements InternalObject & BasicObject {
   platform_login_message: String
   platform_consent_message: String
   platform_consent_confirm_text: String
+  platform_banner_text: String
+  platform_banner_level: String
+  platform_session_idle_timeout: Int
+  platform_session_timeout: Int
   platform_demo: Boolean
   platform_reference_attachment: Boolean @auth
   platform_feature_flags: [Module!] @auth

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19817,6 +19817,8 @@ export type Settings = BasicObject & InternalObject & {
   password_policy_min_symbols?: Maybe<Scalars['Int']>;
   password_policy_min_uppercase?: Maybe<Scalars['Int']>;
   password_policy_min_words?: Maybe<Scalars['Int']>;
+  platform_banner_level?: Maybe<Scalars['String']>;
+  platform_banner_text?: Maybe<Scalars['String']>;
   platform_cluster: Cluster;
   platform_consent_confirm_text?: Maybe<Scalars['String']>;
   platform_consent_message?: Maybe<Scalars['String']>;
@@ -19832,6 +19834,8 @@ export type Settings = BasicObject & InternalObject & {
   platform_organization?: Maybe<Organization>;
   platform_providers: Array<Provider>;
   platform_reference_attachment?: Maybe<Scalars['Boolean']>;
+  platform_session_idle_timeout?: Maybe<Scalars['Int']>;
+  platform_session_timeout?: Maybe<Scalars['Int']>;
   platform_theme?: Maybe<Scalars['String']>;
   platform_theme_dark_accent?: Maybe<Scalars['String']>;
   platform_theme_dark_background?: Maybe<Scalars['String']>;
@@ -32559,6 +32563,8 @@ export type SettingsResolvers<ContextType = any, ParentType extends ResolversPar
   password_policy_min_symbols?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   password_policy_min_uppercase?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   password_policy_min_words?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  platform_banner_level?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  platform_banner_text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_cluster?: Resolver<ResolversTypes['Cluster'], ParentType, ContextType>;
   platform_consent_confirm_text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_consent_message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -32574,6 +32580,8 @@ export type SettingsResolvers<ContextType = any, ParentType extends ResolversPar
   platform_organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType>;
   platform_providers?: Resolver<Array<ResolversTypes['Provider']>, ParentType, ContextType>;
   platform_reference_attachment?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  platform_session_idle_timeout?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  platform_session_timeout?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   platform_theme?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_theme_dark_accent?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platform_theme_dark_background?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -50,6 +50,8 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'platform_login_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_consent_message', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'platform_consent_confirm_text', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'platform_banner_text', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
+    { name: 'platform_banner_level', type: 'string', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'otp_mandatory', type: 'boolean', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'password_policy_min_length', type: 'numeric', mandatoryType: 'no', multiple: false, upsert: false },
     { name: 'password_policy_max_length', type: 'numeric', mandatoryType: 'no', multiple: false, upsert: false },

--- a/opencti-platform/opencti-graphql/src/resolvers/settings.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/settings.js
@@ -1,4 +1,5 @@
 import { withFilter } from 'graphql-subscriptions';
+import nconf from 'nconf';
 import { BUS_TOPICS } from '../config/conf';
 import {
   getApplicationInfo,
@@ -25,6 +26,8 @@ const settingsResolvers = {
     relationships: (_, __, context) => elAggregationCount(context, context.user, READ_DATA_INDICES, { types: ['stix-relationship'], field: 'entity_type' }),
   },
   Settings: {
+    platform_session_idle_timeout: () => Number(nconf.get('app:session_idle_timeout')),
+    platform_session_timeout: () => Number(nconf.get('app:session_timeout')),
     platform_organization: (settings, __, context) => findById(context, context.user, settings.platform_organization),
     activity_listeners: (settings, __, context) => internalFindByIds(context, context.user, settings.activity_listeners_ids),
     otp_mandatory: (settings) => settings.otp_mandatory ?? false,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This change does the following:
* Adds a Customizable Header/Footer text banner with three selectable background colors
   - Colors are Green, Red, or Yellow
   - Can be used to denote a message like "Test Data Only in this system", "Highest Level of Data - XYZ", or whatever text you may wish to advertise.
* Adds a parameter ("session_idle_timeout": 900000) to config/default.json. This will by default after 15 mins of idle on the application - blank/blur the OpenCTI desktop within the browser and start a countdown timer with the remaining time from the parameter ("session_timeout": 1200000). When the countdown officially ends - you will be logged out.
   - This is a security related fix in that many organizations have a time limit before a screen must be obscured while idle.
   - Additionally, on some OpenCTI screens GQL subscriptions reset the session_timeout parameter on idle session - not killing your idle session. This fix - ignores the "automatic GQL subscription queries" - and will correctly terminate an idle session after the official (session_timeout)

### Related issues

None.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ X ] I consider the submitted work as finished
- [ X ] I tested the code for its functionality
- [ X ] I wrote test cases for the relevant uses case
    - This was manually tested for this submission. There are Selenuim autotests that are written but not part of the PR to automate the testing.
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ X ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

* There are a large number of GUI files impacted by this change due to the way the OpenCTI page templates are designed and the need to shift/offset components/fields (if enabled) or not shift/offset (if disabled) to prevent possible text overlap of components.
