### PR TITLE
[frontend] groups and organizations in alphabetical order + clickable organizations in User overview

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -70,7 +70,11 @@ const useStyles = makeStyles<Theme>((theme) => ({
 }));
 
 const groupFragment = graphql`
-  fragment Group_group on Group {
+  fragment Group_group on Group
+  @argumentDefinitions(
+      rolesOrderBy: { type: "RolesOrdering", defaultValue: name }
+      rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
+  ) {
     id
     entity_type
     name
@@ -89,7 +93,10 @@ const groupFragment = graphql`
         }
       }
     }
-    roles {
+    roles(
+        orderBy: $rolesOrderBy,
+        orderMode: $rolesOrderMode,
+    ) {
       id
       name
       description

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -54,12 +54,20 @@ export const groupEditionContainerQuery = graphql`
 `;
 
 const GroupEditionContainerFragment = graphql`
-      fragment GroupEditionContainer_group on Group {
+      fragment GroupEditionContainer_group on Group
+      @argumentDefinitions(
+          rolesOrderBy: { type: "RolesOrdering", defaultValue: name }
+          rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
+      ) {
           id
           ...GroupEditionOverview_group
           ...GroupEditionMarkings_group
           ...GroupEditionUsers_group
           ...GroupEditionRoles_group
+          @arguments(
+              orderBy: $rolesOrderBy
+              orderMode: $rolesOrderMode
+          )
           editContext {
               name
               focusOn

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionRoles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionRoles.tsx
@@ -140,9 +140,16 @@ const GroupEditionRolesComponent: FunctionComponent<GroupEditionRolesComponentPr
 
 const GroupEditionRoles = createFragmentContainer(GroupEditionRolesComponent, {
   group: graphql`
-      fragment GroupEditionRoles_group on Group {
+      fragment GroupEditionRoles_group on Group
+      @argumentDefinitions(
+          orderBy: { type: "RolesOrdering", defaultValue: name }
+          orderMode: { type: "OrderingMode", defaultValue: asc }
+      ) {
           id
-          roles {
+          roles(
+              orderBy: $orderBy,
+              orderMode: $orderMode,
+          ) {
               ... on Role {
                   id
                   name

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
@@ -24,12 +24,24 @@ const subscription = graphql`
 `;
 
 const groupQuery = graphql`
-    query RootGroupQuery($id: String!) {
+    query RootGroupQuery(
+        $id: String!
+        $rolesOrderBy: RolesOrdering
+        $rolesOrderMode: OrderingMode
+    ) {
         group(id: $id) {
             id
             name
             ...Group_group
+            @arguments(
+                rolesOrderBy: $rolesOrderBy
+                rolesOrderMode: $rolesOrderMode
+            )
             ...GroupEditionContainer_group
+            @arguments(
+                rolesOrderBy: $rolesOrderBy
+                rolesOrderMode: $rolesOrderMode
+            )
         }
     }
 `;
@@ -72,7 +84,7 @@ const RootGroupComponent: FunctionComponent<RootGroupComponentProps> = ({ queryR
 
 const RootGroup = () => {
   const { groupId } = useParams() as { groupId: string };
-  const queryRef = useQueryLoading<RootGroupQuery>(groupQuery, { id: groupId });
+  const queryRef = useQueryLoading<RootGroupQuery>(groupQuery, { id: groupId, rolesOrderBy: 'name', rolesOrderMode: 'asc' });
   return (
     <div>
       <TopBar />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/Root.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/Root.js
@@ -14,10 +14,34 @@ import { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 
 const subscription = graphql`
-  subscription RootUsersSubscription($id: ID!) {
+  subscription RootUsersSubscription(
+      $id: ID!
+      $rolesOrderBy: RolesOrdering
+      $rolesOrderMode: OrderingMode
+      $groupsOrderBy: GroupsOrdering
+      $groupsOrderMode: OrderingMode
+      $organizationsOrderBy: OrganizationsOrdering
+      $organizationsOrderMode: OrderingMode
+  ) {
     user(id: $id) {
       ...User_user
+      @arguments(
+          rolesOrderBy: $rolesOrderBy
+          rolesOrderMode: $rolesOrderMode
+          groupsOrderBy: $groupsOrderBy
+          groupsOrderMode: $groupsOrderMode
+          organizationsOrderBy: $organizationsOrderBy
+          organizationsOrderMode: $organizationsOrderMode
+      )
       ...UserEdition_user
+      @arguments(
+          rolesOrderBy: $rolesOrderBy
+          rolesOrderMode: $rolesOrderMode
+          groupsOrderBy: $groupsOrderBy
+          groupsOrderMode: $groupsOrderMode
+          organizationsOrderBy: $organizationsOrderBy
+          organizationsOrderMode: $organizationsOrderMode
+      )
     }
   }
 `;
@@ -51,7 +75,15 @@ class RootUser extends Component {
         <TopBar />
         <QueryRenderer
           query={userQuery}
-          variables={{ id: userId }}
+          variables={{
+            id: userId,
+            rolesOrderBy: 'name',
+            rolesOrderMode: 'asc',
+            groupsOrderBy: 'name',
+            groupsOrderMode: 'asc',
+            organizationsOrderBy: 'name',
+            organizationsOrderMode: 'asc',
+          }}
           render={({ props }) => {
             if (props) {
               if (props.user) {

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.js
@@ -403,7 +403,9 @@ class UserComponent extends Component {
                         key={organization.id}
                         dense={true}
                         divider={true}
-                        button={false}
+                        button={true}
+                        component={Link}
+                        to={`/dashboard/entities/organizations/${organization.id}`}
                       >
                         <ListItemIcon>
                           <AccountBalanceOutlined color="primary" />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.js
@@ -343,8 +343,7 @@ class UserComponent extends Component {
                     {t('Roles')}
                   </Typography>
                   <List>
-                    {R.uniq(user.roles ?? [])
-                      .sort((a, b) => a.name.localeCompare(b.name))
+                    {(user.roles ?? [])
                       .map((role) => (
                         <ListItem
                           key={role.id}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.js
@@ -246,14 +246,6 @@ class UserComponent extends Component {
 
   render() {
     const { classes, theme, user, t, fsd, nsdt } = this.props;
-    const orderedRoles = R.uniq(user.roles ?? [])
-      .sort((a, b) => a.name.localeCompare(b.name));
-    const orderedGroups = user.groups.edges
-      .map((n) => n.node)
-      .sort((a, b) => a.name.localeCompare(b.name));
-    const orderedOrganizations = user.objectOrganization.edges
-      .map((n) => n.node)
-      .sort((a, b) => a.name.localeCompare(b.name));
     const orderedSessions = R.sort(
       (a, b) => timestamp(a.created) - timestamp(b.created),
       user.sessions,
@@ -351,7 +343,8 @@ class UserComponent extends Component {
                     {t('Roles')}
                   </Typography>
                   <List>
-                    {orderedRoles
+                    {R.uniq(user.roles ?? [])
+                      .sort((a, b) => a.name.localeCompare(b.name))
                       .map((role) => (
                         <ListItem
                           key={role.id}
@@ -374,23 +367,21 @@ class UserComponent extends Component {
                     {t('Groups')}
                   </Typography>
                   <List>
-                    {orderedGroups
-                      .map((group) => (
-                        <ListItem
-                          key={group.id}
-                          dense={true}
-                          divider={true}
-                          button={true}
-                          component={Link}
-                          to={`/dashboard/settings/accesses/groups/${group.id}`}
-                        >
-                          <ListItemIcon>
-                            <GroupOutlined color="primary" />
-                          </ListItemIcon>
-                          <ListItemText primary={group.name} />
-                        </ListItem>
-                      ))
-                    }
+                    {user.groups.edges.map((groupEdge) => (
+                      <ListItem
+                        key={groupEdge.node.id}
+                        dense={true}
+                        divider={true}
+                        button={true}
+                        component={Link}
+                        to={`/dashboard/settings/accesses/groups/${groupEdge.node.id}`}
+                      >
+                        <ListItemIcon>
+                          <GroupOutlined color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary={groupEdge.node.name} />
+                      </ListItem>
+                    ))}
                   </List>
                 </Grid>
                 <Grid item={true} xs={6}>
@@ -398,9 +389,9 @@ class UserComponent extends Component {
                     {t('Organizations')}
                   </Typography>
                   <List>
-                    {orderedOrganizations.map((organization) => (
+                    {user.objectOrganization.edges.map((organizationEdge) => (
                       <ListItem
-                        key={organization.id}
+                        key={organizationEdge.node.id}
                         dense={true}
                         divider={true}
                         button={true}
@@ -410,7 +401,7 @@ class UserComponent extends Component {
                         <ListItemIcon>
                           <AccountBalanceOutlined color="primary" />
                         </ListItemIcon>
-                        <ListItemText primary={organization.name} />
+                        <ListItemText primary={organizationEdge.node.name} />
                       </ListItem>
                     ))}
                   </List>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.js
@@ -396,7 +396,7 @@ class UserComponent extends Component {
                         divider={true}
                         button={true}
                         component={Link}
-                        to={`/dashboard/entities/organizations/${organization.id}`}
+                        to={`/dashboard/entities/organizations/${organizationEdge.node.id}`}
                       >
                         <ListItemIcon>
                           <AccountBalanceOutlined color="primary" />
@@ -644,11 +644,27 @@ UserComponent.propTypes = {
 };
 
 export const userQuery = graphql`
-  query UserQuery($id: String!) {
+  query UserQuery(
+      $id: String!
+      $rolesOrderBy: RolesOrdering
+      $rolesOrderMode: OrderingMode
+      $groupsOrderBy: GroupsOrdering
+      $groupsOrderMode: OrderingMode
+      $organizationsOrderBy: OrganizationsOrdering
+      $organizationsOrderMode: OrderingMode
+  ) {
     user(id: $id) {
       id
       name
       ...User_user
+      @arguments(
+          rolesOrderBy: $rolesOrderBy
+          rolesOrderMode: $rolesOrderMode
+          groupsOrderBy: $groupsOrderBy
+          groupsOrderMode: $groupsOrderMode
+          organizationsOrderBy: $organizationsOrderBy
+          organizationsOrderMode: $organizationsOrderMode
+      )
     }
   }
 `;
@@ -657,7 +673,15 @@ const User = createRefetchContainer(
   UserComponent,
   {
     user: graphql`
-      fragment User_user on User {
+      fragment User_user on User
+      @argumentDefinitions(
+          rolesOrderBy: { type: "RolesOrdering", defaultValue: name }
+          rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
+          groupsOrderBy: { type: "GroupsOrdering", defaultValue: name }
+          groupsOrderMode: { type: "OrderingMode", defaultValue: asc }
+          organizationsOrderBy: { type: "OrganizationsOrdering", defaultValue: name }
+          organizationsOrderMode: { type: "OrderingMode", defaultValue: asc }
+      ) {
         id
         name
         description
@@ -668,7 +692,10 @@ const User = createRefetchContainer(
         language
         api_token
         otp_activated
-        roles {
+        roles(
+            orderBy: $rolesOrderBy,
+            orderMode: $rolesOrderMode,
+        ) {
           id
           name
           description
@@ -677,7 +704,10 @@ const User = createRefetchContainer(
           id
           name
         }
-        groups {
+        groups(
+            orderBy: $groupsOrderBy,
+            orderMode: $groupsOrderMode,
+        ) {
           edges {
             node {
               id
@@ -687,7 +717,10 @@ const User = createRefetchContainer(
           }
         }
         default_hidden_types
-        objectOrganization {
+        objectOrganization(
+            orderBy: $organizationsOrderBy,
+            orderMode: $organizationsOrderMode,
+        ) {
           edges {
             node {
               id

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.js
@@ -246,6 +246,14 @@ class UserComponent extends Component {
 
   render() {
     const { classes, theme, user, t, fsd, nsdt } = this.props;
+    const orderedRoles = R.uniq(user.roles ?? [])
+      .sort((a, b) => a.name.localeCompare(b.name));
+    const orderedGroups = user.groups.edges
+      .map((n) => n.node)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    const orderedOrganizations = user.objectOrganization.edges
+      .map((n) => n.node)
+      .sort((a, b) => a.name.localeCompare(b.name));
     const orderedSessions = R.sort(
       (a, b) => timestamp(a.created) - timestamp(b.created),
       user.sessions,
@@ -343,8 +351,7 @@ class UserComponent extends Component {
                     {t('Roles')}
                   </Typography>
                   <List>
-                    {R.uniq(user.roles ?? [])
-                      .sort((a, b) => a.name.localeCompare(b.name))
+                    {orderedRoles
                       .map((role) => (
                         <ListItem
                           key={role.id}
@@ -367,21 +374,23 @@ class UserComponent extends Component {
                     {t('Groups')}
                   </Typography>
                   <List>
-                    {user.groups.edges.map((groupEdge) => (
-                      <ListItem
-                        key={groupEdge.node.id}
-                        dense={true}
-                        divider={true}
-                        button={true}
-                        component={Link}
-                        to={`/dashboard/settings/accesses/groups/${groupEdge.node.id}`}
-                      >
-                        <ListItemIcon>
-                          <GroupOutlined color="primary" />
-                        </ListItemIcon>
-                        <ListItemText primary={groupEdge.node.name} />
-                      </ListItem>
-                    ))}
+                    {orderedGroups
+                      .map((group) => (
+                        <ListItem
+                          key={group.id}
+                          dense={true}
+                          divider={true}
+                          button={true}
+                          component={Link}
+                          to={`/dashboard/settings/accesses/groups/${group.id}`}
+                        >
+                          <ListItemIcon>
+                            <GroupOutlined color="primary" />
+                          </ListItemIcon>
+                          <ListItemText primary={group.name} />
+                        </ListItem>
+                      ))
+                    }
                   </List>
                 </Grid>
                 <Grid item={true} xs={6}>
@@ -389,9 +398,9 @@ class UserComponent extends Component {
                     {t('Organizations')}
                   </Typography>
                   <List>
-                    {user.objectOrganization.edges.map((organizationEdge) => (
+                    {orderedOrganizations.map((organization) => (
                       <ListItem
-                        key={organizationEdge.node.id}
+                        key={organization.id}
                         dense={true}
                         divider={true}
                         button={false}
@@ -399,7 +408,7 @@ class UserComponent extends Component {
                         <ListItemIcon>
                           <AccountBalanceOutlined color="primary" />
                         </ListItemIcon>
-                        <ListItemText primary={organizationEdge.node.name} />
+                        <ListItemText primary={organization.name} />
                       </ListItem>
                     ))}
                   </List>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEdition.tsx
@@ -99,12 +99,30 @@ const UserEdition: FunctionComponent<UserEditionProps> = ({ handleClose, user })
 
 const UserEditionFragment = createFragmentContainer(UserEdition, {
   user: graphql`
-    fragment UserEdition_user on User {
+    fragment UserEdition_user on User
+    @argumentDefinitions(
+        rolesOrderBy: { type: "RolesOrdering", defaultValue: name }
+        rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
+        groupsOrderBy: { type: "GroupsOrdering", defaultValue: name }
+        groupsOrderMode: { type: "OrderingMode", defaultValue: asc }
+        organizationsOrderBy: { type: "OrganizationsOrdering", defaultValue: name }
+        organizationsOrderMode: { type: "OrderingMode", defaultValue: asc }
+    ) {
       id
       external
       ...UserEditionOverview_user
+      @arguments(
+          rolesOrderBy: $rolesOrderBy
+          rolesOrderMode: $rolesOrderMode
+          organizationsOrderBy: $organizationsOrderBy
+          organizationsOrderMode: $organizationsOrderMode
+      )
       ...UserEditionPassword_user
       ...UserEditionGroups_user
+      @arguments(
+          groupsOrderBy: $groupsOrderBy
+          groupsOrderMode: $groupsOrderMode
+      )
       editContext {
         name
         focusOn

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionGroups.js
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionGroups.js
@@ -140,9 +140,16 @@ UserEditionGroupsComponent.propTypes = {
 
 const UserEditionGroups = createFragmentContainer(UserEditionGroupsComponent, {
   user: graphql`
-    fragment UserEditionGroups_user on User {
+    fragment UserEditionGroups_user on User
+    @argumentDefinitions(
+        groupsOrderBy: { type: "GroupsOrdering", defaultValue: name }
+        groupsOrderMode: { type: "OrderingMode", defaultValue: asc }
+    ) {
       id
-      groups {
+      groups(
+          orderBy: $groupsOrderBy,
+          orderMode: $groupsOrderMode,
+      ) {
         edges {
           node {
             id

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
@@ -287,7 +287,13 @@ const UserEditionOverview = createFragmentContainer(
   UserEditionOverviewComponent,
   {
     user: graphql`
-      fragment UserEditionOverview_user on User {
+      fragment UserEditionOverview_user on User
+      @argumentDefinitions(
+          rolesOrderBy: { type: "RolesOrdering", defaultValue: name }
+          rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
+          organizationsOrderBy: { type: "OrganizationsOrdering", defaultValue: name }
+          organizationsOrderMode: { type: "OrderingMode", defaultValue: asc }
+      ) {
         id
         name
         description
@@ -300,11 +306,17 @@ const UserEditionOverview = createFragmentContainer(
         api_token
         otp_activated
         otp_qr
-        roles {
+        roles(
+            orderBy: $rolesOrderBy,
+            orderMode: $rolesOrderMode,
+        ) {
           id
           name
         }
-        objectOrganization {
+        objectOrganization(
+            orderBy: $organizationsOrderBy,
+            orderMode: $organizationsOrderMode,
+        ) {
           edges {
             node {
               id

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1080,7 +1080,7 @@ type Group implements InternalObject & BasicObject {
   members: UserConnection
   created_at: DateTime
   updated_at: DateTime
-  roles: [Role]
+  roles(orderBy: RolesOrdering, orderMode: OrderingMode): [Role]
   allowed_marking: [MarkingDefinition]
   editContext: [EditUserContext!]
 }
@@ -1211,11 +1211,11 @@ type User implements BasicObject & InternalObject {
   language: String
   external: Boolean
   dashboard: String
-  roles: [Role]!
+  roles(orderBy: RolesOrdering, orderMode: OrderingMode): [Role]!
   capabilities: [Capability]!
   default_hidden_types: [String]!
-  groups: GroupConnection
-  objectOrganization: OrganizationConnection
+  groups(orderBy: GroupsOrdering, orderMode: OrderingMode): GroupConnection
+  objectOrganization(orderBy: GroupsOrdering, orderMode: OrderingMode): OrganizationConnection
   created_at: DateTime!
   updated_at: DateTime!
   sessions: [SessionDetail]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1215,7 +1215,7 @@ type User implements BasicObject & InternalObject {
   capabilities: [Capability]!
   default_hidden_types: [String]!
   groups(orderBy: GroupsOrdering, orderMode: OrderingMode): GroupConnection
-  objectOrganization(orderBy: GroupsOrdering, orderMode: OrderingMode): OrganizationConnection
+  objectOrganization(orderBy: OrganizationsOrdering, orderMode: OrderingMode): OrganizationConnection
   created_at: DateTime!
   updated_at: DateTime!
   sessions: [SessionDetail]

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1023,7 +1023,10 @@ type Group implements InternalObject & BasicObject {
   members: UserConnection @auth(for: [SETTINGS_SETACCESSES])
   created_at: DateTime
   updated_at: DateTime
-  roles: [Role]
+  roles(
+    orderBy: RolesOrdering
+    orderMode: OrderingMode
+  ): [Role]
   allowed_marking: [MarkingDefinition]
   # Technical
   editContext: [EditUserContext!]
@@ -1139,11 +1142,20 @@ type User implements BasicObject & InternalObject {
   language: String
   external: Boolean
   dashboard: String
-  roles: [Role]!
+  roles(
+    orderBy: RolesOrdering
+    orderMode: OrderingMode
+  ): [Role]!
   capabilities: [Capability]!
   default_hidden_types: [String]!
-  groups: GroupConnection @auth(for: [SETTINGS_SETACCESSES])
-  objectOrganization: OrganizationConnection @auth(for: [SETTINGS_SETACCESSES])
+  groups(
+    orderBy: GroupsOrdering
+    orderMode: OrderingMode
+  ): GroupConnection @auth(for: [SETTINGS_SETACCESSES])
+  objectOrganization(
+    orderBy: GroupsOrdering
+    orderMode: OrderingMode
+  ): OrganizationConnection @auth(for: [SETTINGS_SETACCESSES])
   created_at: DateTime!
   updated_at: DateTime!
   sessions: [SessionDetail] @auth(for: [SETTINGS_SETACCESSES])

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1153,7 +1153,7 @@ type User implements BasicObject & InternalObject {
     orderMode: OrderingMode
   ): GroupConnection @auth(for: [SETTINGS_SETACCESSES])
   objectOrganization(
-    orderBy: GroupsOrdering
+    orderBy: OrganizationsOrdering
     orderMode: OrderingMode
   ): OrganizationConnection @auth(for: [SETTINGS_SETACCESSES])
   created_at: DateTime!

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -43,7 +43,7 @@ export const batchIsSubAttackPattern = async (context: AuthContext, user: AuthUs
     ENTITY_TYPE_ATTACK_PATTERN,
     { paginate: false }
   );
-  return batchAttackPatterns.map((b) => b.length > 0);
+  return batchAttackPatterns.map((b: AttackPattern[]) => b.length > 0);
 };
 
 export const batchDataComponents = async (context: AuthContext, user: AuthUser, attackPatternIds: Array<string>) => {

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -204,7 +204,7 @@ export const batchRolesForUsers = async (context, user, userIds, opts = {}) => {
   const rolesMap = R.mergeAll(roles.map((r) => ({ [r.id]: r })));
   return userIds.map((u) => {
     const groups = usersWithGroups[u] ?? [];
-    const idRoles = groups.map((g) => groupWithRoles[g] ?? []).flat();
+    const idRoles = uniq(groups.map((g) => groupWithRoles[g] ?? []).flat());
     let roleValues = idRoles.map((r) => rolesMap[r]);
     // sort roles
     if (orderBy && orderMode) {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23592,7 +23592,7 @@ export type UserGroupsArgs = {
 
 
 export type UserObjectOrganizationArgs = {
-  orderBy?: InputMaybe<GroupsOrdering>;
+  orderBy?: InputMaybe<OrganizationsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
 };
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7116,6 +7116,12 @@ export type Group = BasicObject & InternalObject & {
   updated_at?: Maybe<Scalars['DateTime']>;
 };
 
+
+export type GroupRolesArgs = {
+  orderBy?: InputMaybe<RolesOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+};
+
 export type GroupAddInput = {
   auto_new_marking?: InputMaybe<Scalars['Boolean']>;
   clientMutationId?: InputMaybe<Scalars['String']>;
@@ -23578,6 +23584,24 @@ export type User = BasicObject & InternalObject & {
   user_email: Scalars['String'];
 };
 
+
+export type UserGroupsArgs = {
+  orderBy?: InputMaybe<GroupsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+};
+
+
+export type UserObjectOrganizationArgs = {
+  orderBy?: InputMaybe<GroupsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+};
+
+
+export type UserRolesArgs = {
+  orderBy?: InputMaybe<RolesOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+};
+
 export type UserAccount = BasicObject & StixCoreObject & StixCyberObservable & StixObject & {
   __typename?: 'UserAccount';
   account_created?: Maybe<Scalars['DateTime']>;
@@ -28747,7 +28771,7 @@ export type GroupResolvers<ContextType = any, ParentType extends ResolversParent
   members?: Resolver<Maybe<ResolversTypes['UserConnection']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
-  roles?: Resolver<Maybe<Array<Maybe<ResolversTypes['Role']>>>, ParentType, ContextType>;
+  roles?: Resolver<Maybe<Array<Maybe<ResolversTypes['Role']>>>, ParentType, ContextType, Partial<GroupRolesArgs>>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updated_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -33035,18 +33059,18 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   external?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   firstname?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  groups?: Resolver<Maybe<ResolversTypes['GroupConnection']>, ParentType, ContextType>;
+  groups?: Resolver<Maybe<ResolversTypes['GroupConnection']>, ParentType, ContextType, Partial<UserGroupsArgs>>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   individual_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   language?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   lastname?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  objectOrganization?: Resolver<Maybe<ResolversTypes['OrganizationConnection']>, ParentType, ContextType>;
+  objectOrganization?: Resolver<Maybe<ResolversTypes['OrganizationConnection']>, ParentType, ContextType, Partial<UserObjectOrganizationArgs>>;
   otp_activated?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   otp_mandatory?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   otp_qr?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
-  roles?: Resolver<Array<Maybe<ResolversTypes['Role']>>, ParentType, ContextType>;
+  roles?: Resolver<Array<Maybe<ResolversTypes['Role']>>, ParentType, ContextType, Partial<UserRolesArgs>>;
   sessions?: Resolver<Maybe<Array<Maybe<ResolversTypes['SessionDetail']>>>, ParentType, ContextType>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   theme?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/narrative/narrative-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/narrative/narrative-domain.ts
@@ -3,7 +3,7 @@ import { batchListThroughGetFrom, batchListThroughGetTo, createEntity } from '..
 import { notify } from '../../database/redis';
 import { BUS_TOPICS } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
-import type { NarrativeAddInput, QueryNarrativesArgs } from '../../generated/graphql';
+import type { Narrative, NarrativeAddInput, QueryNarrativesArgs } from '../../generated/graphql';
 import { listEntitiesPaginated, storeLoadById } from '../../database/middleware-loader';
 import { BasicStoreEntityNarrative, ENTITY_TYPE_NARRATIVE } from './narrative-types';
 import { RELATION_SUBNARRATIVE_OF } from '../../schema/stixCoreRelationship';
@@ -38,5 +38,5 @@ export const batchIsSubNarrative = async (context: AuthContext, user: AuthUser, 
     ENTITY_TYPE_NARRATIVE,
     { paginate: false }
   );
-  return batchNarratives.map((b) => b.length > 0);
+  return batchNarratives.map((b: Narrative[]) => b.length > 0);
 };

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -76,9 +76,9 @@ const userResolvers = {
     bookmarks: (_, { types }, context) => bookmarks(context, context.user, types),
   },
   User: {
-    roles: (current, _, context) => rolesUsersLoader.load(current.id, context, context.user),
-    groups: (current, _, context) => groupsLoader.load(current.id, context, context.user),
-    objectOrganization: (current, _, context) => organizationsLoader.load(current.id, context, context.user, { withInferences: false }),
+    roles: (current, args, context) => rolesUsersLoader.load(current.id, context, context.user, args),
+    groups: (current, args, context) => groupsLoader.load(current.id, context, context.user, args),
+    objectOrganization: (current, args, context) => organizationsLoader.load(current.id, context, context.user, { ...args, withInferences: false }),
     editContext: (current) => fetchEditContext(current.id),
     sessions: (current) => findUserSessions(current.id),
   },
@@ -93,7 +93,7 @@ const userResolvers = {
     capabilities: (role, _, context) => rolesCapabilitiesLoader.load(role.id, context, context.user),
   },
   Group: {
-    roles: (group, _, context) => rolesGroupsLoader.load(group.id, context, context.user),
+    roles: (group, args, context) => rolesGroupsLoader.load(group.id, context, context.user, args),
   },
   Mutation: {
     otpActivation: (_, { input }, context) => otpUserActivation(context, context.user, input),


### PR DESCRIPTION
github issue: https://github.com/OpenCTI-Platform/opencti/issues/3359

Notion page: https://www.notion.so/filigran/Groups-and-organizations-in-alphabetical-order-3359-d6e1d8c866e54a208fbd9b90aabcdb26

PR content:
- clickable organization in User overview
- roles, groups and organization are sorted in alphabetical order in user overview
- roles are sorted in alphabetical order in group overview
- in back, the queries to fetch roles, groups and organization can have a sortedBy attribute
- bug fix: through API the roles of a user are not de-duplicated