### PR TITLE
[backend] TAXII sort order adaptation fix (#3376)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -509,7 +509,9 @@ export const stixLoadById = async (context, user, id, opts = {}) => {
 };
 export const stixLoadByIds = async (context, user, ids, opts = {}) => {
   const elements = await storeLoadByIdsWithRefs(context, user, ids, opts);
-  return elements.map((instance) => convertStoreToStix(instance));
+  // As stix load by ids doesn't respect the ordering we need to remap the result
+  const elementMap = new Map(elements.map((instance) => [instance.internal_id, instance]));
+  return ids.map((id) => convertStoreToStix(elementMap.get(id)));
 };
 export const stixLoadByIdStringify = async (context, user, id) => {
   const data = await stixLoadById(context, user, id);

--- a/opencti-platform/opencti-graphql/src/database/utils.js
+++ b/opencti-platform/opencti-graphql/src/database/utils.js
@@ -382,3 +382,11 @@ export const wait = (ms) => {
 };
 
 export const waitInSec = (sec) => wait(sec * 1000);
+
+export const extractIdsFromStoreObject = (instance) => {
+  const ids = [instance.internal_id, ...(instance.x_opencti_stix_ids ?? [])];
+  if (instance.standard_id) {
+    ids.push(instance.standard_id);
+  }
+  return ids;
+};

--- a/opencti-platform/opencti-graphql/src/domain/taxii.js
+++ b/opencti-platform/opencti-graphql/src/domain/taxii.js
@@ -62,19 +62,10 @@ export const taxiiCollectionEditContext = async (context, user, collectionId, in
 const prepareManifestElement = async (data) => {
   return {
     id: data.standard_id,
-    date_added: data.created_at,
+    date_added: data.updated_at,
     version: data.updated_at,
     media_type: STIX_MEDIA_TYPE,
   };
-};
-export const collectionCount = async (context, taxiiCollection, user) => {
-  const { filters } = taxiiCollection;
-  const data = await elPaginate(context, user, READ_INDEX_INTERNAL_OBJECTS, {
-    first: 1, // We only need to fetch 1 to get the global count
-    types: [ENTITY_TYPE_TAXII_COLLECTION],
-    filters,
-  });
-  return data.pageInfo.globalCount;
 };
 
 const collectionQuery = async (context, user, collectionId, args) => {


### PR DESCRIPTION
After introducing performance improvment with stix full loading batching, the order of the results is now wrong.
The PR aims to reintroduce this ordering.
We also fix the taxii manifest content to display the real start/last date as we use the updated_at date to do the ordering