### PR TITLE
[frontend] fix entity analyst workbench update (#3408)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.js
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.js
@@ -336,8 +336,8 @@ const WorkbenchFileContentComponent = ({
 
   const saveFile = () => {
     let currentEntityId = null;
-    if (file.metaData.entity) {
-      currentEntityId = file.metaData.entity.standard_id;
+    if (file.metaData.entity_id && file.metaData.entity) {
+      currentEntityId = file.metaData.entity_id;
     }
     const data = {
       id: `bundle--${uuid()}`,
@@ -356,7 +356,7 @@ const WorkbenchFileContentComponent = ({
     });
     commitMutation({
       mutation: workbenchFileContentMutation,
-      variables: { file: fileToUpload, id: currentEntityId },
+      variables: { file: fileToUpload, entityId: currentEntityId },
     });
   };
 
@@ -697,8 +697,8 @@ const WorkbenchFileContentComponent = ({
   // region submission
   const onSubmitValidate = (values, { setSubmitting, resetForm }) => {
     let currentEntityId = null;
-    if (file.metaData.entity) {
-      currentEntityId = file.metaData.entity.standard_id;
+    if (file.metaData.entity_id && file.metaData.entity) {
+      currentEntityId = file.metaData.entity_id;
     }
     const data = {
       id: `bundle--${uuid()}`,
@@ -717,7 +717,7 @@ const WorkbenchFileContentComponent = ({
     });
     commitMutation({
       mutation: workbenchFileContentMutation,
-      variables: { file: fileToUpload, id: currentEntityId },
+      variables: { file: fileToUpload, entityId: currentEntityId },
       onCompleted: () => {
         setTimeout(() => {
           commitMutation({

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.js
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.js
@@ -347,6 +347,7 @@ const WorkbenchFileLine = createFragmentContainer(WorkbenchFileLineComponent, {
         creator {
           name
         }
+        entity_id
         entity {
           ... on AttackPattern {
             name

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.js
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.js
@@ -113,6 +113,7 @@ const WorkbenchFileViewer = createRefetchContainer(
               id
               ...WorkbenchFileLine_file
               metaData {
+                entity_id
                 mimetype
               }
             }

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.js
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.js
@@ -113,7 +113,6 @@ const WorkbenchFileViewer = createRefetchContainer(
               id
               ...WorkbenchFileLine_file
               metaData {
-                entity_id
                 mimetype
               }
             }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix workbench file update : the parameter entityId was wrongly set

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3408

The issue happens as soon as we go in the analyst workbench, even without validating.

#### Steps to reproduce : 
* Go to reports -> create a new report (or select an existing one)
* go to Data panel -> upload a text or pdf file (for example you can create a txt file with an ip adress like 125.0.0.1)
* Import the file (left button on the file after you upload it) => it should create an analyst workbench displayed on the right
* Then you can go in your analyst workbench and if you get back to your report, you'll see not see the workbench displayed anymore in the report data. The bug also happens when you validate the workbench (you need to test both).

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

