### PR TITLE
[frontend] In an Intrusion Set => Knowledge => Malware, keyword is disappearing between Entities / Relations views (#issue/3440)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.jsx
@@ -325,6 +325,7 @@ class EntityStixCoreRelationships extends Component {
               displayImport={true}
               secondaryAction={true}
               iconExtension={true}
+              keyword={searchTerm}
               handleToggleSelectAll={this.handleToggleSelectAll.bind(this)}
               selectAll={selectAll}
               numberOfElements={numberOfElements}
@@ -546,6 +547,7 @@ class EntityStixCoreRelationships extends Component {
               handleToggleSelectAll={this.handleToggleSelectAll.bind(this)}
               paginationOptions={paginationOptions}
               selectAll={selectAll}
+              keyword={searchTerm}
               displayImport={true}
               handleToggleExports={
                 disableExport ? null : this.handleToggleExports.bind(this)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Keyword in lines was missing so I add it

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3440

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
