### PR TITLE
[backend] fix dashboard entities list filtered by related entity (#3476)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1791,6 +1791,7 @@ enum StixCoreObjectsFilter {
   entity_type
   revoked
   relationship_type
+  elementId
   aliases
   x_opencti_aliases
   x_mitre_id

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1727,6 +1727,7 @@ enum StixCoreObjectsFilter {
   entity_type
   revoked
   relationship_type
+  elementId
   aliases
   x_opencti_aliases
   x_mitre_id

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -375,7 +375,7 @@ export const buildEntityFilters = <T extends BasicStoreCommon>(args: EntityFilte
   }
   // endregion
   // Override some special filters
-  builtFilters.types = [...(types ?? []), ...entityTypes, ...relationshipTypes];
+  builtFilters.types = R.uniq([...(types ?? []), ...entityTypes, ...relationshipTypes]);
   builtFilters.filters = customFilters;
   return builtFilters;
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -72,23 +72,16 @@ export const findAll = async (context, user, args) => {
     throw UnsupportedError('Cant find stixCoreObject only based on relationship type, elementId is required');
   }
   let filters = args.filters ?? [];
-  const elementIds = isNotEmptyField(args.elementId) ? [args.elementId] : [];
-  const filterElementId = filters.find((f) => f.key.includes('elementId'));
-  if (filterElementId) {
-    elementIds.push(...filterElementId.values);
-    // remove elementId filter key
-    filters.splice(filters.indexOf(filterElementId), 1);
-  }
-  if (elementIds.length > 0) {
+  if (isNotEmptyField(args.elementId)) {
     // In case of element id, we look for a specific entity used by relationships independent of the direction
     // To do that we need to lookup the element inside the rel_ fields that represent the relationships connections
     // that are denormalized at relation creation.
     // If relation types are also in the query, we filter on specific rel_[TYPE], if not, using a wilcard.
     if (isNotEmptyField(args.relationship_type)) {
       const relationshipFilterKeys = args.relationship_type.map((n) => buildRefRelationKey(n));
-      filters = [...filters, { key: relationshipFilterKeys, values: elementIds }];
+      filters = [...filters, { key: relationshipFilterKeys, values: [args.elementId] }];
     } else {
-      filters = [...filters, { key: buildRefRelationKey('*'), values: elementIds }];
+      filters = [...filters, { key: buildRefRelationKey('*'), values: [args.elementId] }];
     }
   }
   return listEntities(context, user, types, { ...R.omit(['elementId', 'relationship_type'], args), filters });

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -72,16 +72,23 @@ export const findAll = async (context, user, args) => {
     throw UnsupportedError('Cant find stixCoreObject only based on relationship type, elementId is required');
   }
   let filters = args.filters ?? [];
-  if (isNotEmptyField(args.elementId)) {
+  const elementIds = isNotEmptyField(args.elementId) ? [args.elementId] : [];
+  const filterElementId = filters.find((f) => f.key.includes('elementId'));
+  if (filterElementId) {
+    elementIds.push(...filterElementId.values);
+    // remove elementId filter key
+    filters.splice(filters.indexOf(filterElementId), 1);
+  }
+  if (elementIds.length > 0) {
     // In case of element id, we look for a specific entity used by relationships independent of the direction
     // To do that we need to lookup the element inside the rel_ fields that represent the relationships connections
     // that are denormalized at relation creation.
     // If relation types are also in the query, we filter on specific rel_[TYPE], if not, using a wilcard.
     if (isNotEmptyField(args.relationship_type)) {
       const relationshipFilterKeys = args.relationship_type.map((n) => buildRefRelationKey(n));
-      filters = [...filters, { key: relationshipFilterKeys, values: [args.elementId] }];
+      filters = [...filters, { key: relationshipFilterKeys, values: elementIds }];
     } else {
-      filters = [...filters, { key: buildRefRelationKey('*'), values: [args.elementId] }];
+      filters = [...filters, { key: buildRefRelationKey('*'), values: elementIds }];
     }
   }
   return listEntities(context, user, types, { ...R.omit(['elementId', 'relationship_type'], args), filters });

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -20433,6 +20433,7 @@ export enum StixCoreObjectsFilter {
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',
   Creator = 'creator',
+  ElementId = 'elementId',
   EntityType = 'entity_type',
   HasExternalReference = 'hasExternalReference',
   HashesMd5 = 'hashes_MD5',

--- a/opencti-platform/opencti-graphql/src/schema/stixCoreObject.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixCoreObject.ts
@@ -27,6 +27,7 @@ export const stixCoreObjectOptions = {
     hasExternalReference: buildRefRelationKey(RELATION_EXTERNAL_REFERENCE),
     killChainPhase: buildRefRelationKey(RELATION_KILL_CHAIN_PHASE),
     indicates: buildRefRelationKey(RELATION_INDICATES),
+    elementId: buildRefRelationKey('*'),
     creator: 'creator_id',
     hashes_MD5: 'hashes.MD5',
     hashes_SHA1: 'hashes.SHA-1',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add missing elementId filter key
* fix stixCoreObject findAll method : handle elementId in filters
* Minor fix : deduplicate filters types

#### To test
* Add a new widget in a dashboard with entities list, a filter on an entity type and a filter on "related entity" (try to find first a report for example with a related entity like an organization)
=> There should be no error, and you should find your report

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3476

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
