### PR TITLE
[backend] Fix entity creation with associated file (#3534)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2915,7 +2915,7 @@ export const createRelations = async (context, user, inputs, opts = {}) => {
 // endregion
 
 // region mutation entity
-const buildEntityData = async (context, user, input, type, participantIds, opts = {}) => {
+const buildEntityData = async (context, user, input, type, opts = {}) => {
   const { fromRule } = opts;
   const internalId = input.internal_id || generateInternalId();
   const standardId = input.standard_id || generateStandardId(type, input);
@@ -3015,7 +3015,6 @@ const buildEntityData = async (context, user, input, type, participantIds, opts 
     const path = `import/${type}/${internalId}`;
     const file = await upload(context, user, path, input.file, { entity: { internal_id: internalId } });
     data.x_opencti_files = [storeFileConverter(user, file)];
-
     // Add external references from files if necessary
     const entitySetting = await getEntitySettingFromCache(context, type);
     if (entitySetting.platform_entity_files_ref) {
@@ -3161,7 +3160,7 @@ const createEntityRaw = async (context, user, input, type, opts = {}) => {
       }
     } else {
       // Create the object
-      dataEntity = await buildEntityData(context, user, resolvedInput, type, participantIds, opts);
+      dataEntity = await buildEntityData(context, user, resolvedInput, type, opts);
     }
     // Index the created element
     await indexCreatedElement(context, user, dataEntity);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Problem : In uploadJobImport method we need an entityId to resolve an entity, but when we are in creation this entity does not exist yet
* Solution : give an entire entity in this method depending of the case
    * In askJobImport method, load the entity previously
    * In upload method, we have already the entire entity

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3534

### Testing

* I don't have enough knowledge on this part to know all the impacts

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
