### PR TITLE
[frontend] Create analyst workbench from an entity (#3188)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -85,6 +85,7 @@
     "@types/react-router-dom": "5.3.3",
     "@types/react-test-renderer": "18.0.0",
     "@types/relay-test-utils": "14.1.0",
+    "@types/uuid": "9.0.2",
     "@vitejs/plugin-react": "4.0.0",
     "babel-plugin-relay": "15.0.0",
     "chokidar": "3.5.3",

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -366,6 +366,15 @@ const WorkbenchFileContentComponent = ({
     if (file.metaData.entity_id && file.metaData.entity) {
       currentEntityId = file.metaData.entity_id;
     }
+    // update entity container objects_refs
+    if (currentEntityId) {
+      const currentEntityContainer = containers.find((container) => container.x_opencti_id === currentEntityId);
+      if (currentEntityContainer) {
+        const currentEntityObjectRefs = currentEntityContainer.object_refs?.length ? currentEntityContainer.object_refs : [];
+        const objectIds = [...stixDomainObjects.map((s) => s.id), ...stixCyberObservables.map((s) => s.id)];
+        currentEntityContainer.object_refs = R.uniq([...currentEntityObjectRefs, ...objectIds]);
+      }
+    }
     const data = {
       id: `bundle--${uuid()}`,
       type: 'bundle',

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -370,8 +370,8 @@ const WorkbenchFileContentComponent = ({
     if (currentEntityId) {
       const currentEntityContainer = containers.find((container) => container.x_opencti_id === currentEntityId);
       if (currentEntityContainer) {
-        const currentEntityObjectRefs = currentEntityContainer.object_refs?.length ? currentEntityContainer.object_refs : [];
-        const objectIds = [...stixDomainObjects.map((s) => s.id), ...stixCyberObservables.map((s) => s.id)];
+        const currentEntityObjectRefs = Array.isArray(currentEntityContainer.object_refs) ? currentEntityContainer.object_refs : [];
+        const objectIds = [...stixDomainObjects, ...stixCyberObservables].map((s) => s.id);
         currentEntityContainer.object_refs = R.uniq([...currentEntityObjectRefs, ...objectIds]);
       }
     }

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -1,0 +1,177 @@
+import React, { FunctionComponent } from 'react';
+import { graphql, useMutation } from 'react-relay';
+import { v4 as uuid } from 'uuid';
+import { Field, Form, Formik } from 'formik';
+import { FormikConfig } from 'formik/dist/types';
+import * as Yup from 'yup';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import makeStyles from '@mui/styles/makeStyles';
+import TextField from '../../../../../components/TextField';
+import AutocompleteFreeSoloField from '../../../../../components/AutocompleteFreeSoloField';
+import ItemIcon from '../../../../../components/ItemIcon';
+import { useFormatter } from '../../../../../components/i18n';
+import { Theme } from '../../../../../components/Theme';
+import { Option } from '../../form/ReferenceField';
+import { WorkbenchFileCreatorMutation } from './__generated__/WorkbenchFileCreatorMutation.graphql';
+import { WorkbenchFileViewer_entity$data } from './__generated__/WorkbenchFileViewer_entity.graphql';
+
+const useStyles = makeStyles<Theme>((theme) => ({
+  icon: {
+    paddingTop: 4,
+    display: 'inline-block',
+    color: theme.palette.primary.main,
+  },
+  text: {
+    display: 'inline-block',
+    flexGrow: 1,
+    marginLeft: 10,
+  },
+  autoCompleteIndicator: {
+    display: 'none',
+  },
+}));
+
+const workbenchFileCreatorMutation = graphql`
+  mutation WorkbenchFileCreatorMutation($file: Upload!, $labels: [String], $entityId: String) {
+    uploadPending(file: $file, labels: $labels, errorOnExisting: true, entityId: $entityId) {
+      id
+      ...FileLine_file
+    }
+  }
+`;
+
+const fileValidation = (t: (value: string) => string) => Yup.object().shape({
+  name: Yup.string().required(t('This field is required')),
+});
+
+interface WorkbenchFileCreatorFormValues {
+  name: string;
+  labels: Option[];
+}
+
+interface WorkbenchFileCreatorProps {
+  openCreate: boolean;
+  handleCloseCreate: () => void;
+  onCompleted?: () => void;
+  entity?: WorkbenchFileViewer_entity$data;
+}
+
+const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({ openCreate, handleCloseCreate, onCompleted, entity }) => {
+  const { t } = useFormatter();
+  const classes = useStyles();
+  const [commitWorkbench] = useMutation<WorkbenchFileCreatorMutation>(workbenchFileCreatorMutation);
+  const entityId = entity?.id;
+  const onSubmitCreate: FormikConfig<WorkbenchFileCreatorFormValues>['onSubmit'] = (
+    values,
+    { setSubmitting, resetForm },
+  ) => {
+    let { name } = values;
+    const finalLabels = values.labels.map((label) => label.value);
+    if (!name.endsWith('.json')) {
+      name += '.json';
+    }
+    const objects = [];
+    if (entity?.toStix) {
+      const stixEntity = JSON.parse(entity.toStix);
+      delete stixEntity.extensions;
+      stixEntity.x_opencti_id = entity.id;
+      objects.push(stixEntity);
+    }
+    const data = { id: `bundle--${uuid()}`, type: 'bundle', objects };
+    const json = JSON.stringify(data);
+    const blob = new Blob([json], { type: 'text/json' });
+    const file = new File([blob], name, {
+      type: 'application/json',
+    });
+
+    commitWorkbench({
+      variables: { file, labels: finalLabels, entityId },
+      onCompleted: () => {
+        setSubmitting(false);
+        resetForm();
+        handleCloseCreate();
+        if (onCompleted) {
+          onCompleted();
+        }
+      },
+    });
+  };
+
+  const initialValues: WorkbenchFileCreatorFormValues = {
+    name: '',
+    labels: [],
+  };
+
+  return (
+    <Formik
+      enableReinitialize={true}
+      initialValues={initialValues}
+      validationSchema={fileValidation(t)}
+      onSubmit={onSubmitCreate}
+      onReset={handleCloseCreate}
+    >
+      {({ submitForm, handleReset, isSubmitting }) => (
+        <Form>
+          <Dialog
+            PaperProps={{ elevation: 1 }}
+            open={openCreate}
+            onClose={handleCloseCreate}
+            fullWidth
+          >
+            <DialogTitle>{t('Create a workbench')}</DialogTitle>
+            <DialogContent>
+              <Field
+                component={TextField}
+                variant="standard"
+                name="name"
+                label={t('Name')}
+                fullWidth
+              />
+              <Field
+                component={AutocompleteFreeSoloField}
+                style={{ marginTop: 20 }}
+                name="labels"
+                multiple
+                textfieldprops={{
+                  variant: 'standard',
+                  label: t('Labels'),
+                }}
+                options={[]}
+                renderOption={(props: React.HTMLAttributes<HTMLLIElement>, option: Option) => (
+                  <li {...props}>
+                    <div className={classes.icon}>
+                      <ItemIcon type="Label" />
+                    </div>
+                    <div className={classes.text}>{option.label}</div>
+                  </li>
+                )}
+                classes={{
+                  clearIndicator: classes.autoCompleteIndicator,
+                }}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleReset} disabled={isSubmitting}>
+                {t('Cancel')}
+              </Button>
+              <Button
+                type="submit"
+                color="secondary"
+                onClick={submitForm}
+                disabled={isSubmitting}
+              >
+                {t('Create')}
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default WorkbenchFileCreator;

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -94,9 +94,7 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({ op
         setSubmitting(false);
         resetForm();
         handleCloseCreate();
-        if (onCompleted) {
-          onCompleted();
-        }
+        onCompleted?.();
       },
     });
   };

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
@@ -318,7 +318,6 @@ WorkbenchFileLineComponent.propTypes = {
   file: PropTypes.object.isRequired,
   connectors: PropTypes.array,
   dense: PropTypes.bool,
-  disableImport: PropTypes.bool,
   directDownload: PropTypes.bool,
   handleOpenImport: PropTypes.func,
   nested: PropTypes.bool,

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
@@ -32,7 +32,6 @@ const styles = () => ({
 
 const WorkbenchFileViewerBase = ({
   entity,
-  disableImport,
   handleOpenImport,
   connectors,
   relay,
@@ -41,7 +40,6 @@ const WorkbenchFileViewerBase = ({
 }) => {
   const { id, pendingFiles } = entity;
   const { edges } = pendingFiles;
-  const isContainer = entity.entity_type !== 'Report';
   const [openCreate, setOpenCreate] = useState(false);
 
   useEffect(() => {
@@ -89,7 +87,6 @@ const WorkbenchFileViewerBase = ({
                 <WorkbenchFileLine
                   key={file.node.id}
                   dense={true}
-                  disableImport={isContainer || disableImport}
                   file={file.node}
                   connectors={
                     connectors && connectors[file.node.metaData.mimetype]

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { graphql, createRefetchContainer } from 'react-relay';
@@ -8,9 +8,12 @@ import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
+import IconButton from '@mui/material/IconButton';
+import { Add } from '@mui/icons-material';
 import { TEN_SECONDS } from '../../../../../utils/Time';
 import inject18n from '../../../../../components/i18n';
 import WorkbenchFileLine from './WorkbenchFileLine';
+import WorkbenchFileCreator from './WorkbenchFileCreator';
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -19,8 +22,11 @@ const styles = () => ({
     height: '100%',
     minHeight: '100%',
     padding: '10px 15px 10px 15px',
-    marginTop: 8,
+    marginTop: -2,
     borderRadius: 6,
+  },
+  createButton: {
+    marginTop: -15,
   },
 });
 
@@ -36,6 +42,8 @@ const WorkbenchFileViewerBase = ({
   const { id, pendingFiles } = entity;
   const { edges } = pendingFiles;
   const isContainer = entity.entity_type !== 'Report';
+  const [openCreate, setOpenCreate] = useState(false);
+
   useEffect(() => {
     // Refresh the export viewer every interval
     const subscription = interval$.subscribe(() => {
@@ -45,12 +53,34 @@ const WorkbenchFileViewerBase = ({
       subscription.unsubscribe();
     };
   });
+
+  const onCreateWorkbenchCompleted = () => {
+    relay.refetch({ id });
+  };
+
   return (
     <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
       <div style={{ height: '100%' }}>
-        <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
-          {t('Analyst workbenches')}
-        </Typography>
+        <div>
+          <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
+            {t('Analyst workbenches')}
+          </Typography>
+          <IconButton
+            color="secondary"
+            aria-label="Add"
+            onClick={() => setOpenCreate(true)}
+            classes={{ root: classes.createButton }}
+            size="large"
+          >
+            <Add fontSize="small" />
+          </IconButton>
+        </div>
+        <WorkbenchFileCreator
+          handleCloseCreate={() => setOpenCreate(false)}
+          openCreate={openCreate}
+          onCompleted={onCreateWorkbenchCompleted}
+          entity={entity}
+        />
         <div className="clearfix" />
         <Paper classes={{ root: classes.paper }} variant="outlined">
           {edges.length ? (
@@ -107,6 +137,7 @@ const WorkbenchFileViewer = createRefetchContainer(
       fragment WorkbenchFileViewer_entity on StixCoreObject {
         id
         entity_type
+        toStix
         pendingFiles(first: 1000) @connection(key: "Pagination_pendingFiles") {
           edges {
             node {

--- a/opencti-platform/opencti-front/src/private/components/import/ImportContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/import/ImportContent.jsx
@@ -600,7 +600,7 @@ class ImportContentComponent extends Component {
           </Formik>
           <WorkbenchFileCreator
             handleCloseCreate={this.handleCloseCreate.bind(this)}
-            openCreate={!!displayCreate}
+            openCreate={displayCreate}
             onCompleted={this.onCreateWorkbenchCompleted.bind(this)}
           />
         </div>

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -3964,6 +3964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:9.0.2":
+  version: 9.0.2
+  resolution: "@types/uuid@npm:9.0.2"
+  checksum: 1754bcf3444e1e3aeadd6e774fc328eb53bc956665e2e8fb6ec127aa8e1f43d9a224c3d22a9a6233dca8dd81a12dc7fed4d84b8876dd5ec82d40f574f7ff8b68
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
@@ -12305,6 +12312,7 @@ __metadata:
     "@types/react-router-dom": 5.3.3
     "@types/react-test-renderer": 18.0.0
     "@types/relay-test-utils": 14.1.0
+    "@types/uuid": 9.0.2
     "@vitejs/plugin-react": 4.0.0
     apexcharts: 3.41.0
     axios: 1.4.0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Extract WorkbenchFileCreator component to create a new analyst workbench
* Add entity property to be able to create a workbench from an entity : create the workbench file with stix entity in objects data and entityId in the file metadata.
* Bug fix : workbench created from a container entity should link all added entities to the container (in object_refs)

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3188

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
