### PR TITLE
[backend] Fix unusable filters

### DIFF
--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -11354,9 +11354,6 @@ enum StixCoreRelationshipsOrdering {
   creator
 }
 enum StixCoreRelationshipsFilter {
-  elementId
-  fromId
-  toId
   created
   modified
   created_at


### PR DESCRIPTION
Query like 
{
  stixCoreRelationships(
    filters: [{ key: relationship_type, values: ["located-at"] }, { key: toId, values: ["e1b2cf0a-bf12-4894-b64a-8ea595b5087c"] }]
  ) {
    edges {
      ...
      }
    }
  }
}

doesn't work because we don't support toId, fromId and elementId as filter key but only as parameters.