### PR TITLE
[frontend] fix Malware analyses names in Cases/Analyses "Entities" view

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -257,6 +257,9 @@ export const ContainerAddStixCoreObjectsLine = createFragmentContainer(
           aliases
           description
         }
+        ... on MalwareAnalysis {
+          result_name
+        }
         ... on ThreatActor {
           name
           aliases

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
@@ -240,6 +240,9 @@ export const ContainerStixCoreObjectsMappingLine = createFragmentContainer(
         ... on Malware {
           name
         }
+        ... on MalwareAnalysis {
+          result_name
+        }
         ... on ThreatActor {
           name
         }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fixed the names of Malware analyses in the "Entities" view of Cases and Analyses entities

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3845
