### PR TITLE
[frontend] fix global search infinite loading and total count (#3882)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.jsx
@@ -16,7 +16,7 @@ class SearchStixCoreObjectsLines extends Component {
     setNumberOfElements(
       prevProps,
       this.props,
-      'stixCoreObjects',
+      'globalSearch',
       this.props.setNumberOfElements.bind(this),
     );
   }
@@ -383,7 +383,7 @@ export default createPaginationContainer(
   {
     direction: 'forward',
     getConnectionFromProps(props) {
-      return props.data && props.data.stixCoreObjects;
+      return props.data && props.data.globalSearch;
     },
     getFragmentVariables(prevVars, totalCount) {
       return {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix renaming of stixCoreObjects to globalSearch

### Related issues

Infinite loading for global search results was not working anymore and entities total count was always 0 (/dashboard/search)
* https://github.com/OpenCTI-Platform/opencti/issues/3882

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
