### PR TITLE
[frontend] Fix full re-render of the top bar when entering / exiting home dashboard (#3854)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Index.jsx
+++ b/opencti-platform/opencti-front/src/private/Index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -38,10 +38,8 @@ const useStyles = makeStyles((theme) => ({
   toolbar: theme.mixins.toolbar,
 }));
 
-const noTopBarLocations = ['/dashboard'];
 
 const Index = ({ settings }) => {
-  const location = useLocation();
   const theme = useTheme();
   const classes = useStyles();
   const {
@@ -71,7 +69,7 @@ const Index = ({ settings }) => {
         }}
       >
         <CssBaseline />
-        {!noTopBarLocations.includes(location.pathname) && <TopBar />}
+        <TopBar />
         <LeftBar />
         <Message />
         <Box component="main" sx={boxSx}>

--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -40,7 +40,6 @@ import { dayAgo, monthsAgo, yearsAgo } from '../../utils/Time';
 import Chart from './common/charts/Chart';
 import LocationMiniMapTargets from './common/location/LocationMiniMapTargets';
 import StixCoreRelationshipsHorizontalBars from './common/stix_core_relationships/StixCoreRelationshipsHorizontalBars';
-import TopBar from './nav/TopBar';
 import DashboardView from './workspaces/dashboards/Dashboard';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 
@@ -1112,7 +1111,6 @@ const DashboardComponent = ({ queryRef }) => {
   return (
     <UserContext.Provider value={{ me: { ...currentMe, ...me }, ...context }}>
       <div className={classes.root}>
-        <TopBar />
         {defaultDashboard ? (
           <CustomDashboard
             dashboard={defaultDashboard}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -8,7 +8,6 @@ import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
@@ -17,8 +16,6 @@ import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCo
 import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
 import TopBar from '../../nav/TopBar';
 import { RootIncidentCaseQuery } from './__generated__/RootIncidentCaseQuery.graphql';
-import { RootIncidentQuery } from './__generated__/RootIncidentQuery.graphql';
-import { RootIncidentSubscription } from './__generated__/RootIncidentSubscription.graphql';
 import CaseIncident from './CaseIncident';
 import CaseIncidentPopover from './CaseIncidentPopover';
 import IncidentKnowledge from './IncidentKnowledge';
@@ -63,7 +60,6 @@ const caseIncidentQuery = graphql`
 `;
 
 const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
-  const { me } = useAuth();
   const subConfig = useMemo<
   GraphQLSubscriptionConfig<RootIncidentSubscription>
   >(
@@ -81,7 +77,7 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
   } = usePreloadedQuery<RootIncidentCaseQuery>(caseIncidentQuery, queryRef);
   return (
     <div>
-      <TopBar me={me} />
+      <TopBar/>
       <>
         {caseData ? (
           <Switch>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -8,7 +8,6 @@ import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import TopBar from '../../nav/TopBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import ContainerHeader from '../../common/containers/ContainerHeader';
@@ -65,7 +64,6 @@ const caseRfiQuery = graphql`
 `;
 
 const RootCaseRfiComponent = ({ queryRef, caseId }) => {
-  const { me } = useAuth();
   const subConfig = useMemo<
   GraphQLSubscriptionConfig<RootCaseRfiCaseSubscription>
   >(
@@ -83,7 +81,7 @@ const RootCaseRfiComponent = ({ queryRef, caseId }) => {
   } = usePreloadedQuery<RootCaseRfiCaseQuery>(caseRfiQuery, queryRef);
   return (
     <div>
-      <TopBar me={me} />
+      <TopBar/>
       <>
         {caseData ? (
           <Switch>

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -8,7 +8,6 @@ import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import TopBar from '../../nav/TopBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { RootFeedbackSubscription } from './__generated__/RootFeedbackSubscription.graphql';
@@ -57,7 +56,6 @@ const feedbackQuery = graphql`
 `;
 
 const RootFeedbackComponent = ({ queryRef, caseId }) => {
-  const { me } = useAuth();
   const subConfig = useMemo<
   GraphQLSubscriptionConfig<RootFeedbackSubscription>
   >(
@@ -75,7 +73,7 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
   } = usePreloadedQuery<RootFeedbackQuery>(feedbackQuery, queryRef);
   return (
     <div>
-      <TopBar me={me} />
+      <TopBar/>
       <>
         {feedbackData ? (
           <Switch>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -8,7 +8,6 @@ import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import TopBar from '../../nav/TopBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
@@ -67,7 +66,6 @@ const RootThreatActorIndividualComponent = ({
   queryRef,
   threatActorIndividualId,
 }) => {
-  const { me } = useAuth();
   const subConfig = useMemo<
   GraphQLSubscriptionConfig<RootThreatActorIndividualSubscription>
   >(
@@ -90,7 +88,7 @@ const RootThreatActorIndividualComponent = ({
 
   return (
     <div>
-      <TopBar me={me} />
+      <TopBar/>
       <Route path="/dashboard/threats/threat_actors_individual/:threatActorIndividualId/knowledge">
         <StixCoreObjectKnowledgeBar
           stixCoreObjectLink={link}


### PR DESCRIPTION
Fix full re-render of the top bar when entering / exiting home dashboard (#3854)
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix full re-render of the top bar when entering / exiting home dashboard ==> Temporary solution before fixing this 
[issue](https://github.com/OpenCTI-Platform/opencti/issues/2796).
* Remove  `me` legacy  prop from TopBar component calls (useAuth hook is now use directly inside the component)
* Remove 2 unused import in case_incidents > root.tsx

### Related issues

* [issue/3854](https://github.com/OpenCTI-Platform/opencti/issues/3854)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
