### PR TITLE
[backend/frontend] Display of indicators and observables second part

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -13,6 +13,8 @@ import EntityStixSightingRelationships from '../../events/stix_sighting_relation
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -204,21 +206,34 @@ class ChannelKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/arsenal/channels/:channelId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={channel.id}
+                entityLink={`/dashboard/arsenal/channels/${channel.id}/indicators`}
+                defaultStartTime={channel.first_seen}
+                defaultStopTime={channel.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/arsenal/channels/:channelId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
                 entityId={channel.id}
+                entityLink={link}
+                defaultStartTime={channel.first_seen}
+                defaultStopTime={channel.last_seen}
+                isRelationReversed={true}
                 relationshipTypes={[
                   'related-to',
                   'publishes',
                   'uses',
                   'belongs-to',
                 ]}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
-                entityLink={link}
-                allDirections={true}
-                isRelationReversed={true}
-                {...routeProps}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -13,7 +13,6 @@ import EntityStixSightingRelationships from '../../events/stix_sighting_relation
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
-import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
 import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
@@ -201,19 +200,6 @@ class ChannelKnowledgeComponent extends Component {
                 entityLink={link}
                 isRelationReversed={true}
                 {...routeProps}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/dashboard/arsenal/channels/:channelId/knowledge/indicators"
-            render={(routeProps) => (
-              <EntityStixCoreRelationshipsIndicators
-                {...routeProps}
-                entityId={channel.id}
-                entityLink={link}
-                defaultStartTime={channel.first_seen}
-                defaultStopTime={channel.last_seen}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -211,7 +211,7 @@ class ChannelKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={channel.id}
-                entityLink={`/dashboard/arsenal/channels/${channel.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={channel.first_seen}
                 defaultStopTime={channel.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
@@ -95,7 +95,6 @@ class RootChannel extends Component {
               'malwares',
               'attack_patterns',
               'vulnerabilities',
-              'indicators',
               'observables',
               'sightings',
               'channels',

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
@@ -11,7 +11,6 @@ import FileManager from '../../common/files/FileManager';
 import ChannelPopover from './ChannelPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
 import StixCoreObjectOrStixCoreRelationshipContainers
   from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
@@ -96,6 +95,7 @@ class RootChannel extends Component {
               'malwares',
               'attack_patterns',
               'vulnerabilities',
+              'indicators',
               'observables',
               'sightings',
               'channels',
@@ -153,24 +153,6 @@ class RootChannel extends Component {
                             stixDomainObjectOrStixCoreRelationship={
                               props.channel
                             }
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/arsenal/channels/:channelId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Channel'}
-                            stixDomainObject={props.channel}
-                            PopoverComponent={<ChannelPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={channelId}
-                            stixDomainObjectLink={`/dashboard/arsenal/channels/${channelId}/indicators`}
                           />
                         </React.Fragment>
                       )}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
@@ -14,6 +14,8 @@ import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/Sti
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -235,18 +237,29 @@ class MalwareKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/arsenal/malwares/:malwareId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={malware.id}
+                entityLink={`/dashboard/threats/malwares/${malware.id}/indicators`}
+                defaultStartTime={malware.first_seen}
+                defaultStopTime={malware.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/arsenal/malwares/:malwareId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
                 entityId={malware.id}
-                relationshipTypes={['communicates-with', 'related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
                 entityLink={link}
                 defaultStartTime={malware.first_seen}
                 defaultStopTime={malware.last_seen}
-                allDirections={true}
                 isRelationReversed={true}
-                {...routeProps}
+                relationshipTypes={['communicates-with', 'related-to']}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
@@ -242,7 +242,7 @@ class MalwareKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={malware.id}
-                entityLink={`/dashboard/threats/malwares/${malware.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={malware.first_seen}
                 defaultStopTime={malware.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
@@ -15,8 +15,6 @@ import MalwarePopover from './MalwarePopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 
@@ -100,6 +98,7 @@ class RootMalware extends Component {
               'tools',
               'attack_patterns',
               'vulnerabilities',
+              'indicators',
               'observables',
               'infrastructures',
               'sightings',
@@ -159,34 +158,6 @@ class RootMalware extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/arsenal/malwares/:malwareId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Malware'}
-                            stixDomainObject={props.malware}
-                            PopoverComponent={<MalwarePopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={malwareId}
-                            stixDomainObjectLink={`/dashboard/arsenal/malwares/${malwareId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/arsenal/malwares/:intrusionSetId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={malwareId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
@@ -14,7 +14,6 @@ import FileManager from '../../common/files/FileManager';
 import ToolPopover from './ToolPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -97,6 +96,7 @@ class RootTool extends Component {
               'malwares',
               'attack_patterns',
               'vulnerabilities',
+              'indicators',
               'observables',
               'sightings',
             ]}
@@ -148,24 +148,6 @@ class RootTool extends Component {
                           <StixCoreObjectOrStixCoreRelationshipContainers
                             {...routeProps}
                             stixDomainObjectOrStixCoreRelationship={props.tool}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/arsenal/tools/:toolId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Tool'}
-                            stixDomainObject={props.tool}
-                            PopoverComponent={<ToolPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={toolId}
-                            stixDomainObjectLink={`/dashboard/arsenal/tools/${toolId}/indicators`}
                           />
                         </React.Fragment>
                       )}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
@@ -12,6 +12,8 @@ import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainO
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -178,16 +180,29 @@ class ToolKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/arsenal/tools/:toolId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={tool.id}
+                entityLink={`/dashboard/arsenal/tools/${tool.id}/indicators`}
+                defaultStartTime={tool.first_seen}
+                defaultStopTime={tool.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/arsenal/tools/:toolId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
-                entityId={tool.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
-                entityLink={link}
-                allDirections={true}
-                isRelationReversed={true}
+              <EntityStixCoreRelationshipsStixCyberObservable
                 {...routeProps}
+                entityId={tool.id}
+                entityLink={link}
+                defaultStartTime={tool.first_seen}
+                defaultStopTime={tool.last_seen}
+                isRelationReversed={true}
+                relationshipTypes={['related-to']}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
@@ -185,7 +185,7 @@ class ToolKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={tool.id}
-                entityLink={`/dashboard/arsenal/tools/${tool.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={tool.first_seen}
                 defaultStopTime={tool.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
@@ -15,7 +15,6 @@ import VulnerabilityPopover from './VulnerabilityPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 
@@ -98,6 +97,7 @@ class RootVulnerability extends Component {
               'malwares',
               'tools',
               'attack_patterns',
+              'indicators',
               'observables',
               'sightings',
               'infrastructures',
@@ -155,24 +155,6 @@ class RootVulnerability extends Component {
                             stixDomainObjectOrStixCoreRelationship={
                               props.vulnerability
                             }
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/arsenal/vulnerabilities/:vulnerabilityId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Vulnerability'}
-                            stixDomainObject={props.vulnerability}
-                            PopoverComponent={<VulnerabilityPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={vulnerabilityId}
-                            stixDomainObjectLink={`/dashboard/arsenal/vulnerabilities/${vulnerabilityId}/indicators`}
                           />
                         </React.Fragment>
                       )}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
@@ -12,6 +12,8 @@ import VulnerabilityPopover from './VulnerabilityPopover';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -158,6 +160,34 @@ class VulnerabilityKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/arsenal/vulnerabilities/:vulnerabilityId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={vulnerability.id}
+                entityLink={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/indicators`}
+                defaultStartTime={vulnerability.first_seen}
+                defaultStopTime={vulnerability.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/dashboard/arsenal/vulnerabilities/:vulnerabilityId/knowledge/observables"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
+                entityId={vulnerability.id}
+                entityLink={link}
+                defaultStartTime={vulnerability.first_seen}
+                defaultStopTime={vulnerability.last_seen}
+                isRelationReversed={true}
+                relationshipTypes={['related-to']}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/arsenal/vulnerabilities/:vulnerabilityId/knowledge/attack_patterns"
             render={(routeProps) => (
               <EntityStixCoreRelationships
@@ -207,21 +237,6 @@ class VulnerabilityKnowledgeComponent extends Component {
                 relationshipTypes={['has']}
                 stixCoreObjectTypes={['Infrastructure']}
                 entityLink={link}
-                isRelationReversed={true}
-                {...routeProps}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/dashboard/arsenal/vulnerabilities/:vulnerabilityId/knowledge/observables"
-            render={(routeProps) => (
-              <EntityStixCoreRelationships
-                entityId={vulnerability.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
-                entityLink={link}
-                allDirections={true}
                 isRelationReversed={true}
                 {...routeProps}
               />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
@@ -165,7 +165,7 @@ class VulnerabilityKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={vulnerability.id}
-                entityLink={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={vulnerability.first_seen}
                 defaultStopTime={vulnerability.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
@@ -29,7 +29,7 @@ const EntityStixCoreRelationshipsIndicators: FunctionComponent<EntityStixCoreRel
 }) => {
   const classes = useStyles();
 
-  const relationshipTypes = ['indicates'];
+  const relationshipTypes = ['indicates', 'related-to'];
   const entityTypes = ['Indicator'];
 
   const localStorage = usePaginationLocalStorage<PaginationOptions>(

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
@@ -29,7 +29,7 @@ const EntityStixCoreRelationshipsIndicators: FunctionComponent<EntityStixCoreRel
 }) => {
   const classes = useStyles();
 
-  const relationshipTypes = ['indicates', 'related-to'];
+  const relationshipTypes = ['indicates'];
   const entityTypes = ['Indicator'];
 
   const localStorage = usePaginationLocalStorage<PaginationOptions>(

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuAttackPattern.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuAttackPattern.jsx
@@ -128,29 +128,6 @@ class TopMenuAttackPattern extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/techniques/attack_patterns/${attackPatternId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/techniques/attack_patterns/${attackPatternId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/techniques/attack_patterns/${attackPatternId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!attackPatternId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuCampaign.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuCampaign.jsx
@@ -123,29 +123,6 @@ class TopMenuCampaign extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/threats/campaigns/${campaignId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/threats/campaigns/${campaignId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/threats/campaigns/${campaignId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!campaignId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuChannel.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuChannel.jsx
@@ -128,29 +128,6 @@ class TopMenuChannel extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/arsenal/channels/${channelId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/arsenal/channels/${channelId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/arsenal/channels/${channelId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!channelId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuInfrastructure.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuInfrastructure.jsx
@@ -125,29 +125,6 @@ class TopMenuInfrastructure extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/observations/infrastructures/${infrastructureId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/observations/infrastructures/${infrastructureId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/observations/infrastructures/${infrastructureId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!infrastructureId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuIntrusionSet.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuIntrusionSet.jsx
@@ -125,29 +125,6 @@ class TopMenuIntrusionSet extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/threats/intrusion_sets/${intrusionSetId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/threats/intrusion_sets/${intrusionSetId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/threats/intrusion_sets/${intrusionSetId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!intrusionSetId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuMalware.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuMalware.jsx
@@ -123,29 +123,6 @@ class TopMenuMalware extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/arsenal/malwares/${malwareId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/arsenal/malwares/${malwareId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/arsenal/malwares/${malwareId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!malwareId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuNarrative.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuNarrative.jsx
@@ -130,29 +130,6 @@ class TopMenuNarrative extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/techniques/narratives/${narrativeId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/techniques/narratives/${narrativeId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/techniques/narratives/${narrativeId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!narrativeId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuThreatActorGroup.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuThreatActorGroup.tsx
@@ -122,29 +122,6 @@ const TopMenuThreatActorGroup = () => {
       >
         {t('Analyses')}
       </Button>
-      <Button
-        component={Link}
-        to={`/dashboard/threats/threat_actors_group/${threatActorGroupId}/indicators`}
-        variant={
-          location.pathname.includes(
-            `/dashboard/threats/threat_actors_group/${threatActorGroupId}/indicators`,
-          )
-            ? 'contained'
-            : 'text'
-        }
-        size="small"
-        color={
-          location.pathname.includes(
-            `/dashboard/threats/threat_actors_group/${threatActorGroupId}/indicators`,
-          )
-            ? 'secondary'
-            : 'primary'
-        }
-        classes={{ root: classes.button }}
-        disabled={!threatActorGroupId}
-      >
-        {t('Indicators')}
-      </Button>
       <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
         <Button
           component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuTool.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuTool.jsx
@@ -123,29 +123,6 @@ class TopMenuTool extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/arsenal/tools/${toolId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/arsenal/tools/${toolId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/arsenal/tools/${toolId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!toolId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/nav/TopMenuVulnerability.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopMenuVulnerability.jsx
@@ -130,29 +130,6 @@ class TopMenuVulnerability extends Component {
         >
           {t('Analyses')}
         </Button>
-        <Button
-          component={Link}
-          to={`/dashboard/arsenal/vulnerabilities/${vulnerabilityId}/indicators`}
-          variant={
-            location.pathname.includes(
-              `/dashboard/arsenal/vulnerabilities/${vulnerabilityId}/indicators`,
-            )
-              ? 'contained'
-              : 'text'
-          }
-          size="small"
-          color={
-            location.pathname.includes(
-              `/dashboard/arsenal/vulnerabilities/${vulnerabilityId}/indicators`,
-            )
-              ? 'secondary'
-              : 'primary'
-          }
-          classes={{ root: classes.button }}
-          disabled={!vulnerabilityId}
-        >
-          {t('Indicators')}
-        </Button>
         <Security needs={[KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT]}>
           <Button
             component={Link}

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.jsx
@@ -145,7 +145,7 @@ class InfrastructureKnowledgeComponent extends Component {
             <EntityStixCoreRelationshipsIndicators
               {...routeProps}
               entityId={infrastructure.id}
-              entityLink={`/dashboard/observations/infrastructures/${infrastructure.id}/indicators`}
+              entityLink={link}
               defaultStartTime={infrastructure.first_seen}
               defaultStopTime={infrastructure.last_seen}
             />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.jsx
@@ -13,6 +13,10 @@ import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainO
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators
+  from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable
+  from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -44,6 +48,7 @@ class InfrastructureKnowledgeComponent extends Component {
             'tools',
             'vulnerabilities',
             'infrastructures',
+            'indicators',
             'observables',
             'observed_data',
             'sightings',
@@ -135,17 +140,28 @@ class InfrastructureKnowledgeComponent extends Component {
         />
         <Route
           exact
+          path="/dashboard/observations/infrastructures/:infrastructureId/knowledge/indicators"
+          render={(routeProps) => (
+            <EntityStixCoreRelationshipsIndicators
+              {...routeProps}
+              entityId={infrastructure.id}
+              entityLink={`/dashboard/observations/infrastructures/${infrastructure.id}/indicators`}
+              defaultStartTime={infrastructure.first_seen}
+              defaultStopTime={infrastructure.last_seen}
+            />
+          )}
+        />
+        <Route
+          exact
           path="/dashboard/observations/infrastructures/:infrastructureId/knowledge/observables"
           render={(routeProps) => (
-            <EntityStixCoreRelationships
+            <EntityStixCoreRelationshipsStixCyberObservable
+              {...routeProps}
               entityId={infrastructure.id}
-              relationshipTypes={['communicates-with', 'consists-of']}
-              stixCoreObjectTypes={['Stix-Cyber-Observable']}
               entityLink={link}
               defaultStartTime={infrastructure.first_seen}
               defaultStopTime={infrastructure.last_seen}
-              allDirections={true}
-              {...routeProps}
+              relationshipTypes={['communicates-with', 'consists-of', 'related-to']}
             />
           )}
         />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.jsx
@@ -15,8 +15,6 @@ import InfrastructurePopover from './InfrastructurePopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 
 const subscription = graphql`
@@ -138,33 +136,6 @@ class RootInfrastructure extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/observations/infrastructures/:infrastructureId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            stixDomainObject={props.infrastructure}
-                            PopoverComponent={<InfrastructurePopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={infrastructureId}
-                            stixDomainObjectLink={`/dashboard/observations/infrastructures/${infrastructureId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/observations/infrastructures/:infrastructureId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={infrastructureId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
@@ -12,6 +12,8 @@ import AttackPatternPopover from './AttackPatternPopover';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -162,6 +164,34 @@ class AttackPatternKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/techniques/attack_patterns/:attackPatternId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={attackPattern.id}
+                entityLink={`/dashboard/techniques/attack_patterns/${attackPattern.id}/indicators`}
+                defaultStartTime={attackPattern.first_seen}
+                defaultStopTime={attackPattern.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/dashboard/techniques/attack_patterns/:attackPatternId/knowledge/observables"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
+                entityId={attackPattern.id}
+                entityLink={link}
+                defaultStartTime={attackPattern.first_seen}
+                defaultStopTime={attackPattern.last_seen}
+                isRelationReversed={true}
+                relationshipTypes={['related-to']}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/techniques/attack_patterns/:attackPatternId/knowledge/malwares"
             render={(routeProps) => (
               <EntityStixCoreRelationships
@@ -198,21 +228,6 @@ class AttackPatternKnowledgeComponent extends Component {
                 stixCoreObjectTypes={['Vulnerability']}
                 entityLink={link}
                 isRelationReversed={false}
-                {...routeProps}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/dashboard/techniques/attack_patterns/:attackPatternId/knowledge/observables"
-            render={(routeProps) => (
-              <EntityStixCoreRelationships
-                entityId={attackPattern.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
-                entityLink={link}
-                allDirections={true}
-                isRelationReversed={true}
                 {...routeProps}
               />
             )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
@@ -169,7 +169,7 @@ class AttackPatternKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={attackPattern.id}
-                entityLink={`/dashboard/techniques/attack_patterns/${attackPattern.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={attackPattern.first_seen}
                 defaultStopTime={attackPattern.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
@@ -15,8 +15,6 @@ import AttackPatternPopover from './AttackPatternPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 
@@ -100,6 +98,7 @@ class RootAttackPattern extends Component {
               'vulnerabilities',
               'malwares',
               'sightings',
+              'indicators',
               'observables',
             ]}
           />
@@ -157,34 +156,6 @@ class RootAttackPattern extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/techniques/attack_patterns/:attackPatternId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Attack-Pattern'}
-                            stixDomainObject={props.attackPattern}
-                            PopoverComponent={<AttackPatternPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={attackPatternId}
-                            stixDomainObjectLink={`/dashboard/techniques/attack_patterns/${attackPatternId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/techniques/attack_patterns/:attackPatternId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={attackPatternId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -12,6 +12,8 @@ import EntityStixSightingRelationships from '../../events/stix_sighting_relation
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import NarrativePopover from './NarrativePopover';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -209,16 +211,29 @@ class NarrativeKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/techniques/narratives/:narrativeId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={narrative.id}
+                entityLink={`/dashboard/techniques/narratives/${narrative.id}/indicators`}
+                defaultStartTime={narrative.first_seen}
+                defaultStopTime={narrative.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/techniques/narratives/:narrativeId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
-                entityId={narrative.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
-                entityLink={link}
-                allDirections={true}
-                isRelationReversed={true}
+              <EntityStixCoreRelationshipsStixCyberObservable
                 {...routeProps}
+                entityId={narrative.id}
+                entityLink={link}
+                defaultStartTime={narrative.first_seen}
+                defaultStopTime={narrative.last_seen}
+                isRelationReversed={true}
+                relationshipTypes={['related-to']}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -12,7 +12,6 @@ import EntityStixSightingRelationships from '../../events/stix_sighting_relation
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import NarrativePopover from './NarrativePopover';
-import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
 import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
@@ -206,19 +205,6 @@ class NarrativeKnowledgeComponent extends Component {
                 entityLink={link}
                 isRelationReversed={true}
                 {...routeProps}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/dashboard/techniques/narratives/:narrativeId/knowledge/indicators"
-            render={(routeProps) => (
-              <EntityStixCoreRelationshipsIndicators
-                {...routeProps}
-                entityId={narrative.id}
-                entityLink={link}
-                defaultStartTime={narrative.first_seen}
-                defaultStopTime={narrative.last_seen}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -216,7 +216,7 @@ class NarrativeKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={narrative.id}
-                entityLink={`/dashboard/techniques/narratives/${narrative.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={narrative.first_seen}
                 defaultStopTime={narrative.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
@@ -14,7 +14,6 @@ import FileManager from '../../common/files/FileManager';
 import NarrativePopover from './NarrativePopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -98,6 +97,7 @@ class RootNarrative extends Component {
               'channels',
               'attack_patterns',
               'vulnerabilities',
+              'indicators',
               'observables',
               'sightings',
             ]}
@@ -154,24 +154,6 @@ class RootNarrative extends Component {
                             stixDomainObjectOrStixCoreRelationship={
                               props.narrative
                             }
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/techniques/narratives/:narrativeId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Narrative'}
-                            stixDomainObject={props.narrative}
-                            PopoverComponent={<NarrativePopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={narrativeId}
-                            stixDomainObjectLink={`/dashboard/techniques/narratives/${narrativeId}/indicators`}
                           />
                         </React.Fragment>
                       )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
@@ -97,7 +97,6 @@ class RootNarrative extends Component {
               'channels',
               'attack_patterns',
               'vulnerabilities',
-              'indicators',
               'observables',
               'sightings',
             ]}

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
@@ -245,7 +245,7 @@ class CampaignKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={campaign.id}
-                entityLink={`/dashboard/threats/campaigns/${campaign.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={campaign.first_seen}
                 defaultStopTime={campaign.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
@@ -14,6 +14,8 @@ import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/Sti
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -238,18 +240,29 @@ class CampaignKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/threats/campaigns/:campaignId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={campaign.id}
+                entityLink={`/dashboard/threats/campaigns/${campaign.id}/indicators`}
+                defaultStartTime={campaign.first_seen}
+                defaultStopTime={campaign.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/threats/campaigns/:campaignId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
                 entityId={campaign.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
                 entityLink={link}
                 defaultStartTime={campaign.first_seen}
                 defaultStopTime={campaign.last_seen}
-                allDirections={true}
                 isRelationReversed={true}
-                {...routeProps}
+                relationshipTypes={['related-to']}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
@@ -15,8 +15,6 @@ import CampaignPopover from './CampaignPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 
@@ -100,6 +98,7 @@ class RootCampaign extends Component {
               'narratives',
               'attack_patterns',
               'vulnerabilities',
+              'indicators',
               'observables',
               'infrastructures',
               'sightings',
@@ -156,34 +155,6 @@ class RootCampaign extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/campaigns/:campaignId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Campaign'}
-                            stixDomainObject={props.campaign}
-                            PopoverComponent={<CampaignPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={campaignId}
-                            stixDomainObjectLink={`/dashboard/threats/campaigns/${campaignId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/campaigns/:campaignId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={campaignId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -245,7 +245,7 @@ class IntrusionSetKnowledgeComponent extends Component {
               <EntityStixCoreRelationshipsIndicators
                 {...routeProps}
                 entityId={intrusionSet.id}
-                entityLink={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/indicators`}
+                entityLink={link}
                 defaultStartTime={intrusionSet.first_seen}
                 defaultStopTime={intrusionSet.last_seen}
               />

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -14,6 +14,8 @@ import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/Sti
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -238,18 +240,29 @@ class IntrusionSetKnowledgeComponent extends Component {
           />
           <Route
             exact
+            path="/dashboard/threats/intrusion_sets/:intrusionSetId/knowledge/indicators"
+            render={(routeProps) => (
+              <EntityStixCoreRelationshipsIndicators
+                {...routeProps}
+                entityId={intrusionSet.id}
+                entityLink={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/indicators`}
+                defaultStartTime={intrusionSet.first_seen}
+                defaultStopTime={intrusionSet.last_seen}
+              />
+            )}
+          />
+          <Route
+            exact
             path="/dashboard/threats/intrusion_sets/:intrusionSetId/knowledge/observables"
             render={(routeProps) => (
-              <EntityStixCoreRelationships
+              <EntityStixCoreRelationshipsStixCyberObservable
+                {...routeProps}
                 entityId={intrusionSet.id}
-                relationshipTypes={['related-to']}
-                stixCoreObjectTypes={['Stix-Cyber-Observable']}
                 entityLink={link}
                 defaultStartTime={intrusionSet.first_seen}
                 defaultStopTime={intrusionSet.last_seen}
-                allDirections={true}
                 isRelationReversed={true}
-                {...routeProps}
+                relationshipTypes={['related-to']}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
@@ -15,8 +15,6 @@ import IntrusionSetPopover from './IntrusionSetPopover';
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 
@@ -101,6 +99,7 @@ class RootIntrusionSet extends Component {
               'channels',
               'narratives',
               'vulnerabilities',
+              'indicators',
               'observables',
               'infrastructures',
               'sightings',
@@ -161,34 +160,6 @@ class RootIntrusionSet extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/intrusion_sets/:intrusionSetId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Intrusion-Set'}
-                            stixDomainObject={props.intrusionSet}
-                            PopoverComponent={<IntrusionSetPopover />}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={intrusionSetId}
-                            stixDomainObjectLink={`/dashboard/threats/intrusion_sets/${intrusionSetId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/intrusion_sets/:intrusionSetId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={intrusionSetId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
@@ -15,8 +15,6 @@ import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainO
 import ThreatActorGroupPopover from './ThreatActorGroupPopover';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
-import StixDomainObjectIndicators from '../../observations/indicators/StixDomainObjectIndicators';
-import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 
@@ -102,6 +100,7 @@ class RootThreatActorGroup extends Component {
               'narratives',
               'tools',
               'vulnerabilities',
+              'indicators',
               'observables',
               'infrastructures',
               'sightings',
@@ -161,35 +160,6 @@ class RootThreatActorGroup extends Component {
                             }
                           />
                         </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/threat_actors_group/:threatActorGroupId/indicators"
-                      render={(routeProps) => (
-                        <React.Fragment>
-                          <StixDomainObjectHeader
-                            entityType={'Threat-Actor-Group'}
-                            stixDomainObject={props.threatActorGroup}
-                            PopoverComponent={<ThreatActorGroupPopover />}
-                            disableSharing={true}
-                          />
-                          <StixDomainObjectIndicators
-                            {...routeProps}
-                            stixDomainObjectId={threatActorGroupId}
-                            stixDomainObjectLink={`/dashboard/threats/threat_actors_group/${threatActorGroupId}/indicators`}
-                          />
-                        </React.Fragment>
-                      )}
-                    />
-                    <Route
-                      exact
-                      path="/dashboard/threats/threat_actors_group/:threatActorGroupId/indicators/relations/:relationId"
-                      render={(routeProps) => (
-                        <StixCoreRelationship
-                          entityId={threatActorGroupId}
-                          {...routeProps}
-                        />
                       )}
                     />
                     <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -255,7 +255,7 @@ class ThreatActorGroupKnowledgeComponent extends Component {
             <EntityStixCoreRelationshipsIndicators
               {...routeProps}
               entityId={threatActorGroup.id}
-              entityLink={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/indicators`}
+              entityLink={link}
               defaultStartTime={threatActorGroup.first_seen}
               defaultStopTime={threatActorGroup.last_seen}
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -14,6 +14,8 @@ import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/St
 import StixDomainObjectVictimology from '../../common/stix_domain_objects/StixDomainObjectVictimology';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
+import EntityStixCoreRelationshipsIndicators from '../../common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
+import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable';
 
 const styles = () => ({
   container: {
@@ -248,18 +250,29 @@ class ThreatActorGroupKnowledgeComponent extends Component {
         />
         <Route
           exact
+          path="/dashboard/threats/threat_actors_group/:threatActorGroupId/knowledge/indicators"
+          render={(routeProps) => (
+            <EntityStixCoreRelationshipsIndicators
+              {...routeProps}
+              entityId={threatActorGroup.id}
+              entityLink={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/indicators`}
+              defaultStartTime={threatActorGroup.first_seen}
+              defaultStopTime={threatActorGroup.last_seen}
+            />
+          )}
+        />
+        <Route
+          exact
           path="/dashboard/threats/threat_actors_group/:threatActorGroupId/knowledge/observables"
           render={(routeProps) => (
-            <EntityStixCoreRelationships
+            <EntityStixCoreRelationshipsStixCyberObservable
+              {...routeProps}
               entityId={threatActorGroup.id}
-              relationshipTypes={['related-to']}
-              stixCoreObjectTypes={['Stix-Cyber-Observable']}
               entityLink={link}
               defaultStartTime={threatActorGroup.first_seen}
               defaultStopTime={threatActorGroup.last_seen}
-              allDirections={true}
               isRelationReversed={true}
-              {...routeProps}
+              relationshipTypes={['related-to']}
             />
           )}
         />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
@@ -271,19 +271,19 @@ const ThreatActorIndividualKnowledgeComponent = ({
           />
         )}
       />
-        <Route
-          exact
-          path="/dashboard/threats/threat_actors_individual/:threatActorIndividualId/knowledge/indicators"
-          render={(routeProps: any) => (
-            <EntityStixCoreRelationshipsIndicators
-              {...routeProps}
-              entityId={threatActorIndividual.id}
-              entityLink={link}
-              defaultStartTime={threatActorIndividual.first_seen}
-              defaultStopTime={threatActorIndividual.last_seen}
-            />
-          )}
-        />
+      <Route
+        exact
+        path="/dashboard/threats/threat_actors_individual/:threatActorIndividualId/knowledge/indicators"
+        render={(routeProps: any) => (
+          <EntityStixCoreRelationshipsIndicators
+            {...routeProps}
+            entityId={threatActorIndividual.id}
+            entityLink={link}
+            defaultStartTime={threatActorIndividual.first_seen}
+            defaultStopTime={threatActorIndividual.last_seen}
+          />
+        )}
+      />
       <Route
         exact
         path="/dashboard/threats/threat_actors_individual/:threatActorIndividualId/knowledge/observables"


### PR DESCRIPTION
This is the second part of the issue applied to the other entities : Threat Actor Individual, Intrusion Set, Campaign, Malware, Tools, Channels (only observables), Vulnerability, Attack patterns, Narratives (only observables)

### Related Brainstorm

* [Brainstorm](https://www.notion.so/filigran/Display-all-indicators-observables-contained-in-reports-which-contain-a-specific-entity-5f17d4fc1fd04cfbbf87594288beeec8)

### Explanation of code structure and opening on the next step

* [Explanation](https://www.notion.so/filigran/Display-all-indicators-observables-contained-in-reports-which-contain-a-specific-entity-5f17d4fc1fd04cfbbf87594288beeec8?pvs=4#62d37188187f46d49d5d390c00b441ae)

### Proposed changes

* Remove `Indicators` tab from the knowledge Topbar
* `Indicators` are now accesible from the knowledge right bar above `Observables`
*  Add `contextual view` that displays `Observables/Indicators` that are contained in `Reports/Case/Grouping` that contains the Entity
* Create reusable `view component ` to display `EntistixCorerelationships` : `EntitiesView` / `RelationshipView` / `ContextualView`
* Add filtering on `Pattern Type` and `Indicator type` for Indicators entities view

### Related issues

* [Display all indicators/observables contained in reports which contain a specific entity](https://github.com/OpenCTI-Platform/opencti/issues/2559)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
