### PR TITLE
[frontend] Fix default confidence

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservablesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservablesLines.tsx
@@ -63,6 +63,25 @@ const ContainerStixCyberObservablesLinesFragment = graphql`
   @refetchable(queryName: "ContainerStixCyberObservablesLinesRefetchQuery") {
     container(id: $id) {
       id
+      confidence
+      createdBy {
+        ... on Identity {
+          id
+          name
+          entity_type
+        }
+      }
+      objectMarking {
+        edges {
+          node {
+            id
+            definition_type
+            definition
+            x_opencti_order
+            x_opencti_color
+          }
+        }
+      }
       objects(
         types: $types
         search: $search
@@ -177,6 +196,11 @@ ContainerStixCyberObservablesLinesProps
             targetStixCoreObjectTypes={['Stix-Cyber-Observable']}
             onTypesChange={onTypesChange}
             openExports={openExports}
+            defaultCreatedBy={data?.container.createdBy ?? null}
+            defaultMarkingDefinitions={(
+              data?.container.objectMarking?.edges ?? []
+            ).map((n) => n.node)}
+            confidence={data?.container.confidence}
           />
         </Security>
       )}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.jsx
@@ -74,6 +74,11 @@ class ContainerStixDomainObjectsLines extends Component {
               targetStixCoreObjectTypes={['Stix-Domain-Object']}
               onTypesChange={this.props.onTypesChange}
               openExports={openExports}
+              defaultCreatedBy={container.createdBy ?? null}
+              defaultMarkingDefinitions={(
+                container.objectMarking?.edges ?? []
+              ).map((n) => n.node)}
+              confidence={container.confidence}
             />
           </Security>
         )}
@@ -144,6 +149,25 @@ export default createPaginationContainer(
         filters: { type: "[StixObjectOrStixRelationshipsFiltering]" }
       ) {
         id
+        confidence
+        createdBy {
+          ... on Identity {
+            id
+            name
+            entity_type
+          }
+        }
+        objectMarking {
+          edges {
+            node {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+        }
         objects(
           types: $types
           search: $search

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationships.tsx
@@ -109,6 +109,11 @@ ContainerStixObjectsOrStixRelationshipsComponentProps
             targetStixCoreObjectTypes={
               types ?? ['Stix-Domain-Object', 'Stix-Cyber-Observable']
             }
+            defaultCreatedBy={container.createdBy ?? null}
+            defaultMarkingDefinitions={(
+              container.objectMarking?.edges ?? []
+            ).map((n) => n.node)}
+            confidence={container.confidence}
           />
         </Security>
       )}
@@ -154,9 +159,24 @@ const ContainerStixObjectsOrStixRelationships = createFragmentContainer(
     container: graphql`
       fragment ContainerStixObjectsOrStixRelationships_container on Container {
         id
+        confidence
         createdBy {
-          id
-          name
+          ... on Identity {
+            id
+            name
+            entity_type
+          }
+        }
+        objectMarking {
+          edges {
+            node {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
         }
         creators {
           id

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -63,6 +63,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { insertNode } from '../../../../utils/store';
 import { useFormatter } from '../../../../components/i18n';
 import useVocabularyCategory from '../../../../utils/hooks/useVocabularyCategory';
+import { convertMarking } from '../../../../utils/edition';
 
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
@@ -257,6 +258,8 @@ const StixCyberObservableCreation = ({
   inputValue,
   paginationKey,
   paginationOptions,
+  defaultCreatedBy = null,
+  defaultMarkingDefinitions = null,
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
@@ -419,11 +422,15 @@ const StixCyberObservableCreation = ({
         variables={{ elementType: [status.type] }}
         render={({ props }) => {
           if (props && props.schemaAttributes) {
+            const baseCreatedBy = defaultCreatedBy
+              ? { value: defaultCreatedBy.id, label: defaultCreatedBy.name }
+              : undefined;
+            const baseMarkingDefinitions = (defaultMarkingDefinitions ?? []).map((n) => convertMarking(n));
             const initialValues = {
               x_opencti_description: '',
               x_opencti_score: 50,
-              createdBy: '',
-              objectMarking: [],
+              createdBy: baseCreatedBy,
+              objectMarking: baseMarkingDefinitions,
               objectLabel: [],
               externalReferences: [],
               createIndicator: false,

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -79,7 +79,7 @@ const useDefaultValues = <Values extends FormikValues>(
   );
 
   // Default confidence
-  if (keys.includes('confidence') && isEmptyField(defaultValues.confidence)) {
+  if (keys.includes('confidence') && isEmptyField(initialValues.confidence) && isEmptyField(defaultValues.confidence)) {
     defaultValues.confidence = 75;
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Handle default confidence in context of container
* Handle default confidence, author and markins when missing : 
* * create observable from container observables tab
* * create SDO from container entities tab
* * create Stix Object/relationship from container linked entities

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3921

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
