### PR TITLE
[frontend] retro compatibility for entities relations histories (#4012)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistory.jsx
@@ -120,8 +120,12 @@ class StixCoreObjectHistory extends Component {
                     operator: 'wildcard',
                   },
                   {
+                    key: 'event_scope',
+                    values: ['create', 'delete', null], // if event_scope is null, event_type is not
+                  },
+                  {
                     key: 'event_type',
-                    values: ['mutation', 'create', 'update', 'delete', 'merge'],
+                    values: ['create', 'delete', 'mutation'], // retro-compatibility
                   },
                 ],
                 first: 20,


### PR DESCRIPTION
issue: https://github.com/OpenCTI-Platform/opencti/issues/4012

Explanation: 
in the history of an entity, the right panel shows the history of the relations of the entity. It should only show creations and deletions (not updates).

New history entities (after june 2023): 'create' or 'delete' is contained in event_scope
old history entities: 'create' or 'delete' is contained in event_type

The modifications here enable to take both new and old history entities into account (retro compatibility)