### PR TITLE
[frontend] Minor design fix

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
@@ -19,6 +19,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
 import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectLabels';
 import ItemStatus from '../../../../components/ItemStatus';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
@@ -109,12 +110,16 @@ export const tasksDataColumns: DataColumns = {
     render: (task: TasksLine_node$data, { fld, classes }) => {
       const isoDate = new Date().toISOString();
       return (
-        <Chip
-          label={fld(task.due_date)}
-          variant="outlined"
-          color={task.due_date < isoDate ? 'error' : 'info'}
-          classes={{ root: classes.chipInList }}
-        />
+        <div>
+        <FieldOrEmpty source={task.due_date}>
+          <Chip
+            label={fld(task.due_date)}
+            variant="outlined"
+            color={task.due_date < isoDate ? 'error' : 'info'}
+            classes={{ root: classes.chipInList }}
+          />
+        </FieldOrEmpty>
+        </div>
       );
     },
   },

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -232,7 +232,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
             <Tooltip title={toolTip !== 'null' ? toolTip : ''}>
               <WarningOutlined
                 color={nested ? 'primary' : 'inherit'}
-                style={{ fontSize: 15, color: '#f44336' }}
+                style={{ fontSize: 15, color: '#f44336', marginLeft: 4 }}
               />
             </Tooltip>
           )}


### PR DESCRIPTION
Some minor design fixes:
- icons not aligned in Exports list
![image](https://github.com/OpenCTI-Platform/opencti/assets/75783086/43f07edd-6521-4b4f-b031-9189c040d0b3)

- empty due date in Tasks not correctly displayed
![image](https://github.com/OpenCTI-Platform/opencti/assets/75783086/a26e5d87-54c2-4200-b2f8-ab6cc70b327f)
