### PR TITLE
[backend] fix backgroundTask filter issue

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -47,7 +47,7 @@ const buildQueryFilters = async (context, user, rawFilters, search, taskPosition
     let nestedFromRole = false;
     let nestedToRole = false;
     for (let index = 0; index < adaptedFilters.length; index += 1) {
-      const { key, operator, values } = adaptedFilters[index];
+      const { key, operator, values, filterMode } = adaptedFilters[index];
       if (key === TYPE_FILTER) {
         // filter types to keep only the ones that can be handled by background tasks
         const filteredTypes = values.filter((v) => isTaskEnabledEntity(v.id)).map((v) => v.id);
@@ -77,7 +77,7 @@ const buildQueryFilters = async (context, user, rawFilters, search, taskPosition
           nestedTo.push({ key: 'role', values: ['*_to'], operator: 'wildcard' });
         }
       } else {
-        queryFilters.push({ key: GlobalFilters[key] || key, values: values.map((v) => v.id), operator });
+        queryFilters.push({ key: GlobalFilters[key] || key, values: values.map((v) => v.id), operator, filterMode });
       }
     }
     if (nestedFrom.length > 0) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Mapping properly the filterMode (AND/OR)
*

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4071
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

To test this fix, you need to create a background task of deletion using a negative filter on Technical 

- Create a user "A"
- Import a bunch of entites as "A"
- Go to "Data" > "Entities" 
- Apply a filter on "Technical creator" in a way to exclude all the users except the entites of the user "A"
- Select all the entites and delete them
- The number shown on the top of the list (or in the background task popup must be the same as the number of entites in the background task screen 
Here are screeshots from the issue where you see different numbers:
![image](https://github.com/OpenCTI-Platform/opencti/assets/1334279/3ae238f9-5368-4e04-a840-efe9a0325560)



![image](https://github.com/OpenCTI-Platform/opencti/assets/1334279/f8b68215-3a9b-4fa8-a30a-7abbbd607e77)
