### PR TITLE
[backend] Improve stix loader and stream relation resolution

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
@@ -101,7 +101,7 @@ export const policiesFieldPatch = graphql`
 `;
 
 const policiesValidation = () => Yup.object().shape({
-  platform_organization: Yup.object().nullable(),
+  platform_organization: Yup.string().nullable(),
   otp_mandatory: Yup.boolean(),
   password_policy_min_length: Yup.number(),
   password_policy_max_length: Yup.number(),

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7526,6 +7526,7 @@ interface StixRelationship {
   relationship_type: String!
   createdBy: Identity
   objectMarking: MarkingDefinitionConnection
+  toStix: String
   creators: [Creator!]
 }
 
@@ -7864,6 +7865,7 @@ type StixRefRelationship implements BasicRelationship & StixRelationship {
   opinions(first: Int): OpinionConnection
   groupings(first: Int): GroupingConnection
   cases(first: Int): CaseConnection
+  toStix: String
   creators: [Creator!]
   editContext: [EditUserContext!]
 }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -4994,11 +4994,6 @@ type ThreatActorGroupEdge {
   node: ThreatActorGroup!
 }
 
-type ThreatActorConnection {
-  pageInfo: PageInfo!
-  edges: [ThreatActorEdge]
-}
-
 interface ThreatActor implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
   id: ID!
   standard_id: String!
@@ -5064,6 +5059,11 @@ interface ThreatActor implements BasicObject & StixObject & StixCoreObject & Sti
 type ThreatActorEdge {
   cursor: String!
   node: ThreatActor!
+}
+
+type ThreatActorConnection {
+  pageInfo: PageInfo!
+  edges: [ThreatActorEdge]
 }
 
 type ThreatActorGroup implements BasicObject & StixObject & StixCoreObject & StixDomainObject & ThreatActor {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -11311,6 +11311,7 @@ interface StixRelationship {
   relationship_type: String!
   createdBy: Identity
   objectMarking: MarkingDefinitionConnection
+  toStix: String
   # Technical
   creators: [Creator!]
 }
@@ -11674,6 +11675,7 @@ type StixRefRelationship implements BasicRelationship & StixRelationship {
   opinions(first: Int): OpinionConnection
   groupings(first: Int): GroupingConnection
   cases(first: Int): CaseConnection
+  toStix: String
   # Technical
   creators: [Creator!]
   editContext: [EditUserContext!]

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -6351,19 +6351,10 @@ type ThreatActorGroupConnection {
   pageInfo: PageInfo!
   edges: [ThreatActorGroupEdge]
 }
-type ThreatActorGroupEdge {
-  cursor: String!
-  node: ThreatActorGroup!
-}
 
 type ThreatActorGroupEdge {
   cursor: String!
   node: ThreatActorGroup!
-}
-
-type  ThreatActorConnection {
-  pageInfo: PageInfo!
-  edges: [ThreatActorEdge]
 }
 
 interface ThreatActor implements BasicObject & StixObject & StixCoreObject & StixDomainObject {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -472,7 +472,7 @@ const loadElementsWithDependencies = async (context, user, elements, opts = {}) 
         const message = `From ${element.fromId} is ${validFrom}, To ${element.toId} is ${validTo}`;
         logApp.warn(`Auto delete of invalid relation ${element.id}. ${message}`);
         // Auto deletion of the invalid relation
-        // await elDeleteElements(context, SYSTEM_USER, [element], storeLoadByIdWithRefs);
+        await elDeleteElements(context, SYSTEM_USER, [element], storeLoadByIdWithRefs);
       } else {
         const from = R.mergeRight(element, { ...rawFrom, ...depsElementsMap.get(element.fromId) });
         const to = R.mergeRight(element, { ...rawTo, ...depsElementsMap.get(element.toId) });

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -453,7 +453,8 @@ const loadElementsWithDependencies = async (context, user, elements, opts = {}) 
   const depsPromise = loadElementMetaDependencies(context, user, elementsToDeps, opts);
   if (targetsToResolved.length > 0) {
     const args = { toMap: true, connectionFormat: false };
-    fromToPromise = elFindByIds(context, user, targetsToResolved, args);
+    // Load with System user, access rights will be dynamically change after
+    fromToPromise = elFindByIds(context, SYSTEM_USER, targetsToResolved, args);
   }
   const [fromToMap, depsElementsMap] = await Promise.all([fromToPromise, depsPromise]);
   const loadedElements = [];
@@ -471,7 +472,7 @@ const loadElementsWithDependencies = async (context, user, elements, opts = {}) 
         const message = `From ${element.fromId} is ${validFrom}, To ${element.toId} is ${validTo}`;
         logApp.warn(`Auto delete of invalid relation ${element.id}. ${message}`);
         // Auto deletion of the invalid relation
-        await elDeleteElements(context, SYSTEM_USER, [element], storeLoadByIdWithRefs);
+        // await elDeleteElements(context, SYSTEM_USER, [element], storeLoadByIdWithRefs);
       } else {
         const from = R.mergeRight(element, { ...rawFrom, ...depsElementsMap.get(element.fromId) });
         const to = R.mergeRight(element, { ...rawTo, ...depsElementsMap.get(element.toId) });

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23440,6 +23440,7 @@ export type StixRefRelationship = BasicRelationship & StixRelationship & {
   stop_time?: Maybe<Scalars['DateTime']['output']>;
   to?: Maybe<StixObjectOrStixRelationshipOrCreator>;
   toRole?: Maybe<Scalars['String']['output']>;
+  toStix?: Maybe<Scalars['String']['output']>;
   updated_at: Scalars['DateTime']['output'];
   x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
@@ -23578,6 +23579,7 @@ export type StixRelationship = {
   standard_id: Scalars['String']['output'];
   to?: Maybe<StixObjectOrStixRelationshipOrCreator>;
   toRole?: Maybe<Scalars['String']['output']>;
+  toStix?: Maybe<Scalars['String']['output']>;
   updated_at: Scalars['DateTime']['output'];
   x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
@@ -36096,6 +36098,7 @@ export type StixRefRelationshipResolvers<ContextType = any, ParentType extends R
   stop_time?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   to?: Resolver<Maybe<ResolversTypes['StixObjectOrStixRelationshipOrCreator']>, ParentType, ContextType>;
   toRole?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  toStix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
@@ -36141,6 +36144,7 @@ export type StixRelationshipResolvers<ContextType = any, ParentType extends Reso
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   to?: Resolver<Maybe<ResolversTypes['StixObjectOrStixRelationshipOrCreator']>, ParentType, ContextType>;
   toRole?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  toStix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -28,7 +28,12 @@ import {
 import { BYPASS, executionContext, isUserCanAccessStixElement, SYSTEM_USER } from '../utils/access';
 import { FROM_START_STR, utcDate } from '../utils/format';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
-import { ABSTRACT_STIX_CORE_RELATIONSHIP, buildRefRelationKey, ENTITY_TYPE_CONTAINER } from '../schema/general';
+import {
+  ABSTRACT_STIX_CORE_RELATIONSHIP,
+  buildRefRelationKey,
+  ENTITY_TYPE_CONTAINER,
+  STIX_TYPE_RELATION, STIX_TYPE_SIGHTING
+} from '../schema/general';
 import { convertStoreToStix } from '../database/stix-converter';
 import { UnsupportedError } from '../config/errors';
 import { convertFiltersFrontendFormat, convertFiltersToQueryOptions, isStixMatchFilters } from '../utils/filtering';
@@ -350,10 +355,18 @@ const createSseMiddleware = () => {
     const refs = stixRefsExtractor(stixData, generateStandardId);
     const missingElements = await resolveMissingReferences(context, req, refs, cache);
     const missingInstances = await storeLoadByIdsWithRefs(context, req.user, missingElements);
-    const missingAllPerIds = missingInstances.map((m) => {
-      return [m.internal_id, m.standard_id, ...(m.x_opencti_stix_ids ?? [])].map((id) => ({ id, value: m }));
-    }).flat();
+    const missingAllPerIds = missingInstances.map((m) => [m.internal_id, m.standard_id, ...(m.x_opencti_stix_ids ?? [])].map((id) => ({ id, value: m }))).flat();
     const missingMap = new Map(missingAllPerIds.map((m) => [m.id, m.value]));
+    if (stixData.type === STIX_TYPE_RELATION || stixData.type === STIX_TYPE_SIGHTING) {
+      // Check for a relation that the from and the to is correctly accessible.
+      const fromId = stixData.source_ref ?? stixData.sighting_of_ref;
+      const toId = stixData.target_ref ?? stixData.where_sighted_refs[0];
+      const missingFrom = missingMap.get(fromId);
+      const missingTo = missingMap.get(toId);
+      if (!missingFrom || !missingTo) {
+        return false;
+      }
+    }
     for (let missingIndex = 0; missingIndex < missingElements.length; missingIndex += 1) {
       const missingElementId = missingElements[missingIndex];
       const missingInstance = missingMap.get(missingElementId);
@@ -367,12 +380,13 @@ const createSseMiddleware = () => {
         await wait(channel.delay);
       }
     }
+    return true;
   };
   const resolveAndPublishDependencies = async (context, noDependencies, cache, channel, req, eventId, stix) => {
     // Resolving REFS
-    await resolveAndPublishMissingRefs(context, cache, channel, req, eventId, stix);
+    const isValidResolution = await resolveAndPublishMissingRefs(context, cache, channel, req, eventId, stix);
     // Resolving CORE RELATIONS
-    if (noDependencies === false) {
+    if (isValidResolution && noDependencies === false) {
       const allRelCallback = async (relations) => {
         const notCachedRelations = relations.filter((m) => !cache.has(m.standard_id));
         const findRelIds = notCachedRelations.map((r) => r.internal_id);
@@ -404,6 +418,7 @@ const createSseMiddleware = () => {
       const relationTypes = [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP];
       await listAllRelations(context, req.user, relationTypes, allRelOptions);
     }
+    return isValidResolution;
   };
   const isFiltersEntityTypeMatch = (filters, type) => {
     let match = false;
@@ -563,11 +578,15 @@ const createSseMiddleware = () => {
                   if (isPreviouslyVisible && !isCurrentlyVisible) { // No longer visible
                     client.sendEvent(eventId, EVENT_TYPE_DELETE, eventData);
                   } else if (!isPreviouslyVisible && isCurrentlyVisible) { // Newly visible
-                    await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                    client.sendEvent(eventId, EVENT_TYPE_CREATE, eventData);
+                    const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                    if (isValidResolution) {
+                      client.sendEvent(eventId, EVENT_TYPE_CREATE, eventData);
+                    }
                   } else if (isCurrentlyVisible) { // Just an update
-                    await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                    client.sendEvent(eventId, event, eventData);
+                    const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                    if (isValidResolution) {
+                      client.sendEvent(eventId, event, eventData);
+                    }
                   } else if (isRelation && publishDependencies) { // Update but not visible - relation type
                     // In case of relationship publication, from or to can be related to something that
                     // is part of the filtering. We can consider this as dependencies
@@ -600,8 +619,10 @@ const createSseMiddleware = () => {
                       client.sendEvent(eventId, event, eventData);
                     }
                   } else { // Create and merge
-                    await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                    client.sendEvent(eventId, event, eventData);
+                    const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                    if (isValidResolution) {
+                      client.sendEvent(eventId, event, eventData);
+                    }
                   }
                 } else if (isRelation && publishDependencies) { // Not an update and not visible
                   // In case of relationship publication, from or to can be related to something that

--- a/opencti-platform/opencti-graphql/src/resolvers/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixRelationship.js
@@ -14,7 +14,7 @@ import {
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, } from '../schema/general';
 import { STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { STIX_REF_RELATIONSHIP_TYPES } from '../schema/stixRefRelationship';
-import { batchLoader, timeSeriesRelations } from '../database/middleware';
+import { batchLoader, stixLoadByIdStringify, timeSeriesRelations } from '../database/middleware';
 import { elBatchIds } from '../database/engine';
 import { batchCreators } from '../domain/user';
 
@@ -38,6 +38,7 @@ const stixRelationshipResolvers = {
     to: (rel, _, context) => loadByIdLoader.load(rel.toId, context, context.user),
     creators: (rel, _, context) => creatorsLoader.load(rel.creator_id, context, context.user),
     createdBy: (rel, _, context) => createdByLoader.load(rel.id, context, context.user),
+    toStix: (rel, _, context) => stixLoadByIdStringify(context, context.user, rel.id),
     objectMarking: (rel, _, context) => markingDefinitionsLoader.load(rel.id, context, context.user),
     // eslint-disable-next-line
     __resolveType(obj) {


### PR DESCRIPTION
There is conditions where an auto sanity mode think that the relation should be deleted. 
Its due to our process that doesnt not use system user to resolve to be sure about the situation.
Also improve the stream to not publish the relation if one of the from/to is not accessible.