### PR TITLE
[frontend] Field value is not set after author creation from some edition forms (#4180)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -321,6 +321,7 @@ const ReportEditionOverviewComponent = (props) => {
               <SubscriptionFocus context={context} fieldName="createdBy" />
             }
             onChange={editor.changeCreated}
+            setFieldValue={setFieldValue}
           />
           <ObjectMarkingField
             name="objectMarking"

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssCreation.jsx
@@ -171,7 +171,7 @@ const IngestionRssCreation = (props) => {
               uri: '',
               report_types: [],
               user_id: '',
-              createdBy: '',
+              created_by_ref: '',
               objectMarking: [],
               current_state_date: null,
             }}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
@@ -58,7 +58,7 @@ const ingestionRssValidation = (t) => Yup.object().shape({
   uri: Yup.string().required(t('This field is required')),
   object_marking_refs: Yup.array().nullable(),
   report_types: Yup.array().nullable(),
-  created_by_ref: Yup.object().nullable(),
+  created_by_ref: Yup.mixed().nullable(),
   user_id: Yup.object().nullable(),
 });
 

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
@@ -178,6 +178,7 @@ const IngestionRssEditionContainer = ({
                 name="created_by_ref"
                 style={fieldSpacingContainerStyle}
                 onChange={handleSubmitField}
+                setFieldValue={setFieldValue}
               />
               <ObjectMarkingField
                 name="object_marking_refs"

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
@@ -201,7 +201,7 @@ const EntitySettingAttributeEdition = ({
     });
   };
 
-  const field = () => {
+  const field = (setFieldValue: (field: string, value: string) => void) => {
     const label = t('Default value');
     // Handle object marking specific case : activate or deactivate default values (handle in access)
     if (attribute.name === 'objectMarking') {
@@ -242,6 +242,7 @@ const EntitySettingAttributeEdition = ({
           label={label}
           name="default_values"
           style={fieldSpacingContainerStyle}
+          setFieldValue={setFieldValue}
         />
       );
     }
@@ -425,7 +426,7 @@ const EntitySettingAttributeEdition = ({
                 label={t('Mandatory')}
                 disabled={attribute.mandatoryType !== 'customizable'}
               />
-              {field()}
+              {field(setFieldValue)}
               {attribute.scale && (
                 <ScaleConfiguration
                   initialValues={initialValues.scale}


### PR DESCRIPTION
Bugs fixed:
- can't remove author of a RSS ingestion
- when create an author from some forms: the author is not set as input value of the field + error occurs (the case for: report edition, customization>entity edition, RSS ingestion edition, RSS ingestion creation

issue: https://github.com/OpenCTI-Platform/opencti/issues/4180
