### PR TITLE
[backend] add missing migration for renamed entity types (#4156)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix-representative.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-representative.ts
@@ -33,6 +33,7 @@ import type * as SMO from '../types/stix-smo';
 import {
   ENTITY_AUTONOMOUS_SYSTEM,
   ENTITY_BANK_ACCOUNT,
+  ENTITY_CRYPTOGRAPHIC_KEY,
   ENTITY_CRYPTOGRAPHIC_WALLET,
   ENTITY_DIRECTORY,
   ENTITY_DOMAIN_NAME,
@@ -56,6 +57,7 @@ import {
   ENTITY_TEXT,
   ENTITY_URL,
   ENTITY_USER_ACCOUNT,
+  ENTITY_USER_AGENT,
   ENTITY_WINDOWS_REGISTRY_KEY,
   ENTITY_WINDOWS_REGISTRY_VALUE_TYPE
 } from '../schema/stixCyberObservable';
@@ -183,6 +185,9 @@ export const extractStixRepresentative = (
     const bankAccount = stix as SCO.StixBankAccount;
     return bankAccount.iban ?? bankAccount.account_number ?? 'Unknown';
   }
+  if (entityType === ENTITY_CRYPTOGRAPHIC_KEY) {
+    return (stix as SCO.StixCryptographicKey).value ?? 'Unknown';
+  }
   if (entityType === ENTITY_CRYPTOGRAPHIC_WALLET) {
     return (stix as SCO.StixCryptocurrencyWallet).value ?? 'Unknown';
   }
@@ -248,6 +253,9 @@ export const extractStixRepresentative = (
   if (entityType === ENTITY_USER_ACCOUNT) {
     const userAccount = stix as SCO.StixUserAccount;
     return userAccount.account_login ?? userAccount.user_id ?? 'Unknown';
+  }
+  if (entityType === ENTITY_USER_AGENT) {
+    return (stix as SCO.StixUserAgent).value ?? 'Unknown';
   }
   if (entityType === ENTITY_WINDOWS_REGISTRY_KEY) {
     return (stix as SCO.StixWindowsRegistryKey).key ?? 'Unknown';

--- a/opencti-platform/opencti-graphql/src/migrations/1693250393866-fix-old-rename-for-relations.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1693250393866-fix-old-rename-for-relations.js
@@ -1,0 +1,60 @@
+import { logApp } from '../config/conf';
+import { elUpdateByQueryForMigration } from '../database/engine';
+import { READ_RELATIONSHIPS_INDICES } from '../database/utils';
+
+const message = '[MIGRATION] Fix old rename for relations';
+
+export const up = async (next) => {
+  logApp.info(`${message} > started`);
+  const types = [
+    { source: 'X-OpenCTI-Cryptographic-Key', destination: 'Cryptographic-Key' },
+    { source: 'X-OpenCTI-Cryptocurrency-Wallet', destination: 'Cryptocurrency-Wallet' },
+    { source: 'X-OpenCTI-Hostname', destination: 'Hostname' },
+    { source: 'X-OpenCTI-Text', destination: 'Text' },
+    { source: 'X-OpenCTI-User-Agent', destination: 'User-Agent' },
+  ];
+  const scriptSource = `
+    if (ctx._source.fromType == params.type) {
+      ctx._source.fromType = params.target;
+    }
+    if (ctx._source.toType == params.type) {
+      ctx._source.toType = params.target;
+    }
+    for(connection in ctx._source.connections) {
+      if (connection.types.contains(params.type)) {
+        connection.types.remove(params.type);
+        connection.types.add(params.target)
+      }
+    }
+  `;
+  for (let index = 0; index < types.length; index += 1) {
+    const { source, destination } = types[index];
+    const updateQuery = {
+      script: {
+        params: { type: source, target: destination },
+        source: scriptSource,
+      },
+      query: {
+        nested: {
+          path: 'connections',
+          query: {
+            term: {
+              'connections.types.keyword': source,
+            },
+          },
+        },
+      },
+    };
+    await elUpdateByQueryForMigration(
+      `Rename entity type ${source} to ${destination}`,
+      READ_RELATIONSHIPS_INDICES,
+      updateQuery
+    );
+  }
+  logApp.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/migrations/1693339530445-fix-old-rename-for-relations.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1693339530445-fix-old-rename-for-relations.js
@@ -20,9 +20,10 @@ export const up = async (next) => {
     if (ctx._source.toType == params.type) {
       ctx._source.toType = params.target;
     }
-    for(connection in ctx._source.connections) {
-      if (connection.types.contains(params.type)) {
-        connection.types.remove(params.type);
+    for (connection in ctx._source.connections) {
+      def typeIndex = connection.types.indexOf(params.type);
+      if (typeIndex >= 0) {
+        connection.types.remove(typeIndex);
         connection.types.add(params.target)
       }
     }

--- a/opencti-platform/opencti-graphql/src/python/runtime/stix2_create_pattern.py
+++ b/opencti-platform/opencti-graphql/src/python/runtime/stix2_create_pattern.py
@@ -31,6 +31,7 @@ PATTERN_MAPPING = {
     "Cryptographic-Key": ["value"],
     "Cryptocurrency-Wallet": ["value"],
     "User-Account": ["acount_login"],
+    "User-Agent": ["value"],
     "Windows-Registry-Key": ["key"],
     "Windows-Registry-Value-Type": ["name"],
     "Bank-Account": ["iban"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add a migration to rename old types in relations
* Fix creation of indicator from User-Agent observable (was not working)
* Fix errors (history / notification) due to missing cases for observables (in stix representative)

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4156

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If you want to test the migration, I suggest to create observables for all concerned types and relationships (like create an indicator from the observable), then run the migration script on the other side (swap source and destination), check on elastic, then run it again.
