### PR TITLE
[backend] Fix relations types mapping(#4177)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -132,11 +132,11 @@ export const schemaRelationsTypesMapping = () => {
   const flatEntries = [];
   entries.forEach(([key, values]) => {
     const [fromType, toType] = key.split('_');
-    const generatedEntries = generateEntries(fromType, toType, values);
+    const generatedEntries = flattenEntries(fromType, toType, values);
     flatEntries.push(...generatedEntries);
   });
 
-  return mergedEntries(flatEntries.map(([key, values]) => {
+  return mergeEntries(flatEntries.map(([key, values]) => {
     return {
       key,
       values: values.map((def) => def.name)
@@ -156,7 +156,7 @@ const getChildren = (type) => {
   return schemaTypesDefinition.get(type);
 };
 
-const generateEntries = (fromType, toType, values) => {
+const flattenEntries = (fromType, toType, values) => {
   if (!isParentType(fromType) && !isParentType(toType)) {
     return [[`${fromType}_${toType}`, values]];
   }
@@ -166,7 +166,7 @@ const generateEntries = (fromType, toType, values) => {
   if (isParentType(fromType) && !isParentType(toType)) {
     const children = getChildren(fromType);
     children.forEach((child) => {
-      const newEntry = generateEntries(child, toType, values).flat();
+      const newEntry = flattenEntries(child, toType, values).flat();
       entries.push(newEntry);
     });
   }
@@ -174,7 +174,7 @@ const generateEntries = (fromType, toType, values) => {
   if (!isParentType(fromType) && isParentType(toType)) {
     const children = getChildren(toType);
     children.forEach((child) => {
-      const newEntry = generateEntries(fromType, child, values).flat();
+      const newEntry = flattenEntries(fromType, child, values).flat();
       entries.push(newEntry);
     });
   }
@@ -185,7 +185,7 @@ const generateEntries = (fromType, toType, values) => {
 
     fromTypeChildren.forEach((fromChild) => {
       toTypeChildren.forEach((toChild) => {
-        const newEntry = generateEntries(fromChild, toChild, values).flat();
+        const newEntry = flattenEntries(fromChild, toChild, values).flat();
         entries.push(newEntry);
       });
     });
@@ -194,7 +194,7 @@ const generateEntries = (fromType, toType, values) => {
   return entries;
 };
 
-const mergedEntries = (entries) => entries.reduce((result, currentItem) => {
+const mergeEntries = (entries) => entries.reduce((result, currentItem) => {
   const existingItem = result.find((item) => item.key === currentItem.key);
   if (existingItem) {
     currentItem.values.forEach((value) => {

--- a/opencti-platform/opencti-graphql/src/schema/schema-types.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-types.ts
@@ -20,5 +20,8 @@ export const schemaTypesDefinition = {
   get(type: string): string[] {
     return Array.from(this.types[type].keys());
   },
+  hasChildren(type: string): boolean {
+    return this.types[type]?.size > 0;
+  }
 
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
@@ -76,7 +76,7 @@ import {
 } from '../../../src/schema/stixDomainObject';
 import { ENTITY_TYPE_LABEL, ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 import {
-  isStixCoreRelationship,
+  isStixCoreRelationship, RELATION_COMMUNICATES_WITH, RELATION_CONSISTS_OF,
   RELATION_DERIVED_FROM,
   RELATION_DETECTS,
   RELATION_HOSTS,
@@ -116,7 +116,8 @@ import { getParentTypes } from '../../../src/schema/schemaUtils';
 import { ENTITY_TYPE_RULE } from '../../../src/schema/internalObject';
 import { RELATION_MIGRATES } from '../../../src/schema/internalRelationship';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../../src/schema/stixSightingRelationship';
-import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from "../../../src/modules/organization/organization-types";
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../src/modules/organization/organization-types';
+import { schemaRelationsTypesMapping } from '../../../src/domain/stixRelationship';
 
 describe('Testing relation consistency', () => {
   it.concurrent.each([
@@ -464,5 +465,17 @@ describe('Testing stix ref extractor', () => {
     const refs = stixRefsExtractor(json, generateStandardId);
     expect(refs.includes('identity--1f02efe5-c752-589e-85d4-a8da3898f690')).toBe(true);
     expect(refs.includes('marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da')).toBe(true);
+  });
+});
+
+describe('Test if needed', () => {
+  it('Mapping', () => {
+    const mapping = schemaRelationsTypesMapping();
+    let relations = mapping.find((m) => m.key === 'Infrastructure_IPv4-Addr').values;
+    expect(relations.includes(RELATION_COMMUNICATES_WITH)).toBe(true); // Inheritance
+    expect(relations.includes(RELATION_CONSISTS_OF)).toBe(true); // Merge
+
+    relations = mapping.find((m) => m.key === 'Infrastructure_Software').values;
+    expect(relations.filter((r) => r === RELATION_CONSISTS_OF).length).toBe(1); // Deduplication
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
@@ -468,8 +468,8 @@ describe('Testing stix ref extractor', () => {
   });
 });
 
-describe('Test if needed', () => {
-  it('Mapping', () => {
+describe('Testing relations mapping', () => {
+  it('Relations types should map', () => {
     const mapping = schemaRelationsTypesMapping();
     let relations = mapping.find((m) => m.key === 'Infrastructure_IPv4-Addr').values;
     expect(relations.includes(RELATION_COMMUNICATES_WITH)).toBe(true); // Inheritance


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix relations types mapping in `schemaRelationsTypesMapping` => relations were created for entity-type to` stix-cyber-observables` but not for ` stix-cyber-observables children` . Some relationship types where missing.
* Add a method to check if a type hasChildren
* Add a test to check if the mapping is ok (no dupplicates and merged attributes)

### Related issues

* [issue/4177](https://github.com/OpenCTI-Platform/opencti/issues/4177)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
