### PR TITLE
[frontend] fix dashboard - allow setting dashboard to display back the default one

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -12,11 +12,7 @@ import Slide from '@mui/material/Slide';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { makeStyles, useTheme } from '@mui/styles';
-import {
-  Database,
-  GraphOutline,
-  HexagonMultipleOutline,
-} from 'mdi-material-ui';
+import { Database, GraphOutline, HexagonMultipleOutline } from 'mdi-material-ui';
 import { assoc, head, last, map, pathOr, pluck } from 'ramda';
 import React, { Suspense } from 'react';
 import { graphql, useFragment, usePreloadedQuery } from 'react-relay';
@@ -42,6 +38,7 @@ import LocationMiniMapTargets from './common/location/LocationMiniMapTargets';
 import StixRelationshipsHorizontalBars from './common/stix_relationships/StixRelationshipsHorizontalBars';
 import DashboardView from './workspaces/dashboards/Dashboard';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
+import TopBar from './nav/TopBar';
 
 // region styles
 const Transition = React.forwardRef((props, ref) => (
@@ -1120,6 +1117,7 @@ const DashboardComponent = ({ queryRef }) => {
   return (
     <UserContext.Provider value={{ me: { ...currentMe, ...me }, ...context }}>
       <div className={classes.root}>
+        <TopBar />
         {defaultDashboard ? (
           <CustomDashboard
             dashboard={defaultDashboard}


### PR DESCRIPTION

### Proposed changes

* revert part of commit 150de4b8dae2a1bd0252dbffdc34784e4b974696 concerning `Dashboard` component, putting back the render of the topbar when navigating to or from the home.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3854
* https://github.com/OpenCTI-Platform/opencti/issues/2796