### PR TITLE
[frontend] fix trigger digest time with right timezone (#4310)

### DIFF
--- a/opencti-platform/opencti-front/src/components/TimePickerField.jsx
+++ b/opencti-platform/opencti-front/src/components/TimePickerField.jsx
@@ -66,69 +66,25 @@ const TimePickerField = (props) => {
       onSubmit(name, value ? parse(value).toISOString() : null);
     }
   }, [setTouched, onSubmit, name]);
-  if (withSeconds) {
-    return (
-      <TimePicker
-        {...fieldToTimePicker(props)}
-        variant="inline"
-        disableToolbar={false}
-        autoOk={true}
-        allowKeyboardControl={true}
-        onAccept={internalOnAccept}
-        onChange={internalOnChange}
-        views={['hours', 'minutes', 'seconds']}
-        inputFormat={timeFormatsMapWithSeconds[intl.locale] || 'hh:mm:ss a'}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            onFocus={internalOnFocus}
-            onBlur={internalOnBlur}
-            error={!R.isNil(meta.error)}
-            helperText={
-              (!R.isNil(meta.error) && meta.error) || TextFieldProps.helperText
-            }
-          />
-        )}
-      />
-    );
+  const views = ['hours'];
+  if (withSeconds) { // 'hours', 'minutes', 'seconds'
+    views.push('minutes');
+    views.push('seconds');
+  } else if (withMinutes) { // 'hours', 'minutes'
+    views.push('minutes');
   }
-  if (withMinutes) {
-    return (
-      <TimePicker
-        {...fieldToTimePicker(props)}
-        variant="inline"
-        disableToolbar={false}
-        autoOk={true}
-        allowKeyboardControl={true}
-        onAccept={internalOnAccept}
-        onChange={internalOnChange}
-        views={['hours', 'minutes']}
-        inputFormat={timeFormatsMapWithSeconds[intl.locale] || 'hh:mm:ss a'}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            onFocus={internalOnFocus}
-            onBlur={internalOnBlur}
-            error={!R.isNil(meta.error)}
-            helperText={
-              (!R.isNil(meta.error) && meta.error) || TextFieldProps.helperText
-            }
-          />
-        )}
-      />
-    );
-  }
+  const inputFormat = (withMinutes || withSeconds) ? (timeFormatsMapWithSeconds[intl.locale] || 'hh:mm:ss a')
+    : (timeFormatsMap[intl.locale] || 'hh:mm a');
   return (
     <TimePicker
       {...fieldToTimePicker(props)}
-      variant="inline"
       disableToolbar={false}
       autoOk={true}
       allowKeyboardControl={true}
       onAccept={internalOnAccept}
       onChange={internalOnChange}
-      views={['hours']}
-      inputFormat={timeFormatsMap[intl.locale] || 'hh:mm a'}
+      views={views}
+      inputFormat={inputFormat}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
@@ -17,7 +17,7 @@ import TimePickerField from '../../../../components/TimePickerField';
 import { convertEventTypes, convertNotifiers, convertTriggers, filterEventTypesOptions, instanceEventTypesOptions } from '../../../../utils/edition';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { isUniqFilter } from '../../../../utils/filters/filtersUtils';
-import { dayStartDate, parse } from '../../../../utils/Time';
+import { dayStartDate, formatTimeForToday, parse } from '../../../../utils/Time';
 import NotifierField from '../../common/form/NotifierField';
 import { Option } from '../../common/form/ReferenceField';
 import FilterAutocomplete from '../../common/lists/FilterAutocomplete';
@@ -282,7 +282,7 @@ TriggerEditionOverviewProps
     trigger_ids: convertTriggers(trigger),
     period: trigger.period,
     day: currentTime.length > 1 ? currentTime[0] : '1',
-    time: currentTime.length > 1 ? `2000-01-01T${currentTime[1]}` : `2000-01-01T${currentTime[0]}`,
+    time: currentTime.length > 1 ? formatTimeForToday(currentTime[1]) : formatTimeForToday(currentTime[0]),
   };
   return (
     <Formik

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -19,7 +19,7 @@ import { TriggerLine_node$key } from './__generated__/TriggerLine_node.graphql';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../components/i18n';
 import TriggerPopover from './TriggerPopover';
-import { dayStartDate } from '../../../../utils/Time';
+import { dayStartDate, formatTimeForToday } from '../../../../utils/Time';
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -127,8 +127,8 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
   ];
   const day = currentTime.length > 1 ? currentTime[0] : '1';
   const time = currentTime.length > 1
-    ? new Date(`2000-01-01T${currentTime[1]}`)
-    : new Date(`2000-01-01T${currentTime[0]}`);
+    ? formatTimeForToday(currentTime[1])
+    : formatTimeForToday(currentTime[0]);
 
   return (
     <ListItem classes={{ root: classes.item }} divider={true}>

--- a/opencti-platform/opencti-front/src/utils/Time.js
+++ b/opencti-platform/opencti-front/src/utils/Time.js
@@ -80,6 +80,11 @@ export const dateFormat = (data, specificFormat = null) => {
     : '';
 };
 
+export const formatTimeForToday = (time) => {
+  const today = dateFormat(new Date(), 'YYYY-MM-DD');
+  return `${today}T${time}`;
+};
+
 export const timestamp = (date) => parse(date).unix();
 
 export const jsDate = (date) => parse(date).toDate();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set today's date along with digest trigger time : we used to set a fixed date, which doesn't get us the right timezone, with daylight savings time
* refactor TimePickerField to remove some duplicate code

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4310

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

