### PR TITLE
Allow using insecure ciphers in OpenSSL based softwares (system-wide)

### DIFF
--- a/opencti-platform/Dockerfile_circleci
+++ b/opencti-platform/Dockerfile_circleci
@@ -28,6 +28,7 @@ RUN yarn build:prod
 
 FROM base AS app
 
+RUN sed -ri 's/\[openssl_init\]/&\nssl_conf = ssl_sect\n[ssl_sect]\nsystem_default = system_default_sect\n[system_default_sect]\nCipherString = DEFAULT:@SECLEVEL=0/' /etc/ssl/openssl.cnf
 RUN set -ex; \
     apk add --no-cache git tini gcc g++ make musl-dev cargo python3 python3-dev postfix postfix-pcre; \
     python3 -m ensurepip; \


### PR DESCRIPTION
### Related issues

Ingestion of remote sources available through the HTTPS protocol using weak ciphers is not possible because of default configuration of OpenSSL.
While the general idea of preventing the use of weak and obsolete protocols and ciphers is good, OpenCTI is not responsible for the lack of updates or misconfiguration of remote sources and it would be great to be able to use them anyway.

### Proposed changes

*  either allow per-source configuration in octi (might require a lot of work)
* or allow using weak ciphers system-wide (this PR)

### Checklist

Proposed solution was tested in a running container, dockerfile was **not tested** because it fails building on my workstation

(
Step 27/35 : COPY --from=graphql-builder /opt/opencti-build/opencti-graphql/public ./public
COPY failed: stat opt/opencti-build/opencti-graphql/public: file does not exist
) -- also happens with master

### Further comments


