### PR TITLE
[frontend] Fix global search keyword undefined (#4395)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -8,6 +8,7 @@ import {
   SearchStixCoreObjectsLinesPaginationQuery,
   SearchStixCoreObjectsLinesPaginationQuery$variables,
 } from '@components/search/__generated__/SearchStixCoreObjectsLinesPaginationQuery.graphql';
+import { useParams } from 'react-router-dom';
 import TopBar from './nav/TopBar';
 import ListLines from '../../components/list_lines/ListLines';
 import ToolBar from './data/ToolBar';
@@ -27,7 +28,7 @@ const Search = () => {
     platformModuleHelpers: { isRuntimeFieldEnable },
   } = useAuth();
   const { t } = useFormatter();
-  const { viewStorage, helpers: storageHelpers, paginationOptions } = usePaginationLocalStorage<SearchStixCoreObjectsLinesPaginationQuery$variables>(
+  const { viewStorage, helpers: storageHelpers, paginationOptions: rawPaginationOptions } = usePaginationLocalStorage<SearchStixCoreObjectsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
       searchTerm: '',
@@ -54,6 +55,13 @@ const Search = () => {
     onToggleEntity,
     numberOfSelectedElements,
   } = useEntityToggle<SearchStixCoreObjectLine_node$data>(LOCAL_STORAGE_KEY);
+
+  const { keyword } = useParams() as { keyword: string };
+  const paginationOptions = {
+    ...rawPaginationOptions,
+    search: keyword,
+  };
+
   const queryRef = useQueryLoading<SearchStixCoreObjectsLinesPaginationQuery>(
     searchStixCoreObjectsLinesQuery,
     paginationOptions,

--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -28,10 +28,16 @@ const Search = () => {
     platformModuleHelpers: { isRuntimeFieldEnable },
   } = useAuth();
   const { t } = useFormatter();
-  const { viewStorage, helpers: storageHelpers, paginationOptions: rawPaginationOptions } = usePaginationLocalStorage<SearchStixCoreObjectsLinesPaginationQuery$variables>(
+  const { keyword } = useParams() as { keyword: string };
+  let searchTerm = '';
+  try {
+    searchTerm = decodeURIComponent(keyword || '');
+  } catch (e) {
+    // Do nothing
+  }
+  const { viewStorage, helpers: storageHelpers, paginationOptions } = usePaginationLocalStorage<SearchStixCoreObjectsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      searchTerm: '',
       sortBy: '_score',
       orderAsc: true,
       openExports: false,
@@ -41,7 +47,6 @@ const Search = () => {
   const {
     numberOfElements,
     filters,
-    searchTerm,
     sortBy,
     orderAsc,
     openExports,
@@ -56,15 +61,9 @@ const Search = () => {
     numberOfSelectedElements,
   } = useEntityToggle<SearchStixCoreObjectLine_node$data>(LOCAL_STORAGE_KEY);
 
-  const { keyword } = useParams() as { keyword: string };
-  const paginationOptions = {
-    ...rawPaginationOptions,
-    search: keyword,
-  };
-
   const queryRef = useQueryLoading<SearchStixCoreObjectsLinesPaginationQuery>(
     searchStixCoreObjectsLinesQuery,
-    paginationOptions,
+    { ...paginationOptions, search: searchTerm },
   );
 
   const renderLines = () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use `useParams()` to get  `keyword`


### Related issues

* [issue/4395](https://github.com/OpenCTI-Platform/opencti/issues/4395)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
