### PR TITLE
[frontend] Fix edit malware overview (#4409)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEdition.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
 import { graphql } from 'react-relay';
 import { compose } from 'ramda';
+import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import MalwareEditionContainer from './MalwareEditionContainer';
 import { malwareEditionOverviewFocus } from './MalwareEditionOverview';
@@ -59,7 +59,10 @@ class MalwareEdition extends Component {
             );
           }
           return (
-            <Drawer open={this.state.open}>
+            <Drawer
+              title={t('Update a malware')}
+              open={this.state.open}
+            >
               <Loader variant="inElement" />
             </Drawer>
           );

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
@@ -14,7 +14,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import Slide from '@mui/material/Slide';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
 import inject18n from '../../../../components/i18n';
 import { QueryRenderer, commitMutation } from '../../../../relay/environment';
 import { malwareEditionQuery } from './MalwareEdition';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
@@ -7,7 +7,6 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import Drawer from '@mui/material/Drawer';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -15,6 +14,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import Slide from '@mui/material/Slide';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
+import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
 import inject18n from '../../../../components/i18n';
 import { QueryRenderer, commitMutation } from '../../../../relay/environment';
 import { malwareEditionQuery } from './MalwareEdition';
@@ -160,12 +160,10 @@ class MalwarePopover extends Component {
           </DialogActions>
         </Dialog>
         <Drawer
+          title={t('Update a malware')}
           open={this.state.displayEdit}
-          anchor="right"
-          elevation={1}
-          sx={{ zIndex: 1202 }}
-          classes={{ paper: classes.drawerPaper }}
           onClose={this.handleCloseEdit.bind(this)}
+          variant={DrawerVariant.update}
         >
           <QueryRenderer
             query={malwareEditionQuery}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use the custom Drawer component instead of the one directly provided by MUI

### Related issues

* #4409 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Changes in `MalwareEdition.jsx` are made to fix eslint warning (1) and error (1)
