### PR TITLE
[backend/frontend] fix knowledge relations count and distribution (#4350)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectKnowledge.jsx
@@ -73,12 +73,16 @@ const stixDomainObjectKnowledgeReportsNumberQuery = graphql`
 
 const stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery = graphql`
   query StixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery(
+    $elementId: [String]
+    $elementWithTargetTypes: [String]
     $relationship_type: [String]
     $fromId: [String]
     $toTypes: [String]
     $endDate: DateTime
   ) {
     stixCoreRelationshipsNumber(
+      elementId: $elementId
+      elementWithTargetTypes: $elementWithTargetTypes
       relationship_type: $relationship_type
       fromId: $fromId
       toTypes: $toTypes
@@ -148,8 +152,8 @@ class StixDomainObjectKnowledge extends Component {
                   stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
                 }
                 variables={{
-                  fromId: stixDomainObjectId,
-                  toTypes: ['Stix-Cyber-Observable'],
+                  elementId: stixDomainObjectId,
+                  elementWithTargetTypes: ['Stix-Cyber-Observable'],
                   endDate: monthsAgo(1),
                 }}
                 render={({ props }) => {
@@ -192,7 +196,7 @@ class StixDomainObjectKnowledge extends Component {
                   stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
                 }
                 variables={{
-                  fromId: stixDomainObjectId,
+                  elementId: stixDomainObjectId,
                   endDate: monthsAgo(1),
                 }}
                 render={({ props }) => {
@@ -233,7 +237,7 @@ class StixDomainObjectKnowledge extends Component {
           <Grid item={true} xs={6}>
             <StixCoreObjectStixCoreRelationshipsCloud
               stixCoreObjectId={stixDomainObjectId}
-              stixCoreObjectType="Stix-Domain-Object"
+              stixCoreObjectType="Stix-Core-Object"
               relationshipType="stix-core-relationship"
               title={t('Distribution of relations')}
               field="entity_type"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.jsx
@@ -474,7 +474,7 @@ class StixDomainObjectThreatKnowledge extends Component {
           <Grid item={true} xs={6} style={{ marginBottom: 20 }}>
             <StixCoreObjectStixCoreRelationshipsCloud
               stixCoreObjectId={stixDomainObjectId}
-              stixCoreObjectType="Stix-Domain-Object"
+              stixCoreObjectType="Stix-Core-Object"
               relationshipType="stix-core-relationship"
               title={t('Distribution of relations')}
               field="entity_type"

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1669,7 +1669,7 @@ export const elAggregationRelationsCount = async (context, user, indexName, opti
             aggs: {
               genres: {
                 terms: {
-                  size: limit,
+                  size: MAX_AGGREGATION_SIZE,
                   field: field === 'internal_id' ? 'connections.internal_id.keyword' : 'connections.types.keyword',
                 },
                 aggs: {

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1650,7 +1650,7 @@ const buildAggregationRelationFilters = async (context, user, aggregationFilters
   };
 };
 export const elAggregationRelationsCount = async (context, user, indexName, options = {}) => {
-  const { types = [], field = null, limit = MAX_AGGREGATION_SIZE, searchOptions, aggregationOptions } = options;
+  const { types = [], field = null, searchOptions, aggregationOptions } = options;
   if (!R.includes(field, ['entity_type', 'internal_id', 'rel_object-marking.internal_id', 'rel_kill-chain-phase.internal_id', 'creator_id', 'rel_created-by.internal_id', null])) {
     throw FunctionalError('[SEARCH] Unsupported field', field);
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix "total relations" and "total observables" count : get all relations 'from' & 'to' the entity (we were only counting 'from')
* Display distribution of relations for all Stix-Core-Object (we were filtering on Stix-Domain-Object which excludes observables)
* Increase limit of aggregation size, because it returns parent types, which are filtered after to only display core types.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4350

Tested on different entity types : Incident, Malware, Threat Actors, Sectors, Organizations, ...

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

