### PR TITLE
[frontend] Fix edit datasource error when platforms are null (#4451)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -242,8 +242,8 @@ DataSourceEditionOverviewProps
     objectMarking: convertMarkings(dataSource),
     x_opencti_workflow_id: convertStatus(t, dataSource) as Option,
     confidence: dataSource.confidence,
-    x_mitre_platforms: dataSource.x_mitre_platforms,
-    collection_layers: dataSource.collection_layers,
+    x_mitre_platforms: dataSource.x_mitre_platforms || [],
+    collection_layers: dataSource.collection_layers || [],
     references: [],
   };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* when platforms are null, the autocomplete field doesn't work, it should be an empty array

### Related issues

The issue happens when platforms are null, reproduced on testing platform on this datasource : `/dashboard/techniques/data_sources/bb88cfb4-d1fa-45b5-870e-a0f2732b5eed`
To reproduce it locally, you can export it in stix and import (without validation)

* https://github.com/OpenCTI-Platform/opencti/issues/4451

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
