### PR TITLE
[frontend] fix dashboard date reference settings update (#4470)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -36,6 +36,7 @@ const rootPrivateQuery = graphql`
       default_dashboard {
         id
       }
+      default_time_field
       default_hidden_types
       default_marking {
         entity_type


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix dashboard date reference setting : default_time_field is now retrieved using useAuth, it needs to be in the root "me" query
* This doesn't fix the dashboard "functional date" targeted countries map => after discussion with @richard-julien, it's not an issue.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4470

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

