### PR TITLE
[frontend] Fix expand relationship in investigation graph

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -1766,8 +1766,8 @@ class InvestigationGraphComponent extends Component {
   // eslint-disable-next-line class-methods-use-this
   async handleExpandElements(filters) {
     this.handleToggleDisplayProgress();
-    const selectedNodes = Array.from(this.selectedNodes);
-    const selectedNodesIds = R.map((n) => n.id, selectedNodes);
+    const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
+    const selectedNodesIds = R.map((n) => n.id, selectedEntities);
     let newElementsIds = [];
     for (const n of selectedNodesIds) {
       // eslint-disable-next-line no-await-in-loop

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -1767,9 +1767,9 @@ class InvestigationGraphComponent extends Component {
   async handleExpandElements(filters) {
     this.handleToggleDisplayProgress();
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
-    const selectedNodesIds = R.map((n) => n.id, selectedEntities);
+    const selectedEntitiesIds = R.map((n) => n.id, selectedEntities);
     let newElementsIds = [];
-    for (const n of selectedNodesIds) {
+    for (const n of selectedEntitiesIds) {
       // eslint-disable-next-line no-await-in-loop
       const newElements = await fetchQuery(
         investigationGraphStixRelationshipsQuery,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When `handleExpandElements` occurs, handle expand on selected nodes OR selected links

### Related issues

Issue: https://github.com/OpenCTI-Platform/opencti/issues/4474

### Step by step test case

1. Create a threat actors group and create a Sector entity
2. Create a relationship between threat actors group and the sector
3. Link a country to this relationship
4. Go in Investigation Graph, add threat actors group and expand the node
5. Expand the relationship "targets" to see expanded relationship

### Expected behavior

![image](https://github.com/OpenCTI-Platform/opencti/assets/75518128/d98043c9-79aa-489b-a5e9-930fa833e865)


<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
