### PR TITLE
[frontend] Added padding to toolbar to not overlap with FAB

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileToolbar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileToolbar.jsx
@@ -183,7 +183,7 @@ class WorkbenchFileToolbar extends Component {
               },
             }}
           >
-            <Toolbar style={{ minHeight: 54 }}>
+            <Toolbar style={{ minHeight: 54, paddingRight: 100 }}>
               <Typography
                 className={classes.title}
                 color="inherit"

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -1327,7 +1327,7 @@ class ToolBar extends Component {
               },
             }}
           >
-            <Toolbar style={{ minHeight: 54 }}>
+            <Toolbar style={{ minHeight: 54, paddingRight: 100 }}>
               <Typography
                 className={classes.title}
                 color="inherit"

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -80,6 +80,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'fixed',
     bottom: 30,
     right: 280,
+    zIndex: 1200,
     transition: theme.transitions.create('right', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,


### PR DESCRIPTION
### Proposed changes

* Added padding to toolbars so as to not overlap with the floating action button

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

