### PR TITLE
[frontend] Fix tables wider than page width when exporting to pdf (#4501)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -428,10 +428,10 @@ class StixDomainObjectContentComponent extends Component {
       )(ret.images);
 
       let pdfElementMaxWidth = 0;
-      // We need to get the children width in order to know which mode we should save the PDF
+      // We need to get tables width inside ckeditor in order to know which mode we should save the PDF
       const elementCkEditor = document.querySelector('.ck-content.ck-editor__editable.ck-editor__editable_inline');
       if (elementCkEditor) {
-        Array.from(elementCkEditor.children).forEach((c) => {
+        Array.from((elementCkEditor.querySelectorAll('figure.table') ?? [])).forEach((c) => {
           if (c.offsetWidth > pdfElementMaxWidth) {
             pdfElementMaxWidth = c.offsetWidth;
           }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -430,16 +430,19 @@ class StixDomainObjectContentComponent extends Component {
       let pdfElementMaxWidth = 0;
       // We need to get the children width in order to know which mode we should save the PDF
       const elementCkEditor = document.querySelector('.ck-content.ck-editor__editable.ck-editor__editable_inline');
-      Array.from(elementCkEditor.children).forEach((c) => {
-        if (c.offsetWidth > pdfElementMaxWidth) {
-          pdfElementMaxWidth = c.offsetWidth;
-        }
-      });
+      if (elementCkEditor) {
+        Array.from(elementCkEditor.children).forEach((c) => {
+          if (c.offsetWidth > pdfElementMaxWidth) {
+            pdfElementMaxWidth = c.offsetWidth;
+          }
+        });
+      }
       const maxContentForPortraitMode = 680;
+      const pageOrientation = pdfElementMaxWidth > maxContentForPortraitMode ? 'landscape' : 'portrait';
       const pdfData = {
         content: ret.content,
         images,
-        pageOrientation: pdfElementMaxWidth > maxContentForPortraitMode ? 'landscape' : 'portrait',
+        pageOrientation,
       };
       const { protocol, hostname, port } = window.location;
       const url = `${protocol}//${hostname}:${port || ''}`;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -429,6 +429,7 @@ class StixDomainObjectContentComponent extends Component {
       const pdfData = {
         content: ret.content,
         images,
+        pageSize: 'A2',
       };
       const { protocol, hostname, port } = window.location;
       const url = `${protocol}//${hostname}:${port || ''}`;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -429,7 +429,6 @@ class StixDomainObjectContentComponent extends Component {
       const pdfData = {
         content: ret.content,
         images,
-        pageSize: 'A2',
       };
       const { protocol, hostname, port } = window.location;
       const url = `${protocol}//${hostname}:${port || ''}`;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -426,9 +426,20 @@ class StixDomainObjectContentComponent extends Component {
           ])),
         R.fromPairs,
       )(ret.images);
+
+      let pdfElementMaxWidth = 0;
+      // We need to get the children width in order to know which mode we should save the PDF
+      const elementCkEditor = document.querySelector('.ck-content.ck-editor__editable.ck-editor__editable_inline');
+      Array.from(elementCkEditor.children).forEach((c) => {
+        if (c.offsetWidth > pdfElementMaxWidth) {
+          pdfElementMaxWidth = c.offsetWidth;
+        }
+      });
+      const maxContentForPortraitMode = 680;
       const pdfData = {
         content: ret.content,
         images,
+        pageOrientation: pdfElementMaxWidth > maxContentForPortraitMode ? 'landscape' : 'portrait',
       };
       const { protocol, hostname, port } = window.location;
       const url = `${protocol}//${hostname}:${port || ''}`;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

adjusts page orientation according to element width
### Related issues

* [issue/4501](https://github.com/OpenCTI-Platform/opencti/issues/4501)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
