### PR TITLE
[frontend] Fix filters layout is incorrect in feeds (#4646)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.jsx
@@ -484,7 +484,7 @@ const FeedCreation = (props) => {
                         label={t('Include headers in the feed')}
                         containerstyle={{ marginTop: 20 }}
                       />
-                      <div style={{ marginTop: 35 }}>
+                      <div style={{ paddingTop: 35 }}>
                         <Filters
                           variant="text"
                           availableFilterKeys={[

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedEdition.jsx
@@ -446,7 +446,7 @@ const FeedEditionContainer = (props) => {
                       label={t('Include headers in the feed')}
                       containerstyle={{ marginTop: 20 }}
                     />
-                    <div style={{ marginTop: 35 }}>
+                    <div style={{ paddingTop: 35 }}>
                       <Filters
                         variant="text"
                         availableFilterKeys={[

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.jsx
@@ -215,7 +215,7 @@ const StreamCollectionCreation = (props) => {
                   />
                 )}
               </Alert>
-              <div style={{ marginTop: 35 }}>
+              <div style={{ paddingTop: 35 }}>
                 <Filters
                   variant="text"
                   availableFilterKeys={[

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.jsx
@@ -170,7 +170,7 @@ const StreamCollectionEditionContainer = ({ streamCollection }) => {
               />
             )}
           </Alert>
-          <div style={{ marginTop: 35 }}>
+          <div style={{ paddingTop: 35 }}>
             <Filters
               variant="text"
               availableFilterKeys={[

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.jsx
@@ -210,7 +210,7 @@ const TaxiiCollectionCreation = (props) => {
                   />
                 )}
               </Alert>
-              <div style={{ marginTop: 35 }}>
+              <div style={{ paddingTop: 35 }}>
                 <Filters
                   variant="text"
                   availableFilterKeys={[

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.jsx
@@ -205,7 +205,7 @@ const TaxiiCollectionEditionContainer = (props) => {
               />
             )}
           </Alert>
-          <div style={{ marginTop: 35 }}>
+          <div style={{ paddingTop: 35 }}>
             <Filters
               variant="text"
               availableFilterKeys={[


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change margin for padding, tested on streams / feeds / taxii. Triggers are displayed correctly already (because there is a span around the filters div)

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4646

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
