### PR TITLE
[backend] handle priority and severity attributes in filters

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/filtering.js
+++ b/opencti-platform/opencti-graphql/src/utils/filtering.js
@@ -459,11 +459,11 @@ export const isStixMatchFilters = async (context, user, stix, adaptedFilters, us
         // comparison is case-insensitive (P2 or p2 for instance)
         const ids = values.map((v) => (v.id ? v.id.toLowerCase() : null));
         const isSeverityAvailable = severity ? ids.includes(severity.toLowerCase()) : ids.includes(null);
-        // If severity is available but must not be
+        // If available but must not be
         if (operator === 'not_eq' && isSeverityAvailable) {
           return false;
         }
-        // If severity is not available but must be
+        // If not available but must be
         if (operator === 'eq' && !isSeverityAvailable) {
           return false;
         }
@@ -472,11 +472,11 @@ export const isStixMatchFilters = async (context, user, stix, adaptedFilters, us
         const priority = stix[PRIORITY_FILTER];
         const ids = values.map((v) => (v.id ? v.id.toLowerCase() : null));
         const isPriorityAvailable = priority ? ids.includes(priority.toLowerCase()) : ids.includes(null);
-        // If severity is available but must not be
+        // If available but must not be
         if (operator === 'not_eq' && isPriorityAvailable) {
           return false;
         }
-        // If severity is not available but must be
+        // If not available but must be
         if (operator === 'eq' && !isPriorityAvailable) {
           return false;
         }

--- a/opencti-platform/opencti-graphql/src/utils/filtering.js
+++ b/opencti-platform/opencti-graphql/src/utils/filtering.js
@@ -49,6 +49,8 @@ export const TYPE_FILTER = 'entity_type';
 export const INDICATOR_FILTER = 'indicator_types';
 export const SCORE_FILTER = 'x_opencti_score';
 export const DETECTION_FILTER = 'x_opencti_detection';
+export const SEVERITY_FILTER = 'severity';
+export const PRIORITY_FILTER = 'priority';
 export const WORKFLOW_FILTER = 'x_opencti_workflow_id';
 export const CONFIDENCE_FILTER = 'confidence';
 export const REVOKED_FILTER = 'revoked';
@@ -448,6 +450,34 @@ export const isStixMatchFilters = async (context, user, stix, adaptedFilters, us
         const { id } = values.at(0) ?? {};
         const isDetection = (id === 'true') === stix.extensions?.[STIX_EXT_OCTI]?.detection;
         if (!isDetection) {
+          return false;
+        }
+      }
+      if (key === SEVERITY_FILTER) {
+        const severity = stix[SEVERITY_FILTER];
+        // no-severity is a filter { id: '', value '' } ; we use null to track it below
+        // comparison is case-insensitive (P2 or p2 for instance)
+        const ids = values.map((v) => (v.id ? v.id.toLowerCase() : null));
+        const isSeverityAvailable = severity ? ids.includes(severity.toLowerCase()) : ids.includes(null);
+        // If severity is available but must not be
+        if (operator === 'not_eq' && isSeverityAvailable) {
+          return false;
+        }
+        // If severity is not available but must be
+        if (operator === 'eq' && !isSeverityAvailable) {
+          return false;
+        }
+      }
+      if (key === PRIORITY_FILTER) {
+        const priority = stix[PRIORITY_FILTER];
+        const ids = values.map((v) => (v.id ? v.id.toLowerCase() : null));
+        const isPriorityAvailable = priority ? ids.includes(priority.toLowerCase()) : ids.includes(null);
+        // If severity is available but must not be
+        if (operator === 'not_eq' && isPriorityAvailable) {
+          return false;
+        }
+        // If severity is not available but must be
+        if (operator === 'eq' && !isPriorityAvailable) {
           return false;
         }
       }

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filters-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filters-test.js
@@ -136,4 +136,26 @@ describe('Filters testing', () => {
     const filteredObjects = await applyFilters(filters);
     expect(filteredObjects.length).toBe(1);
   });
+
+  // severity
+  it('Should severity filters correctly applied', async () => {
+    const filters = { severity: [{ id: 'low', value: 'low' }] };
+    const filteredObjects = await applyFilters(filters);
+    expect(filteredObjects.length).toBe(0); // no severity in the data
+
+    const filtersNo = { severity: [{ id: '', value: '' }] };
+    const filteredObjectsNo = await applyFilters(filtersNo);
+    expect(filteredObjectsNo.length).toBe(64);
+  });
+
+  // priority
+  it('Should priority filters correctly applied', async () => {
+    const filters = { priority: [{ id: 'p2', value: 'p2' }] };
+    const filteredObjects = await applyFilters(filters);
+    expect(filteredObjects.length).toBe(0); // no priority in the data
+
+    const filtersNo = { priority: [{ id: '', value: '' }] };
+    const filteredObjectsNo = await applyFilters(filtersNo);
+    expect(filteredObjectsNo.length).toBe(64);
+  });
 });


### PR DESCRIPTION
* used by streams, triggers and playbooks

### Proposed changes

All changes inside `isStixMatchFilter` to handle the `priority` and `severity` attributes filters. 
There is 2 things to consider
* comparison should be case insensitive, as the filter can be saved as priority `p2` where stix value is `P2`
* user is able to select "no priority" or "no severity" and the filter is that case is `{ id: '', value '' }`

### Related issues

* #4789 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
