### PR TITLE
On manual logout, invalidate referrer

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -7,7 +7,6 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContentText from '@mui/material/DialogContentText';
 import { useFormatter } from '../../components/i18n';
 import { formatSeconds, ONE_SECOND, secondsBetweenDates } from '../../utils/Time';
-import { handleLogout } from './nav/TopBar';
 import useAuth from '../../utils/hooks/useAuth';
 
 /**
@@ -122,6 +121,14 @@ const TimeoutLock: React.FunctionComponent<TimeoutLockProps> = () => {
    */
   const lockScreen = () => {
     setDialogOpen(true);
+  };
+
+  /**
+   * Going to /logout disconnects the user from the platform (see backend middleware).
+   * Referrer is kept so user will be redirected there on next login.
+   */
+  const handleLogout = () => {
+    window.location.pathname = '/logout';
   };
 
   /**

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -11,6 +11,7 @@ import Menu from '@mui/material/Menu';
 import Divider from '@mui/material/Divider';
 import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
+import MuiLink from '@mui/material/Link';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
@@ -496,8 +497,17 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
                 {t('Profile')}
               </MenuItem>
               <MenuItem onClick={handleOpenDrawer}>{t('Feedback')}</MenuItem>
-              <MenuItem id="logout-button" onClick={() => handleLogout()}>
-                {t('Logout')}
+              <MenuItem id="logout-button">
+                <MuiLink
+                  underline="none"
+                  color="secondary"
+                  href="/logout"
+                  // user will be redirected to login, but we do not want to keep the referrer url
+                  // on next login, the user might not be the same and might not have access to this url
+                  rel="noreferrer"
+                >
+                  {t('Logout')}
+                </MuiLink>
               </MenuItem>
             </Menu>
           </div>

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -133,10 +133,6 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-export const handleLogout = () => {
-  window.location.pathname = '/logout';
-};
-
 const topBarNotificationNumberSubscription = graphql`
   subscription TopBarNotificationNumberSubscription {
     notificationsNumber {
@@ -502,7 +498,7 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
                   underline="none"
                   color="secondary"
                   href="/logout"
-                  // user will be redirected to login, but we do not want to keep the referrer url
+                  // user will be logged out automatically, but we do not want to keep the referrer url for next login
                   // on next login, the user might not be the same and might not have access to this url
                   rel="noreferrer"
                 >

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -257,7 +257,7 @@ const createApp = async (app) => {
   // Logout
   app.get(`${basePath}/logout`, async (req, res, next) => {
     try {
-      const referer = extractRefererPathFromReq(req);
+      const referer = extractRefererPathFromReq(req) ?? '/';
       const strategy = passport._strategy(req.session.session_provider?.provider);
       const { user } = req.session;
       const withOrigin = userWithOrigin(req, user);


### PR DESCRIPTION
When a user logs our using the top bar button, we redirect to the signin page. However, the referrer is kept and when a user logs in again, he is redirected to this URL.

This is not suitable as the user who logs in after the first might not be the same, and might not have access to this specific URL (for instance, an admin logs out from some deep configuration in the platform settings ; next user is not admin and does not have the right capabilities).

### Proposed changes

* frontend: on logout from the top bar, invalidate referrer in the link to `/logout`
* backend: on logout, if no referrer is given, redirect to '/'

### Related issues

* #4823

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

To clarify the UI, I suggest we use the secondary color for the link text
![image](https://github.com/OpenCTI-Platform/opencti/assets/146674147/3d57a62a-67ef-4213-b9d0-d1588d8cab0f)

Logging out is not like a redirection to profile or something "light"... Let's highlight it in the menu.
