### PR TITLE
[frontend] by default, redirect invalid URLS to /dashboard

### DIFF
--- a/opencti-platform/opencti-front/src/app.tsx
+++ b/opencti-platform/opencti-front/src/app.tsx
@@ -18,12 +18,13 @@ const App = () => (
       <AuthBoundaryComponent>
         <RedirectManager>
           <Routes>
-            <Route
-              path="/"
-              element={<Navigate to="/dashboard" replace={true} />}
-            />
             <Route path="/dashboard/*" element={<PrivateRoot />} />
             <Route path="/public/*" element={<PublicRoot />} />
+            {/* By default, redirect to dashboard */}
+            <Route
+              path="/*"
+              element={<Navigate to="/dashboard" replace={true} />}
+            />
           </Routes>
         </RedirectManager>
       </AuthBoundaryComponent>


### PR DESCRIPTION
### Proposed changes
Going to an invalid URL from root like `/invalid` leads to a blank page.

* redirect all invalid URLs `/invalid` to `/dashboard` like we already do with invalid URLs starting with `/dashboard` like `/dashboard/invalid`

### Related issues

* #4842 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I chose this solution over a new 404 public page as it fits the existing strategy.