### PR TITLE
[frontend] Align selected dashboard (#4849)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
@@ -14,6 +14,8 @@ import Slide from '@mui/material/Slide';
 import React, { useState } from 'react';
 import { graphql, useMutation } from 'react-relay';
 import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../components/i18n';
 import { QueryRenderer } from '../../relay/environment';
 import useAuth from '../../utils/hooks/useAuth';
@@ -25,6 +27,16 @@ const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
 ));
 Transition.displayName = 'TransitionSlide';
+
+const useStyles = makeStyles({
+  muiSelect: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  muiSelectIcon: {
+    minWidth: 36,
+  },
+});
 
 export const dashboardSettingsDashboardsQuery = graphql`
   query DashboardSettingsDashboardsQuery(
@@ -58,6 +70,7 @@ const dashboardSettingsMutation = graphql`
 `;
 
 const DashboardSettings = () => {
+  const classes = useStyles();
   const { t } = useFormatter();
   const {
     me: {
@@ -160,6 +173,9 @@ const DashboardSettings = () => {
                           )
                           }
                           fullWidth={true}
+                          classes={{
+                            select: classes.muiSelect,
+                          }}
                         >
                           <MenuItem value="default">
                             <em>{t('Automatic')}</em>
@@ -171,10 +187,12 @@ const DashboardSettings = () => {
                           )}
                           {dashboards?.map(({ id, name }) => (
                             <MenuItem key={id} value={id}>
-                              <ListItemIcon>
+                              <ListItemIcon classes={{
+                                root: classes.muiSelectIcon,
+                              }}>
                                 <ItemIcon type="Dashboard" variant="inline" />
                               </ListItemIcon>
-                              {name}
+                              <ListItemText>{name}</ListItemText>
                             </MenuItem>
                           ))}
                           {workspaces?.length > 0 && (
@@ -182,10 +200,12 @@ const DashboardSettings = () => {
                           )}
                           {workspaces?.map(({ node }) => (
                             <MenuItem key={node.id} value={node.id}>
-                              <ListItemIcon>
+                              <ListItemIcon classes={{
+                                root: classes.muiSelectIcon,
+                              }}>
                                 <ItemIcon type="Dashboard" />
                               </ListItemIcon>
-                              {node.name}
+                              <ListItemText>{node.name}</ListItemText>
                             </MenuItem>
                           ))}
                         </Select>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add MUI element (from MUI doc) + styles to align items

### Related issues

* #4849 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

By default MUI `MenuItem` set width of `ListItemIcon` to 36 pixels but `Select` component doesn't. So I set it manually to have consistent display between items in the list and selected item.
