### PR TITLE
[Frontend] Put configurations options into dialog (#4505)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/Attribute.d.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/Attribute.d.ts
@@ -7,10 +7,7 @@ export interface Attribute {
   } | null;
   column: {
     column_name: string | null;
-    configuration?: {
-      separator?: string;
-      pattern_date?: string;
-    };
+    configuration?: AttributeConfiguration;
   } | null;
 }
 
@@ -19,4 +16,9 @@ export interface AttributeWithMetadata extends Attribute {
   mandatory?: boolean;
   multiple?: boolean | null;
   type?: string;
+}
+
+export interface AttributeConfiguration {
+  separator?: string;
+  pattern_date?: string;
 }

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeForm.tsx
@@ -11,6 +11,10 @@ import {
 } from '@components/data/csvMapper/representations/attributes/Attribute';
 import { useFormikContext } from 'formik';
 import { CsvMapper } from '@components/data/csvMapper/CsvMapper';
+import CsvMapperRepresentationDialogOption
+  from '@components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption';
+import CsvMapperRepresentionAttributeSelectedConfigurations
+  from '@components/data/csvMapper/representations/attributes/CsvMapperRepresentionAttributeSelectedConfigurations';
 import { useFormatter } from '../../../../../../components/i18n';
 import { isEmptyField } from '../../../../../../utils/utils';
 
@@ -21,6 +25,7 @@ const useStyles = makeStyles(() => ({
     gridTemplateColumns: '1fr 1fr 1fr',
     alignItems: 'center',
     marginTop: '10px',
+    gap: '10px',
   },
   inputError: {
     '& fieldset': {
@@ -138,11 +143,21 @@ CsvMapperRepresentationAttributeFormProps
         />
       </div>
       <div>
-        <CsvMapperRepresentationAttributeOptions
-          attribute={attribute}
-          indexRepresentation={indexRepresentation}
-        />
+        {
+          (attribute.type === 'date' || attribute.multiple)
+          && <CsvMapperRepresentationDialogOption attribute={attribute}>
+            <CsvMapperRepresentationAttributeOptions
+                attribute={attribute}
+                indexRepresentation={indexRepresentation}
+            />
+          </CsvMapperRepresentationDialogOption>
+        }
       </div>
+        <CsvMapperRepresentionAttributeSelectedConfigurations
+          configuration={ formikContext.values.representations[indexRepresentation]
+            .attributes[indexAttribute]?.column?.configuration}
+        />
+
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeOptions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeOptions.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../../../components/i18n';
 const useStyles = makeStyles(() => ({
   container: {
     display: 'flex',
-    justifyContent: 'right',
+    alignItems: 'center',
   },
 }));
 
@@ -44,7 +44,7 @@ CsvMapperRepresentationAttributeOptionsProps
   const enabled = !!selectedAttributes.find((a) => a.key === attribute.key);
 
   return (
-    <div>
+    <>
       {attribute.type === 'date' && (
         <div className={classes.container}>
           <MuiTextField
@@ -97,7 +97,7 @@ CsvMapperRepresentationAttributeOptionsProps
           </Tooltip>
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
@@ -1,0 +1,58 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+import Dialog from '@mui/material/Dialog';
+import Button from '@mui/material/Button';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import { CogOutline } from 'mdi-material-ui';
+import IconButton from '@mui/material/IconButton';
+import { AttributeWithMetadata } from '@components/data/csvMapper/representations/attributes/Attribute';
+import { useFormatter } from '../../../../../../components/i18n';
+
+interface CsvMapperRepresentationDialogOptionProps {
+  attribute: AttributeWithMetadata
+  children: ReactNode
+}
+
+const CsvMapperRepresentationDialogOption: FunctionComponent<CsvMapperRepresentationDialogOptionProps> = ({ attribute, children }) => {
+  const [open, setOpen] = React.useState(false);
+  const { t } = useFormatter();
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label={t('Settings')}
+        onClick={handleClickOpen}
+        size="large"
+        disabled={!attribute.column?.column_name}
+      ><CogOutline/></IconButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="csv-mapper-dialog-title"
+        aria-describedby="Configure optional settings to the field"
+      >
+        <DialogTitle id="csv-mapper-dialog-title">
+          {t('Attribute mapping configuration')}
+        </DialogTitle>
+        <DialogContent>
+          {children}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} autoFocus>
+            {t('Close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default CsvMapperRepresentationDialogOption;

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
@@ -31,8 +31,9 @@ const CsvMapperRepresentationDialogOption: FunctionComponent<CsvMapperRepresenta
         aria-label={t('Settings')}
         onClick={handleClickOpen}
         size="large"
-        disabled={!attribute.column?.column_name}
-      ><CogOutline/></IconButton>
+        disabled={!attribute.column?.column_name}>
+        <CogOutline/>
+      </IconButton>
       <Dialog
         open={open}
         onClose={handleClose}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentionAttributeSelectedConfigurations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentionAttributeSelectedConfigurations.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 import { AttributeConfiguration } from '@components/data/csvMapper/representations/attributes/Attribute';
 import makeStyles from '@mui/styles/makeStyles';
+import { SubdirectoryArrowRight } from 'mdi-material-ui';
 import { useFormatter } from '../../../../../../components/i18n';
 
 interface CsvMapperRepresentionAttributSeelectedConfigurationsProps {
@@ -11,6 +12,8 @@ const useStyles = makeStyles(() => ({
   attributeOptionsContainer: {
     gridColumnStart: 2,
     gridColumnEnd: 4,
+    display: 'flex',
+    alignItems: 'center',
   },
   selectedOption: {
     border: '1px solid currentColor',
@@ -26,15 +29,21 @@ const CsvMapperRepresentionAttributeSelectedConfigurations: FunctionComponent<Cs
   }
 
   return <div className={classes.attributeOptionsContainer}>
-        {
-            configuration.pattern_date
-          && <div>{t('Date pattern')}: <span className={classes.selectedOption}>{configuration.pattern_date}</span></div>
-        }
-        {
-            configuration.separator
-          && <div>{t('List separator')}: <span className={classes.selectedOption}>{configuration.separator}</span></div>
-        }
-    </div>;
+    {
+      configuration.pattern_date
+      && <>
+        <SubdirectoryArrowRight/>{t('Date pattern')}:
+        <span className={classes.selectedOption}>{configuration.pattern_date}</span>
+      </>
+    }
+    {
+      configuration.separator
+      && <>
+        <SubdirectoryArrowRight/> {t('List separator')}:
+        <span className={classes.selectedOption}>{configuration.separator}</span>
+      </>
+    }
+  </div>;
 };
 
 export default CsvMapperRepresentionAttributeSelectedConfigurations;

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentionAttributeSelectedConfigurations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentionAttributeSelectedConfigurations.tsx
@@ -1,0 +1,40 @@
+import { FunctionComponent } from 'react';
+import { AttributeConfiguration } from '@components/data/csvMapper/representations/attributes/Attribute';
+import makeStyles from '@mui/styles/makeStyles';
+import { useFormatter } from '../../../../../../components/i18n';
+
+interface CsvMapperRepresentionAttributSeelectedConfigurationsProps {
+  configuration?: AttributeConfiguration
+}
+
+const useStyles = makeStyles(() => ({
+  attributeOptionsContainer: {
+    gridColumnStart: 2,
+    gridColumnEnd: 4,
+  },
+  selectedOption: {
+    border: '1px solid currentColor',
+    padding: '0 8px',
+    marginLeft: '4px',
+  },
+}));
+const CsvMapperRepresentionAttributeSelectedConfigurations: FunctionComponent<CsvMapperRepresentionAttributSeelectedConfigurationsProps> = ({ configuration }) => {
+  const classes = useStyles();
+  const { t } = useFormatter();
+  if (!configuration?.pattern_date && !configuration?.separator) {
+    return null;
+  }
+
+  return <div className={classes.attributeOptionsContainer}>
+        {
+            configuration.pattern_date
+          && <div>{t('Date pattern')}: <span className={classes.selectedOption}>{configuration.pattern_date}</span></div>
+        }
+        {
+            configuration.separator
+          && <div>{t('List separator')}: <span className={classes.selectedOption}>{configuration.separator}</span></div>
+        }
+    </div>;
+};
+
+export default CsvMapperRepresentionAttributeSelectedConfigurations;

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -2227,6 +2227,7 @@ const i18n = {
       'Create a CSV Mapper configuration': 'Crear una configuración de mapeo CSV',
       'There are not any configurations set yet': 'Todavía no se han configurado ninguna configuración',
       'Do you want to delete this CSV mapper ?': '¿Desea eliminar este mapeador CSV?',
+      'Attribute mapping configuration': 'Configuración de mapeo de atributos',
     },
     'fr-fr': {
       // Titles
@@ -4458,6 +4459,7 @@ const i18n = {
       'Create a CSV Mapper configuration': 'Créer une configuration de mappage CSV',
       'There are not any configurations set yet': 'Il n\'y a pas encore de configurations définies',
       'Do you want to delete this CSV mapper ?': 'Voulez-vous supprimer ce mappage CSV ?',
+      'Attribute mapping configuration': 'Configuration de mappage d\'attributs',
     },
     'ja-jp': {
       // Titles
@@ -6608,6 +6610,7 @@ const i18n = {
       'Create a CSV Mapper configuration': 'CSVマッパーの構成を作成',
       'There are not any configurations set yet': 'まだ設定がありません',
       'Do you want to delete this CSV mapper ?': 'このCSVマッパーを削除しますか？',
+      'Attribute mapping configuration': '属性マッピングの設定',
     },
     'zh-cn': {
       // Titles
@@ -8655,6 +8658,7 @@ const i18n = {
       'Create a CSV Mapper configuration': '创建CSV映射配置',
       'There are not any configurations set yet': '目前尚未设置任何配置',
       'Do you want to delete this CSV mapper ?': '您要删除此CSV映射吗？',
+      'Attribute mapping configuration': '属性映射配置',
     },
     'en-us': {
       gt: 'Greater than',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* CSV mappers : Put configurations options into dialog

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4505


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
