### PR TITLE
[frontend] Fix trigger background task on entity knowledge indicators (#4860)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
@@ -113,6 +113,12 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
     indicates: [{ id: entityId, value: entityId }],
   });
 
+  const toolBarFilters = {
+    ...cleanedFilters,
+    entity_type: [{ id: 'Indicator', value: 'Indicator' }],
+    indicates: [{ id: entityId, value: entityId }],
+  };
+
   const paginationOptions = {
     search: searchTerm,
     orderBy: (sortBy && (sortBy in dataColumns) && dataColumns[sortBy].isSortable) ? sortBy : 'name',
@@ -186,7 +192,7 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
             deSelectedElements={deSelectedElements}
             numberOfSelectedElements={numberOfSelectedElements}
             selectAll={selectAll}
-            filters={cleanedFilters}
+            filters={toolBarFilters}
             search={searchTerm}
             handleClearSelectedElements={handleClearSelectedElements}
             variant="medium"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add missing toolbar filters for background tasks

### Related issues

The issue happens on all knowledge indicators views (not only for campaigns)
* https://github.com/OpenCTI-Platform/opencti/issues/4860

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->