### PR TITLE
[frontend/backend] Duplicate custom dashboard with new name (#issue/3…

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -86,7 +86,8 @@ WorkspaceDuplicationDialogProps
       },
       onCompleted: (data) => {
         handleCloseDuplicate();
-        if (!paginationOptions) {
+        const isDashboardView = !paginationOptions;
+        if (isDashboardView) {
           MESSAGING$.notifySuccess(
             <span>
             {t('The dashboard has been duplicated. You can manage it')}{' '}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -140,7 +140,7 @@ WorkspaceDuplicationDialogProps
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCloseDuplicate} disabled={duplicating || !newName}>
+        <Button onClick={handleCloseDuplicate}>
           {t('Cancel')}
         </Button>
         <Button

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -1,0 +1,158 @@
+import React, { FunctionComponent, useMemo, useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+import { graphql, useMutation } from 'react-relay';
+import { Link } from 'react-router-dom';
+import {
+  WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation,
+  WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation$data,
+} from '@components/workspaces/__generated__/WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation.graphql';
+import { RecordSourceSelectorProxy } from 'relay-runtime';
+import { useFormatter } from '../../../components/i18n';
+import Transition from '../../../components/Transition';
+import { handleError, MESSAGING$ } from '../../../relay/environment';
+
+interface WorkspaceDuplicationDialogProps {
+  workspace: {
+    name: string;
+    type: string;
+    description: string;
+    manifest: string;
+  };
+  displayDuplicate: boolean;
+  duplicating: boolean;
+  handleCloseDuplicate: () => void;
+  setDuplicating: (value: boolean) => void;
+  updater?: (store: RecordSourceSelectorProxy<WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation$data>) => void;
+  paginationOptions?: {
+    search: string;
+    orderBy: string;
+    orderMode: string;
+    filters: Array<{ key: string, values: Array<string> }>;
+  };
+}
+
+const workspaceDuplicationDialogDuplicatedWorkspaceCreation = graphql`
+  mutation WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation(
+    $input: WorkspaceDuplicateInput!
+  ) {
+    workspaceDuplicate(input: $input) {
+      id
+      ...WorkspaceLine_node
+    }
+  }
+`;
+const WorkspaceDuplicationDialog: FunctionComponent<
+WorkspaceDuplicationDialogProps
+> = ({
+  workspace,
+  duplicating,
+  setDuplicating,
+  displayDuplicate,
+  handleCloseDuplicate,
+  updater,
+  paginationOptions,
+}) => {
+  const { t } = useFormatter();
+  const duplicatedDashboardInitialName = useMemo(() => `${workspace.name} - ${t('copy')}`, [t, workspace.name]);
+  const [newName, setNewName] = useState(duplicatedDashboardInitialName);
+  const [commitDuplicatedWorkspaceCreation] = useMutation<WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation>(
+    workspaceDuplicationDialogDuplicatedWorkspaceCreation,
+  );
+
+  const submitDashboardDuplication = (submittedWorkspace: {
+    name: string;
+    type: string;
+    description: string;
+    manifest: string;
+  }) => {
+    commitDuplicatedWorkspaceCreation({
+      variables: {
+        input: {
+          name: submittedWorkspace.name,
+          type: submittedWorkspace.type,
+          description: submittedWorkspace.description,
+          manifest: submittedWorkspace.manifest,
+        },
+      },
+      updater: (store) => updater && updater(store),
+      onError: (error) => {
+        handleError(error);
+      },
+      onCompleted: (data) => {
+        handleCloseDuplicate();
+        if (!paginationOptions) {
+          MESSAGING$.notifySuccess(
+            <span>
+            {t('The dashboard has been duplicated. You can manage it')}{' '}
+              <Link to={`/dashboard/workspaces/dashboards/${data.workspaceDuplicate?.id}`}>
+              {t('here')}
+            </Link>
+            .
+          </span>,
+          );
+        }
+      },
+    });
+  };
+
+  const handleSubmitDuplicate = (submittedNewName: string) => {
+    setDuplicating(true);
+    submitDashboardDuplication({ ...workspace, name: submittedNewName });
+  };
+
+  return (
+    <Dialog
+      open={displayDuplicate}
+      PaperProps={{ elevation: 1 }}
+      keepMounted={true}
+      TransitionComponent={Transition}
+      onClose={handleCloseDuplicate}
+    >
+      <DialogTitle>{t('Duplicate')}</DialogTitle>
+      <DialogContent sx={{ height: 130 }}>
+        <DialogContentText>
+          {t('Do you want to duplicate this workspace?')}
+          <TextField
+            error={!newName}
+            autoFocus
+            margin="dense"
+            id="duplicated_dashboard_name"
+            label={t('New name')}
+            type="text"
+            fullWidth
+            variant="standard"
+            helperText={!newName ? `${t('This field is required')}` : ''}
+            defaultValue={newName}
+            onChange={(event) => {
+              event.preventDefault();
+              setNewName(
+                event.target.value,
+              );
+            }
+            }
+          />
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCloseDuplicate} disabled={duplicating || !newName}>
+          {t('Cancel')}
+        </Button>
+        <Button
+          color="secondary"
+          onClick={() => handleSubmitDuplicate(newName)}
+          disabled={duplicating || !newName}
+        >
+          {t('Duplicate')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default WorkspaceDuplicationDialog;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
@@ -21,11 +21,13 @@ import {
   CloseOutlined,
   MoveToInboxOutlined,
   LockPersonOutlined,
+  ContentCopyOutlined,
 } from '@mui/icons-material';
 import { DotsHorizontalCircleOutline } from 'mdi-material-ui';
 import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import PropTypes from 'prop-types';
+import WorkspaceDuplicationDialog from './WorkspaceDuplicationDialog';
 import handleExportJson from './workspaceExportHandler';
 import WorkspaceTurnToContainerDialog from './WorkspaceTurnToContainerDialog';
 import {
@@ -56,6 +58,10 @@ const useStyles = makeStyles(() => ({
   turnToReportOrCase: {
     margin: '-8px 4px 0 0',
     float: 'right',
+  },
+  duplicate: {
+    float: 'right',
+    margin: '-8px 4px 0 0',
   },
   export: {
     float: 'right',
@@ -104,6 +110,9 @@ const WorkspaceHeader = ({
   const [openTags, setOpenTags] = useState(false);
   const userCanManage = workspace.currentUserAccessRight === 'admin';
   const userCanEdit = userCanManage || workspace.currentUserAccessRight === 'edit';
+  const [displayDuplicate, setDisplayDuplicate] = useState(false);
+  const handleCloseDuplicate = () => setDisplayDuplicate(false);
+  const [duplicating, setDuplicating] = useState(false);
   const getCurrentTags = () => workspace.tags;
   const onSubmitCreateTag = (data, { resetForm }) => {
     const currentTags = getCurrentTags();
@@ -164,6 +173,10 @@ const WorkspaceHeader = ({
 
   const handleExportDashboard = () => {
     handleExportJson(workspace);
+  };
+
+  const handleDashboardDuplication = () => {
+    setDisplayDuplicate(true);
   };
 
   const [
@@ -320,6 +333,30 @@ const WorkspaceHeader = ({
           </div>
         </Security>
       )}
+      <div className={classes.duplicate}>
+        <Tooltip title={t('Duplicate dashboard')}>
+          <ToggleButtonGroup size="small" color="primary" exclusive={true}>
+            <ToggleButton sx={{ padding: '2px' }} size="small" value={'duplicate-dashboard'}>
+              <IconButton
+                  aria-label="copy"
+                  disabled={!workspace}
+                  onClick={() => handleDashboardDuplication()}
+                  color="primary"
+                  size="small"
+              >
+                <ContentCopyOutlined fontSize="small" />
+              </IconButton>
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Tooltip>
+      </div>
+      <WorkspaceDuplicationDialog
+          workspace={workspace}
+          displayDuplicate={displayDuplicate}
+          handleCloseDuplicate={handleCloseDuplicate}
+          duplicating={duplicating}
+          setDuplicating={setDuplicating}
+      />
       <div className={classes.export}>
         <ExportButtons
           domElementId="container"

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9172,6 +9172,7 @@ type Mutation {
   feedbackDelete(id: ID!): ID
   entitySettingsFieldPatch(ids: [ID!]!, input: [EditInput!]!, commitMessage: String, references: [String]): [EntitySetting]
   workspaceAdd(input: WorkspaceAddInput!): Workspace
+  workspaceDuplicate(input: WorkspaceDuplicateInput!): Workspace
   workspaceDelete(id: ID!): ID
   workspaceFieldPatch(id: ID!, input: [EditInput!]!): Workspace
   workspaceEditAuthorizedMembers(id: ID!, input: [MemberAccessInput!]!): Workspace
@@ -11541,6 +11542,15 @@ input WorkspaceAddInput {
   tags: [String]
   authorized_members: [MemberAccessInput!]
   investigated_entities_ids: [String]
+}
+
+input WorkspaceDuplicateInput {
+  type: String!
+  name: String!
+  description: String
+  manifest: String
+  tags: [String]
+  authorized_members: [MemberAccessInput!]
 }
 
 type MalwareAnalysis implements BasicObject & StixCoreObject & StixDomainObject & StixObject {

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -2650,7 +2650,7 @@ const i18n = {
       'Add an action': 'Ajouter une action',
       Export: 'Exporter',
       Duplicate: 'Dupliquer',
-      'The dashboard has been duplicated. You can manage it': `The dashboard has been duplicated. You can manage it': 'Le tableau de bord a été dupliqué. Vous pouvez l'administrer`,
+      'The dashboard has been duplicated. You can manage it': 'The dashboard has been duplicated. You can manage it\': \'Le tableau de bord a été dupliqué. Vous pouvez l\'administrer',
       here: 'ici',
       Delete: 'Supprimer',
       Remove: 'Retirer',

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -136,6 +136,8 @@ const i18n = {
         '¿Quieres borrar esta observación?',
       'Do you want to delete this workspace?':
         '¿Quieres borrar este área de trabajo?',
+      'Do you want to duplicate this workspace?':
+        '¿Quieres duplicar este espacio de trabajo?',
       'Do you want to delete this widget?':
         '¿Quieres borrar este elemento gráfico?',
       'Do you want to delete this attack pattern?':
@@ -343,6 +345,9 @@ const i18n = {
       Replace: 'Reemplazarr',
       'Add an action': 'Añadir una acción',
       Export: 'Exportar',
+      Duplicate: 'Duplicar',
+      'The dashboard has been duplicated. You can manage it': 'El tablero ha sido duplicado. puedes gestionarlo',
+      here: 'aquí',
       Delete: 'Suprimir',
       Remove: 'Borrar',
       Merge: 'Fusionar',
@@ -1218,6 +1223,8 @@ const i18n = {
       'Sort by': 'Ordenar por',
       'Filter by': 'Filtrar por',
       Name: 'Nombre',
+      'New name': 'Nuevo nombre',
+      copy: 'copia',
       Description: 'Descripción',
       description: 'Descripción',
       'Is family': 'Es una familia',
@@ -2434,6 +2441,8 @@ const i18n = {
         'Souhaitez-vous supprimer cette détection ?',
       'Do you want to delete this workspace?':
         'Souhaitez-vous supprimer cet espace de travail ?',
+      'Do you want to duplicate this workspace?':
+        'Souhaitez-vous dupliquer cet espace de travail ?',
       'Do you want to delete this widget?':
         'Souhaitez-vous supprimer ce widget ?',
       'Do you want to delete this attack pattern?':
@@ -2640,6 +2649,9 @@ const i18n = {
       Replace: 'Remplacer',
       'Add an action': 'Ajouter une action',
       Export: 'Exporter',
+      Duplicate: 'Dupliquer',
+      'The dashboard has been duplicated. You can manage it': 'Le tableau de bord a été dupliqué. Vous pouvez le gérer',
+      here: 'ici',
       Delete: 'Supprimer',
       Remove: 'Retirer',
       Merge: 'Fusionner',
@@ -3508,6 +3520,8 @@ const i18n = {
       'Sort by': 'Trier par',
       'Filter by': 'Filtrer par',
       Name: 'Nom',
+      'New name': 'Nouveau nom',
+      copy: 'copie',
       Description: 'Description',
       description: 'Description',
       'Is family': 'Est une famille',
@@ -4694,6 +4708,7 @@ const i18n = {
       'Do you want to delete this sighting?': 'この目撃情報を削除しますか？',
       'Do you want to delete this workspace?':
         'このワークスペースを削除しますか？',
+      'Do you want to duplicate this workspace?': 'このワークスペースを複製しますか?',
       'Do you want to delete this widget?': 'このウィジェットを削除しますか？',
       'Do you want to delete this attack pattern?':
         'この攻撃パターンを削除しますか？',
@@ -4886,6 +4901,9 @@ const i18n = {
       Replace: '置換',
       'Add an action': 'アクションを追加',
       Export: '出力',
+      Duplicate: '重複',
+      'The dashboard has been duplicated. You can manage it': 'ダッシュボードが複製されました。管理できるよ',
+      here: 'ここ',
       Delete: '削除',
       Remove: '解除',
       Merge: 'マージ',
@@ -5740,6 +5758,8 @@ const i18n = {
       'Sort by': 'ソート',
       'Filter by': 'フィルタ',
       Name: '名前',
+      'New name': '新しい名前',
+      copy: 'コピー',
       Description: '説明',
       description: '説明',
       'Is family': 'ファミリ',
@@ -6878,6 +6898,7 @@ const i18n = {
       'Do you want to delete this relation?': '是否要删除此关系？',
       'Do you want to delete this sighting?': '是否要删除此目击？',
       'Do you want to delete this workspace?': '是否要删除此工作区？',
+      'Do you want to duplicate this workspace?': '您想复制此工作区吗？',
       'Do you want to delete this widget?': '你想删除这个小部件吗？',
       'Do you want to delete this attack pattern?': '是否要删除此攻击模式？',
       'Do you want to delete this course of action?': '是否要删除此应对措施？',
@@ -7042,6 +7063,9 @@ const i18n = {
       Replace: '替换',
       'Add an action': '增加一个动作',
       Export: '导出',
+      Duplicate: '复制',
+      'The dashboard has been duplicated. You can manage it': '仪表板已被复制。你可以管理它',
+      here: '这里',
       Delete: '删除',
       Remove: '移除',
       Merge: '归并',
@@ -7853,6 +7877,8 @@ const i18n = {
       'Sort by': '排序方式',
       'Filter by': '过滤条件',
       Name: '姓名',
+      'New name': '新名字',
+      copy: '复制',
       Description: '描述',
       description: '描述',
       'Is family': '是同一家族',

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -2650,7 +2650,7 @@ const i18n = {
       'Add an action': 'Ajouter une action',
       Export: 'Exporter',
       Duplicate: 'Dupliquer',
-      'The dashboard has been duplicated. You can manage it': 'Le tableau de bord a été dupliqué. Vous pouvez le gérer',
+      'The dashboard has been duplicated. You can manage it': `The dashboard has been duplicated. You can manage it': 'Le tableau de bord a été dupliqué. Vous pouvez l'administrer`,
       here: 'ici',
       Delete: 'Supprimer',
       Remove: 'Retirer',

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -13164,6 +13164,7 @@ export type Mutation = {
   workspaceContextClean?: Maybe<Workspace>;
   workspaceContextPatch?: Maybe<Workspace>;
   workspaceDelete?: Maybe<Scalars['ID']['output']>;
+  workspaceDuplicate?: Maybe<Workspace>;
   workspaceEditAuthorizedMembers?: Maybe<Workspace>;
   workspaceFieldPatch?: Maybe<Workspace>;
 };
@@ -14847,6 +14848,11 @@ export type MutationWorkspaceContextPatchArgs = {
 
 export type MutationWorkspaceDeleteArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationWorkspaceDuplicateArgs = {
+  input: WorkspaceDuplicateInput;
 };
 
 
@@ -28795,6 +28801,15 @@ export type WorkspaceConnection = {
   pageInfo: PageInfo;
 };
 
+export type WorkspaceDuplicateInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  manifest?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  tags?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  type: Scalars['String']['input'];
+};
+
 export type WorkspaceEdge = {
   __typename?: 'WorkspaceEdge';
   cursor: Scalars['String']['output'];
@@ -30037,6 +30052,7 @@ export type ResolversTypes = ResolversObject<{
   Workspace: ResolverTypeWrapper<BasicStoreEntityWorkspace>;
   WorkspaceAddInput: WorkspaceAddInput;
   WorkspaceConnection: ResolverTypeWrapper<Omit<WorkspaceConnection, 'edges'> & { edges: Array<ResolversTypes['WorkspaceEdge']> }>;
+  WorkspaceDuplicateInput: WorkspaceDuplicateInput;
   WorkspaceEdge: ResolverTypeWrapper<Omit<WorkspaceEdge, 'node'> & { node: ResolversTypes['Workspace'] }>;
   WorkspacesFilter: WorkspacesFilter;
   WorkspacesFiltering: WorkspacesFiltering;
@@ -30743,6 +30759,7 @@ export type ResolversParentTypes = ResolversObject<{
   Workspace: BasicStoreEntityWorkspace;
   WorkspaceAddInput: WorkspaceAddInput;
   WorkspaceConnection: Omit<WorkspaceConnection, 'edges'> & { edges: Array<ResolversParentTypes['WorkspaceEdge']> };
+  WorkspaceDuplicateInput: WorkspaceDuplicateInput;
   WorkspaceEdge: Omit<WorkspaceEdge, 'node'> & { node: ResolversParentTypes['Workspace'] };
   WorkspacesFiltering: WorkspacesFiltering;
   X509Certificate: Omit<X509Certificate, 'cases' | 'containers' | 'createdBy' | 'groupings' | 'indicators' | 'notes' | 'objectOrganization' | 'observedData' | 'opinions' | 'reports' | 'stixCoreRelationships'> & { cases?: Maybe<ResolversParentTypes['CaseConnection']>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, indicators?: Maybe<ResolversParentTypes['IndicatorConnection']>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectOrganization?: Maybe<ResolversParentTypes['OrganizationConnection']>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']> };
@@ -34991,6 +35008,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   workspaceContextClean?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceContextCleanArgs, 'id'>>;
   workspaceContextPatch?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceContextPatchArgs, 'id' | 'input'>>;
   workspaceDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationWorkspaceDeleteArgs, 'id'>>;
+  workspaceDuplicate?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceDuplicateArgs, 'input'>>;
   workspaceEditAuthorizedMembers?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceEditAuthorizedMembersArgs, 'id' | 'input'>>;
   workspaceFieldPatch?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceFieldPatchArgs, 'id' | 'input'>>;
 }>;

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-resolver.ts
@@ -6,6 +6,7 @@ import {
   findById,
   getCurrentUserAccessRight,
   getOwnerId,
+  duplicateWorkspace,
   objects,
   workspaceCleanContext,
   workspaceDelete,
@@ -40,6 +41,9 @@ const workspaceResolvers: Resolvers = {
   Mutation: {
     workspaceAdd: (_, { input }, context) => {
       return addWorkspace(context, context.user, input);
+    },
+    workspaceDuplicate: (_, { input }, context) => {
+      return duplicateWorkspace(context, context.user, input);
     },
     workspaceDelete: (_, { id }, context) => {
       return workspaceDelete(context, context.user, id);

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
@@ -94,7 +94,6 @@ input WorkspaceDuplicateInput {
     description: String
     manifest: String
     tags: [String]
-    authorized_members: [MemberAccessInput!]
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
@@ -88,8 +88,18 @@ input WorkspaceAddInput {
     investigated_entities_ids: [String]
 }
 
+input WorkspaceDuplicateInput {
+    type: String!
+    name: String!
+    description: String
+    manifest: String
+    tags: [String]
+    authorized_members: [MemberAccessInput!]
+}
+
 type Mutation {
     workspaceAdd(input: WorkspaceAddInput!): Workspace @auth(for: [EXPLORE_EXUPDATE])
+    workspaceDuplicate(input: WorkspaceDuplicateInput!): Workspace @auth(for: [EXPLORE_EXUPDATE])
     workspaceDelete(id: ID!): ID @auth(for: [EXPLORE_EXUPDATE_EXDELETE])
     workspaceFieldPatch(id: ID!, input: [EditInput!]!): Workspace @auth(for: [EXPLORE_EXUPDATE])
     workspaceEditAuthorizedMembers(id: ID!, input:[MemberAccessInput!]!): Workspace @auth(for: [EXPLORE_EXUPDATE])

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
@@ -293,6 +293,30 @@ describe('Workspace resolver standard behavior', () => {
     });
   });
 
+  it('can duplicate workspace', async () => {
+    const queryResult = await queryAsAdmin({
+      query: gql`
+        mutation duplicateWorkspace($input: WorkspaceDuplicateInput!) {
+          workspaceDuplicate(input: $input){
+            id
+          }
+        }
+      `,
+      variables: {
+        input: {
+          type: 'dashboard',
+          name: 'Dashboard to duplicate',
+        },
+      },
+    });
+
+    expect(queryResult).not.toBeUndefined();
+    await queryAsAdmin({
+      query: DELETE_QUERY,
+      variables: { id: queryResult.data?.workspaceDuplicate.id },
+    });
+  });
+
   it('can not investigate on an internal object', async () => {
     const queryResult = await queryAsAdmin({
       query: gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
@@ -299,6 +299,11 @@ describe('Workspace resolver standard behavior', () => {
         mutation duplicateWorkspace($input: WorkspaceDuplicateInput!) {
           workspaceDuplicate(input: $input){
             id
+            entity_type
+            name
+            authorizedMembers {
+              access_right
+            }
           }
         }
       `,
@@ -310,10 +315,14 @@ describe('Workspace resolver standard behavior', () => {
       },
     });
 
-    expect(queryResult).not.toBeUndefined();
+    expect(queryResult.data.workspaceDuplicate.id).toBeDefined();
+    expect(queryResult.data.workspaceDuplicate.name).toBe('Dashboard to duplicate');
+    expect(queryResult.data.workspaceDuplicate.entity_type).toBe('Workspace');
+    expect(queryResult.data.workspaceDuplicate.authorizedMembers.length).toBe(1);
+    expect(queryResult.data.workspaceDuplicate.authorizedMembers[0].access_right).toBe('admin');
     await queryAsAdmin({
       query: DELETE_QUERY,
-      variables: { id: queryResult.data?.workspaceDuplicate.id },
+      variables: { id: queryResult.data.workspaceDuplicate.id },
     });
   });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Second lot (2/3) dedicated to custom-named duplication of custom dashboards

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3242

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Duplication can be done from dashboard view and dashboards list.
