### PR TITLE
[frontend] Keep html body attribute 'data-theme' in sync when changing theme (#4693)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Index.jsx
+++ b/opencti-platform/opencti-front/src/private/Index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
@@ -52,6 +52,19 @@ const Index = ({ settings }) => {
     overflowX: 'hidden',
   };
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+
+  // Change the theme body attribute when the mode changes in
+  // the palette because some components like CKEditor uses this
+  // body attribute to display correct styles.
+  useEffect(() => {
+    const body = document.querySelector('body');
+    const bodyMode = body.getAttribute('data-theme');
+    const themeMode = `${theme.palette.mode}`;
+    if (bodyMode !== themeMode) {
+      body.setAttribute('data-theme', themeMode);
+    }
+  }, [theme]);
+
   return (
     <>
       <SystemBanners settings={settings} />

--- a/opencti-platform/opencti-front/src/private/Index.tsx
+++ b/opencti-platform/opencti-front/src/private/Index.tsx
@@ -4,6 +4,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
 import { useTheme } from '@mui/styles';
+import { BoundaryRoute, NoMatch } from '@components/Error';
 import Search from './components/Search';
 import TopBar from './components/nav/TopBar';
 import LeftBar from './components/nav/LeftBar';
@@ -23,7 +24,6 @@ import RootNotifications from './components/profile/Root';
 import RootData from './components/data/Root';
 import RootWorkspaces from './components/workspaces/Root';
 import Message from '../components/Message';
-import { BoundaryRoute, NoMatch } from './components/Error';
 import StixObjectOrStixRelationship from './components/StixObjectOrStixRelationship';
 import SearchBulk from './components/SearchBulk';
 import RootCases from './components/cases/Root';
@@ -31,13 +31,19 @@ import SystemBanners from '../public/components/SystemBanners';
 import TimeoutLock from './components/TimeoutLock';
 import useAuth from '../utils/hooks/useAuth';
 import SettingsMessagesBanner, { useSettingsMessagesBannerHeight } from './components/settings/settings_messages/SettingsMessagesBanner';
+import { Theme } from '../components/Theme';
+import { RootPrivateQuery$data } from './__generated__/RootPrivateQuery.graphql';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   toolbar: theme.mixins.toolbar,
 }));
 
-const Index = ({ settings }) => {
-  const theme = useTheme();
+interface IndexProps {
+  settings: RootPrivateQuery$data['settings']
+}
+
+const Index = ({ settings }: IndexProps) => {
+  const theme = useTheme<Theme>();
   const classes = useStyles();
   const {
     bannerSettings: { bannerHeight },
@@ -58,17 +64,23 @@ const Index = ({ settings }) => {
   // body attribute to display correct styles.
   useEffect(() => {
     const body = document.querySelector('body');
-    const bodyMode = body.getAttribute('data-theme');
-    const themeMode = `${theme.palette.mode}`;
-    if (bodyMode !== themeMode) {
-      body.setAttribute('data-theme', themeMode);
+    if (body) {
+      const bodyMode = body.getAttribute('data-theme');
+      const themeMode = `${theme.palette.mode}`;
+      if (bodyMode !== themeMode) {
+        body.setAttribute('data-theme', themeMode);
+      }
     }
   }, [theme]);
 
   return (
     <>
       <SystemBanners settings={settings} />
-      {settings.platform_session_idle_timeout > 0 && <TimeoutLock />}
+      {
+        settings.platform_session_idle_timeout
+        && settings.platform_session_idle_timeout > 0
+        && <TimeoutLock />
+      }
       <SettingsMessagesBanner />
       <Box
         sx={{
@@ -113,6 +125,10 @@ const Index = ({ settings }) => {
             <BoundaryRoute path="/dashboard/events" component={RootEvents} />
             <Route
               path="/dashboard/observations"
+              // Because mismatch of types between react-router v5 and v6.
+              // It uses types of v6, but we are using v5 here and compiler is lost.
+              /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+              /* @ts-ignore */
               component={RootObservations}
             />
             <BoundaryRoute path="/dashboard/threats" component={RootThreats} />
@@ -144,7 +160,13 @@ const Index = ({ settings }) => {
               path="/dashboard/profile"
               component={RootNotifications}
             />
-            <Route component={NoMatch} />
+            <Route
+              // Because mismatch of types between react-router v5 and v6.
+              // It uses types of v6, but we are using v5 here and compiler is lost.
+              /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+              /* @ts-ignore */
+              component={NoMatch}
+            />
           </Switch>
         </Box>
       </Box>

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -86,7 +86,11 @@ export const BoundaryRoute = (props) => {
 };
 
 BoundaryRoute.propTypes = {
+  component: PropTypes.object,
   display: PropTypes.object,
+  exact: PropTypes.bool,
+  path: PropTypes.string,
+  render: PropTypes.func,
 };
 
 // 404

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -86,7 +86,7 @@ export const BoundaryRoute = (props) => {
 };
 
 BoundaryRoute.propTypes = {
-  component: PropTypes.object,
+  component: PropTypes.func,
   display: PropTypes.object,
   exact: PropTypes.bool,
   path: PropTypes.string,

--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -64,11 +64,7 @@ const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
   return state;
 };
 
-interface TimeoutLockProps {
-  handleLogout: (url?: string) => void;
-}
-
-const TimeoutLock: React.FunctionComponent<TimeoutLockProps> = () => {
+const TimeoutLock: React.FunctionComponent = () => {
   const { t } = useFormatter();
   const {
     bannerSettings: { bannerHeightNumber, idleLimit, sessionLimit },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update the attribute 'data-theme' of the body when we change mode (light, dark)
* Move `Index.jsx` in TypeScript

> How this fix the initial issue? CKEditor uses this body attribute to determine which style to apply.

### Related issues

* #4693 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->