### PR TITLE
[frontend] Changes to helper text for search widgets

### DIFF
--- a/opencti-platform/opencti-front/src/components/SearchInput.jsx
+++ b/opencti-platform/opencti-front/src/components/SearchInput.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import withStyles from '@mui/styles/withStyles';
 import TextField from '@mui/material/TextField';
@@ -53,7 +53,11 @@ const styles = (theme) => ({
 
 class SearchInput extends Component {
   render() {
-    const { t, classes, onChange, onSubmit, variant, keyword, fullWidth } = this.props;
+    const {
+      t,
+      classes, onChange, onSubmit, variant, keyword, fullWidth,
+      placeholder = `${t('Search these results')}...`,
+    } = this.props;
     let classRoot = classes.searchRoot;
     if (variant === 'inDrawer') {
       classRoot = classes.searchRootInDrawer;
@@ -71,7 +75,7 @@ class SearchInput extends Component {
         defaultValue={keyword}
         variant="outlined"
         size="small"
-        placeholder={`${t('Search')}...`}
+        placeholder={placeholder}
         onChange={(event) => {
           const { value } = event.target;
           if (typeof onChange === 'function') {
@@ -115,6 +119,7 @@ SearchInput.propTypes = {
   onSubmit: PropTypes.func,
   variant: PropTypes.string,
   fullWidth: PropTypes.bool,
+  placeholder: PropTypes.func,
 };
 
 export default compose(inject18n, withStyles(styles))(SearchInput);

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
@@ -8,7 +8,6 @@ import { Add } from '@mui/icons-material';
 import Skeleton from '@mui/material/Skeleton';
 import makeStyles from '@mui/styles/makeStyles';
 import Drawer from '../../common/drawer/Drawer';
-import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddExternalReferencesLines, { addExternalReferencesLinesQuery } from './AddExternalReferencesLines';
@@ -32,7 +31,6 @@ const AddExternalReferences = ({
   stixCoreObjectOrStixCoreRelationshipReferences,
 }) => {
   const classes = useStyles();
-  const { t } = useFormatter();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
 
@@ -69,7 +67,6 @@ const AddExternalReferences = ({
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={handleSearch}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotes.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotes.jsx
@@ -72,7 +72,6 @@ class AddNotes extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwares.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwares.jsx
@@ -89,7 +89,6 @@ class AddSoftwares extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
@@ -422,7 +422,6 @@ class StixCoreRelationshipCreationFromRelation extends Component {
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={this.handleSearch.bind(this)}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -480,7 +480,6 @@ class StixNestedRefRelationshipCreationFromEntity extends Component {
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={this.handleSearch.bind(this)}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
@@ -379,7 +379,6 @@ const StixSightingRelationshipCreationFromEntity = ({
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               keyword={search}
               onSubmit={handleSearch}
             />

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -405,6 +405,7 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
                   onSubmit={handleSearch}
                   keyword={keyword}
                   variant="topBar"
+                  placeholder={`${t('Search OpenCTI')}...`}
                 />
                 <Filters
                   variant="dialog"

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
@@ -125,7 +125,6 @@ class IndicatorAddObservables extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicators.jsx
@@ -109,7 +109,6 @@ class StixCyberObservableAddIndicators extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfAction.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfAction.jsx
@@ -99,7 +99,6 @@ class AddCoursesOfAction extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponents.tsx
@@ -67,7 +67,6 @@ const AddDataComponents: FunctionComponent<{
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={handleSearch}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPattern.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPattern.jsx
@@ -99,7 +99,6 @@ class AddSubAttackPattern extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatterns.jsx
@@ -62,7 +62,6 @@ class AddAttackPatterns extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
@@ -66,7 +66,6 @@ const AddAttackPatterns: FunctionComponent<{
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={handleSearch}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
@@ -67,7 +67,6 @@ const AddDataSources: FunctionComponent<{ dataComponentId: string }> = ({
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={handleSearch}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
@@ -67,7 +67,6 @@ const AddDataComponents: FunctionComponent<{
           <div className={classes.search}>
             <SearchInput
               variant="inDrawer"
-              placeholder={`${t('Search')}...`}
               onSubmit={handleSearch}
             />
           </div>

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
@@ -64,7 +64,6 @@ class AddSubNarrative extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
@@ -65,7 +65,6 @@ class AddLocations extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroup.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroup.jsx
@@ -65,7 +65,6 @@ class AddLocationsThreatActorGroup extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividual.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividual.jsx
@@ -72,7 +72,6 @@ class AddLocationsThreatActorIndividual extends Component {
             <div className={classes.search}>
               <SearchInput
                 variant="inDrawer"
-                placeholder={`${t('Search')}...`}
                 onSubmit={this.handleSearch.bind(this)}
               />
             </div>

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -56,6 +56,8 @@ const i18n = {
       'When enforcing 2FA authentication, all users will be asked to enable 2FA to be able to login in the platform.':
         'Al aplicar la autenticación 2FA, se pedirá a todos los usuarios que habiliten 2FA para poder iniciar sesión en la plataforma.',
       Search: 'Buscar',
+      'Search these results': 'Buscar estos resultados',
+      'Search OpenCTI': 'Buscar OpenCTI',
       Active: 'Activo',
       Inactive: 'Inactivo',
       'Last update': 'Última actualización',
@@ -2285,6 +2287,8 @@ const i18n = {
       'When enforcing 2FA authentication, all users will be asked to enable 2FA to be able to login in the platform.':
         "Lors de l’application de l'authentication à deux facteurs, tous les utilisateurs seront invités à activer l'authentication à deux facteurs pour pouvoir se connecter à la plate-forme.",
       Search: 'Rechercher',
+      'Search these results': 'Rechercher ces résultats',
+      'Search OpenCTI': 'Rechercher OpenCTI',
       Active: 'Actif',
       Inactive: 'Inactif',
       'Last update': 'Dernière mise à jour',
@@ -4514,6 +4518,8 @@ const i18n = {
       'When enforcing 2FA authentication, all users will be asked to enable 2FA to be able to login in the platform.':
         '2要素認証を強制する場合、すべてのユーザーは、プラットフォームにログインできるように2要素認証を有効にするように求められます。',
       Search: '検索',
+      'Search these results': 'これらの結果を検索',
+      'Search OpenCTI': 'OpenCTI を検索',
       Active: 'アクティブ',
       Inactive: '非活性',
       'Last update': '最終更新',
@@ -6658,6 +6664,8 @@ const i18n = {
       'When enforcing 2FA authentication, all users will be asked to enable 2FA to be able to login in the platform.':
         '強制執行雙因素身份驗證時，將要求所有使用者啟用雙因素身份驗證才能登錄平臺。',
       Search: '搜索',
+      'Search these results': '搜索这些结果',
+      'Search OpenCTI': '搜索 OpenCTI',
       Active: '活跃',
       Inactive: '不活跃',
       'Last update': '上次更新',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR updates the helper text in the search widgets of OpenCTI to more clearly convey what the search target of the widget is:
* Top Right widget now says 'Search OpenCTI...' since this widget searches the whole platform
* Top Left widget nested within a section now says 'Search these results....'
* The SearchInput component was updated to accept a 'placeholder' value which is defaulted to the 'Search these results' option but can be overload - like in TopBar to be replaced with 'Search OpenCTI'

### Related issues

* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
