### PR TITLE
[frontend] Updated colors for Drawer titles to not match active text for clarity

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -87,6 +87,11 @@ const ThemeDark = (
       fontSize: 18,
       color: primary || '#00b1ff',
     },
+    subtitle2: {
+      fontWeight: 400,
+      fontSize: 18,
+      color: 'rgba(255, 255, 255, 0.7)',
+    },
   },
   components: {
     MuiAccordion: {

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -85,6 +85,11 @@ const ThemeLight = (
       fontSize: 18,
       color: primary || '#007fff',
     },
+    subtitle2: {
+      fontWeight: 400,
+      fontSize: 18,
+      color: 'rgba(0, 0, 0, 0.87)',
+    },
   },
   components: {
     MuiTooltip: {

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -155,7 +155,7 @@ const Drawer = ({
           >
             <Close fontSize="small" color="primary" />
           </IconButton>
-          <Typography variant="h6">{title}</Typography>
+          <Typography variant="subtitle2">{title}</Typography>
           {context && <SubscriptionAvatars context={context} />}
           {header}
         </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR is a subtle change to the default Drawer title text. It replaces it with a new materialUI supported class of subtitle2 versus the h6 class.

* The text is black in the light mode - versus the "active text" blue
* The text is gray in dark mode (matches the other gray on the forms for field titles)

This subtle change helps to clarify to a user that this text title is not clickable - since it now does not match the clickable font used in OpenCTI in other areas that are clickable.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
