### PR TITLE
[frontend] Use base path to construct logout URL (#4894)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -67,7 +67,7 @@ import TopMenuPosition from './TopMenuPosition';
 import TopMenuData from './TopMenuData';
 import TopMenuSettings from './TopMenuSettings';
 import TopMenuTechniques from './TopMenuTechniques';
-import { MESSAGING$ } from '../../../relay/environment';
+import { APP_BASE_PATH, MESSAGING$ } from '../../../relay/environment';
 import Security from '../../../utils/Security';
 import TopMenuCourseOfAction from './TopMenuCourseOfAction';
 import TopMenuWorkspacesDashboards from './TopMenuWorkspacesDashboards';
@@ -563,9 +563,8 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
               </MenuItem>
               <MenuItem onClick={handleOpenDrawer}>{t('Feedback')}</MenuItem>
               <MenuItem
-                id="logout-button"
                 component="a"
-                href="/logout"
+                href={`${APP_BASE_PATH}/logout`}
                 rel="noreferrer"
               >
                 {t('Logout')}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use BASE_PATH to construct logout URL otherwise it does not work if base path is different than /

### Related issues

* #4894

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Steps to reproduce locally:
- Add `"base_path": "/opencti",` below `"port": 4000` in `opencti-graphql/config/development.json`,
- Build the frontend (not start, build),
- Start the backend,
- Go on http://localhost:4000/opencti,
- Login,
- Logout.

Expected result:
- You are redirected to the login form,
- If you try to access a page of the app you are redirected to login form also.

Try also with `"base_path": "/",` and without base_path.
