### PR TITLE
[backend] OpenID Connect: Allow to optionally use userinfo for groups & organizations

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -346,13 +346,17 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           // endregion
           // region groups mapping
           const computeGroupsMapping = () => {
+            const readUserinfo = mappedConfig.groups_management?.read_userinfo || false;
             const token = mappedConfig.groups_management?.token_reference || 'access_token';
             const groupsPath = mappedConfig.groups_management?.groups_path || ['groups'];
             const groupsMapping = mappedConfig.groups_management?.groups_mapping || [];
             const decodedUser = jwtDecode(tokenset[token]);
-            logApp.debug(`[OPENID] Groups mapping on decoded ${token}`, { decoded: decodedUser });
+            if (!readUserinfo) {
+              logApp.debug(`[OPENID] Groups mapping on decoded ${token}`, { decoded: decodedUser });
+            }
             const availableGroups = R.flatten(groupsPath.map((path) => {
-              const value = R.path(path.split('.'), decodedUser) || [];
+              const userClaims = (readUserinfo) ? userinfo : decodedUser;
+              const value = R.path(path.split('.'), userClaims) || [];
               return Array.isArray(value) ? value : [value];
             }));
             const groupsMapper = genConfigMapper(groupsMapping);
@@ -365,12 +369,14 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           const isOrgaMapping = isNotEmptyField(mappedConfig.organizations_default) || isNotEmptyField(mappedConfig.organizations_management);
           const computeOrganizationsMapping = () => {
             const orgaDefault = mappedConfig.organizations_default ?? [];
+            const readUserinfo = mappedConfig.organizations_management?.read_userinfo || false;
             const orgasMapping = mappedConfig.organizations_management?.organizations_mapping || [];
             const token = mappedConfig.organizations_management?.token_reference || 'access_token';
             const orgaPath = mappedConfig.organizations_management?.organizations_path || ['organizations'];
             const decodedUser = jwtDecode(tokenset[token]);
             const availableOrgas = R.flatten(orgaPath.map((path) => {
-              const value = R.path(path.split('.'), decodedUser) || [];
+              const userClaims = (readUserinfo) ? userinfo : decodedUser;
+              const value = R.path(path.split('.'), userClaims) || [];
               return Array.isArray(value) ? value : [value];
             }));
             const orgasMapper = genConfigMapper(orgasMapping);


### PR DESCRIPTION
OpenCTI currently support mapping groups and organizations from claims in OpenID JWTs (`access_token` and  `id_token`).

This is great, but depending on how the OpenID Server (OP) is configured, organizations/groups may not be present in these tokens at all (tokens can become very long, it is advised to use the `userinfo` endpoint for getting a user's organisation instead of having a lengthy JWT...).

OpenCTI does query the userinfo endpoint, but it only uses the response to fetch the user name and email (not the organizations/groups). 
This PR adds two optional settings to use userinfo instead of the JWTs for getting a user's orgs/groups. Also, this PR is non-breaking (If these settings are not defined or set to false, then the current behavior is preserved)

Related: https://github.com/OpenCTI-Platform/opencti/pull/1522 (which was closed because it was a breaking change) and https://github.com/OpenCTI-Platform/opencti/issues/1521

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case 
  - I believe there is no need for test case here. Similar settings (`token_reference`, etc...) do not have associated test cases. Please let me know if I should change something.
- [x] I added/update the relevant documentation (either on github or on notion) 
- [x] Where necessary I refactored code to improve the overall quality