### PR TITLE
[frontend] Fix ItemIcon type (#4933)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
@@ -106,7 +106,7 @@ const CreatorField: FunctionComponent<CreatorFieldProps> = ({
         ) => (
           <li {...props}>
             <div className={classes.icon} style={{ color: option.color }}>
-              <ItemIcon type="UserOverview" />
+              <ItemIcon type="user" />
             </div>
             <div className={classes.text}>{option.label}</div>
           </li>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `<ItemIcon/>` component had `UserOverview` type, which did not correspond to any type inside the component.


### Related issues

* [issue/4933](https://github.com/OpenCTI-Platform/opencti/issues/4933)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
