### PR TITLE
[backend] entity_type filter with different operators and modes fix

### DIFF
--- a/opencti-platform/opencti-front/src/components/TaskFilterValue.tsx
+++ b/opencti-platform/opencti-front/src/components/TaskFilterValue.tsx
@@ -68,7 +68,7 @@ const TaskFilterValue = ({
                   ) : (
                     currentFilter.values.map((o) => {
                       const localFilterMode = t(
-                        currentFilter.mode.toUpperCase(),
+                        (currentFilter.mode ?? 'eq').toUpperCase(),
                       );
                       return (
                         <span key={o}>

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1721,7 +1721,7 @@ const adaptFilterToSourceReliabilityFilterKey = async (context, user, filter) =>
     filters: [{ key: ['x_opencti_reliability'], operator, values, mode }],
     filterGroups: [],
   };
-  const opts = { types: authorTypes, filter: reliabilityFilter, connectionFormat: false };
+  const opts = { types: authorTypes, filters: reliabilityFilter, connectionFormat: false };
   const authors = await elList(context, user, READ_INDEX_STIX_DOMAIN_OBJECTS, opts); // the authors with reliability matching the filter
   // we construct a new filter that will match against the creator internal_id respecting the filtering (= those in the listed authors)
   const authorIds = authors.length > 0 ? authors.map((author) => author.internal_id) : ['<no-author-matching-filter>'];
@@ -1778,7 +1778,7 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
     } else if (arrayKeys.includes(SOURCE_RELIABILITY_FILTER)) {
       // in case we want to filter by source reliability (reliability of author)
       // we need to find all authors filtered by reliability and filter on these authors
-      const { newFilter, newFilterGroup } = adaptFilterToSourceReliabilityFilterKey(context, user, filter);
+      const { newFilter, newFilterGroup } = await adaptFilterToSourceReliabilityFilterKey(context, user, filter);
       if (newFilter) {
         finalFilters.push(newFilter);
       }

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -182,3 +182,20 @@ export const convertStixToInternalTypes = (type) => {
       return pascalize(type);
   }
 };
+
+export const keepMostRestrictiveTypes = (entityTypes) => {
+  let restrictedEntityTypes = entityTypes;
+  for (let i = 0; i < entityTypes.length; i += 1) {
+    const type = entityTypes[i];
+    console.log('type', type);
+    const parentTypes = getParentTypes(type);
+    console.log('parentTypes', parentTypes);
+    for (let j = 0; j < parentTypes.length; j += 1) {
+      const parentType = parentTypes[j];
+      if (restrictedEntityTypes.includes(parentType)) {
+        restrictedEntityTypes = restrictedEntityTypes.filter((t) => t !== parentType);
+      }
+    }
+  }
+  return restrictedEntityTypes;
+};

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -187,9 +187,7 @@ export const keepMostRestrictiveTypes = (entityTypes) => {
   let restrictedEntityTypes = entityTypes;
   for (let i = 0; i < entityTypes.length; i += 1) {
     const type = entityTypes[i];
-    console.log('type', type);
     const parentTypes = getParentTypes(type);
-    console.log('parentTypes', parentTypes);
     for (let j = 0; j < parentTypes.length; j += 1) {
       const parentType = parentTypes[j];
       if (restrictedEntityTypes.includes(parentType)) {

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -183,12 +183,17 @@ export const convertStixToInternalTypes = (type) => {
   }
 };
 
+/**
+ * Takes an array of entity types and return it filtered by removing
+ * parent types of types already in the array.
+ * Example: [Report, Container, Stix-Relationship] => [Report, Stix-Relationship] because a Report is a Container
+ */
 export const keepMostRestrictiveTypes = (entityTypes) => {
   let restrictedEntityTypes = [...entityTypes];
   for (let i = 0; i < entityTypes.length; i += 1) {
     const type = entityTypes[i];
     const parentTypes = getParentTypes(type);
-    restrictedEntityTypes = restrictedEntityTypes.filter((t) => parentTypes.includes(t));
+    restrictedEntityTypes = restrictedEntityTypes.filter((t) => !parentTypes.includes(t));
   }
   return restrictedEntityTypes;
 };

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -184,16 +184,11 @@ export const convertStixToInternalTypes = (type) => {
 };
 
 export const keepMostRestrictiveTypes = (entityTypes) => {
-  let restrictedEntityTypes = entityTypes;
+  let restrictedEntityTypes = [...entityTypes];
   for (let i = 0; i < entityTypes.length; i += 1) {
     const type = entityTypes[i];
     const parentTypes = getParentTypes(type);
-    for (let j = 0; j < parentTypes.length; j += 1) {
-      const parentType = parentTypes[j];
-      if (restrictedEntityTypes.includes(parentType)) {
-        restrictedEntityTypes = restrictedEntityTypes.filter((t) => t !== parentType);
-      }
-    }
+    restrictedEntityTypes = restrictedEntityTypes.filter((t) => parentTypes.includes(t));
   }
   return restrictedEntityTypes;
 };

--- a/opencti-platform/opencti-graphql/src/utils/filtering/boolean-logic-engine.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/boolean-logic-engine.ts
@@ -177,12 +177,14 @@ export const testFilterGroup = (data: any, filterGroup: FilterGroup, testerByFil
   }
 
   if (filterGroup.mode === 'or') {
+    const results: boolean[] = [];
     if (filterGroup.filters.length > 0) {
-      return filterGroup.filters.some((filter) => testerByFilterKeyMap[filter.key[0]]?.(data, filter));
+      results.push(filterGroup.filters.some((filter) => testerByFilterKeyMap[filter.key[0]]?.(data, filter)));
     }
     if (filterGroup.filterGroups.length > 0) {
-      return filterGroup.filterGroups.some((fg) => testFilterGroup(data, fg, testerByFilterKeyMap));
+      results.push(filterGroup.filterGroups.some((fg) => testFilterGroup(data, fg, testerByFilterKeyMap)));
     }
+    return results.length > 0 && results.some((isTrue) => isTrue);
   }
 
   return false;

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -42,6 +42,8 @@ export const RULE_FILTER = 'rule';
 export const USER_ID_FILTER = 'user_id';
 export const SOURCE_RELIABILITY_FILTER = 'source_reliability';
 
+export const SOURCE_RELIABILITY_FILTER = 'source_reliability';
+
 // for audit logging (Elastic + Stream)
 export const CONTEXT_ENTITY_ID_FILTER = 'contextEntityId';
 export const CONTEXT_ENTITY_TYPE_FILTER = 'contextEntityType';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -42,8 +42,6 @@ export const RULE_FILTER = 'rule';
 export const USER_ID_FILTER = 'user_id';
 export const SOURCE_RELIABILITY_FILTER = 'source_reliability';
 
-export const SOURCE_RELIABILITY_FILTER = 'source_reliability';
-
 // for audit logging (Elastic + Stream)
 export const CONTEXT_ENTITY_ID_FILTER = 'contextEntityId';
 export const CONTEXT_ENTITY_TYPE_FILTER = 'contextEntityType';

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -12,7 +12,7 @@ import {
   ID_INTERNAL
 } from '../../../src/schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
-import { IDS_FILTER } from '../../../src/utils/filtering/filtering-constants';
+import { IDS_FILTER, SOURCE_RELIABILITY_FILTER } from '../../../src/utils/filtering/filtering-constants';
 
 // test queries involving dynamic filters
 
@@ -1001,17 +1001,17 @@ describe('Complex filters combinations for elastic queries', () => {
           filterGroups: [],
         },
       } });
-    expect(queryResult.errors[0].message).toEqual('Not supported filter: \'And\' operator between values of a filter with key = \'ids\' is not supported');
+    expect(queryResult.errors[0].message).toEqual('Unsupported filter: \'And\' operator between values of a filter with key = \'ids\' is not supported');
     // --- 15. combinations of operators and modes with the special filter key 'source_reliability' --- //
     // (source_reliability = A - Completely reliable)
     queryResult = await queryAsAdmin({ query: LIST_QUERY,
       variables: {
-        first: 10,
+        first: 20,
         filters: {
           mode: 'or',
           filters: [
             {
-              key: IDS_FILTER,
+              key: SOURCE_RELIABILITY_FILTER,
               operator: 'eq',
               values: ['A - Completely reliable'],
               mode: 'or',
@@ -1029,7 +1029,7 @@ describe('Complex filters combinations for elastic queries', () => {
           mode: 'or',
           filters: [
             {
-              key: IDS_FILTER,
+              key: SOURCE_RELIABILITY_FILTER,
               operator: 'eq',
               values: ['A - Completely reliable', 'B - Usually reliable'],
               mode: 'or',
@@ -1047,7 +1047,7 @@ describe('Complex filters combinations for elastic queries', () => {
           mode: 'or',
           filters: [
             {
-              key: IDS_FILTER,
+              key: SOURCE_RELIABILITY_FILTER,
               operator: 'eq',
               values: ['A - Completely reliable', 'B - Usually reliable'],
               mode: 'and',
@@ -1065,7 +1065,7 @@ describe('Complex filters combinations for elastic queries', () => {
           mode: 'or',
           filters: [
             {
-              key: IDS_FILTER,
+              key: SOURCE_RELIABILITY_FILTER,
               operator: 'not_eq',
               values: ['A - Completely reliable', 'B - Usually reliable'],
               mode: 'and',
@@ -1083,7 +1083,7 @@ describe('Complex filters combinations for elastic queries', () => {
           mode: 'or',
           filters: [
             {
-              key: IDS_FILTER,
+              key: SOURCE_RELIABILITY_FILTER,
               operator: 'not_eq',
               values: ['A - Completely reliable', 'B - Usually reliable'],
               mode: 'or',

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -5,7 +5,12 @@ import { addMarkingDefinition } from '../../../src/domain/markingDefinition';
 import { distributionRelations } from '../../../src/database/middleware';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 import { RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship';
-import { ENTITY_TYPE_CONTAINER, ID_INTERNAL } from '../../../src/schema/general';
+import {
+  ABSTRACT_INTERNAL_OBJECT,
+  ABSTRACT_STIX_CORE_OBJECT,
+  ENTITY_TYPE_CONTAINER,
+  ID_INTERNAL
+} from '../../../src/schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
 import { IDS_FILTER } from '../../../src/utils/filtering/filtering-constants';
 
@@ -745,6 +750,24 @@ describe('Complex filters combinations for elastic queries', () => {
               key: 'entity_type',
               operator: 'eq',
               values: [ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_CONTAINER],
+              mode: 'and',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(5); // 5 reports
+    // (entity_type = Report AND container AND Stix-Core-Object)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: 'entity_type',
+              operator: 'eq',
+              values: [ABSTRACT_STIX_CORE_OBJECT, ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_CONTAINER, ABSTRACT_INTERNAL_OBJECT],
               mode: 'and',
             }
           ],

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -817,7 +817,7 @@ describe('Complex filters combinations, behavior tested on reports', () => {
     const entitiesNumberWithoutMalwaresAndSoftware = queryResult.data.globalSearch.edges.length; // all the entities except Malwares and Softwares
     expect(entitiesNumber - entitiesNumberWithoutMalwaresAndSoftware).toEqual(3); // 2 malwares + 1 software
     // --- 14. combinations of operators and modes with the special filter key 'ids' --- //
-    // (id(stix/internal/standard) = XX OR YY)
+    // (id(stix/internal/standard) = standard-XX OR standard-YY)
     queryResult = await queryAsAdmin({ query: LIST_QUERY,
       variables: {
         first: 10,
@@ -835,7 +835,7 @@ describe('Complex filters combinations, behavior tested on reports', () => {
         },
       } });
     expect(queryResult.data.globalSearch.edges.length).toEqual(2);
-    // (id(stix/internal/standard) = XX AND YY)
+    // (id(stix/internal/standard) = standard-XX AND standard-YY)
     queryResult = await queryAsAdmin({ query: LIST_QUERY,
       variables: {
         first: 10,
@@ -853,6 +853,42 @@ describe('Complex filters combinations, behavior tested on reports', () => {
         },
       } });
     expect(queryResult.data.globalSearch.edges.length).toEqual(0);
+    // (id(stix/internal/standard) = internal-XX OR stix-XX)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: IDS_FILTER,
+              operator: 'eq',
+              values: [report1InternalId, report1StixId],
+              mode: 'or',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(1);
+    // (id(stix/internal/standard) = internal-XX AND stix-XX)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: IDS_FILTER,
+              operator: 'eq',
+              values: [report1InternalId, report1StixId],
+              mode: 'and',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(1);
   });
   it('should test environnement deleted', async () => {
     const DELETE_REPORT_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -1020,7 +1020,7 @@ describe('Complex filters combinations for elastic queries', () => {
           filterGroups: [],
         },
       } });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(13);
+    expect(queryResult.data.globalSearch.edges.length).toEqual(6);
     // (source_reliability = A - Completely reliable OR B - Usually reliable)
     queryResult = await queryAsAdmin({ query: LIST_QUERY,
       variables: {
@@ -1038,7 +1038,7 @@ describe('Complex filters combinations for elastic queries', () => {
           filterGroups: [],
         },
       } });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(16);
+    expect(queryResult.data.globalSearch.edges.length).toEqual(9); // 6 entities with source_reliability A + 3 with source_reliability B
     // (source_reliability = A - Completely reliable AND B - Usually reliable)
     queryResult = await queryAsAdmin({ query: LIST_QUERY,
       variables: {
@@ -1093,7 +1093,7 @@ describe('Complex filters combinations for elastic queries', () => {
         },
       } });
     const numberOfEntitiesWithSourceReliabilityNotAOrNotB = queryResult.data.globalSearch.edges.length;
-    expect(numberOfEntitiesWithSourceReliabilityNotAOrNotB - numberOfEntitiesWithSourceReliabilityNotAAndNotB).toEqual(16); // number of entities with source_reliability A or B
+    expect(numberOfEntitiesWithSourceReliabilityNotAOrNotB - numberOfEntitiesWithSourceReliabilityNotAAndNotB).toEqual(9); // number of entities with source_reliability A or B
   });
   it('should test environnement deleted', async () => {
     const DELETE_REPORT_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -7,6 +7,7 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObje
 import { RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship';
 import { ID_INTERNAL } from '../../../src/schema/general';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
+import { IDS_FILTER } from '../../../src/utils/filtering/filtering-constants';
 
 // test queries involving dynamic filters
 
@@ -815,6 +816,43 @@ describe('Complex filters combinations, behavior tested on reports', () => {
       } });
     const entitiesNumberWithoutMalwaresAndSoftware = queryResult.data.globalSearch.edges.length; // all the entities except Malwares and Softwares
     expect(entitiesNumber - entitiesNumberWithoutMalwaresAndSoftware).toEqual(3); // 2 malwares + 1 software
+    // --- 14. combinations of operators and modes with the special filter key 'ids' --- //
+    // (id(stix/internal/standard) = XX OR YY)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: IDS_FILTER,
+              operator: 'eq',
+              values: ['course-of-action--ae56a49d-5281-45c5-ab95-70a1439c338e', 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17'],
+              mode: 'or',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(2);
+    // (id(stix/internal/standard) = XX AND YY)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: IDS_FILTER,
+              operator: 'eq',
+              values: ['course-of-action--ae56a49d-5281-45c5-ab95-70a1439c338e', 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17'],
+              mode: 'and',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(0);
   });
   it('should test environnement deleted', async () => {
     const DELETE_REPORT_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
@@ -295,7 +295,14 @@ describe('Stix Filtering', () => {
         filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Core-Relationship'], mode: 'or' }],
         filterGroups: [],
       } as FilterGroup;
-      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([26, 38]); // all of rels are Stix-core-rel
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([24, 40]); // 24/26 rels are Stix-core-rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Sighting-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([2, 62]); // 2/24 rels are Stix-sighting-rel
 
       filterGroup = {
         mode: 'or',

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
@@ -5,6 +5,7 @@ import { isStixMatchFilterGroup_MockableForUnitTests } from '../../../src/utils/
 
 import stixReports from '../../data/stream-events/stream-event-stix2-reports.json';
 import stixIndicators from '../../data/stream-events/stream-event-stix2-indicators.json';
+import stixBundle from '../../data/DATA-TEST-STIX2_v2.json';
 import type { FilterGroup } from '../../../src/generated/graphql';
 
 const stixReport = stixReports[0]; //  confidence 3, revoked=false, labels=report, TLP:TEST
@@ -17,98 +18,19 @@ const MOCK_RESOLUTION_MAP: Map<string, string> = new Map();
 MOCK_RESOLUTION_MAP.set('id-for-label-indicator', 'indicator');
 MOCK_RESOLUTION_MAP.set('id-for-marking-tlp:green', 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9');
 
+const testManyStix = async (stixs: any[], callback: (stix: any) => Promise<boolean>): Promise<[match: number, notMatch: number]> => {
+  const results = await Promise.all(stixs.map(async (stix) => callback(stix)));
+  return [
+    results.reduce((acc, cur) => (cur ? acc + 1 : acc), 0),
+    results.reduce((acc, cur) => (!cur ? acc + 1 : acc), 0),
+  ];
+};
+
+const makeCallback = (filterGroup: FilterGroup): (stix: any) => Promise<boolean> => {
+  return async (stix: any) => isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stix, filterGroup, MOCK_RESOLUTION_MAP);
+};
+
 describe('Stix Filtering', () => {
-  it('matches stix objects with basic filter groups', async () => {
-    let filterGroup = {
-      mode: 'and',
-      filters: [{
-        key: ['entity_type'],
-        mode: 'or',
-        operator: 'eq',
-        values: ['Report']
-      }],
-      filterGroups: [],
-    } as FilterGroup;
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
-
-    filterGroup = {
-      mode: 'and',
-      filters: [{
-        key: ['entity_type'],
-        mode: 'or',
-        operator: 'eq',
-        values: ['Report', 'Indicator']
-      }],
-      filterGroups: [],
-    } as FilterGroup;
-
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
-  });
-
-  it('prevent access to stix object according to marking', async () => {
-    const filterGroup = {
-      mode: 'and',
-      filters: [{
-        key: ['entity_type'],
-        mode: 'or',
-        operator: 'eq',
-        values: ['Report']
-      }],
-      filterGroups: [],
-    } as FilterGroup;
-
-    const WHITE_USER = buildStandardUser([WHITE_TLP]);
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, WHITE_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
-  });
-
-  it('matches stix objects with complex filter groups', async () => {
-    const filterGroup = {
-      mode: 'and',
-      filters: [],
-      filterGroups: [
-        {
-          mode: 'and',
-          filters: [{
-            key: ['entity_type'],
-            mode: 'or',
-            operator: 'eq',
-            values: ['Report', 'Indicator']
-          }, {
-            key: ['confidence'],
-            mode: 'and',
-            operator: 'gt',
-            values: ['25']
-          }],
-          filterGroups: [],
-        },
-        {
-          mode: 'and',
-          filters: [{
-            key: ['revoked'],
-            mode: 'or',
-            operator: 'eq',
-            values: ['true']
-          }, {
-            key: ['objectLabel'],
-            mode: 'or',
-            operator: 'eq',
-            values: ['id-for-label-indicator']
-          }, {
-            key: ['objectMarking'],
-            mode: 'or',
-            operator: 'eq',
-            values: ['id-for-marking-tlp:green']
-          }],
-          filterGroups: [],
-        },
-      ],
-    } as FilterGroup;
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
-    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
-  });
-
   it('throws error when filter group is invalid', async () => {
     const multipleKeys = {
       mode: 'and',
@@ -170,5 +92,247 @@ describe('Stix Filtering', () => {
     } as unknown as FilterGroup;
 
     await expect(() => isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, notArrayKeys, MOCK_RESOLUTION_MAP)).rejects.toThrowError('The provided filter key is not an array - got "entity_type"');
+  });
+
+  it('prevent access to stix object according to marking', async () => {
+    const filterGroup = {
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        mode: 'or',
+        operator: 'eq',
+        values: ['Report']
+      }],
+      filterGroups: [],
+    } as FilterGroup;
+
+    const WHITE_USER = buildStandardUser([WHITE_TLP]);
+    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, WHITE_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
+  });
+
+  it('matches stix objects with basic filter groups', async () => {
+    let filterGroup = {
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        mode: 'or',
+        operator: 'eq',
+        values: ['Report']
+      }],
+      filterGroups: [],
+    } as FilterGroup;
+    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
+    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
+
+    filterGroup = {
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        mode: 'or',
+        operator: 'eq',
+        values: ['Report', 'Indicator']
+      }],
+      filterGroups: [],
+    } as FilterGroup;
+
+    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
+    expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
+  });
+
+  //--------------------------------------------------------------------------------------------------------------------
+  // Now testing complex filters with edge cases
+  describe('Complex filtering cases', () => {
+    it('using all types of filter keys (string, numeric, boolean)', async () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: ['entity_type'], mode: 'or', operator: 'eq', values: ['Report', 'Indicator'] },
+              { key: ['confidence'], mode: 'and', operator: 'gt', values: ['25'] }
+            ],
+            filterGroups: [],
+          },
+          {
+            mode: 'and',
+            filters: [
+              { key: ['revoked'], mode: 'or', operator: 'eq', values: ['true'] },
+              { key: ['objectLabel'], mode: 'or', operator: 'eq', values: ['id-for-label-indicator'] },
+              { key: ['objectMarking'], mode: 'or', operator: 'eq', values: ['id-for-marking-tlp:green'] }
+            ],
+            filterGroups: [],
+          },
+        ],
+      } as FilterGroup;
+      expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
+      expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
+    });
+
+    it('using mixed entity types', async () => {
+      let filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware', 'Software'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([3, 61]); // 2 malware + 1 software
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware'], mode: 'or' }],
+        filterGroups: [
+          {
+            mode: 'or',
+            filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software'], mode: 'or' }],
+            filterGroups: [],
+          }
+        ],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([3, 61]); // 2 malware + 1 software
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware', 'Software'], mode: 'and' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // nothing is both malware and software
+
+      filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware'], mode: 'or' }],
+        filterGroups: [
+          {
+            mode: 'or',
+            filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software'], mode: 'or' }],
+            filterGroups: [],
+          }
+        ],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // nothing is both malware and software
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'not_eq', values: ['Malware', 'Software'], mode: 'and' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([61, 3]); // all but malware and software
+    });
+
+    it('using parent entity types', async () => {
+      let filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Basic-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([38, 26]); // 38 objects, 26 rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([38, 26]); // all objects are stix-objects
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Internal-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // no internal-objects in bundle
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Meta-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([3, 61]); // 3 Markings
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Core-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([35, 29]); // all but the 3 markings and 26 rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Domain-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([34, 30]); // 34 SDO among the 35 core-objects
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Cyber-Observable'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([1, 63]); // only 1 (a software)
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Basic-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([26, 38]); // 26 rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([26, 38]); // all of rels are Stix-rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Internal-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // no internal-rel in bundle
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Core-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([26, 38]); // all of rels are Stix-core-rel
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Ref-Relationship'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // no ref-rel in bundle
+    });
+
+    it('using combination of child and parent entity types', async () => {
+      let filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware', 'Stix-Domain-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([34, 30]); // Malware are SDO, so all 34 SDO
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware', 'Stix-Domain-Object'], mode: 'and' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([2, 62]); // Malware AND SDO => only 2 malware
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software', 'Stix-Domain-Object'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([35, 29]); // Software is NOT an SDO, so 34 SDO + 1 Software
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software', 'Stix-Domain-Object'], mode: 'and' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // Software is NOT an SDO, so 0 matching both
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
@@ -322,6 +322,20 @@ describe('Stix Filtering', () => {
 
       filterGroup = {
         mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Report', 'Container'], mode: 'or' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([4, 60]); // 1 report, 1 Note, 1 Opinion, 1 Observed-Data
+
+      filterGroup = {
+        mode: 'or',
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Report', 'Container'], mode: 'and' }],
+        filterGroups: [],
+      } as FilterGroup;
+      expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([1, 63]); // only 1 report which is a Container
+
+      filterGroup = {
+        mode: 'or',
         filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software', 'Stix-Domain-Object'], mode: 'or' }],
         filterGroups: [],
       } as FilterGroup;

--- a/opencti-platform/opencti-graphql/tests/04-sync/sync-utils.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/sync-utils.js
@@ -61,7 +61,7 @@ export const SYNC_START_QUERY = `mutation SynchronizerStart($id: ID!) {
     }
   `;
 
-export const UPLOADED_FILE_SIZE = 40438;
+export const UPLOADED_FILE_SIZE = 40551;
 
 export const checkPreSyncContent = async () => {
   const initObjectAggregation = await elAggregationCount(testContext, ADMIN_USER, READ_DATA_INDICES, { types: ['Stix-Object'], field: 'entity_type' });

--- a/opencti-platform/opencti-graphql/tests/data/DATA-TEST-STIX2_v2.json
+++ b/opencti-platform/opencti-graphql/tests/data/DATA-TEST-STIX2_v2.json
@@ -11,7 +11,8 @@
       "labels": ["identity"],
       "created": "2020-02-23T23:40:53.575Z",
       "modified": "2020-02-27T08:45:39.351Z",
-      "x_opencti_organization_type": "CSIRT"
+      "x_opencti_organization_type": "CSIRT",
+      "x_opencti_reliability": "A - Completely reliable"
     },
     {
       "id": "marking-definition--78ca4366-f5b8-4764-83f7-34ce38198e27",
@@ -346,7 +347,8 @@
       "identity_class": "organization",
       "labels": ["identity"],
       "created": "2020-02-25T22:23:20.648Z",
-      "modified": "2020-02-25T22:23:20.648Z"
+      "modified": "2020-02-25T22:23:20.648Z",
+      "x_opencti_reliability": "B - Usually reliable"
     },
     {
       "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",


### PR DESCRIPTION
ewemple of a query that is not working well: entity_type = Malware AND Software