### PR TITLE
[frontend] Updated required fields for TA Individual to include External References

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.jsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.jsx
@@ -16,6 +16,7 @@ const AutocompleteField = (props) => {
     onFocus,
     noOptionsText,
     renderOption,
+    required,
     isOptionEqualToValue,
     textfieldprops,
     openCreate,
@@ -52,6 +53,7 @@ const AutocompleteField = (props) => {
     <div style={{ position: 'relative' }}>
       <MUIAutocomplete
         size="small"
+        required={required}
         selectOnFocus={true}
         autoHighlight={true}
         handleHomeEndKeys={true}
@@ -69,6 +71,7 @@ const AutocompleteField = (props) => {
             {...textfieldprops}
             value={value}
             name={name}
+            required={required}
             fullWidth={true}
             error={!isNil(meta.error)}
             helperText={meta.error || textfieldprops.helperText}

--- a/opencti-platform/opencti-front/src/components/MarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/MarkdownField.jsx
@@ -11,6 +11,7 @@ const MarkdownField = (props) => {
   const {
     form: { setFieldValue, setTouched },
     field: { name },
+    required,
     onFocus,
     onSubmit,
     onSelect,
@@ -59,7 +60,9 @@ const MarkdownField = (props) => {
       onBlur={internalOnBlur}
       onFocus={internalOnFocus}
     >
-      <InputLabel shrink={true}>
+      <InputLabel
+        required={required}
+      >
         {label}
       </InputLabel>
       <ReactMde

--- a/opencti-platform/opencti-front/src/private/components/common/form/CountryField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CountryField.tsx
@@ -31,6 +31,7 @@ interface CountryFieldProps {
   onChange?: (name: string, value: Option) => void;
   containerStyle?: Record<string, string | number>;
   helpertext?: string;
+  required: boolean;
 }
 
 const CountryFieldQuery = graphql`
@@ -53,6 +54,7 @@ const CountryField: FunctionComponent<CountryFieldProps> = ({
   containerStyle,
   onChange,
   helpertext,
+  required,
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
@@ -92,11 +94,13 @@ const CountryField: FunctionComponent<CountryFieldProps> = ({
         id={id}
         component={AutocompleteField}
         name={name}
+        required={required}
         textfieldprops={{
           variant: 'standard',
           label: t(label),
           helperText: helpertext,
           onFocus: searchCountries,
+          required,
         }}
         onChange={onChange}
         style={containerStyle}

--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatedByField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatedByField.jsx
@@ -107,6 +107,7 @@ class CreatedByField extends Component {
       helpertext,
       disabled,
       dryrun,
+      required,
     } = this.props;
     return (
       <div>
@@ -114,12 +115,14 @@ class CreatedByField extends Component {
           component={AutocompleteField}
           style={style}
           name={name}
+          required={required}
           disabled={disabled}
           textfieldprops={{
             variant: 'standard',
             label: label ?? t('Author'),
             helperText: helpertext,
             onFocus: this.searchIdentities.bind(this),
+            required,
           }}
           noOptionsText={t('No available options')}
           options={this.state.identities.sort((a, b) => a.label.localeCompare(b.label))}

--- a/opencti-platform/opencti-front/src/private/components/common/form/ExternalReferencesField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ExternalReferencesField.tsx
@@ -49,6 +49,7 @@ export type ExternalReferencesValues = {
 
 interface ExternalReferencesFieldProps {
   name: string;
+  label?: string;
   style?: { marginTop: number; width: string };
   onChange?: (name: string, values: Option[]) => void;
   setFieldValue: (
@@ -72,12 +73,14 @@ interface ExternalReferencesFieldProps {
   noStoreUpdate?: boolean;
   id?: string;
   dryrun?: boolean;
+  required:boolean;
 }
 
 export const ExternalReferencesField: FunctionComponent<
 ExternalReferencesFieldProps
 > = ({
   name,
+  label,
   style,
   onChange,
   setFieldValue,
@@ -86,6 +89,7 @@ ExternalReferencesFieldProps
   noStoreUpdate,
   id,
   dryrun,
+  required,
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
@@ -164,12 +168,15 @@ ExternalReferencesFieldProps
         component={AutocompleteField}
         style={style}
         name={name}
+        required={required}
         multiple={true}
         textfieldprops={{
           variant: 'standard',
-          label: t('External references'),
+          label: t(label || 'External references'),
           helperText: helpertext,
           onFocus: searchExternalReferences,
+          required,
+
         }}
         noOptionsText={t('No available options')}
         options={externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
@@ -46,6 +46,7 @@ export const objectMarkingFieldAllowedMarkingsQuery = graphql`
 
 interface ObjectMarkingFieldProps {
   name: string;
+  required: boolean;
   style?: React.CSSProperties;
   onChange?: (
     name: string,
@@ -71,6 +72,7 @@ const ObjectMarkingField: FunctionComponent<ObjectMarkingFieldProps> = ({
   disabled,
   label,
   setFieldValue,
+  required,
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
@@ -156,6 +158,7 @@ const ObjectMarkingField: FunctionComponent<ObjectMarkingFieldProps> = ({
         component={AutocompleteField}
         style={style}
         name={name}
+        required={required}
         multiple={true}
         disabled={disabled}
         textfieldprops={{

--- a/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
@@ -15,6 +15,7 @@ interface OpenVocabProps {
   type: string;
   name: string;
   label: string;
+  required: boolean;
   variant?: string;
   onFocus?: (name: string, value: Option) => void;
   containerStyle?: Record<string, string | number>;
@@ -52,6 +53,7 @@ Omit<OpenVocabProps, 'type'>
 > = ({
   name,
   label,
+  required,
   variant,
   onChange,
   onSubmit,
@@ -105,6 +107,7 @@ Omit<OpenVocabProps, 'type'>
       <Field
         component={AutocompleteField}
         name={name}
+        required={required}
         onFocus={onFocus}
         onChange={(n: string, v: Option & Option[]) => {
           internalOnChange?.(n, v);
@@ -130,6 +133,7 @@ Omit<OpenVocabProps, 'type'>
     <Field
       component={AutocompleteField}
       name={name}
+      required={required}
       onChange={internalOnChange}
       fullWidth={true}
       multiple={multiple}
@@ -151,7 +155,7 @@ Omit<OpenVocabProps, 'type'>
 const OpenVocabField: FunctionComponent<Omit<OpenVocabProps, 'queryRef'>> = (
   props,
 ) => {
-  const { name, label, multiple, containerStyle } = props;
+  const { name, label, multiple, containerStyle, required } = props;
   const { typeToCategory } = useVocabularyCategory();
   const queryRef = useQueryLoading<OpenVocabFieldQuery>(vocabularyQuery, {
     category: typeToCategory(props.type),
@@ -162,6 +166,7 @@ const OpenVocabField: FunctionComponent<Omit<OpenVocabProps, 'queryRef'>> = (
         <Field
           component={AutocompleteField}
           name={name}
+          required={required}
           disabled={true}
           fullWidth={true}
           multiple={multiple}
@@ -180,6 +185,7 @@ const OpenVocabField: FunctionComponent<Omit<OpenVocabProps, 'queryRef'>> = (
     <Field
       component={AutocompleteField}
       name={name}
+      required={required}
       disabled={true}
       fullWidth={true}
       multiple={multiple}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -24,7 +24,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useSchemaCreationValidation, useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
@@ -142,11 +142,15 @@ ThreatActorIndividualFormProps
   const { heightsConverterSave, weightsConverterSave } = useUserMetric();
   const [currentTab, setCurrentTab] = useState(0);
   const handleChangeTab = (_: React.SyntheticEvent, value: number) => setCurrentTab(value);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    THREAT_ACTOR_INDIVIDUAL_TYPE,
+  );
   const basicShape = {
-    name: Yup.string().required(t('This field is required')),
+    name: Yup.string(),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
+    objectMarking: Yup.array().nullable(),
     first_seen: Yup.date()
       .nullable()
       .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -334,6 +338,7 @@ ThreatActorIndividualFormProps
                 style={{ marginTop: 20 }}
                 name="name"
                 label={t('Name')}
+                required={(mandatoryAttributes.includes('name'))}
                 fullWidth={true}
                 detectDuplicate={[
                   'Threat-Actor',
@@ -346,6 +351,7 @@ ThreatActorIndividualFormProps
                 type="threat-actor-individual-type-ov"
                 name="threat_actor_types"
                 label={t('Threat actor types')}
+                required={(mandatoryAttributes.includes('threat_actor_types'))}
                 multiple={true}
                 containerStyle={{ width: '100%', marginTop: 20 }}
                 onChange={setFieldValue}
@@ -358,6 +364,7 @@ ThreatActorIndividualFormProps
                 component={MarkdownField}
                 name="description"
                 label={t('Description')}
+                required={(mandatoryAttributes.includes('description'))}
                 fullWidth={true}
                 multiline={true}
                 rows="4"
@@ -365,6 +372,7 @@ ThreatActorIndividualFormProps
               />
               <CreatedByField
                 name="createdBy"
+                required={(mandatoryAttributes.includes('createdBy'))}
                 style={fieldSpacingContainerStyle}
                 setFieldValue={setFieldValue}
               />
@@ -376,10 +384,14 @@ ThreatActorIndividualFormProps
               />
               <ObjectMarkingField
                 name="objectMarking"
+                label={t('Markings')}
+                required={(mandatoryAttributes.includes('objectMarking'))}
                 style={fieldSpacingContainerStyle}
               />
               <ExternalReferencesField
                 name="externalReferences"
+                label={t('External references')}
+                required={(mandatoryAttributes.includes('externalReferences'))}
                 style={fieldSpacingContainerStyle}
                 setFieldValue={setFieldValue}
                 values={values?.externalReferences}
@@ -394,6 +406,7 @@ ThreatActorIndividualFormProps
                 name="first_seen"
                 TextFieldProps={{
                   label: t('First seen'),
+                  required: (mandatoryAttributes.includes('first_seen')),
                   variant: 'standard',
                   fullWidth: true,
                   style: { marginTop: 20 },
@@ -404,55 +417,62 @@ ThreatActorIndividualFormProps
                 name="last_seen"
                 TextFieldProps={{
                   label: t('Last seen'),
+                  required: (mandatoryAttributes.includes('last_seen')),
                   variant: 'standard',
                   fullWidth: true,
                   style: { marginTop: 20 },
                 }}
               />
               <OpenVocabField
-                label={t('Sophistication')}
                 type="threat_actor_individual_sophistication_ov"
                 name="sophistication"
+                label={t('Sophistication')}
+                required={(mandatoryAttributes.includes('sophistication'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={false}
               />
               <OpenVocabField
-                label={t('Resource level')}
                 type="attack-resource-level-ov"
                 name="resource_level"
+                label={t('Resource level')}
+                required={(mandatoryAttributes.includes('resource_level'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={false}
               />
               <OpenVocabField
-                label={t('Roles')}
                 type="threat-actor-individual-role-ov"
                 name="roles"
+                label={t('Roles')}
+                required={(mandatoryAttributes.includes('roles'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={true}
               />
               <OpenVocabField
-                label={t('Primary motivation')}
                 type="attack-motivation-ov"
                 name="primary_motivation"
+                label={t('Primary motivation')}
+                required={(mandatoryAttributes.includes('primary_motivation'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={false}
               />
               <OpenVocabField
-                label={t('Secondary motivations')}
                 type="attack-motivation-ov"
                 name="secondary_motivations"
+                label={t('Secondary motivations')}
+                required={(mandatoryAttributes.includes('secondary_motivations'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={true}
               />
               <OpenVocabField
-                label={t('Personal motivations')}
                 type="attack-motivation-ov"
                 name="personal_motivations"
+                label={t('Personal motivations')}
+                required={(mandatoryAttributes.includes('personal_motivations'))}
                 containerStyle={fieldSpacingContainerStyle}
                 variant="edit"
                 multiple={true}
@@ -461,6 +481,7 @@ ThreatActorIndividualFormProps
                 component={TextField}
                 name="goals"
                 label={t('Goals (1 / line)')}
+                required={(mandatoryAttributes.includes('goals'))}
                 fullWidth={true}
                 multiline={true}
                 rows="4"
@@ -473,7 +494,8 @@ ThreatActorIndividualFormProps
               <CountryField
                 id="PlaceOfBirth"
                 name="bornIn"
-                label={t('Place of Birth')}
+                label={t('Place of birth')}
+                required={(mandatoryAttributes.includes('bornIn'))}
                 containerStyle={fieldSpacingContainerStyle}
                 onChange={setFieldValue}
               />
@@ -481,6 +503,7 @@ ThreatActorIndividualFormProps
                 id="Ethnicity"
                 name="ethnicity"
                 label={t('Ethnicity')}
+                required={(mandatoryAttributes.includes('ethnicity'))}
                 containerStyle={fieldSpacingContainerStyle}
                 onChange={setFieldValue}
               />
@@ -490,7 +513,8 @@ ThreatActorIndividualFormProps
                 name="date_of_birth"
                 onSubmit={setFieldValue}
                 TextFieldProps={{
-                  label: t('Date of Birth'),
+                  label: t('Date of birth'),
+                  required: (mandatoryAttributes.includes('date_of_birth')),
                   variant: 'standard',
                   fullWidth: true,
                   style: { marginTop: 20 },
@@ -498,7 +522,8 @@ ThreatActorIndividualFormProps
               />
               <OpenVocabField
                 name="marital_status"
-                label={t('Marital Status')}
+                label={t('Marital status')}
+                required={(mandatoryAttributes.includes('marital_status'))}
                 type="marital_status_ov"
                 variant="edit"
                 onChange={setFieldValue}
@@ -509,6 +534,7 @@ ThreatActorIndividualFormProps
               <OpenVocabField
                 name="gender"
                 label={t('Gender')}
+                required={(mandatoryAttributes.includes('gender'))}
                 type="gender_ov"
                 variant="edit"
                 onChange={setFieldValue}
@@ -519,8 +545,9 @@ ThreatActorIndividualFormProps
               <Field
                 component={MarkdownField}
                 name="job_title"
+                label={t('Job title')}
+                required={(mandatoryAttributes.includes('job_title'))}
                 id="job_title"
-                label={t('Job Title')}
                 fullWidth={true}
                 multiline={false}
                 rows="1"
@@ -533,7 +560,8 @@ ThreatActorIndividualFormProps
             <>
               <OpenVocabField
                 name="eye_color"
-                label={t('Eye Color')}
+                label={t('Eye color')}
+                required={(mandatoryAttributes.includes('eye_color'))}
                 type="eye_color_ov"
                 variant="edit"
                 onChange={setFieldValue}
@@ -543,7 +571,8 @@ ThreatActorIndividualFormProps
               />
               <OpenVocabField
                 name="hair_color"
-                label={t('Hair Color')}
+                label={t('Hair color')}
+                required={(mandatoryAttributes.includes('hair_color'))}
                 type="hair_color_ov"
                 variant="edit"
                 onChange={setFieldValue}

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntitySettings.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntitySettings.tsx
@@ -67,6 +67,19 @@ export const useIsEnforceReference = (id: string): boolean => {
   );
 };
 
+export const useIsMandatoryAttribute = (id: string) => {
+  const entitySettings = useEntitySettings(id).at(0);
+  if (!entitySettings) {
+    throw Error(`Invalid type for setting: ${id}`);
+  }
+  const mandatoryAttributes = [...entitySettings.mandatoryAttributes];
+  // In creation, if enforce_reference is activated, externalReferences is required
+  if (entitySettings.enforce_reference === true) {
+    mandatoryAttributes.push('externalReferences');
+  }
+  return { entitySettings, mandatoryAttributes };
+};
+
 export const useYupSchemaBuilder = (
   id: string,
   existingShape: ObjectShape,
@@ -80,30 +93,24 @@ export const useYupSchemaBuilder = (
 
   // we're in creation mode, let's find if all mandatory fields are set
   const { t } = useFormatter();
-  const entitySettings = useEntitySettings(id).at(0);
-  if (!entitySettings) {
-    throw Error(`Invalid type for setting: ${id}`);
-  }
-  const mandatoryAttributes = [...entitySettings.mandatoryAttributes];
-  // In creation, if enforce_reference is activated, externalReferences is required
-  if (entitySettings.enforce_reference === true) {
-    mandatoryAttributes.push('externalReferences');
-  }
+  const { mandatoryAttributes } = useIsMandatoryAttribute(id);
   const existingKeys = Object.keys(existingShape);
 
   const newShape: ObjectShape = Object.fromEntries(
     mandatoryAttributes
       .filter((attr) => !(exclusions ?? []).includes(attr))
       .map((attrName: string) => {
+        let validator: Schema;
         if (existingKeys.includes(attrName)) {
-          const validator: Schema = (existingShape[attrName] as Schema)
+          validator = (existingShape[attrName] as Schema)
+            .transform((v) => ((Array.isArray(v) && v.length === 0) ? undefined : v))
+            .required(t('This field is required'))
+            .nullable(false);
+        } else {
+          validator = Yup.mixed()
             .transform((v) => ((Array.isArray(v) && v.length === 0) ? undefined : v))
             .required(t('This field is required'));
-          return [attrName, validator];
         }
-        const validator = Yup.mixed()
-          .transform((v) => ((Array.isArray(v) && v.length === 0) ? undefined : v))
-          .required(t('This field is required'));
         return [attrName, validator];
       }),
   );


### PR DESCRIPTION
Yup() basicShape configuration modified for Threat Actor Individual to allow Customized Configured Fields on Threat Actor Individual to denote "*" stars on the required fields. External References added as a field than can be enabled as required.

Customized required fields is an existing capability per object type off the Admin console.

### Proposed changes

* "*" Stars shown next to labels on required fields for Threat Actor Individual form. (Could be extended to all platform forms)
* uses Yup() to track required fields marking

### Related issues

* This is only a modification to the Threat Actor Individual forms - but could be applied sitewide.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

N/A
