### PR TITLE
[backend] sanitize dates coming from RSS feed

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -13,7 +13,7 @@ import { TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { type GetHttpClient, getHttpClient } from '../utils/http-client';
 import { isEmptyField, isNotEmptyField } from '../database/utils';
-import { FROM_START_STR, utcDate } from '../utils/format';
+import { FROM_START_STR, sanitizeForMomentParsing, utcDate } from '../utils/format';
 import { generateStandardId } from '../schema/identifier';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../schema/stixDomainObject';
 import { pushToSync } from '../database/rabbitmq';
@@ -86,7 +86,7 @@ const rssItemV1Convert = (turndownService: TurndownService, feed: RssElement, en
     link: isNotEmptyField(entry.link) ? entry.link.href?.trim() : '',
     content: turndownService.turndown(entry.content?._ ?? ''),
     labels: [], // No label in rss v1
-    pubDate: utcDate(entry.updated?._ ?? updated?._ ?? FROM_START_STR),
+    pubDate: utcDate(sanitizeForMomentParsing(entry.updated?._ ?? updated?._ ?? FROM_START_STR)),
   };
 };
 
@@ -98,7 +98,7 @@ const rssItemV2Convert = (turndownService: TurndownService, channel: RssElement,
     link: isNotEmptyField(item.link) ? (item.link._ ?? '').trim() : '',
     content: turndownService.turndown(item['content:encoded']?._ ?? item.content?._ ?? ''),
     labels: R.uniq(asArray(item.category).filter((c) => isNotEmptyField(c)).map((c) => c._.trim())),
-    pubDate: utcDate(item.pubDate?._ ?? pubDate?._ ?? FROM_START_STR),
+    pubDate: utcDate(sanitizeForMomentParsing(item.pubDate?._ ?? pubDate?._ ?? FROM_START_STR)),
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -18,6 +18,9 @@ import {
   ENTITY_WINDOWS_REGISTRY_VALUE_TYPE
 } from '../schema/stixCyberObservable';
 
+//----------------------------------------------------------------------------------------------------------------------
+// Date formatting
+
 const moment = extendMoment(Moment);
 
 export const FROM_START = 0;
@@ -26,6 +29,7 @@ export const UNTIL_END = 100000000000000;
 export const UNTIL_END_STR = '5138-11-16T09:46:40.000Z';
 
 const dateFormat = 'YYYY-MM-DDTHH:mm:ss.SSS';
+
 export const utcDate = (date) => (date ? moment(date).utc() : moment().utc());
 export const now = () => utcDate().toISOString();
 export const nowTime = () => timeFormat(now());
@@ -50,7 +54,9 @@ export const escape = (chars) => {
   }
   return chars;
 };
+
 export const buildPeriodFromDates = (a, b) => moment.range(a, b);
+
 export const computeRangeIntersection = (a, b) => {
   const range = a.intersect(b);
   if (range) {
@@ -61,6 +67,7 @@ export const computeRangeIntersection = (a, b) => {
   const maxStop = moment.max([b.end, b.end]);
   return { start: minStart.toISOString(), end: maxStop.toISOString() };
 };
+
 export const minutesAgo = (minutes) => moment().utc().subtract(minutes, 'minutes');
 export const hoursAgo = (hours) => moment().utc().subtract(hours, 'hours');
 
@@ -76,6 +83,17 @@ export const hashValue = (stixCyberObservable) => {
   }
   return null;
 };
+
+// Moment.js parsing is only compatible with ISO-8601 and RFC-2822 date formats
+// see https://momentjs.com/docs/#/parsing/string/
+// We handle cases that might happen in the platform (data ingestion for instance)
+export const sanitizeForMomentParsing = (date) => date
+  .replace('CET', '+0100') // reported in RSS feeds
+  .replace('CEST', '+0200'); // reported in RSS feeds
+  // add more if needed.
+
+//----------------------------------------------------------------------------------------------------------------------
+
 // TODO for now this list is duplicated in Front, think about updating it aswell
 export const observableValue = (stixCyberObservable) => {
   switch (stixCyberObservable.entity_type) {
@@ -266,5 +284,7 @@ export const runtimeFieldObservableValueScript = () => {
     }
   `;
 };
+
+//----------------------------------------------------------------------------------------------------------------------
 
 export const mergeDeepRightAll = R.unapply(R.reduce(R.mergeDeepRight, {}));


### PR DESCRIPTION
### Proposed changes

Some RSS feeds give dates as non-standard string values, such as `Mon, 04 Dec 2023 10:25:00 CEST` (the `CEST` is not part of ISO8601 nor RFC-2822).

We add a sanitization step for the string dates in RSS feeds, before parsing them with moment.js in the Ingestion Manager

For now this pre-processing only handle CEST/CET to turn it into GMT+1/+2 timezones.

### Related issues

* #5028 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
