### PR TITLE
[frontend] fix filtergroup not set correctly for Cases (#5093)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -5,7 +5,7 @@ import {
   Filter,
   FilterGroup,
   GqlFilterGroup,
-  initialFilterGroup,
+  emptyFilterGroup,
   removeIdFromFilterObject,
 } from '../utils/filters/filtersUtils';
 import { filterIconButtonContentQuery } from './FilterIconButtonContent';
@@ -31,7 +31,7 @@ interface FilterIconButtonProps {
 
 const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
   availableFilterKeys,
-  filters = initialFilterGroup,
+  filters = emptyFilterGroup,
   handleRemoveFilter,
   handleSwitchGlobalMode,
   handleSwitchLocalMode,

--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -19,7 +19,7 @@ import useEntityToggle from '../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 import useAuth from '../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../utils/hooks/useEnterpriseEdition';
-import { initialFilterGroup } from '../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../utils/filters/filtersUtils';
 import { decodeSearchKeyword, handleSearchByKeyword } from '../../utils/SearchUtils';
 import { useFormatter } from '../../components/i18n';
 
@@ -40,7 +40,7 @@ const Search = () => {
       sortBy: '_score',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/analyses/ExternalReferences.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/ExternalReferences.tsx
@@ -17,7 +17,7 @@ import {
 import ToolBar from '../data/ToolBar';
 import { ExternalReferenceLineDummy } from './external_references/ExternalReferenceLine';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'externalReferences';
 
@@ -37,7 +37,7 @@ const ExternalReferences: FunctionComponent<ExternalReferencesProps> = () => {
       sortBy: 'created',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const { sortBy, orderAsc, searchTerm, filters, numberOfElements } = viewStorage;

--- a/opencti-platform/opencti-front/src/private/components/analyses/Groupings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Groupings.tsx
@@ -17,7 +17,7 @@ import {
 } from './groupings/__generated__/GroupingsLinesPaginationQuery.graphql';
 import { GroupingLine_node$data } from './groupings/__generated__/GroupingLine_node.graphql';
 import { GroupingLineDummy } from './groupings/GroupingLine';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'groupings';
 
@@ -61,7 +61,7 @@ const Groupings: FunctionComponent<GroupingsProps> = ({
     LOCAL_STORAGE_KEY,
     {
       numberOfElements: { number: 0, symbol: '', original: 0 },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/analyses/MalwareAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/MalwareAnalyses.tsx
@@ -14,7 +14,7 @@ import { MalwareAnalysisLineDummy } from './malware_analyses/MalwareAnalysisLine
 import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import { MalwareAnalysisLine_node$data } from './malware_analyses/__generated__/MalwareAnalysisLine_node.graphql';
 import ToolBar from '../data/ToolBar';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'malwareAnalyses';
 
@@ -26,7 +26,7 @@ const MalwareAnalyses: FunctionComponent = () => {
       sortBy: 'submitted',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/analyses/Notes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Notes.tsx
@@ -16,7 +16,7 @@ import {
   NotesLinesPaginationQuery$variables,
 } from './notes/__generated__/NotesLinesPaginationQuery.graphql';
 import NoteCreation from './notes/NoteCreation';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'notes';
 
@@ -57,7 +57,7 @@ const Notes: FunctionComponent<NotesProps> = ({ objectId, authorId, onChangeOpen
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
     additionnalFilters,
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/Opinions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Opinions.tsx
@@ -16,7 +16,7 @@ import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import { OpinionLine_node$data } from './opinions/__generated__/OpinionLine_node.graphql';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { OpinionLineDummy } from './opinions/OpinionLine';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'opinions';
 
@@ -39,7 +39,7 @@ const Opinions: FunctionComponent<OpinionsProps> = ({
   } = usePaginationLocalStorage<OpinionsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
@@ -16,7 +16,7 @@ import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { ReportLineDummy } from './reports/ReportLine';
 import ExportContextProvider from '../../../utils/ExportContextProvider';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'reports';
 
@@ -58,7 +58,7 @@ const Reports: FunctionComponent<ReportsProps> = ({
   } = usePaginationLocalStorage<ReportsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'published',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -26,7 +26,7 @@ import ReportKnowledgeTimeLine, {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import ContainerContent, {
@@ -138,7 +138,7 @@ class ReportKnowledgeComponent extends Component {
         params,
       ),
       timeLineFunctionalDate: propOr(false, 'timeLineFunctionalDate', params),
-      timeLineFilters: propOr(initialFilterGroup, 'timeLineFilters', params),
+      timeLineFilters: propOr(emptyFilterGroup, 'timeLineFilters', params),
       timeLineSearchTerm: R.propOr('', 'timeLineSearchTerm', params),
     };
   }

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Channels.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Channels.tsx
@@ -11,7 +11,7 @@ import {
   ChannelsLinesPaginationQuery,
   ChannelsLinesPaginationQuery$variables,
 } from './channels/__generated__/ChannelsLinesPaginationQuery.graphql';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'channels';
 
@@ -23,7 +23,7 @@ const Channels = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
 

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Malwares.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Malwares.tsx
@@ -12,7 +12,7 @@ import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { GenericAttackCardDummy } from '../common/cards/GenericAttackCard';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'malwares';
 
@@ -24,7 +24,7 @@ const Malwares = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Tools.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Tools.tsx
@@ -11,7 +11,7 @@ import {
   ToolsLinesPaginationQuery,
   ToolsLinesPaginationQuery$variables,
 } from './tools/__generated__/ToolsLinesPaginationQuery.graphql';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'tools';
 
@@ -23,7 +23,7 @@ const Tools = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
 

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Vulnerabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Vulnerabilities.tsx
@@ -12,7 +12,7 @@ import {
 } from './vulnerabilities/__generated__/VulnerabilitiesLinesPaginationQuery.graphql';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useAuth from '../../../utils/hooks/useAuth';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'vulnerabilities';
 
@@ -28,7 +28,7 @@ const Vulnerabilities = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const renderLines = () => {

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
@@ -16,7 +16,7 @@ import {
   CaseIncidentsLinesCasesPaginationQuery$variables,
 } from './case_incidents/__generated__/CaseIncidentsLinesCasesPaginationQuery.graphql';
 import { CaseIncidentLineCase_node$data } from './case_incidents/__generated__/CaseIncidentLineCase_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 interface CaseIncidentsProps {
   inputValue?: string;
@@ -39,7 +39,7 @@ const CaseIncidents: FunctionComponent<CaseIncidentsProps> = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseRfis.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseRfis.tsx
@@ -16,7 +16,7 @@ import {
   CaseRfiLinesCasesPaginationQuery$variables,
 } from './case_rfis/__generated__/CaseRfiLinesCasesPaginationQuery.graphql';
 import { CaseRfiLineCase_node$data } from './case_rfis/__generated__/CaseRfiLineCase_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 interface CaseRfisProps {
   inputValue?: string;
@@ -39,7 +39,7 @@ const CaseRfis: FunctionComponent<CaseRfisProps> = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseRfts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseRfts.tsx
@@ -16,7 +16,7 @@ import {
 import { CaseRftLineCase_node$data } from './case_rfts/__generated__/CaseRftLineCase_node.graphql';
 import { CaseRftLineDummy } from './case_rfts/CaseRftLine';
 import CaseRftCreation from './case_rfts/CaseRftCreation';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 interface CaseRftsProps {
   inputValue?: string;
@@ -39,7 +39,7 @@ const CaseRfts: FunctionComponent<CaseRftsProps> = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
@@ -13,7 +13,7 @@ import {
   FeedbacksLinesPaginationQuery$variables,
 } from './feedbacks/__generated__/FeedbacksLinesPaginationQuery.graphql';
 import { FeedbackLine_node$data } from './feedbacks/__generated__/FeedbackLine_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 interface FeedbacksProps {
   inputValue?: string;
@@ -36,7 +36,7 @@ const Feedbacks: FunctionComponent<FeedbacksProps> = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/cases/Tasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Tasks.tsx
@@ -12,7 +12,7 @@ import {
   TasksLinesPaginationQuery$variables,
 } from './tasks/__generated__/TasksLinesPaginationQuery.graphql';
 import { TasksLine_node$data } from './tasks/__generated__/TasksLine_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY_TASKS = 'cases-casesTasks';
 
@@ -28,7 +28,7 @@ const Tasks = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -26,7 +26,7 @@ import IncidentKnowledgeTimeLine, {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import ContainerContent, {
@@ -139,7 +139,7 @@ class IncidentKnowledgeComponent extends Component {
         params,
       ),
       timeLineFunctionalDate: propOr(false, 'timeLineFunctionalDate', params),
-      timeLineFilters: propOr(initialFilterGroup, 'timeLineFilters', params),
+      timeLineFilters: propOr(emptyFilterGroup, 'timeLineFilters', params),
       timeLineSearchTerm: R.propOr('', 'timeLineSearchTerm', params),
     };
   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -16,7 +16,7 @@ import {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import CaseRfiPopover from './CaseRfiPopover';
 import CaseRfiKnowledgeGraph, {
@@ -139,7 +139,7 @@ class CaseRfiKnowledgeComponent extends Component {
         params,
       ),
       timeLineFunctionalDate: propOr(false, 'timeLineFunctionalDate', params),
-      timeLineFilters: propOr(initialFilterGroup, 'timeLineFilters', params),
+      timeLineFilters: propOr(emptyFilterGroup, 'timeLineFilters', params),
       timeLineSearchTerm: R.propOr('', 'timeLineSearchTerm', params),
     };
   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -16,7 +16,7 @@ import {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import CaseRftPopover from './CaseRftPopover';
 import CaseRftKnowledgeGraph, {
@@ -136,7 +136,7 @@ class CaseRftKnowledgeComponent extends Component {
         params,
       ),
       timeLineFunctionalDate: propOr(false, 'timeLineFunctionalDate', params),
-      timeLineFilters: propOr(initialFilterGroup, 'timeLineFilters', params),
+      timeLineFilters: propOr(emptyFilterGroup, 'timeLineFilters', params),
       timeLineSearchTerm: R.propOr('', 'timeLineSearchTerm', params),
     };
   }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -22,7 +22,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+²  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import Drawer from '../drawer/Drawer';
 
@@ -85,25 +85,28 @@ const ContainerAddStixCoreObjects = (props) => {
   const [openCreateObservable, setOpenCreateObservable] = useState(false);
   const [sortBy, setSortBy] = useState('_score');
   const [orderAsc, setOrderAsc] = useState(false);
+
+  const targetEntityTypesFilterGroup = {
+    mode: 'and',
+    filterGroups: [],
+    filters: [
+      {
+        key: 'entity_type',
+        values: targetStixCoreObjectTypes,
+        operator: 'eq',
+        mode: 'or',
+      },
+    ],
+  };
+
   const [filters, setFilters] = useState(
     targetStixCoreObjectTypes
         && !(
           targetStixCoreObjectTypes.includes('Stix-Domain-Object')
             || targetStixCoreObjectTypes.includes('Stix-Cyber-Observable')
         )
-      ? {
-        mode: 'and',
-        filterGroups: [],
-        filters: [
-          {
-            key: 'entity_type',
-            values: targetStixCoreObjectTypes,
-            operator: 'eq',
-            mode: 'or',
-          },
-        ],
-      }
-      : initialFilterGroup,
+      ? targetEntityTypesFilterGroup
+      : emptyFilterGroup,
   );
   const [numberOfElements, setNumberOfElements] = useState({
     number: 0,
@@ -464,13 +467,8 @@ const ContainerAddStixCoreObjects = (props) => {
               targetStixCoreObjectTypes.includes('Stix-Domain-Object')
                 || targetStixCoreObjectTypes.includes('Stix-Cyber-Observable')
             )
-        ? {
-          key: 'entity_type',
-          values: targetStixCoreObjectTypes,
-          operator: 'eq',
-          mode: 'or',
-        }
-        : initialFilterGroup,
+        ? targetEntityTypesFilterGroup
+        : emptyFilterGroup,
     );
   };
   return (

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -22,7 +22,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-²  emptyFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import Drawer from '../drawer/Drawer';
 

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMapping.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMapping.jsx
@@ -9,7 +9,7 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import ContainerAddStixCoreObjects from './ContainerAddStixCoreObjects';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -43,7 +43,7 @@ const ContainerStixCoreObjectsMapping = ({
     LOCAL_STORAGE_KEY,
     {
       id: container.id,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -29,7 +29,7 @@ import {
 } from './__generated__/ContainerStixCyberObservableLine_node.graphql';
 import {
   GqlFilterGroup,
-  initialFilterGroup, removeIdFromFilterObject,
+  emptyFilterGroup, removeIdFromFilterObject,
 } from '../../../../utils/filters/filtersUtils';
 
 export const ContainerStixCyberObservablesLinesSearchQuery = graphql`
@@ -83,7 +83,7 @@ ContainerStixCyberObservablesComponentProps
     LOCAL_STORAGE_KEY,
     {
       id: container.id,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created_at',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.tsx
@@ -22,7 +22,7 @@ import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStora
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useAuth from '../../../../utils/hooks/useAuth';
-import { initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const ContainerStixDomainObjectsFragment = graphql`
     fragment ContainerStixDomainObjects_container on Container {
@@ -69,7 +69,7 @@ const ContainerStixDomainObjects = ({
   } = usePaginationLocalStorage<ContainerStixDomainObjectsLinesQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
@@ -16,7 +16,7 @@ import Filters from '../lists/Filters';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import {
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
@@ -80,7 +80,7 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
   const { viewStorage, paginationOptions, helpers } = usePaginationLocalStorage(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
@@ -7,7 +7,7 @@ import {
   Filter,
   FilterGroup,
   FiltersVariant,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import FiltersElement, { FilterElementsInputValue } from './FiltersElement';
 import ListFilters from './ListFilters';
@@ -66,7 +66,7 @@ const Filters: FunctionComponent<FiltersProps> = ({
   const [open, setOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const [filters, setFilters] = useState<FilterGroup | undefined>(
-    initialFilterGroup,
+    emptyFilterGroup,
   );
   const [inputValues, setInputValues] = useState<FilterElementsInputValue[]>(
     [],

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
@@ -5,7 +5,7 @@ import EntityStixCoreRelationshipsRelationshipsView from './views/EntityStixCore
 import EntityStixCoreRelationshipsEntitiesView from './views/EntityStixCoreRelationshipsEntitiesView';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { PaginationOptions } from '../../../../components/list_lines';
-import { initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -60,7 +60,7 @@ EntityStixCoreRelationshipsProps
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       view: 'entities',
     },
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.jsx
@@ -30,7 +30,7 @@ import {
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
   findFilterFromKey,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import StixCoreRelationshipCreationFromEntityStixCoreObjectsLines, {
   stixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery,
@@ -280,7 +280,7 @@ const StixCoreRelationshipCreationFromEntity = (props) => {
           mode: 'or',
         }],
       }
-      : initialFilterGroup,
+      : emptyFilterGroup,
   );
   const [numberOfElements, setNumberOfElements] = useState({
     number: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
@@ -6,7 +6,7 @@ import EntityStixCoreRelationshipsRelationshipsView from '../EntityStixCoreRelat
 import EntityStixCoreRelationshipsIndicatorsEntitiesView from './EntityStixCoreRelationshipsIndicatorsEntitiesView';
 import { PaginationOptions } from '../../../../../../components/list_lines';
 import EntityStixCoreRelationshipsIndicatorsContextualView from './EntityStixCoreRelationshipsIndicatorsContextualView';
-import { initialFilterGroup } from '../../../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -38,7 +38,7 @@ const EntityStixCoreRelationshipsIndicators: FunctionComponent<EntityStixCoreRel
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       view: 'entities',
     },
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable.tsx
@@ -6,7 +6,7 @@ import { PaginationOptions } from '../../../../../../components/list_lines';
 import EntityStixCoreRelationshipsEntitiesView from '../EntityStixCoreRelationshipsEntitiesView';
 import EntityStixCoreRelationshipsRelationshipsView from '../EntityStixCoreRelationshipsRelationshipsView';
 import ExportContextProvider from '../../../../../../utils/ExportContextProvider';
-import { initialFilterGroup } from '../../../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -35,7 +35,7 @@ const EntityStixCoreRelationshipsStixCyberObservable: FunctionComponent<EntitySt
     LOCAL_STORAGE_KEY,
     {
       numberOfElements: { number: 0, symbol: '', original: 0 },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
@@ -6,7 +6,7 @@ import StixDomainObjectAttackPatternsKillChain, {
   stixDomainObjectAttackPatternsKillChainStixCoreRelationshipsQuery,
 } from './StixDomainObjectAttackPatternsKillChain';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
-import { initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -33,7 +33,7 @@ const StixDomainObjectAttackPatterns = ({
   } = usePaginationLocalStorage(LOCAL_STORAGE_KEY, {
     searchTerm: '',
     openExports: false,
-    filters: initialFilterGroup,
+    filters: emptyFilterGroup,
     view: 'matrix',
   });
   const { searchTerm, filters, view, openExports } = viewStorage;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
@@ -45,7 +45,7 @@ import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStora
 import { Theme } from '../../../../components/Theme';
 import {
   findFilterFromKey,
-  initialFilterGroup,
+  emptyFilterGroup,
 
   removeFilter,
 } from '../../../../utils/filters/filtersUtils';
@@ -149,7 +149,7 @@ const StixDomainObjectThreatKnowledge: FunctionComponent<StixDomainObjectThreatK
   const { viewStorage, helpers, paginationOptions: rawPaginationOptions } = usePaginationLocalStorage<StixDomainObjectThreatKnowledgeQueryStixRelationshipsQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
@@ -15,7 +15,7 @@ import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'entities';
 
@@ -30,7 +30,7 @@ const Entities = () => {
   } = usePaginationLocalStorage<EntitiesStixDomainObjectsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       sortBy: 'created_at',
       orderAsc: false,
       openExports: false,

--- a/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
@@ -17,7 +17,7 @@ import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import {
   filtersWithEntityType,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'relationships';
@@ -33,7 +33,7 @@ const Relationships = () => {
   } = usePaginationLocalStorage<RelationshipsStixCoreRelationshipsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created_at',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.jsx
@@ -37,7 +37,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
@@ -175,14 +175,14 @@ const sharedUpdater = (store, userId, paginationOptions, newEdge) => {
 const FeedCreation = (props) => {
   const { t, classes } = props;
   const [selectedTypes, setSelectedTypes] = useState([]);
-  const [filters, setFilters] = useState(initialFilterGroup);
+  const [filters, setFilters] = useState(emptyFilterGroup);
   const [feedAttributes, setFeedAttributes] = useState({ 0: {} });
 
   const { ignoredAttributesInFeeds } = useAttributes();
 
   const handleClose = () => {
     setSelectedTypes([]);
-    setFilters(initialFilterGroup);
+    setFilters(emptyFilterGroup);
     setFeedAttributes({ 0: {} });
   };
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -28,7 +28,7 @@ import {
   constructHandleRemoveFilter,
   deserializeFilterGroupForFrontend,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -99,7 +99,7 @@ const PlaybookAddComponentsContent = ({
   const classes = useStyles();
   const { t } = useFormatter();
   const currentConfig = action === 'config' ? selectedNode?.data?.configuration : null;
-  const [filters, setFilters] = useState(currentConfig?.filters ? deserializeFilterGroupForFrontend(currentConfig?.filters) : initialFilterGroup);
+  const [filters, setFilters] = useState(currentConfig?.filters ? deserializeFilterGroupForFrontend(currentConfig?.filters) : emptyFilterGroup);
 
   const [actionsInputs, setActionsInputs] = useState(
     currentConfig?.actions ? currentConfig.actions : [],

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.jsx
@@ -19,7 +19,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
@@ -108,7 +108,7 @@ const sharedUpdater = (store, userId, paginationOptions, newEdge) => {
 
 const StreamCollectionCreation = (props) => {
   const { t, classes } = props;
-  const [filters, setFilters] = useState(initialFilterGroup);
+  const [filters, setFilters] = useState(emptyFilterGroup);
   const onSubmit = (values, { setSubmitting, resetForm }) => {
     const jsonFilters = serializeFilterGroupForBackend(filters);
     const authorized_members = values.authorized_members.map(({ value }) => ({
@@ -162,7 +162,7 @@ const StreamCollectionCreation = (props) => {
     <Drawer
       title={t('Create a stream')}
       variant={DrawerVariant.createWithPanel}
-      onClose={() => setFilters(initialFilterGroup)}
+      onClose={() => setFilters(emptyFilterGroup)}
     >
       {({ onClose }) => (
         <Formik

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.jsx
@@ -17,7 +17,7 @@ import {
   constructHandleRemoveFilter,
   deserializeFilterGroupForFrontend,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
@@ -133,7 +133,7 @@ const StreamCollectionEditionContainer = ({ streamCollection }) => {
         ...filters,
         mode: filters.mode === 'and' ? 'or' : 'and',
       }
-      : initialFilterGroup;
+      : emptyFilterGroup;
     const variables = {
       id: streamCollection.id,
       input: { key: 'filters', value: serializeFilterGroupForBackend(newFiltersContent) },

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.jsx
@@ -20,7 +20,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   isFilterGroupNotEmpty,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
@@ -109,7 +109,7 @@ const sharedUpdater = (store, userId, paginationOptions, newEdge) => {
 
 const TaxiiCollectionCreation = (props) => {
   const { t, classes } = props;
-  const [filters, setFilters] = useState(initialFilterGroup);
+  const [filters, setFilters] = useState(emptyFilterGroup);
 
   const onSubmit = (values, { setSubmitting, resetForm }) => {
     const jsonFilters = serializeFilterGroupForBackend(filters);

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.jsx
@@ -19,7 +19,7 @@ import {
   constructHandleRemoveFilter,
   deserializeFilterGroupForFrontend,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
@@ -170,7 +170,7 @@ const TaxiiCollectionEditionContainer = (props) => {
         ...filters,
         mode: filters.mode === 'and' ? 'or' : 'and',
       }
-      : initialFilterGroup;
+      : emptyFilterGroup;
     const variables = {
       id: props.taxiiCollection.id,
       input: { key: 'filters', value: serializeFilterGroupForBackend(newFiltersContent) },

--- a/opencti-platform/opencti-front/src/private/components/entities/Events.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Events.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'events';
 
@@ -23,7 +23,7 @@ const Events = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
 

--- a/opencti-platform/opencti-front/src/private/components/entities/Individuals.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Individuals.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'individuals';
 
@@ -23,7 +23,7 @@ const Individuals = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const renderLines = () => {

--- a/opencti-platform/opencti-front/src/private/components/entities/Organizations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Organizations.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'organizations';
 
@@ -23,7 +23,7 @@ const Organizations = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const renderLines = () => {

--- a/opencti-platform/opencti-front/src/private/components/entities/Systems.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Systems.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'systems';
 
@@ -23,7 +23,7 @@ const Systems = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
 

--- a/opencti-platform/opencti-front/src/private/components/events/Incidents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/Incidents.tsx
@@ -16,7 +16,7 @@ import {
   IncidentsLinesPaginationQuery,
   IncidentsLinesPaginationQuery$variables,
 } from './incidents/__generated__/IncidentsLinesPaginationQuery.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY = 'incidents';
 
@@ -31,7 +31,7 @@ const Incidents: FunctionComponent = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/events/ObservedDatas.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/ObservedDatas.tsx
@@ -16,7 +16,7 @@ import {
   ObservedDatasLinesPaginationQuery$variables,
 } from './observed_data/__generated__/ObservedDatasLinesPaginationQuery.graphql';
 import { ModuleHelper } from '../../../utils/platformModulesHelper';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'observedDatas';
 
@@ -59,7 +59,7 @@ const ObservedDatas: FunctionComponent<ObservedDatasProps> = ({
       sortBy: 'last_observed',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
     additionnalFilters,
   );

--- a/opencti-platform/opencti-front/src/private/components/events/StixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/StixSightingRelationships.tsx
@@ -19,7 +19,7 @@ import {
   filtersWithEntityType,
   findFilterFromKey,
   GqlFilterGroup,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../utils/filters/filtersUtils';
 
 const dataColumns = {
@@ -79,7 +79,7 @@ const StixSightingRelationships = () => {
   } = usePaginationLocalStorage<StixSightingRelationshipsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'last_seen',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
@@ -16,7 +16,7 @@ import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { FilterGroup, initialFilterGroup, removeIdFromFilterObject } from '../../../../utils/filters/filtersUtils';
+import { FilterGroup, emptyFilterGroup, removeIdFromFilterObject } from '../../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY = 'sightings';
 
@@ -52,7 +52,7 @@ const EntityStixSightingRelationships: FunctionComponent<EntityStixSightingRelat
       sortBy: 'first_seen',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/locations/AdministrativeAreas.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/AdministrativeAreas.tsx
@@ -13,7 +13,7 @@ import {
   AdministrativeAreasLinesPaginationQuery,
   AdministrativeAreasLinesPaginationQuery$variables,
 } from './administrative_areas/__generated__/AdministrativeAreasLinesPaginationQuery.graphql';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'administrative-areas';
 
@@ -25,7 +25,7 @@ const AdministrativeAreas: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/locations/Cities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/Cities.tsx
@@ -11,7 +11,7 @@ import {
   CitiesLinesPaginationQuery,
   CitiesLinesPaginationQuery$variables,
 } from './cities/__generated__/CitiesLinesPaginationQuery.graphql';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'cities';
 
@@ -23,7 +23,7 @@ const Cities: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/locations/Countries.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/Countries.tsx
@@ -11,7 +11,7 @@ import {
 } from './countries/__generated__/CountriesLinesPaginationQuery.graphql';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { CountryLineDummy } from './countries/CountryLine';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'countries';
 
@@ -23,7 +23,7 @@ const Countries: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/locations/Positions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/Positions.tsx
@@ -11,7 +11,7 @@ import {
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { PositionLineDummy } from './positions/PositionLine';
 import PositionsLines, { positionsLinesQuery } from './positions/PositionsLines';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY_POSITIONS = 'positions';
 
@@ -23,7 +23,7 @@ const Positions: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/locations/Regions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/Regions.tsx
@@ -11,7 +11,7 @@ import {
 } from './regions/__generated__/RegionsLinesPaginationQuery.graphql';
 import RegionCreation from './regions/RegionCreation';
 import { RegionLineDummy } from './regions/RegionLine';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'regions';
 
@@ -23,7 +23,7 @@ const Regions: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/observations/Artifacts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Artifacts.tsx
@@ -16,7 +16,7 @@ import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'artifacts';
 
@@ -29,7 +29,7 @@ const Artifacts: FunctionComponent = () => {
   const { viewStorage, paginationOptions, helpers } = usePaginationLocalStorage<ArtifactsLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created_at',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -21,7 +21,7 @@ import {
 } from './indicators/__generated__/IndicatorsLinesPaginationQuery.graphql';
 import { ModuleHelper } from '../../../utils/platformModulesHelper';
 import { IndicatorLineDummyComponent } from './indicators/IndicatorLine';
-import { filtersWithEntityType, findFilterFromKey, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, findFilterFromKey, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -42,7 +42,7 @@ const Indicators = () => {
     LOCAL_STORAGE_KEY,
     {
       numberOfElements: { number: 0, symbol: '', original: 0 },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/observations/Infrastructures.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Infrastructures.tsx
@@ -16,7 +16,7 @@ import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { InfrastructureLineDummy } from './infrastructures/InfrastructureLine';
 import ToolBar from '../data/ToolBar';
 import { InfrastructureLine_node$data } from './infrastructures/__generated__/InfrastructureLine_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY_INFRASTRUCTURES = 'infrastructures';
 
@@ -35,7 +35,7 @@ const Infrastructures = () => {
       sortBy: 'created',
       orderAsc: false,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
@@ -24,7 +24,7 @@ import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import {
   StixCyberObservableLine_node$data,
 } from './stix_cyber_observables/__generated__/StixCyberObservableLine_node.graphql';
-import { filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'stixCyberObservables';
 
@@ -37,7 +37,7 @@ const StixCyberObservables: FunctionComponent = () => {
   const { viewStorage, paginationOptions, helpers } = usePaginationLocalStorage(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created_at',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicators.tsx
@@ -18,7 +18,7 @@ import ToolBar from '../../data/ToolBar';
 import ExportContextProvider from '../../../../utils/ExportContextProvider';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
-import { initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 interface StixDomainObjectIndicatorsProps {
   stixDomainObjectId: string,
@@ -59,7 +59,7 @@ const StixDomainObjectIndicators: FunctionComponent<StixDomainObjectIndicatorsPr
   const { viewStorage, helpers, paginationOptions } = usePaginationLocalStorage<StixDomainObjectIndicatorsLinesQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created_at',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -12,7 +12,7 @@ import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import { NotificationLine_node$data } from './notifications/__generated__/NotificationLine_node.graphql';
 import useAuth from '../../../utils/hooks/useAuth';
 import NotificationsToolBar from './notifications/NotificationsToolBar';
-import { addFilter, FilterGroup, filtersWithEntityType, initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { addFilter, FilterGroup, filtersWithEntityType, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY = 'notifiers';
 
@@ -24,7 +24,7 @@ const Notifications: FunctionComponent = () => {
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/profile/Triggers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Triggers.tsx
@@ -9,7 +9,7 @@ import {
 } from './triggers/__generated__/TriggersLinesPaginationQuery.graphql';
 import { TriggerLineDummy } from './triggers/TriggerLine';
 import TriggerCreation from './triggers/TriggerCreation';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY_TRIGGERS = 'triggers';
 
@@ -20,7 +20,7 @@ const Triggers: FunctionComponent = () => {
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
@@ -27,7 +27,7 @@ import {
   deserializeFilterGroupForFrontend,
   Filter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import { dayStartDate, formatTimeForToday, parse } from '../../../../utils/Time';
@@ -145,7 +145,7 @@ TriggerEditionOverviewProps
         ...filters,
         mode: filters.mode === 'and' ? 'or' : 'and',
       }
-      : initialFilterGroup;
+      : emptyFilterGroup;
     commitFieldPatch({
       variables: {
         id: trigger.id,

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
@@ -32,7 +32,7 @@ import {
   Filter,
   FilterGroup,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import { insertNode } from '../../../../utils/store';
@@ -133,7 +133,7 @@ const TriggerLiveCreation: FunctionComponent<TriggerLiveCreationProps> = ({
 }) => {
   const { t } = useFormatter();
   const classes = useStyles();
-  const [filters, setFilters] = useState<FilterGroup | undefined>(initialFilterGroup);
+  const [filters, setFilters] = useState<FilterGroup | undefined>(emptyFilterGroup);
   const [instance_trigger, setInstanceTrigger] = useState<boolean>(false);
   const [instanceFilters, setInstanceFilters] = useState<FilterAutocompleteInputValue[]>([]);
   const eventTypesOptions: { value: TriggerEventType, label: string }[] = [
@@ -148,14 +148,14 @@ const TriggerLiveCreation: FunctionComponent<TriggerLiveCreationProps> = ({
 
   const onReset = () => {
     handleClose?.();
-    setFilters(initialFilterGroup);
+    setFilters(emptyFilterGroup);
     setInstanceTrigger(false);
     setInstanceFilters([]);
   };
   const onChangeInstanceTrigger = (setFieldValue: (key: string, value: { value: string, label: string }[]) => void) => {
     setFieldValue('event_types', instance_trigger ? eventTypesOptions : instanceEventTypesOptions);
     setInstanceTrigger(!instance_trigger);
-    setFilters(initialFilterGroup);
+    setFilters(emptyFilterGroup);
   };
   const handleAddFilter = (k: string, id: string, op = 'eq') => {
     setFilters(constructHandleAddFilter(filters, k, id, op));

--- a/opencti-platform/opencti-front/src/private/components/settings/Notifiers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Notifiers.tsx
@@ -15,7 +15,7 @@ import { NotifierLineDummy } from './notifiers/NotifierLine';
 import NotifierCreation from './notifiers/NotifierCreation';
 import { useFormatter } from '../../../components/i18n';
 import CustomizationMenu from './CustomizationMenu';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'notifiers';
 
@@ -37,7 +37,7 @@ const Notifiers = () => {
     LOCAL_STORAGE_KEY,
     {
       numberOfElements: { number: 0, symbol: '', original: 0 },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'created',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -18,7 +18,7 @@ import VocabularyCreation from './attributes/VocabularyCreation';
 import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import ToolBar from '../data/ToolBar';
 import useVocabularyCategory from '../../../utils/hooks/useVocabularyCategory';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -44,7 +44,7 @@ const Vocabularies = () => {
   const { viewStorage, paginationOptions, helpers } = usePaginationLocalStorage<VocabulariesLines_DataQuery$variables>(
     LOCAL_STORAGE_KEY,
     {
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       sortBy: 'name',
       orderAsc: true,
       searchTerm: '',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
@@ -20,7 +20,7 @@ import ActivityMenu from '../../ActivityMenu';
 import { AlertingLines_data$key } from './__generated__/AlertingLines_data.graphql';
 import { AlertingLineComponent, AlertingLineDummy } from './AlertingLine';
 import { Theme } from '../../../../../components/Theme';
-import { initialFilterGroup } from '../../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY_DATA_SOURCES = 'alerting';
 const nbOfRowsToLoad = 50;
@@ -140,7 +140,7 @@ const Alerting: FunctionComponent = () => {
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
@@ -35,7 +35,7 @@ import { AuditLine_node$data } from './__generated__/AuditLine_node.graphql';
 import { AuditLineDummy } from './AuditLine';
 import useAuth from '../../../../../utils/hooks/useAuth';
 import { useFormatter } from '../../../../../components/i18n';
-import { initialFilterGroup } from '../../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../../../utils/filters/filtersUtils';
 import { fetchQuery } from '../../../../../relay/environment';
 
 const useStyles = makeStyles<Theme>(() => ({
@@ -107,7 +107,7 @@ const Audit = () => {
     LOCAL_STORAGE_KEY,
     {
       numberOfElements: { number: 0, symbol: '', original: 0 },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'timestamp',
       orderAsc: false,

--- a/opencti-platform/opencti-front/src/private/components/settings/common/Triggers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/common/Triggers.tsx
@@ -21,7 +21,7 @@ import SearchInput from '../../../../components/SearchInput';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { LOCAL_STORAGE_KEY_TRIGGERS } from '../../profile/Triggers';
 import { TriggerLineDummy } from '../../profile/triggers/TriggerLine';
-import { GqlFilterGroup, initialFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { GqlFilterGroup, emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const useStyles = makeStyles(() => ({
   paper: {
@@ -58,7 +58,7 @@ const Triggers: FunctionComponent<TriggersProps> = ({
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionCreation.jsx
@@ -18,7 +18,7 @@ import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
   filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
   serializeFilterGroupForBackend,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
@@ -91,7 +91,7 @@ const RetentionCreationValidation = (t) => Yup.object().shape({
 
 const RetentionCreation = (props) => {
   const { t, classes } = props;
-  const [filters, setFilters] = useState(initialFilterGroup);
+  const [filters, setFilters] = useState(emptyFilterGroup);
   const [verified, setVerified] = useState(false);
 
   const onSubmit = (values, { setSubmitting, resetForm }) => {
@@ -170,7 +170,7 @@ const RetentionCreation = (props) => {
     <Drawer
       title={t('Create a retention policy')}
       variant={DrawerVariant.createWithPanel}
-      onClose={() => setFilters(initialFilterGroup)}
+      onClose={() => setFilters(emptyFilterGroup)}
     >
       {({ onClose }) => (
         <Formik

--- a/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'attackPattern';
 
@@ -23,7 +23,7 @@ const AttackPatterns = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
 

--- a/opencti-platform/opencti-front/src/private/components/techniques/CoursesOfAction.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/CoursesOfAction.tsx
@@ -11,7 +11,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'coursesOfAction';
 
@@ -23,7 +23,7 @@ const CoursesOfAction = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const renderLines = () => {

--- a/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
@@ -11,7 +11,7 @@ import {
 } from './data_components/__generated__/DataComponentsLinesPaginationQuery.graphql';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import DataComponentLineDummy from './data_components/DataComponentLineDummy';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY_DATA_COMPONENTS = 'dataComponents';
 
@@ -23,7 +23,7 @@ const DataComponents: FunctionComponent = () => {
         number: 0,
         symbol: '',
       },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,

--- a/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
@@ -11,7 +11,7 @@ import {
   DataSourcesLinesPaginationQuery$variables,
 } from './data_sources/__generated__/DataSourcesLinesPaginationQuery.graphql';
 import { DataSourceLineDummy } from './data_sources/DataSourceLine';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY_DATA_SOURCES = 'dataSources';
 
@@ -23,7 +23,7 @@ const DataSources: FunctionComponent = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       numberOfElements: {
         number: 0,
         symbol: '',

--- a/opencti-platform/opencti-front/src/private/components/threats/Campaigns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/Campaigns.tsx
@@ -14,7 +14,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'campaigns';
 
@@ -26,7 +26,7 @@ const Campaigns = () => {
         number: 0,
         symbol: '',
       },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,

--- a/opencti-platform/opencti-front/src/private/components/threats/IntrusionSets.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/IntrusionSets.tsx
@@ -14,7 +14,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'intrusionSets';
 
@@ -26,7 +26,7 @@ const IntrusionSets = () => {
       sortBy: 'name',
       orderAsc: true,
       openExports: false,
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
     },
   );
   const {

--- a/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsGroup.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsGroup.tsx
@@ -14,7 +14,7 @@ import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'threatActorsGroups';
 
@@ -26,7 +26,7 @@ const ThreatActorsGroup = () => {
         number: 0,
         symbol: '',
       },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,

--- a/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsIndividual.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsIndividual.tsx
@@ -14,7 +14,7 @@ import {
   ThreatActorsIndividualCardsPaginationQuery$variables,
 } from './threat_actors_individual/__generated__/ThreatActorsIndividualCardsPaginationQuery.graphql';
 import ThreatActorIndividualCreation from './threat_actors_individual/ThreatActorIndividualCreation';
-import { initialFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY_THREAT_ACTORS_INDIVIDUAL = 'threatActorsIndividuals';
 
@@ -26,7 +26,7 @@ const ThreatActorsIndividual = () => {
         number: 0,
         symbol: '',
       },
-      filters: initialFilterGroup,
+      filters: emptyFilterGroup,
       searchTerm: '',
       sortBy: 'name',
       orderAsc: true,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
@@ -66,7 +66,7 @@ import {
   findFilterFromKey,
   findFilterIndexFromKey,
   findFiltersFromKeys,
-  initialFilterGroup, isFilterGroupNotEmpty,
+  emptyFilterGroup, isFilterGroupNotEmpty,
   isUniqFilter,
 } from '../../../../utils/filters/filtersUtils';
 import { capitalizeFirstLetter, toB64 } from '../../../../utils/String';
@@ -400,9 +400,9 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
     date_attribute: 'created_at',
     perspective: null,
     isTo: true,
-    filters: initialFilterGroup,
-    dynamicFrom: initialFilterGroup,
-    dynamicTo: initialFilterGroup,
+    filters: emptyFilterGroup,
+    dynamicFrom: emptyFilterGroup,
+    dynamicTo: emptyFilterGroup,
   };
   const [dataSelection, setDataSelection] = useState(
     widget?.dataSelection ?? [initialSelection],
@@ -499,7 +499,7 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
       ...n,
       perspective: selectedPerspective,
       filters:
-                selectedPerspective === n.perspective ? n.filters : initialFilterGroup,
+                selectedPerspective === n.perspective ? n.filters : emptyFilterGroup,
     }));
     setDataSelection(newDataSelection);
     setPerspective(selectedPerspective);
@@ -513,9 +513,9 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
         attribute: 'entity_type',
         date_attribute: 'created_at',
         perspective: subPerspective,
-        filters: initialFilterGroup,
-        dynamicFrom: initialFilterGroup,
-        dynamicTo: initialFilterGroup,
+        filters: emptyFilterGroup,
+        dynamicFrom: emptyFilterGroup,
+        dynamicTo: emptyFilterGroup,
       },
     ]);
   };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjects.jsx
@@ -13,7 +13,7 @@ import ListLines from '../../../../components/list_lines/ListLines';
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter, filtersAfterSwitchLocalMode,
-  initialFilterGroup,
+  emptyFilterGroup,
 } from '../../../../utils/filters/filtersUtils';
 import Drawer from '../../common/drawer/Drawer';
 
@@ -47,7 +47,7 @@ const InvestigationAddStixCoreObjects = (props) => {
         }],
         filterGroups: [],
       }
-      : initialFilterGroup,
+      : emptyFilterGroup,
   );
   const [numberOfElements, setNumberOfElements] = useState({
     number: 0,
@@ -167,7 +167,7 @@ const InvestigationAddStixCoreObjects = (props) => {
           }],
           filterGroups: [],
         }
-        : initialFilterGroup,
+        : emptyFilterGroup,
     );
   };
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -23,7 +23,7 @@ export type Filter = {
   mode: string;
 };
 
-export const initialFilterGroup = {
+export const emptyFilterGroup = {
   mode: 'and',
   filters: [],
   filterGroups: [],
@@ -336,7 +336,7 @@ export const serializeFilterGroupForBackend = (
   filterGroup?: FilterGroup | null,
 ): string => {
   if (!filterGroup) {
-    return JSON.stringify(initialFilterGroup);
+    return JSON.stringify(emptyFilterGroup);
   }
   return JSON.stringify(sanitizeFilterGroupKeysForBackend(filterGroup));
 };


### PR DESCRIPTION
### Proposed changes

The filters stored in the component state are incorrectly reset when leaving the edition form.

### Related issues

* #5093

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Quick refacto of the filter utils on this occasion, for a clearer naming.