### PR TITLE
[frontend/backend] restrict api filter keys to EQ operator and OR local mode (#5103)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -27,6 +27,7 @@ interface FilterIconButtonProps {
   disabledPossible?: boolean;
   redirection?: boolean;
   helpers?: UseLocalStorageHelpers;
+  availableRelationFilterTypes?: Record<string, string[]>;
 }
 
 const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
@@ -40,6 +41,7 @@ const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
   redirection,
   chipColor,
   helpers,
+  availableRelationFilterTypes,
 }) => {
   const hasRenderedRef = useRef(false);
   const setHasRenderedRef = () => {
@@ -77,6 +79,7 @@ const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
             helpers={helpers}
             hasRenderedRef={hasRenderedRef.current}
             setHasRenderedRef={setHasRenderedRef}
+            availableRelationFilterTypes={availableRelationFilterTypes}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -151,7 +151,6 @@ FilterIconButtonContainerProps
   const globalMode = filters.mode;
   let classFilter = classes.filter1;
   const itemRefToPopover = useRef(null);
-  const storeLastDisplayFilter = useRef<Filter[]>([]);
 
   const filtersRepresentativesMap = new Map(
     filtersRepresentatives.map((n) => [n.id, n.value]),
@@ -176,7 +175,6 @@ FilterIconButtonContainerProps
       } else {
         setHasRenderedRef();
       }
-      storeLastDisplayFilter.current = displayedFilters;
     }, [displayedFilters]);
   }
   const handleClose = () => {

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -124,6 +124,7 @@ interface FilterIconButtonContainerProps {
   helpers?: UseLocalStorageHelpers;
   hasRenderedRef: boolean;
   setHasRenderedRef: () => void;
+  availableRelationFilterTypes?: Record<string, string[]>;
 }
 
 const FilterIconButtonContainer: FunctionComponent<
@@ -141,6 +142,7 @@ FilterIconButtonContainerProps
   helpers,
   hasRenderedRef,
   setHasRenderedRef,
+  availableRelationFilterTypes,
 }) => {
   const { t } = useFormatter();
   const classes = useStyles();
@@ -501,6 +503,7 @@ FilterIconButtonContainerProps
           handleClose={handleClose}
           open={open}
           helpers={helpers}
+          availableRelationFilterTypes={availableRelationFilterTypes}
         />
         </Box>
       )}

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -5,7 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import Box from '@mui/material/Box';
-import { useTheme } from '@mui/material/styles';
+import { InformationOutline } from 'mdi-material-ui';
 import { truncate } from '../utils/String';
 import { DataColumns } from './list_lines';
 import { useFormatter } from './i18n';
@@ -143,7 +143,6 @@ FilterIconButtonContainerProps
   setHasRenderedRef,
 }) => {
   const { t } = useFormatter();
-  const theme = useTheme();
   const classes = useStyles();
   const { filtersRepresentatives } = usePreloadedQuery<FilterIconButtonContentQuery>(
     filterIconButtonContentQuery,
@@ -313,9 +312,9 @@ FilterIconButtonContainerProps
               }
             >
               <Box sx={{
-                padding: '8px',
+                padding: '8px 4px',
                 display: 'flex',
-                ...(othersFilters.length > 0 && backgroundGroupingChipsStyle),
+                ...backgroundGroupingChipsStyle,
               }}>
               <Chip
                 color={chipColor}
@@ -356,11 +355,11 @@ FilterIconButtonContainerProps
               />
               </Box>
             </Tooltip>
-            {isNotLastFilter && (
+            {isNotLastFilter ? (
               <Box sx={{
-                padding: '8px',
+                padding: '8px 4px',
                 display: 'flex',
-                ...(othersFilters.length > 0 && backgroundGroupingChipsStyle),
+                ...backgroundGroupingChipsStyle,
               }}>
               <FilterIconButtonGlobalOperator
                 currentIndex={index}
@@ -369,26 +368,34 @@ FilterIconButtonContainerProps
                 globalMode={globalMode}
                 handleSwitchGlobalMode={handleSwitchGlobalMode}/>
               </Box>
-            )}
+            ) : <Box sx={{
+              position: 'relative',
+              zIndex: 0,
+            }}>
+              <Tooltip
+              title={t(
+                'The operators and modes are restricted for these filters.',
+              )}
+            >
+              <InformationOutline
+                fontSize="small"
+                color="primary"
+                style={{ position: 'absolute', zIndex: 1, top: -10, left: -10 }}
+              />
+            </Tooltip>
+            </Box>}
           </Fragment>
         );
       })}
 
       { displayedSpecificFilters.length > 0 && othersFilters.length > 0
       && <Box sx={{
-        padding: '4px 16px',
+        padding: '8px 4px 8px 8px',
         display: 'flex',
       }}>
-        <Box sx={{
-          borderRadius: '5px',
-          fontFamily: 'Consolas, monaco, monospace',
-          backgroundColor: theme?.palette.action?.selected,
-          padding: '0 8px',
-          display: 'flex',
-          alignItems: 'center',
-        }}>
-          {t('AND')}
-        </Box>
+          <div className={classOperator} onClick={handleSwitchGlobalMode}>
+            {t(globalMode.toUpperCase())}
+          </div>
       </Box>
       }
 
@@ -427,9 +434,8 @@ FilterIconButtonContainerProps
               }
             >
               <Box sx={{
-                padding: '8px',
+                padding: '8px 4px',
                 display: 'flex',
-                ...(displayedSpecificFilters.length > 0 && backgroundGroupingChipsStyle),
               }}>
               <Chip
                 color={chipColor}
@@ -472,9 +478,8 @@ FilterIconButtonContainerProps
             </Tooltip>
             {isNotLastFilter && (
               <Box sx={{
-                padding: '8px',
+                padding: '8px 4px',
                 display: 'flex',
-                ...(displayedSpecificFilters.length > 0 && backgroundGroupingChipsStyle),
               }}>
 
                 <FilterIconButtonGlobalOperator

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -373,9 +373,7 @@ FilterIconButtonContainerProps
               zIndex: 0,
             }}>
               <Tooltip
-              title={t(
-                'The operators and modes are restricted for these filters.',
-              )}
+              title={t('The operators and modes are restricted for these filters.')}
             >
               <InformationOutline
                 fontSize="small"

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -19,6 +19,7 @@ import {
 } from './filters/FilterChipPopover';
 import DisplayFilterGroup from './filters/DisplayFilterGroup';
 import { UseLocalStorageHelpers } from '../utils/hooks/useLocalStorage';
+import FilterIconButtonGlobalOperator from './FilterIconButtonGlobalOperator';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   filter3: {
@@ -149,8 +150,8 @@ FilterIconButtonContainerProps
   const displayedFilters = filters.filters;
   const globalMode = filters.mode;
   let classFilter = classes.filter1;
-  const latestItemRef = useRef(null);
-  const nbDisplayFilter = useRef(0);
+  const itemRefToPopover = useRef(null);
+  const storeLastDisplayFilter = useRef<Filter[]>([]);
 
   const filtersRepresentativesMap = new Map(
     filtersRepresentatives.map((n) => [n.id, n.value]),
@@ -166,17 +167,16 @@ FilterIconButtonContainerProps
     useEffect(() => {
       if (
         hasRenderedRef
-        && latestItemRef.current
-        && nbDisplayFilter.current < displayedFilters.length
+        && itemRefToPopover.current
       ) {
         setFilterChipsParams({
-          filterId: displayedFilters[displayedFilters.length - 1].id,
-          anchorEl: latestItemRef.current as unknown as HTMLElement,
+          filterId: helpers?.getLatestAddFilterId(),
+          anchorEl: itemRefToPopover.current as unknown as HTMLElement,
         });
       } else {
         setHasRenderedRef();
       }
-      nbDisplayFilter.current = displayedFilters.length;
+      storeLastDisplayFilter.current = displayedFilters;
     }, [displayedFilters]);
   }
   const handleClose = () => {
@@ -305,7 +305,7 @@ FilterIconButtonContainerProps
             >
               <Chip
                 color={chipColor}
-                ref={isNotLastFilter ? null : latestItemRef}
+                ref={helpers?.getLatestAddFilterId() === currentFilter.id ? itemRefToPopover : null}
                 classes={{ root: classFilter, label: classes.chipLabel }}
                 variant={
                   currentFilter.values.length === 0
@@ -342,9 +342,12 @@ FilterIconButtonContainerProps
               />
             </Tooltip>
             {isNotLastFilter && (
-              <div className={classOperator} onClick={handleSwitchGlobalMode}>
-                {t(globalMode.toUpperCase())}
-              </div>
+                <FilterIconButtonGlobalOperator
+                    currentIndex={index}
+                    displayedFilters={displayedFilters}
+                    classOperator={classOperator}
+                    globalMode={globalMode}
+                    handleSwitchGlobalMode={handleSwitchGlobalMode}/>
             )}
           </Fragment>
         );

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonGlobalOperator.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonGlobalOperator.tsx
@@ -1,0 +1,52 @@
+import React, { FunctionComponent } from 'react';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import { useFormatter } from './i18n';
+import { Filter, filtersUsedAsApiParameters } from '../utils/filters/filtersUtils';
+
+interface FilterIconButtonGlobalOperatorProps {
+  classOperator: string;
+  globalMode: string;
+  displayedFilters: Filter[];
+  currentIndex: number;
+  handleSwitchGlobalMode?: () => void
+}
+const FilterIconButtonGlobalOperator: FunctionComponent<FilterIconButtonGlobalOperatorProps> = ({
+  classOperator,
+  globalMode,
+  displayedFilters,
+  currentIndex,
+  handleSwitchGlobalMode }) => {
+  const { t } = useFormatter();
+  const theme = useTheme();
+  if (filtersUsedAsApiParameters.includes(displayedFilters[currentIndex].key)) {
+    if (displayedFilters[currentIndex].key === displayedFilters[currentIndex + 1].key) {
+      return <Box sx={{
+        borderRadius: '5px',
+        fontFamily: 'Consolas, monaco, monospace',
+        backgroundColor: theme?.palette.action?.selected,
+        padding: '0 8px',
+        display: 'flex',
+        alignItems: 'center',
+      }}>
+            {t('OR')}
+        </Box>;
+    }
+    return <Box sx={{
+      borderRadius: '5px',
+      fontFamily: 'Consolas, monaco, monospace',
+      backgroundColor: theme?.palette.action?.selected,
+      padding: '0 8px',
+      display: 'flex',
+      alignItems: 'center',
+    }}>
+          {t('AND')}
+      </Box>;
+  }
+
+  return <div className={classOperator} onClick={handleSwitchGlobalMode}>
+        {t(globalMode.toUpperCase())}
+    </div>;
+};
+
+export default FilterIconButtonGlobalOperator;

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode, useEffect, useState } from 'react';
+import React, { FunctionComponent, ReactNode, useState } from 'react';
 import Popover from '@mui/material/Popover';
 import MUIAutocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
@@ -13,15 +13,13 @@ import {
   dateFilters,
   Filter,
   getAvailableOperatorForFilter,
-  integerFilters, isStixObjectTypes,
+  integerFilters,
+  isStixObjectTypes,
   textFilters,
 } from '../../utils/filters/filtersUtils';
 import { useFormatter } from '../i18n';
 import ItemIcon from '../ItemIcon';
-import {
-  getOptionsFromEntities,
-  getUseSearch,
-} from '../../utils/filters/SearchEntitiesUtil';
+import { getOptionsFromEntities, getUseSearch, } from '../../utils/filters/SearchEntitiesUtil';
 import { UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 
 interface FilterChipMenuProps {

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../utils/filters/filtersUtils';
 import { useFormatter } from '../i18n';
 import ItemIcon from '../ItemIcon';
-import { getOptionsFromEntities, getUseSearch, } from '../../utils/filters/SearchEntitiesUtil';
+import { getOptionsFromEntities, getUseSearch } from '../../utils/filters/SearchEntitiesUtil';
 import { UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 
 interface FilterChipMenuProps {
@@ -290,6 +290,11 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             getOptionLabel={(option) => option.label ?? ''}
             noOptionsText={t('No available options')}
             options={optionValues}
+            groupBy={
+              isStixObjectTypes.includes(filterKey)
+                ? (option) => option.type
+                : (option) => t(option.group ? option.group : filterKey)
+            }
             onInputChange={(event) => searchEntities(filterKey, cacheEntities, setCacheEntities, event)
             }
             renderInput={(paramsInput) => (

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -4,7 +4,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../i18n';
 import FilterIconButtonContent from '../FilterIconButtonContent';
 import { Theme } from '../Theme';
-import { Filter } from '../../utils/filters/filtersUtils';
+import { Filter, filtersUsedAsApiParameters } from '../../utils/filters/filtersUtils';
 import { UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -71,6 +71,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   const classes = useStyles();
   const deactivatePopoverMenu = !helpers;
   const onCLick = deactivatePopoverMenu ? () => {} : onClickLabel;
+  const isFiltersUsedAsApiParameters = filtersUsedAsApiParameters.includes(filterKey);
   if (isOperatorNil) {
     return (
       <>
@@ -101,11 +102,11 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         {last(filterValues) !== id && (
           <div
             className={
-              isReadWriteFilter
+              (isReadWriteFilter && !isFiltersUsedAsApiParameters)
                 ? classes.inlineOperator
                 : classes.inlineOperatorReadOnly
             }
-            onClick={() => handleSwitchLocalMode?.(currentFilter)}
+            onClick={(isReadWriteFilter && !isFiltersUsedAsApiParameters) ? () => handleSwitchLocalMode?.(currentFilter) : undefined}
           >
             {t((currentFilter.mode ?? 'or').toUpperCase())}
           </div>

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -463,6 +463,7 @@ class ListLines extends Component {
           handleRemoveFilter={handleRemoveFilter}
           handleSwitchGlobalMode={handleSwitchGlobalMode}
           handleSwitchLocalMode={handleSwitchLocalMode}
+          availableRelationFilterTypes={availableRelationFilterTypes}
           redirection
         />
         {message && (

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -26,7 +26,7 @@ import ReportKnowledgeTimeLine, {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  emptyFilterGroup,
+  emptyFilterGroup, filtersAfterSwitchLocalMode,
 } from '../../../../utils/filters/filtersUtils';
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import ContainerContent, {
@@ -218,6 +218,19 @@ class ReportKnowledgeComponent extends Component {
     this.setState({ timeLineFilters: newFilters }, () => this.saveView());
   }
 
+  handleSwitchFilterLocalMode(localFilter) {
+    const newFilters = filtersAfterSwitchLocalMode(this.state.timeLineFilters, localFilter);
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
+  handleSwitchFilterGlobalMode() {
+    const newFilters = {
+      ...this.state.timeLineFilters,
+      mode: this.state.timeLineFilters.mode === 'and' ? 'or' : 'and',
+    };
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
   handleTimeLineSearch(value) {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
@@ -344,6 +357,8 @@ class ReportKnowledgeComponent extends Component {
                 handleRemoveTimeLineFilter={this.handleRemoveTimeLineFilter.bind(
                   this,
                 )}
+                handleSwitchFilterLocalMode={this.handleSwitchFilterLocalMode.bind(this)}
+                handleSwitchFilterGlobalMode={this.handleSwitchFilterGlobalMode.bind(this)}
               />
               <QueryRenderer
                 query={reportKnowledgeTimeLineQuery}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -26,7 +26,7 @@ import IncidentKnowledgeTimeLine, {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  emptyFilterGroup,
+  emptyFilterGroup, filtersAfterSwitchLocalMode,
 } from '../../../../utils/filters/filtersUtils';
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import ContainerContent, {
@@ -219,6 +219,19 @@ class IncidentKnowledgeComponent extends Component {
     this.setState({ timeLineFilters: newFilters }, () => this.saveView());
   }
 
+  handleSwitchFilterLocalMode(localFilter) {
+    const newFilters = filtersAfterSwitchLocalMode(this.state.timeLineFilters, localFilter);
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
+  handleSwitchFilterGlobalMode() {
+    const newFilters = {
+      ...this.state.timeLineFilters,
+      mode: this.state.timeLineFilters.mode === 'and' ? 'or' : 'and',
+    };
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
   handleTimeLineSearch(value) {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
@@ -343,6 +356,8 @@ class IncidentKnowledgeComponent extends Component {
                 handleRemoveTimeLineFilter={this.handleRemoveTimeLineFilter.bind(
                   this,
                 )}
+                handleSwitchFilterLocalMode={this.handleSwitchFilterLocalMode.bind(this)}
+                handleSwitchFilterGlobalMode={this.handleSwitchFilterGlobalMode.bind(this)}
               />
               <QueryRenderer
                 query={incidentKnowledgeTimeLineQuery}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -16,7 +16,7 @@ import {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  emptyFilterGroup,
+  emptyFilterGroup, filtersAfterSwitchLocalMode,
 } from '../../../../utils/filters/filtersUtils';
 import CaseRfiPopover from './CaseRfiPopover';
 import CaseRfiKnowledgeGraph, {
@@ -219,6 +219,19 @@ class CaseRfiKnowledgeComponent extends Component {
     this.setState({ timeLineFilters: newFilters }, () => this.saveView());
   }
 
+  handleSwitchFilterLocalMode(localFilter) {
+    const newFilters = filtersAfterSwitchLocalMode(this.state.timeLineFilters, localFilter);
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
+  handleSwitchFilterGlobalMode() {
+    const newFilters = {
+      ...this.state.timeLineFilters,
+      mode: this.state.timeLineFilters.mode === 'and' ? 'or' : 'and',
+    };
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
   handleTimeLineSearch(value) {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
@@ -348,6 +361,8 @@ class CaseRfiKnowledgeComponent extends Component {
                 handleRemoveTimeLineFilter={this.handleRemoveTimeLineFilter.bind(
                   this,
                 )}
+                handleSwitchFilterLocalMode={this.handleSwitchFilterLocalMode.bind(this)}
+                handleSwitchFilterGlobalMode={this.handleSwitchFilterGlobalMode.bind(this)}
               />
               <QueryRenderer
                 query={caseRfiKnowledgeTimeLineQuery}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -16,7 +16,7 @@ import {
 import {
   constructHandleAddFilter,
   constructHandleRemoveFilter,
-  emptyFilterGroup,
+  emptyFilterGroup, filtersAfterSwitchLocalMode,
 } from '../../../../utils/filters/filtersUtils';
 import CaseRftPopover from './CaseRftPopover';
 import CaseRftKnowledgeGraph, {
@@ -216,6 +216,19 @@ class CaseRftKnowledgeComponent extends Component {
     this.setState({ timeLineFilters: newFilters }, () => this.saveView());
   }
 
+  handleSwitchFilterLocalMode(localFilter) {
+    const newFilters = filtersAfterSwitchLocalMode(this.state.timeLineFilters, localFilter);
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
+  handleSwitchFilterGlobalMode() {
+    const newFilters = {
+      ...this.state.timeLineFilters,
+      mode: this.state.timeLineFilters.mode === 'and' ? 'or' : 'and',
+    };
+    this.setState({ timeLineFilters: newFilters }, () => this.saveView());
+  }
+
   handleTimeLineSearch(value) {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
@@ -324,6 +337,8 @@ class CaseRftKnowledgeComponent extends Component {
                 handleRemoveTimeLineFilter={this.handleRemoveTimeLineFilter.bind(
                   this,
                 )}
+                handleSwitchFilterLocalMode={this.handleSwitchFilterLocalMode.bind(this)}
+                handleSwitchFilterGlobalMode={this.handleSwitchFilterGlobalMode.bind(this)}
               />
               <QueryRenderer
                 query={caseRftKnowledgeTimeLineQuery}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.jsx
@@ -40,6 +40,8 @@ const ContentKnowledgeTimeLineBar = ({
   timeLineFilters,
   handleAddTimeLineFilter,
   handleRemoveTimeLineFilter,
+  handleSwitchFilterLocalMode,
+  handleSwitchFilterGlobalMode,
 }) => {
   const classes = useStyles();
   const { t } = useFormatter();
@@ -157,6 +159,8 @@ const ContentKnowledgeTimeLineBar = ({
               <FilterIconButton
                 filters={timeLineFilters}
                 handleRemoveFilter={handleRemoveTimeLineFilter}
+                handleSwitchLocalMode={handleSwitchFilterLocalMode}
+                handleSwitchGlobalMode={handleSwitchFilterGlobalMode}
                 classNameNumber={1}
                 redirection
               />

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
@@ -239,11 +239,12 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
             availableFilterKeys={availableFilterKeys}
             handleAddFilter={defaultHandleAddFilter}
           />
-
             <FilterIconButton
               helpers={helpers}
               filters={filters}
               handleRemoveFilter={helpers.handleRemoveFilter}
+              handleSwitchLocalMode={helpers.handleSwitchLocalMode}
+              handleSwitchGlobalMode={helpers.handleSwitchGlobalMode}
               className={5}
               redirection
             />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
@@ -191,6 +191,8 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
           <FilterIconButton
             filters={filters}
             handleRemoveFilter={handleRemoveFilter}
+            handleSwitchLocalMode={handleSwitchLocalMode}
+            handleSwitchGlobalMode={handleSwitchGlobalMode}
             classNameNumber={6}
             styleNumber={2}
             redirection

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
@@ -505,6 +505,8 @@ StixDomainObjectThreatKnowledgeProps
         helpers={helpers}
         filters={filters}
         handleRemoveFilter={helpers.handleRemoveFilter}
+        handleSwitchGlobalMode={helpers.handleSwitchGlobalMode}
+        handleSwitchLocalMode={helpers.handleSwitchLocalMode}
         classNameNumber={8}
       />
       <QueryRenderer

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
@@ -43,10 +43,9 @@ import Filters from '../lists/Filters';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { Theme } from '../../../../components/Theme';
 import {
-  findFilterFromKey,
   emptyFilterGroup,
   removeFilter,
-  removeIdFromFilterObject,
+  removeIdFromFilterObject, extractAllValueFromFilters,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
 
@@ -198,7 +197,7 @@ StixDomainObjectThreatKnowledgeProps
   )}/${stixDomainObjectId}/knowledge`;
   const buildPaginationOptions = () => {
     let toTypes: string[];
-    const entityTypeFilters = findFilterFromKey(
+    const entityTypeFilters = extractAllValueFromFilters(
       filters?.filters ?? [],
       'elementTargetTypes',
     );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
@@ -200,7 +200,7 @@ StixDomainObjectThreatKnowledgeProps
     let toTypes: string[];
     const entityTypeFilters = findFilterFromKey(
       filters?.filters ?? [],
-      'entity_type',
+      'elementTargetTypes',
     );
     if (entityTypeFilters && entityTypeFilters.values.length > 0) {
       if (entityTypeFilters.values.filter((id) => id === 'all').length > 0) {
@@ -231,7 +231,7 @@ StixDomainObjectThreatKnowledgeProps
       toTypes = ['Attack-Pattern', 'Malware', 'Tool', 'Vulnerability'];
     }
     const finalFilters = filters
-      ? removeFilter(filters, 'entity_type')
+      ? removeFilter(filters, 'elementTargetTypes')
       : undefined;
     const finalPaginationOptions = {
       ...rawPaginationOptions,
@@ -439,7 +439,7 @@ StixDomainObjectThreatKnowledgeProps
         <Filters
           helpers={helpers}
           availableFilterKeys={[
-            'entity_type',
+            'elementTargetTypes',
             'objectMarking',
             'createdBy',
             'objectLabel',

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -2353,6 +2353,7 @@ const i18n = {
       'not ends with': 'no termina con',
       'Add filter': 'Agregar filtro',
       elementTargetTypes: 'Tipos de objetivo',
+      'The operators and modes are restricted for these filters.': 'Los operadores y modos están restringidos para estos filtros.',
     },
     'fr-fr': {
       // Titles
@@ -4715,6 +4716,7 @@ const i18n = {
       'not ends with': 'ne se termine pas par',
       'Add filter': 'Ajouter un filtre',
       elementTargetTypes: 'Types de cible',
+      'The operators and modes are restricted for these filters.': 'Les opérateurs et les modes sont restreints pour ces filtres.',
     },
     'ja-jp': {
       // Titles
@@ -6979,6 +6981,7 @@ const i18n = {
       'not ends with': 'で終わらない',
       'Add filter': 'フィルターを追加',
       elementTargetTypes: 'ターゲットタイプ',
+      'The operators and modes are restricted for these filters.': 'これらのフィルタには演算子とモードの制限があります。',
     },
     'zh-cn': {
       // Titles
@@ -9129,6 +9132,7 @@ const i18n = {
       'not ends with': '不以...结尾',
       'Add filter': '添加过滤器',
       elementTargetTypes: '目标类型',
+      'The operators and modes are restricted for these filters.': '这些过滤器的运算符和模式受到限制。',
     },
     'en-us': {
       gt: 'Greater than',

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -2352,6 +2352,7 @@ const i18n = {
       'ends with': 'termina con',
       'not ends with': 'no termina con',
       'Add filter': 'Agregar filtro',
+      elementTargetTypes: 'Tipos de objetivo',
     },
     'fr-fr': {
       // Titles
@@ -4713,6 +4714,7 @@ const i18n = {
       'ends with': 'se termine par',
       'not ends with': 'ne se termine pas par',
       'Add filter': 'Ajouter un filtre',
+      elementTargetTypes: 'Types de cible',
     },
     'ja-jp': {
       // Titles
@@ -6976,6 +6978,7 @@ const i18n = {
       'ends with': 'で終わる',
       'not ends with': 'で終わらない',
       'Add filter': 'フィルターを追加',
+      elementTargetTypes: 'ターゲットタイプ',
     },
     'zh-cn': {
       // Titles
@@ -9125,6 +9128,7 @@ const i18n = {
       'ends with': '以...结尾',
       'not ends with': '不以...结尾',
       'Add filter': '添加过滤器',
+      elementTargetTypes: '目标类型',
     },
     'en-us': {
       gt: 'Greater than',
@@ -9573,6 +9577,7 @@ const i18n = {
       info_authorizedmembers_knowledge_off: 'By deactivating Access Restriction, specific accesses you created will be removed and Access Restriction will be lift off for this Entity. But the Entity will still be covered by Marking Definition and Organization sharing.',
       'I would like to use a EE feature ...':
         "I would like to use a EE feature ({feature}) but I don't have EE activated.\nI would like to discuss with you about activating EE.",
+      elementTargetTypes: 'Target Types',
     },
   },
 };

--- a/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
@@ -1,6 +1,7 @@
 import { Dispatch, SyntheticEvent } from 'react';
 import { OptionValue } from '@components/common/lists/FilterAutocomplete';
 import useSearchEntities, { SearchEntitiesProps } from './useSearchEntities';
+import { isStixObjectTypes } from './filtersUtils';
 
 let searchEntitiesScope: SearchEntitiesProps | undefined;
 
@@ -11,43 +12,24 @@ export const getSearchEntitiesScope = (): SearchEntitiesProps | undefined => {
   return searchEntitiesScope;
 };
 
-export const getOptionsFromEntities = (filterKey: string) => {
-  let options: OptionValue[] = [];
-  if (!searchEntitiesScope) {
-    return [];
-  }
-  const [entities, _] = useSearchEntities(searchEntitiesScope) as [
-    Record<string, OptionValue[]>,
-    (
-      filterKey: string,
-      cacheEntities: Record<string, { label: string; value: string; type: string }[]>,
-      setCacheEntities: Dispatch<Record<string, { label: string; value: string; type: string }[]>>,
-      event: SyntheticEvent
-    ) => Record<string, OptionValue[]>,
-  ];
-  const { searchScope } = searchEntitiesScope;
-  const isStixObjectTypes = [
-    'elementId',
-    'fromId',
-    'toId',
-    'objects',
-    'targets',
-    'elementId',
-    'indicates',
-  ].includes(filterKey);
-  if (isStixObjectTypes) {
+export const getOptionsFromEntities = (
+  entities: Record<string, OptionValue[]>,
+  searchScope: Record<string, string[]>,
+  filterKey: string,
+): OptionValue[] => {
+  let filteredOptions: OptionValue[] = [];
+  if (isStixObjectTypes.includes(filterKey)) {
     if (searchScope[filterKey] && searchScope[filterKey].length > 0) {
-      options = (entities[filterKey] || [])
+      filteredOptions = (entities[filterKey] || [])
         .filter((n) => searchScope[filterKey].some((s) => (n.parentTypes ?? []).concat(n.type).includes(s)))
         .sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
     } else {
-      options = (entities[filterKey] || []).sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
+      filteredOptions = (entities[filterKey] || []).sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
     }
   } else if (entities[filterKey]) {
-    options = entities[filterKey];
+    filteredOptions = entities[filterKey];
   }
-
-  return options;
+  return filteredOptions;
 };
 
 export const getUseSearch = () => {
@@ -63,24 +45,4 @@ export const getUseSearch = () => {
       event: SyntheticEvent
     ) => Record<string, OptionValue[]>,
   ];
-};
-
-export const getOptions = (filterKey: string, entities: Record<string, OptionValue[]>) => {
-  let options: OptionValue[] = [];
-  const isStixObjectTypes = [
-    'elementId',
-    'fromId',
-    'toId',
-    'objects',
-    'targets',
-    'elementId',
-    'indicates',
-  ].includes(filterKey);
-
-  if (isStixObjectTypes) {
-    options = (entities[filterKey] || []).sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
-  } else if (entities[filterKey]) {
-    options = entities[filterKey];
-  }
-  return options;
 };

--- a/opencti-platform/opencti-front/src/utils/filters/filtersLocalStorageUtil.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersLocalStorageUtil.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { Filter, FilterGroup } from './filtersUtils';
+import { Filter, FilterGroup, filtersUsedAsApiParameters } from './filtersUtils';
 import { LocalStorage } from '../hooks/useLocalStorageModel';
 
 type FiltersLocalStorageUtilProps<U> = {
@@ -7,22 +7,29 @@ type FiltersLocalStorageUtilProps<U> = {
   setValue: Dispatch<SetStateAction<LocalStorage>>
 } & U;
 
-const setFiltersValue = (setValue: Dispatch<SetStateAction<LocalStorage>>, filters: FilterGroup) => {
+const setFiltersValue = (setValue: Dispatch<SetStateAction<LocalStorage>>, filters: FilterGroup, latestAddFilterId?: string) => {
   setValue((c) => ({
     ...c,
     filters,
+    latestAddFilterId,
   }));
 };
 
+const sortSpecificFilterAtFirst = (a: Filter, b: Filter) => {
+  return filtersUsedAsApiParameters.indexOf(b.key) - filtersUsedAsApiParameters.indexOf(a.key);
+};
 const updateFilters = (viewStorage: LocalStorage, setValue: Dispatch<SetStateAction<LocalStorage>>, updateFn: (filter: Filter) => Filter) => {
   if (viewStorage.filters) {
     const newBaseFilters: FilterGroup = {
       ...viewStorage.filters,
-      filters: viewStorage.filters.filters.map(updateFn),
+      filters: viewStorage.filters.filters
+        .map(updateFn)
+        .sort(sortSpecificFilterAtFirst),
     };
     setFiltersValue(setValue, newBaseFilters);
   }
 };
+
 export const handleAddFilterWithEmptyValueUtil = ({ viewStorage, setValue, filter }: FiltersLocalStorageUtilProps<{
   filter: Filter
 }>) => {
@@ -32,9 +39,9 @@ export const handleAddFilterWithEmptyValueUtil = ({ viewStorage, setValue, filte
       filters: [
         ...viewStorage.filters.filters,
         filter,
-      ],
+      ].sort(sortSpecificFilterAtFirst),
     };
-    setFiltersValue(setValue, newBaseFilters);
+    setFiltersValue(setValue, newBaseFilters, filter.id);
   }
 };
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -209,6 +209,21 @@ export const findFilterFromKey = (
   return null;
 };
 
+export const extractAllValueFromFilters = (filters: Filter[], key: string): Filter | null => {
+  const extractFilter: Filter = {
+    key,
+    mode: 'or',
+    operator: 'eq',
+    values: [],
+  };
+  filters.forEach((filter) => {
+    if (filter.key === key) {
+      extractFilter.values.push(...filter.values);
+    }
+  });
+  return extractFilter.values.length > 0 ? extractFilter : null;
+};
+
 export const findFiltersFromKeys = (
   filters: Filter[],
   keys: string[],

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -642,8 +642,8 @@ export const getDefaultFilterObject = (key: string): Filter => {
 };
 
 export const getAvailableOperatorForFilter = (filterKey: string): string[] => {
-  if (EqFilters.includes(filterKey)) {
-    return ['eq', 'not_eq', 'nil', 'not_nil'];
+  if (filtersUsedAsApiParameters.includes(filterKey)) {
+    return ['eq'];
   }
   if (dateFilters.includes(filterKey)) {
     return ['gt', 'gte', 'lt', 'lte'];

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -117,6 +117,7 @@ export const filtersUsedAsApiParameters = [
   'fromTypes',
   'toId',
   'toTypes',
+  'elementTargetTypes',
 ];
 
 // filters that represents a date, can have lt (end date) or gt (start date) operators

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -696,3 +696,14 @@ export const removeIdFromFilterObject = (
       }),
   };
 };
+
+export const isStixObjectTypes = [
+  'elementId',
+  'fromId',
+  'toId',
+  'objects',
+  'targets',
+  'elementId',
+  'indicates',
+  'contextEntityId',
+];

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -111,6 +111,14 @@ export const EqFilters = [
   'organization_ids',
 ];
 
+// filters that can only have an 'eq' operator and a 'or' mode
+export const filtersUsedAsApiParameters = [
+  'fromId',
+  'fromTypes',
+  'toId',
+  'toTypes',
+];
+
 // filters that represents a date, can have lt (end date) or gt (start date) operators
 export const dateFilters = [
   'published',

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -1242,6 +1242,7 @@ const useSearchEntities = ({
         const elementTypeTypes = elementTypeResult.sort((a, b) => a.label.localeCompare(b.label));
         unionSetEntities(filterKey, elementTypeTypes);
         break;
+      case 'elementTargetTypes':
       case 'entity_type':
       case 'entity_types':
       case 'fromTypes':

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -47,6 +47,7 @@ export interface UseLocalStorageHelpers {
   handleClearAllFilters: (filters?: Filter[]) => void;
   handleChangeOperatorFilters: HandleOperatorFilter;
   handleAddFilterWithEmptyValue: (filter: Filter) => void;
+  getLatestAddFilterId: () => string | undefined;
 }
 
 const localStorageToPaginationOptions = (
@@ -64,6 +65,7 @@ const localStorageToPaginationOptions = (
   delete localOptions.numberOfElements;
   delete localOptions.view;
   delete localOptions.zoom;
+  delete localOptions.latestAddFilterId;
   // Rebuild some pagination options
   const basePagination: PaginationOptions = { ...localOptions };
   if (searchTerm) {
@@ -541,6 +543,7 @@ export const usePaginationLocalStorage = <U>(
           filters: filters ? [...filters] : [],
           mode: 'and',
         },
+        latestAddFilterId: undefined,
       }));
     },
     handleAddFilterWithEmptyValue: (filter: Filter) => {
@@ -548,6 +551,9 @@ export const usePaginationLocalStorage = <U>(
     },
     handleChangeOperatorFilters: (id: string, operator: string) => {
       handleChangeOperatorFiltersUtil({ viewStorage, setValue, id, operator });
+    },
+    getLatestAddFilterId: () => {
+      return viewStorage.latestAddFilterId;
     },
   };
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, SyntheticEvent, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { OrderMode, PaginationOptions } from '../../components/list_lines';
 import {
+  extractAllValueFromFilters,
   Filter,
   FilterGroup,
   findFilterFromKey,
@@ -73,10 +74,10 @@ const localStorageToPaginationOptions = (
     basePagination.orderBy = sortBy;
   }
   let convertedFilters = filters?.filters as Filter[];
-  const fromId = convertedFilters ? R.head(convertedFilters.filter((n) => n.key === 'fromId'))?.values : undefined;
-  const toId = convertedFilters ? R.head(convertedFilters.filter((n) => n.key === 'toId'))?.values : undefined;
-  const fromTypes = convertedFilters ? R.head(convertedFilters.filter((n) => n.key === 'fromTypes'))?.values : undefined;
-  const toTypes = convertedFilters ? R.head(convertedFilters.filter((n) => n.key === 'toTypes'))?.values : undefined;
+  const fromId = convertedFilters ? extractAllValueFromFilters(convertedFilters, 'fromId')?.values : undefined;
+  const toId = convertedFilters ? extractAllValueFromFilters(convertedFilters, 'toId')?.values : undefined;
+  const fromTypes = convertedFilters ? extractAllValueFromFilters(convertedFilters, 'fromTypes')?.values : undefined;
+  const toTypes = convertedFilters ? extractAllValueFromFilters(convertedFilters, 'toTypes')?.values : undefined;
   convertedFilters = convertedFilters?.filter(
     (n) => !['fromId', 'toId', 'fromTypes', 'toTypes'].includes(Array.isArray(n.key) ? n.key[0] : n.key),
   );

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -549,7 +549,6 @@ export const usePaginationLocalStorage = <U>(
       }));
     },
     handleAddFilterWithEmptyValue: (filter: Filter) => {
-      console.log(filter);
       if (filtersUsedAsApiParameters.includes(filter.key)) {
         const existedFilter = viewStorage.filters?.filters.find((f) => f.key === filter.key);
         // If the specific filter is already defined, set the latestAddFilterId in order to open the menu popover

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -6,6 +6,7 @@ import {
   extractAllValueFromFilters,
   Filter,
   FilterGroup,
+  filtersUsedAsApiParameters,
   findFilterFromKey,
   isFilterGroupNotEmpty,
   isUniqFilter,
@@ -495,6 +496,7 @@ export const usePaginationLocalStorage = <U>(
         setValue((c) => ({
           ...c,
           filters: newBaseFilters,
+          latestAddFilterId: undefined,
         }));
       }
     },
@@ -547,6 +549,20 @@ export const usePaginationLocalStorage = <U>(
       }));
     },
     handleAddFilterWithEmptyValue: (filter: Filter) => {
+      console.log(filter);
+      if (filtersUsedAsApiParameters.includes(filter.key)) {
+        const existedFilter = viewStorage.filters?.filters.find((f) => f.key === filter.key);
+        // If the specific filter is already defined, set the latestAddFilterId in order to open the menu popover
+        // and return void to finish the task.
+        // In the other side if not existed, create a new one filter
+        if (existedFilter) {
+          setValue({
+            ...viewStorage,
+            latestAddFilterId: existedFilter.id,
+          });
+          return;
+        }
+      }
       handleAddFilterWithEmptyValueUtil({ viewStorage, setValue, filter });
     },
     handleChangeOperatorFilters: (id: string, operator: string) => {

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorageModel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorageModel.ts
@@ -34,4 +34,5 @@ export interface LocalStorage {
   messages?: MessageFromLocalStorage[];
   timeField?: string;
   dashboard?: string;
+  latestAddFilterId?: string;
 }

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -337,7 +337,7 @@ export const buildEntityFilters = <T extends BasicStoreCommon>(args: EntityFilte
   const { toId, toRole, toTypes = [] } = args;
   const { filters = null } = args;
   // Config
-  const customFiltersContent = filters?.filters ?? [];
+  const customFiltersContent = [];
   // region element
   const nestedElement = [];
   const optsElementIds = Array.isArray(elementId) ? elementId : [elementId];
@@ -405,12 +405,22 @@ export const buildEntityFilters = <T extends BasicStoreCommon>(args: EntityFilte
   )(args);
   // Override some special filters
   builtArgs.types = R.uniq([...(types ?? []), ...entityTypes, ...relationshipTypes]);
-  const customFilters = {
-    mode: filters?.mode ?? FilterMode.And,
-    filters: customFiltersContent,
-    filterGroups: filters?.filterGroups ?? [],
-  };
-  return { ...builtArgs, filters: customFilters };
+  let finalFilters = filters;
+  if (customFiltersContent.length > 0) {
+    const customFilters = {
+      mode: FilterMode.And,
+      filters: customFiltersContent,
+      filterGroups: [],
+    };
+    finalFilters = filters
+      ? {
+        mode: filters.mode,
+        filters: [],
+        filterGroups: [customFilters, filters],
+      }
+      : customFilters;
+  }
+  return { ...builtArgs, filters: finalFilters };
 };
 
 const entitiesAggregations = [

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -289,18 +289,22 @@ export const buildRelationsFilter = <T extends BasicStoreCommon>(relationshipTyp
     R.dissoc('lastSeenStop'),
     R.dissoc('confidences'),
   )(args);
-  const filtersFromOptions = {
-    mode: FilterMode.And,
-    filters: filtersFromOptionsContent,
-    filterGroups: [],
-  };
-  const finalFilters = filters
-    ? {
-      mode: filters.mode,
-      filters: [],
-      filterGroups: [filters, filtersFromOptions],
-    }
-    : filtersFromOptions;
+  let finalFilters = filters;
+  if (filtersFromOptionsContent.length > 0) {
+    const filtersFromOptions = {
+      mode: FilterMode.And,
+      filters: filtersFromOptionsContent,
+      filterGroups: [],
+    };
+    finalFilters = filters
+      ? {
+        mode: filters.mode,
+        filters: [],
+        filterGroups: [filters, filtersFromOptions],
+      }
+      : filtersFromOptions;
+  }
+
   return {
     ...cleanedArgs,
     types: relationsToGet,

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -297,8 +297,8 @@ export const buildRelationsFilter = <T extends BasicStoreCommon>(relationshipTyp
   const finalFilters = filters
     ? {
       mode: filters.mode,
-      filters: filters.filters,
-      filterGroups: filters.filterGroups.concat(filtersFromOptions),
+      filters: [],
+      filterGroups: [filters, filtersFromOptions],
     }
     : filtersFromOptions;
   return {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -6,7 +6,6 @@ import { compareUnsorted } from 'js-deep-equals';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { JSONPath } from 'jsonpath-plus';
 import * as jsonpatch from 'fast-json-patch';
-import { checkAndConvertFilters } from '../utils/filtering/filtering-utils';
 
 import {
   ALREADY_DELETED_ERROR,
@@ -556,8 +555,7 @@ export const stixLoadByIdStringify = async (context, user, id) => {
   return data ? JSON.stringify(data) : '';
 };
 export const stixLoadByFilters = async (context, user, types, args) => {
-  const convertedFilters = checkAndConvertFilters(args.filters);
-  const elements = await loadByFiltersWithDependencies(context, user, types, { args, filters: convertedFilters });
+  const elements = await loadByFiltersWithDependencies(context, user, types, args);
   return elements ? elements.map((element) => convertStoreToStix(element)) : [];
 };
 // endregion
@@ -624,7 +622,7 @@ export const distributionHistory = async (context, user, types, args) => {
   return R.take(limit, R.sortWith([orderingFunction(R.prop('value'))])(distributionData));
 };
 export const distributionEntities = async (context, user, types, args) => {
-  const distributionArgs = buildEntityFilters({ types, ...args, filters: convertedFilters });
+  const distributionArgs = buildEntityFilters({ types, ...args });
   const { limit = 10, order = 'desc', field } = args;
   if (field.includes('.') && !field.endsWith('internal_id')) {
     throw FunctionalError('Distribution entities does not support relation aggregation field');
@@ -670,7 +668,7 @@ export const distributionRelations = async (context, user, args) => {
     finalField = REL_INDEX_PREFIX + field;
   }
   // Using elastic can only be done if the distribution is a count on types
-  const opts = { ...args, dateAttribute: distributionDateAttribute, field: finalField, filters: convertedFilters };
+  const opts = { ...args, dateAttribute: distributionDateAttribute, field: finalField };
   const distributionArgs = buildAggregationRelationFilter(types, opts);
   const distributionData = await elAggregationRelationsCount(context, user, args.onlyInferred ? READ_INDEX_INFERRED_RELATIONSHIPS : READ_RELATIONSHIPS_INDICES, distributionArgs);
   // Take a maximum amount of distribution depending on the ordering.

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -388,14 +388,12 @@ export const loadThroughGetTo = async (context, user, sources, relationType, tar
 // Standard listing
 export const listThings = async (context, user, thingsTypes, args = {}) => {
   const { indices = READ_DATA_INDICES } = args;
-  const convertedFilters = checkAndConvertFilters(args.filters);
-  const paginateArgs = buildEntityFilters({ types: thingsTypes, ...args, filters: convertedFilters });
+  const paginateArgs = buildEntityFilters({ types: thingsTypes, ...args });
   return elPaginate(context, user, indices, paginateArgs);
 };
 export const listAllThings = async (context, user, thingsTypes, args = {}) => {
-  const { indices = READ_DATA_INDICES, noFiltersChecking = false } = args;
-  const convertedFilters = noFiltersChecking ? args.filters : checkAndConvertFilters(args.filters);
-  const paginateArgs = buildEntityFilters({ types: thingsTypes, ...args, filters: convertedFilters });
+  const { indices = READ_DATA_INDICES } = args;
+  const paginateArgs = buildEntityFilters({ types: thingsTypes, ...args });
   return elList(context, user, indices, paginateArgs);
 };
 export const paginateAllThings = async (context, user, thingsTypes, args = {}) => {
@@ -574,13 +572,11 @@ const convertAggregateDistributions = async (context, user, limit, orderingFunct
 };
 export const timeSeriesHistory = async (context, user, types, args) => {
   const { startDate, endDate, interval } = args;
-  const convertedFilters = checkAndConvertFilters(args.filters);
-  const histogramData = await elHistogramCount(context, user, READ_INDEX_HISTORY, { ...args, filters: convertedFilters });
+  const histogramData = await elHistogramCount(context, user, READ_INDEX_HISTORY, args);
   return fillTimeSeries(startDate, endDate, interval, histogramData);
 };
 export const timeSeriesEntities = async (context, user, types, args) => {
-  const convertedFilters = checkAndConvertFilters(args.filters);
-  const timeSeriesArgs = buildEntityFilters({ types, ...args, filters: convertedFilters });
+  const timeSeriesArgs = buildEntityFilters({ types, ...args });
   const { startDate, endDate, interval } = args;
   const histogramData = await elHistogramCount(context, user, args.onlyInferred ? READ_DATA_INDICES_INFERRED : READ_DATA_INDICES, timeSeriesArgs);
   return fillTimeSeries(startDate, endDate, interval, histogramData);
@@ -588,14 +584,12 @@ export const timeSeriesEntities = async (context, user, types, args) => {
 export const timeSeriesRelations = async (context, user, args) => {
   const { startDate, endDate, relationship_type: relationshipTypes, interval } = args;
   const types = relationshipTypes || ['stix-core-relationship'];
-  const convertedFilters = checkAndConvertFilters(args.filters);
-  const timeSeriesArgs = buildEntityFilters({ types, ...args, filters: convertedFilters });
+  const timeSeriesArgs = buildEntityFilters({ types, ...args });
   const histogramData = await elHistogramCount(context, user, args.onlyInferred ? INDEX_INFERRED_RELATIONSHIPS : READ_RELATIONSHIPS_INDICES, timeSeriesArgs);
   return fillTimeSeries(startDate, endDate, interval, histogramData);
 };
 export const distributionHistory = async (context, user, types, args) => {
   const { limit = 10, order = 'desc', field } = args;
-  const convertedFilters = checkAndConvertFilters(args.filters);
   if (field.includes('.') && (!field.endsWith('internal_id') && !field.includes('context_data'))) {
     throw FunctionalError('Distribution entities does not support relation aggregation field');
   }
@@ -609,7 +603,6 @@ export const distributionHistory = async (context, user, types, args) => {
   const distributionData = await elAggregationCount(context, user, READ_INDEX_HISTORY, {
     ...args,
     field: finalField,
-    filters: convertedFilters,
   });
   // Take a maximum amount of distribution depending on the ordering.
   const orderingFunction = order === 'asc' ? R.ascend : R.descend;
@@ -631,7 +624,6 @@ export const distributionHistory = async (context, user, types, args) => {
   return R.take(limit, R.sortWith([orderingFunction(R.prop('value'))])(distributionData));
 };
 export const distributionEntities = async (context, user, types, args) => {
-  const convertedFilters = checkAndConvertFilters(args.filters);
   const distributionArgs = buildEntityFilters({ types, ...args, filters: convertedFilters });
   const { limit = 10, order = 'desc', field } = args;
   if (field.includes('.') && !field.endsWith('internal_id')) {
@@ -671,7 +663,6 @@ export const distributionRelations = async (context, user, args) => {
   const { field } = args; // Mandatory fields
   const { limit = 50, order } = args;
   const { relationship_type: relationshipTypes, dateAttribute = 'created_at' } = args;
-  const convertedFilters = checkAndConvertFilters(args.filters);
   const types = relationshipTypes || [ABSTRACT_BASIC_RELATIONSHIP];
   const distributionDateAttribute = dateAttribute || 'created_at';
   let finalField = field;

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -3,7 +3,6 @@ import { INDEX_INTERNAL_OBJECTS, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_IN
 import { ENTITY_TYPE_BACKGROUND_TASK } from '../schema/internalObject';
 import { deleteElementById, patchAttribute } from '../database/middleware';
 import { TYPE_FILTER } from '../utils/filtering/filtering-constants';
-import { checkAndConvertFilters } from '../utils/filtering/filtering-utils';
 import { resolveFilterGroupValuesWithCache } from '../utils/filtering/filtering-resolution';
 import { getUserAccessRight, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../utils/access';
 import { ABSTRACT_STIX_DOMAIN_OBJECT, RULE_PREFIX } from '../schema/general';
@@ -46,7 +45,7 @@ const buildQueryFiltersContent = (adaptedFiltersGroup) => {
       filterGroups: [],
     };
   }
-  const { filters, filterGroups = [] } = checkAndConvertFilters(adaptedFiltersGroup);
+  const { filters, filterGroups = [] } = adaptedFiltersGroup;
   const queryFilterGroups = [];
   for (let index = 0; index < filterGroups.length; index += 1) {
     const currentGroup = filterGroups[index];

--- a/opencti-platform/opencti-graphql/src/domain/log.ts
+++ b/opencti-platform/opencti-graphql/src/domain/log.ts
@@ -6,15 +6,15 @@ import { INDEX_HISTORY, READ_INDEX_HISTORY, } from '../database/utils';
 import { ENTITY_TYPE_HISTORY } from '../schema/internalObject';
 import type { AuthContext, AuthUser } from '../types/user';
 import type { QueryAuditsArgs, QueryLogsArgs } from '../generated/graphql';
-import { addFilter, checkAndConvertFilters } from '../utils/filtering/filtering-utils';
+import { addFilter } from '../utils/filtering/filtering-utils';
 
 export const findHistory = (context: AuthContext, user: AuthUser, args: QueryLogsArgs) => {
-  const finalArgs = { ...args, orderBy: args.orderBy ?? 'timestamp', orderMode: args.orderMode ?? 'desc', types: [ENTITY_TYPE_HISTORY], filters: checkAndConvertFilters(args.filters ?? undefined) };
+  const finalArgs = { ...args, orderBy: args.orderBy ?? 'timestamp', orderMode: args.orderMode ?? 'desc', types: [ENTITY_TYPE_HISTORY] };
   return elPaginate(context, user, READ_INDEX_HISTORY, finalArgs);
 };
 
 export const findAudits = (context: AuthContext, user: AuthUser, args: QueryAuditsArgs) => {
-  const finalArgs = { ...args, types: args.types ? args.types : [ENTITY_TYPE_HISTORY], filters: checkAndConvertFilters(args.filters ?? undefined) };
+  const finalArgs = { ...args, types: args.types ? args.types : [ENTITY_TYPE_HISTORY] };
   return elPaginate(context, user, READ_INDEX_HISTORY, finalArgs);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -65,15 +65,8 @@ export const worksForConnector = async (context, user, connectorId, args = {}) =
 };
 
 export const worksForSource = async (context, user, sourceId, args = {}) => {
-  const { first = 10, type } = args;
-  let finalFilters = {
-    mode: 'and',
-    filters: [{
-      key: 'event_source_id',
-      values: [sourceId],
-    }],
-    filterGroups: [],
-  };
+  const { first = 10, filters = null, type } = args;
+  let finalFilters = addFilter(filters, 'event_source_id', sourceId);
   if (type) {
     finalFilters = addFilter(finalFilters, 'event_type', type);
   }
@@ -84,7 +77,6 @@ export const worksForSource = async (context, user, sourceId, args = {}) => {
     orderMode: 'desc',
     first,
     filters: finalFilters,
-    noFiltersChecking: true,
   });
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -65,8 +65,15 @@ export const worksForConnector = async (context, user, connectorId, args = {}) =
 };
 
 export const worksForSource = async (context, user, sourceId, args = {}) => {
-  const { first = 10, filters = null, type } = args;
-  let finalFilters = addFilter(filters, 'event_source_id', sourceId);
+  const { first = 10, type } = args;
+  let finalFilters = {
+    mode: 'and',
+    filters: [{
+      key: 'event_source_id',
+      values: [sourceId],
+    }],
+    filterGroups: [],
+  };
   if (type) {
     finalFilters = addFilter(finalFilters, 'event_type', type);
   }
@@ -77,6 +84,7 @@ export const worksForSource = async (context, user, sourceId, args = {}) => {
     orderMode: 'desc',
     first,
     filters: finalFilters,
+    noFiltersChecking: true,
   });
 };
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -76,6 +76,22 @@ export const specialFilterKeys = [
   SOURCE_RELIABILITY_FILTER, // reliability of the author
 ];
 
+// filter keys that should be in the schema but are not
+// TODO remove this list and register the attributes
+export const internalFilterKeys = [
+  'connector_id',
+  'source_event_id',
+  'event_access',
+  // attributes of the entity of type Work that are not registered elsewhere
+  'status',
+  'event_source_id',
+  'received_time',
+  'processed_time',
+  'completed_time',
+  'completed_number',
+  'tracking',
+];
+
 // list of filter keys that are not relation refs keys but whose values need to be resolved (= values point an entity with an id)
 // used in findFiltersRepresentatives
 export const filterKeysWhoseValueToResolve = [

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -82,7 +82,6 @@ export const internalFilterKeys = [
   'connector_id',
   'source_event_id',
   'event_access',
-  'i_rule_sighting_incident',
   // attributes of the entity of type Work that are not registered elsewhere
   'status',
   'event_source_id',

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -82,7 +82,7 @@ export const internalFilterKeys = [
   'connector_id',
   'source_event_id',
   'event_access',
-  'types',
+  'i_rule_sighting_incident',
   // attributes of the entity of type Work that are not registered elsewhere
   'status',
   'event_source_id',

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -61,10 +61,6 @@ export const specialFilterKeys = [
   CONNECTIONS_FILTER, // for nested filters
   `rel_${RELATION_OBJECT}`,
   CREATOR_FILTER, // technical creator
-  RELATION_FROM_FILTER, // nested relation for the from of a relationship
-  RELATION_TO_FILTER, // nested relation for the to of a relationship
-  RELATION_FROM_TYPES_FILTER, // nested relation for the from type of a relationship
-  RELATION_TO_TYPES_FILTER, // nested relation for the to type of a relationship
   CONNECTED_TO_INSTANCE_FILTER, // listened instances for an instance trigger
   IDS_FILTER, // values should match any id (internal_id, standard_id, or stix_id)
   CONTEXT_ENTITY_ID_FILTER,

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -82,6 +82,7 @@ export const internalFilterKeys = [
   'connector_id',
   'source_event_id',
   'event_access',
+  'types',
   // attributes of the entity of type Work that are not registered elsewhere
   'status',
   'event_source_id',

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
@@ -19,7 +19,7 @@ import type { StixObject } from '../../types/stix-common';
 import { isUserCanAccessStixElement, SYSTEM_USER } from '../access';
 import { getEntitiesMapFromCache } from '../../database/cache';
 import { ENTITY_TYPE_RESOLVED_FILTERS } from '../../schema/stixDomainObject';
-import { checkAndConvertFilters, extractFilterGroupValues, isFilterGroupNotEmpty } from './filtering-utils';
+import { extractFilterGroupValues, isFilterGroupNotEmpty } from './filtering-utils';
 
 // list of all filters that needs resolution
 export const RESOLUTION_FILTERS = [
@@ -196,9 +196,8 @@ export const resolveFiltersMapForUser = async (context: AuthContext, user: AuthU
 export const convertFiltersToQueryOptions = async (context: AuthContext, user: AuthUser, filters: FilterGroup | null, opts: any = {}) => {
   const { after, before, defaultTypes = [], field = 'updated_at', orderMode = 'asc' } = opts;
   const types = [...defaultTypes];
-  const convertedFilters = filters ? checkAndConvertFilters(filters) : undefined;
-  let finalFilters = convertedFilters
-    ? await resolveFilterGroupValuesWithCache(context, user, convertedFilters)
+  let finalFilters = filters
+    ? await resolveFilterGroupValuesWithCache(context, user, filters)
     : {
       mode: FilterMode.And,
       filters: [],

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
@@ -198,11 +198,7 @@ export const convertFiltersToQueryOptions = async (context: AuthContext, user: A
   const types = [...defaultTypes];
   let finalFilters = filters
     ? await resolveFilterGroupValuesWithCache(context, user, filters)
-    : {
-      mode: FilterMode.And,
-      filters: [],
-      filterGroups: [],
-    };
+    : undefined;
   if (after || before) {
     const filtersContent = [];
     if (after) {
@@ -214,7 +210,7 @@ export const convertFiltersToQueryOptions = async (context: AuthContext, user: A
     finalFilters = {
       mode: FilterMode.And,
       filters: filtersContent,
-      filterGroups: isFilterGroupNotEmpty(finalFilters) ? [finalFilters] : [],
+      filterGroups: (finalFilters && isFilterGroupNotEmpty(finalFilters)) ? [finalFilters] : [],
     };
   }
   return { types, orderMode, orderBy: [field, 'internal_id'], filters: finalFilters };

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'ramda';
-import { buildRefRelationKey } from '../../schema/general';
+import { buildRefRelationKey, RULE_PREFIX } from '../../schema/general';
 import { schemaAttributesDefinition } from '../../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../schema/schema-relationsRef';
 import type { Filter, FilterGroup } from '../../generated/graphql';
@@ -11,7 +11,9 @@ import {
   CONTEXT_ENTITY_TYPE_FILTER,
   CONTEXT_OBJECT_LABEL_FILTER,
   CONTEXT_OBJECT_MARKING_FILTER,
-  INSTANCE_FILTER, internalFilterKeys, MEMBERS_GROUP_FILTER,
+  INSTANCE_FILTER,
+  internalFilterKeys,
+  MEMBERS_GROUP_FILTER,
   MEMBERS_ORGANIZATION_FILTER,
   MEMBERS_USER_FILTER,
   SIGHTED_BY_FILTER,
@@ -244,7 +246,7 @@ export const checkAndConvertFilters = (filterGroup?: FilterGroup | null) => {
         .concat(specialFilterKeys)
         .concat(internalFilterKeys);
       keys.forEach((k) => {
-        if (availableKeys.includes(k)) {
+        if (availableKeys.includes(k) || k.startsWith(RULE_PREFIX)) {
           incorrectKeys = incorrectKeys.filter((n) => n !== k);
         }
       });

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -11,7 +11,7 @@ import {
   CONTEXT_ENTITY_TYPE_FILTER,
   CONTEXT_OBJECT_LABEL_FILTER,
   CONTEXT_OBJECT_MARKING_FILTER,
-  INSTANCE_FILTER, MEMBERS_GROUP_FILTER,
+  INSTANCE_FILTER, internalFilterKeys, MEMBERS_GROUP_FILTER,
   MEMBERS_ORGANIZATION_FILTER,
   MEMBERS_USER_FILTER,
   SIGHTED_BY_FILTER,
@@ -241,7 +241,8 @@ export const checkAndConvertFilters = (filterGroup?: FilterGroup | null) => {
         .concat(availableConvertedRefRelations)
         .concat(STIX_CORE_RELATIONSHIPS)
         .concat(availableConvertedStixCoreRelationships)
-        .concat(specialFilterKeys);
+        .concat(specialFilterKeys)
+        .concat(internalFilterKeys);
       keys.forEach((k) => {
         if (availableKeys.includes(k)) {
           incorrectKeys = incorrectKeys.filter((n) => n !== k);

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -210,8 +210,10 @@ const convertRelationRefsFilterKeys = (filterGroup: FilterGroup): FilterGroup =>
 
 // input: an array of relations names
 // return an array of the converted names in the rel_'database_name' format
-const getRelationsConvertedNames = (relationNames: string[]) => {
-  return relationNames.map((relationName) => `rel_${relationName}`);
+const getConvertedRelationsNames = (relationNames: string[]) => {
+  const convertedRelationsNames = relationNames.map((relationName) => `rel_${relationName}`);
+  convertedRelationsNames.push('rel_*'); // means 'all the relations'
+  return convertedRelationsNames;
 };
 
 /**
@@ -236,8 +238,8 @@ export const checkAndConvertFilters = (filterGroup?: FilterGroup | null) => {
       let incorrectKeys = keys;
       const availableAttributes = schemaAttributesDefinition.getAllAttributesNames();
       const availableRefRelations = schemaRelationsRefDefinition.getAllInputNames();
-      const availableConvertedRefRelations = getRelationsConvertedNames(schemaRelationsRefDefinition.getAllDatabaseName());
-      const availableConvertedStixCoreRelationships = getRelationsConvertedNames(STIX_CORE_RELATIONSHIPS);
+      const availableConvertedRefRelations = getConvertedRelationsNames(schemaRelationsRefDefinition.getAllDatabaseName());
+      const availableConvertedStixCoreRelationships = getConvertedRelationsNames(STIX_CORE_RELATIONSHIPS);
       const availableKeys = availableAttributes
         .concat(availableRefRelations)
         .concat(availableConvertedRefRelations)

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -17,7 +17,11 @@ import {
   ENTITY_TYPE_INTRUSION_SET,
   ENTITY_TYPE_MALWARE
 } from '../../../src/schema/stixDomainObject';
-import { IDS_FILTER, SOURCE_RELIABILITY_FILTER } from '../../../src/utils/filtering/filtering-constants';
+import {
+  IDS_FILTER,
+  RELATION_FROM_FILTER,
+  SOURCE_RELIABILITY_FILTER
+} from '../../../src/utils/filtering/filtering-constants';
 import { storeLoadById } from '../../../src/database/middleware-loader';
 
 // test queries involving dynamic filters
@@ -1202,6 +1206,43 @@ describe('Complex filters combinations for elastic queries', () => {
       } });
     expect(queryResult.data.globalSearch.edges.length).toEqual(1); // 1 intrusion-set targets this location
     expect(queryResult.data.globalSearch.edges[0].node.id).toEqual(intrusionSetInternalId);
+    // --- 17. filters with not supported keys --- //
+    // bad_filter_key = XX
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 20,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: 'bad_filter_key',
+              operator: 'eq',
+              values: ['Report'],
+              mode: 'or',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.errors.length).toEqual(1);
+    // fromId = XXX (API filters are passed via options)
+    queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 20,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: RELATION_FROM_FILTER,
+              operator: 'eq',
+              values: [locationInternalId],
+              mode: 'or',
+            }
+          ],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.errors.length).toEqual(1);
   });
   it('should test environnement deleted', async () => {
     const DELETE_REPORT_QUERY = gql`


### PR DESCRIPTION
PR content:

- fix issue https://github.com/OpenCTI-Platform/opencti/issues/5103
- api filters can only be used with EQ operator and OR mode
- add backend tests for nested filters

Only reviewed by the Filters Team !!!