### PR TITLE
[backend] do not convert empty filter group into null in elastic query

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1649,8 +1649,10 @@ const buildSubQueryForFilterGroup = async (context, user, inputFilters) => {
   // Handle filterGroups
   for (let index = 0; index < filterGroups.length; index += 1) {
     const group = filterGroups[index];
-    const subQuery = await buildSubQueryForFilterGroup(context, user, group);
-    localMustFilters.push(subQuery);
+    if (isFilterGroupNotEmpty(group)) {
+      const subQuery = await buildSubQueryForFilterGroup(context, user, group);
+      localMustFilters.push(subQuery);
+    }
   }
   // Handle filters
   for (let index = 0; index < filters.length; index += 1) {


### PR DESCRIPTION
issues with dashboard that do not load or end up empty

an empty filter group is turned into  a `null` inside the elastic query body, which fails to be executed.

### Proposed changes

* empty groups shall be removed during the conversion process into elastic query

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

