### PR TITLE
[backend] fix file deletion (#5166)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
@@ -101,6 +101,7 @@ class RootArtifact extends Component {
                   <>
                     <StixCyberObservableHeader
                       stixCyberObservable={stixCyberObservable}
+                      isArtifact={true}
                     />
                     <Box
                       sx={{

--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -402,6 +402,6 @@ export const deleteAllObjectFiles = async (context, user, element) => {
     importWorkPromise,
     exportWorkPromise
   ]);
-  const ids = [...importFiles, ...exportFiles].map((file) => file.Key);
+  const ids = [...importFiles, ...exportFiles].map((file) => file.id);
   return deleteFiles(context, user, ids);
 };


### PR DESCRIPTION
Error in file deletion since bb0387e4

`file.Key `does not exist in DB, this must be `file.id`

### Related issues

#5166

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

