### PR TITLE
[backend] Implement SSO based on HTTP headers of the reverse proxy (#5107)

### DIFF
--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -11546,8 +11546,8 @@ type Query {
     dynamicFrom: FilterGroup
     dynamicTo: FilterGroup
   ): Number @auth(for: [KNOWLEDGE, EXPLORE])
-  schemaRelationsTypesMapping: [StixRelationshipSchema!]! @auth(for: [KNOWLEDGE])
-  schemaRelationsRefTypesMapping: [StixRelationshipSchema!]! @auth(for: [KNOWLEDGE])
+  schemaRelationsTypesMapping: [StixRelationshipSchema!]! @auth
+  schemaRelationsRefTypesMapping: [StixRelationshipSchema!]! @auth
 
   ######## STIX CORE RELATIONSHIPS
 

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -557,7 +557,14 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           }, opts);
         });
       };
-      const headerProvider = { name: providerName, reqLoginHandler, type: AUTH_REQ, strategy, provider: providerRef };
+      const headerProvider = {
+        name: providerName,
+        reqLoginHandler,
+        type: AUTH_REQ,
+        strategy,
+        logout_uri: mappedConfig.logout_uri,
+        provider: providerRef
+      };
       providers.push(headerProvider);
       HEADERS_AUTHENTICATORS.push(headerProvider);
     }

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -11,10 +11,10 @@ import { Strategy as SamlStrategy } from 'passport-saml';
 import { custom as OpenIDCustom, Issuer as OpenIDIssuer, Strategy as OpenIDStrategy } from 'openid-client';
 import { OAuth2Strategy as GoogleStrategy } from 'passport-google-oauth';
 import validator from 'validator';
-import { initAdmin, login, loginFromProvider } from '../domain/user';
+import { HEADERS_AUTHENTICATORS, initAdmin, login, loginFromProvider } from '../domain/user';
 import conf, { logApp } from './conf';
 import { AuthenticationFailure, ConfigurationError, UnsupportedError } from './errors';
-import { isNotEmptyField } from '../database/utils';
+import { isEmptyField, isNotEmptyField } from '../database/utils';
 
 export const empty = R.anyPass([R.isNil, R.isEmpty]);
 
@@ -99,6 +99,7 @@ const configRemapping = (config) => {
 export const INTERNAL_SECURITY_PROVIDER = '__internal_security_local_provider__';
 const STRATEGY_LOCAL = 'LocalStrategy';
 export const STRATEGY_CERT = 'ClientCertStrategy';
+const STRATEGY_HEADER = 'HeaderStrategy';
 const STRATEGY_LDAP = 'LdapStrategy';
 const STRATEGY_OPENID = 'OpenIDConnectStrategy';
 const STRATEGY_FACEBOOK = 'FacebookStrategy';
@@ -107,6 +108,7 @@ const STRATEGY_GOOGLE = 'GoogleStrategy';
 const STRATEGY_GITHUB = 'GithubStrategy';
 const STRATEGY_AUTH0 = 'Auth0Strategy';
 const AUTH_SSO = 'SSO';
+const AUTH_REQ = 'REQ';
 const AUTH_FORM = 'FORM';
 
 const providers = [];
@@ -509,6 +511,55 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const providerRef = identifier || 'cert';
       // This strategy is directly handled by express
       providers.push({ name: providerName, type: AUTH_SSO, strategy, provider: providerRef });
+    }
+    // HEADER Strategies
+    if (strategy === STRATEGY_HEADER) {
+      // This strategy is directly handled on the fly on graphql
+      const providerRef = identifier || 'header';
+      const reqLoginHandler = async (req) => {
+        // Group computations
+        const isGroupMapping = isNotEmptyField(mappedConfig.groups_management) && isNotEmptyField(mappedConfig.groups_management?.groups_mapping);
+        const computeGroupsMapping = () => {
+          const groupsMapping = mappedConfig.groups_management?.groups_mapping || [];
+          const groupsSplitter = mappedConfig.groups_management?.groups_splitter || ',';
+          const availableGroups = (req.headers[mappedConfig.groups_management?.groups_header] ?? '').split(groupsSplitter);
+          const groupsMapper = genConfigMapper(groupsMapping);
+          return availableGroups.map((a) => groupsMapper[a]).filter((r) => isNotEmptyField(r));
+        };
+        const mappedGroups = isGroupMapping ? computeGroupsMapping() : [];
+        // Organization computations
+        const isOrgaMapping = isNotEmptyField(mappedConfig.organizations_default) || isNotEmptyField(mappedConfig.organizations_management);
+        const computeOrganizationsMapping = () => {
+          const orgaDefault = mappedConfig.organizations_default ?? [];
+          const orgasMapping = mappedConfig.organizations_management?.organizations_mapping || [];
+          const orgasSplitter = mappedConfig.organizations_management?.organizations_splitter || ',';
+          const availableOrgas = (req.headers[mappedConfig.organizations_management?.organizations_header] ?? '').split(orgasSplitter);
+          const orgasMapper = genConfigMapper(orgasMapping);
+          return [...orgaDefault, ...availableOrgas.map((a) => orgasMapper[a]).filter((r) => isNotEmptyField(r))];
+        };
+        const organizationsToAssociate = isOrgaMapping ? computeOrganizationsMapping() : [];
+        // Build the user login
+        const email = req.headers[mappedConfig.header_email];
+        if (isEmptyField(email) || !validator.isEmail(email)) {
+          return null;
+        }
+        const name = req.headers[mappedConfig.header_name];
+        const firstname = req.headers[mappedConfig.header_firstname];
+        const lastname = req.headers[mappedConfig.header_lastname];
+        const opts = {
+          providerGroups: mappedGroups,
+          providerOrganizations: organizationsToAssociate,
+          autoCreateGroup: mappedConfig.auto_create_group ?? false,
+        };
+        return new Promise((resolve) => {
+          providerLoginHandler({ email, name, firstname, lastname }, (_, user) => {
+            resolve(user);
+          }, opts);
+        });
+      };
+      const headerProvider = { name: providerName, reqLoginHandler, type: AUTH_REQ, strategy, provider: providerRef };
+      providers.push(headerProvider);
+      HEADERS_AUTHENTICATORS.push(headerProvider);
     }
   }
   // In case of disable local strategy, setup protected fallback for the admin user

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1286,6 +1286,7 @@ export const authenticateUser = async (context, req, user, provider, opts = {}) 
   return internalAuthenticateUser(context, req, user, provider, opts);
 };
 
+export const HEADERS_AUTHENTICATORS = [];
 export const authenticateUserFromRequest = async (context, req, res, isSessionRefresh = false) => {
   const auth = req.session?.user;
   // If user already have a session
@@ -1352,6 +1353,16 @@ export const authenticateUserFromRequest = async (context, req, res, isSessionRe
       }
     } catch (err) {
       logApp.error(err);
+    }
+  }
+  // If user still not identified, try headers authentication
+  if (HEADERS_AUTHENTICATORS.length > 0) {
+    for (let i = 0; i < HEADERS_AUTHENTICATORS.length; i += 1) {
+      const headProvider = HEADERS_AUTHENTICATORS[i];
+      const user = await headProvider.reqLoginHandler(req);
+      if (user) {
+        return await authenticateUser(context, req, user, headProvider.provider);
+      }
     }
   }
   // No auth, return undefined


### PR DESCRIPTION
See #5107.

- Login: add a provider "header" with configuration to map headers
If the config is available and at least header_email contains a valid email, the user is auto logged by the system

```
    "header": {
      "strategy": "HeaderStrategy",
      "config": {
        "disabled": false,
        "header_email": "auth_email_address",
        "header_name": "auth_name",
        "header_firstname": "auth_firstname",
        "header_lastname": "auth_lastname",
        "logout_uri": "https://www.filigran.io",
        "groups_management": {
          "groups_header": "auth_groups",
          "groups_splitter": ",",
          "groups_mapping": ["admin:admin", "root:root"]
        },
        "organizations_management": {
          "organizations_header": "auth_institution",
          "organizations_splitter": ",",
          "organizations_mapping": ["test:test"]
        }
      }
    }
```
- Logout: thats still an open question. For now a logout will auto login back directly
