### PR TITLE
[backend/frontend] Add Sighted in/at in the relationships representation list (#4846)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -130,7 +130,7 @@ const rootPrivateQuery = graphql`
         }
       }
     }
-    schemaSROs: subTypes(type: "stix-core-relationship") {
+    schemaSCRs: subTypes(type: "stix-core-relationship") {
       edges {
         node {
           id
@@ -177,13 +177,13 @@ interface RootComponentProps {
 
 const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
   const queryData = usePreloadedQuery(rootPrivateQuery, queryRef);
-  const { me, settings: settingsFragment, entitySettings, schemaSCOs, schemaSDOs, schemaSMOs, schemaSROs, schemaRelationsTypesMapping, schemaRelationsRefTypesMapping } = queryData;
+  const { me, settings: settingsFragment, entitySettings, schemaSCOs, schemaSDOs, schemaSMOs, schemaSCRs, schemaRelationsTypesMapping, schemaRelationsRefTypesMapping } = queryData;
   const settings = useFragment<RootSettings$key>(rootSettingsFragment, settingsFragment);
   const schema = {
     scos: schemaSCOs.edges.map((sco) => sco.node),
     sdos: schemaSDOs.edges.map((sco) => sco.node),
     smos: schemaSMOs.edges.map((smo) => smo.node),
-    sros: schemaSROs.edges.map((sco) => sco.node),
+    scrs: schemaSCRs.edges.map((scr) => scr.node),
     schemaRelationsTypesMapping: new Map(schemaRelationsTypesMapping.map((n) => [n.key, n.values])),
     schemaRelationsRefTypesMapping: new Map(schemaRelationsRefTypesMapping.map((n) => [n.key, n.values])),
   };

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -105,7 +105,12 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
       ...sro,
       value: sro.id,
       type: 'entity_Stix-Core-Relationship',
-    }));
+    })).concat({
+      id: 'stix-sighting-relationship',
+      label: 'stix-sighting-relationship',
+      value: 'stix-sighting-relationship',
+      type: 'entity_stix-sighting-relationship',
+    });
 
     setAvailableEntityTypes(entityTypes);
     setAvailableRelationshipTypes(relationshipTypes);

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -80,7 +80,7 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
 
   // load the available types once in state
   useEffect(() => {
-    const { sdos, scos, smos, sros } = schema;
+    const { sdos, scos, smos, scrs } = schema;
     const entityTypes = sdos
       .map((sdo) => ({
         ...sdo,
@@ -101,16 +101,17 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
           type: 'entity_Stix-Meta-Objects',
         })),
       );
-    const relationshipTypes = sros.map((sro) => ({
-      ...sro,
-      value: sro.id,
-      type: 'entity_Stix-Core-Relationship',
-    })).concat({
-      id: 'stix-sighting-relationship',
-      label: 'stix-sighting-relationship',
-      value: 'stix-sighting-relationship',
-      type: 'entity_stix-sighting-relationship',
-    });
+    const relationshipTypes = scrs
+      .map((scr) => ({
+        ...scr,
+        value: scr.id,
+        type: 'entity_Stix-Core-Relationship',
+      })).concat({
+        id: 'stix-sighting-relationship',
+        label: 'stix-sighting-relationship',
+        value: 'stix-sighting-relationship',
+        type: 'entity_stix-sighting-relationship',
+      });
 
     setAvailableEntityTypes(entityTypes);
     setAvailableRelationshipTypes(relationshipTypes);

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
@@ -346,7 +346,7 @@ const InvestigationExpandFormContent = ({
       .sort((a, b) => a.label.localeCompare(b.label));
 
     // Uses to determine which key of translation to use below.
-    const relationshipsNames = schema.sros.map(({ label }) => label);
+    const relationshipsNames = schema.scrs.map(({ label }) => label);
     setTargets(
       graphDistribution.map(({ label, value }) => {
         const isRelationship = relationshipsNames.includes(label.toLowerCase());

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -948,7 +948,7 @@ const useSearchEntities = ({
             || availableEntityTypes.includes('stix-core-relationship')
           ) {
             result = [
-              ...(schema.sros ?? []).map((n) => ({
+              ...(schema.scrs ?? []).map((n) => ({
                 label: t(`relationship_${n.label}`),
                 value: n.label,
                 type: n.label,
@@ -983,7 +983,7 @@ const useSearchEntities = ({
             .sort((a, b) => a.label.localeCompare(b.label));
           unionSetEntities(filterKey, relationshipsTypes);
         } else {
-          const relationshipsTypes = (schema.sros ?? [])
+          const relationshipsTypes = (schema.scrs ?? [])
             .map((n) => ({
               label: t(`relationship_${n.label}`),
               value: n.label,

--- a/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
@@ -22,7 +22,7 @@ export interface UserContextType {
     scos: { id: string, label: string }[]
     sdos: { id: string, label: string }[]
     smos: { id: string, label: string }[]
-    sros: { id: string, label: string }[]
+    scrs: { id: string, label: string }[]
     schemaRelationsTypesMapping: Map<string, readonly string[]>
     schemaRelationsRefTypesMapping: Map<string, readonly string[]>
   } | undefined;

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
@@ -7,12 +7,11 @@ import { csvMapperMockSimpleRelationship } from './simple-relationship-test/csv-
 import { csvMapperMockSimpleEntityWithRef } from './simple-entity-with-ref-test/csv-mapper-mock-simple-entity-with-ref';
 import { columnNameToIdx } from '../../../src/parser/csv-helper';
 import { csvMapperMockRealUseCase } from './real-use-case/csv-mapper-mock-real-use-case';
-import { csvMapperMockSimpleDifferentEntities } from './simple-different-entities-test/csv-mapper-mock-simple-different-entities';
+import { csvMapperMockSimpleDifferentEntities } from '../../data/csv-mapper-mock-simple-different-entities';
 import { csvMapperMockSimpleSighting } from './simple-sighting-test/csv-mapper-mock-simple-sighting';
 import { bundleProcess } from '../../../src/parser/csv-bundler';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { csvMapperMockSimpleSkipLine } from './simple-skip-line-test/csv-mapper-mock-simple-skip-line';
-import { logApp } from '../../../src/config/conf';
 
 describe('CSV-HELPER', () => {
   it('Column name to idx', async () => {
@@ -69,7 +68,7 @@ describe('CSV-PARSER', () => {
   it('Parse CSV - Simple sighting', async () => {
     const filPath = './tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv';
     const bundle = await bundleProcess(testContext, ADMIN_USER, filPath, csvMapperMockSimpleSighting);
-    logApp.info('[BUNDLE]', bundle);
+
     const { objects } = bundle;
     expect(objects.length)
       .toBe(3);

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
@@ -7,11 +7,12 @@ import { csvMapperMockSimpleRelationship } from './simple-relationship-test/csv-
 import { csvMapperMockSimpleEntityWithRef } from './simple-entity-with-ref-test/csv-mapper-mock-simple-entity-with-ref';
 import { columnNameToIdx } from '../../../src/parser/csv-helper';
 import { csvMapperMockRealUseCase } from './real-use-case/csv-mapper-mock-real-use-case';
-import { csvMapperMockSimpleDifferentEntities } from '../../data/csv-mapper-mock-simple-different-entities';
+import { csvMapperMockSimpleDifferentEntities } from './simple-different-entities-test/csv-mapper-mock-simple-different-entities';
 import { csvMapperMockSimpleSighting } from './simple-sighting-test/csv-mapper-mock-simple-sighting';
 import { bundleProcess } from '../../../src/parser/csv-bundler';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { csvMapperMockSimpleSkipLine } from './simple-skip-line-test/csv-mapper-mock-simple-skip-line';
+import { logApp } from '../../../src/config/conf';
 
 describe('CSV-HELPER', () => {
   it('Column name to idx', async () => {
@@ -68,7 +69,7 @@ describe('CSV-PARSER', () => {
   it('Parse CSV - Simple sighting', async () => {
     const filPath = './tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv';
     const bundle = await bundleProcess(testContext, ADMIN_USER, filPath, csvMapperMockSimpleSighting);
-
+    logApp.info('[BUNDLE]', bundle);
     const { objects } = bundle;
     expect(objects.length)
       .toBe(3);
@@ -78,6 +79,9 @@ describe('CSV-PARSER', () => {
       .toBe(1);
     expect(objects.filter((o) => o.type === 'sighting').length)
       .toBe(1);
+    const sighting = objects.filter((o) => o.type === 'sighting')[0];
+    expect(sighting.first_seen).not.toBeUndefined();
+    expect(sighting.last_seen).toBeUndefined();
   });
   it('Parse CSV - Simple entity with refs', async () => {
     const filPath = './tests/02-integration/05-parser/simple-entity-with-ref-test/Threat-Actor-Group_with-ref.csv';

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv
@@ -1,2 +1,2 @@
-Threat Actor Name;Organization Name;sighting confidence;sighting attribute count
-A threat actor group;Org;0;2
+Threat Actor Name;Organization Name;sighting confidence;sighting attribute count;first seen;last seen
+A threat actor group;Org;0;2;2023-12-18T23:00:00.000Z;2023-12-18T23:00:00.000Z

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/Threat-Actor-Group_SIGHTING_org.csv
@@ -1,2 +1,2 @@
 Threat Actor Name;Organization Name;sighting confidence;sighting attribute count;first seen;last seen
-A threat actor group;Org;0;2;2023-12-18T23:00:00.000Z;2023-12-18T23:00:00.000Z
+A threat actor group;Org;0;2;2023-12-18T23:00:00.000Z;00:00.000Z

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/csv-mapper-mock-simple-sighting.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/simple-sighting-test/csv-mapper-mock-simple-sighting.ts
@@ -1,10 +1,7 @@
 import { ENTITY_TYPE_THREAT_ACTOR_GROUP } from '../../../../src/schema/stixDomainObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../../src/modules/organization/organization-types';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../../../src/schema/stixSightingRelationship';
-import {
-  type BasicStoreEntityCsvMapper,
-  CsvMapperRepresentationType
-} from '../../../../src/modules/internal/csvMapper/csvMapper-types';
+import { type BasicStoreEntityCsvMapper, CsvMapperRepresentationType } from '../../../../src/modules/internal/csvMapper/csvMapper-types';
 
 export const csvMapperMockSimpleSighting: Partial<BasicStoreEntityCsvMapper> = {
   id: 'mapper-mock-simple-relationship',
@@ -71,7 +68,19 @@ export const csvMapperMockSimpleSighting: Partial<BasicStoreEntityCsvMapper> = {
             column_name: 'D',
           },
         },
+        {
+          key: 'first_seen',
+          column: {
+            column_name: 'E',
+          },
+        },
+        {
+          key: 'last_seen',
+          column: {
+            column_name: 'F',
+          },
+        },
       ]
     },
   ]
-}
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* As a user, I want to be able to represent a Sighting in/at relationship in CSV Mappers.

### Related issues

* #4846 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
