### PR TITLE
[backend] add user_confidence_level attribute to Users (#4303)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1352,6 +1352,16 @@ type Creator {
   representative: Representative!
 }
 
+type UserConfidenceLevel {
+  max_confidence: Int!
+  overrides: [ConfidenceLevelOverride!]!
+}
+
+type ConfidenceLevelOverride {
+  entity_type: String!
+  max_confidence: Int!
+}
+
 type User implements BasicObject & InternalObject {
   id: ID!
   standard_id: String!
@@ -1373,6 +1383,7 @@ type User implements BasicObject & InternalObject {
   roles(orderBy: RolesOrdering, orderMode: OrderingMode): [Role]!
   capabilities: [Capability]!
   default_hidden_types: [String!]!
+  user_confidence_level: UserConfidenceLevel!
   groups(orderBy: GroupsOrdering, orderMode: OrderingMode): GroupConnection
   objectOrganization(orderBy: OrganizationsOrdering, orderMode: OrderingMode): OrganizationConnection
   created_at: DateTime!

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -56,6 +56,7 @@
       "Locked": "Your account has been locked for security reasons. Please contact your administrator."
     },
     "account_statuses_default": "Active",
+    "user_confidence_level_default": 100,
     "session_idle_timeout": 0,
     "session_manager": "shared",
     "rate_protection": {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1282,6 +1282,14 @@ type Creator {
   entity_type: String!
   representative: Representative!
 }
+type UserConfidenceLevel {
+  max_confidence: Int!
+  overrides: [ConfidenceLevelOverride!]!
+}
+type ConfidenceLevelOverride {
+  entity_type: String!
+  max_confidence: Int!
+}
 type User implements BasicObject & InternalObject {
   id: ID! # internal_id
   standard_id: String!
@@ -1307,6 +1315,7 @@ type User implements BasicObject & InternalObject {
   ): [Role]!
   capabilities: [Capability]!
   default_hidden_types: [String!]!
+  user_confidence_level: UserConfidenceLevel!
   groups(
     orderBy: GroupsOrdering
     orderMode: OrderingMode

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -607,7 +607,7 @@ const computePlatformMappings = () => {
           overrides: {
             type: 'nested',
             properties: {
-              entity_type: { type: 'text' },
+              entity_type: { type: 'keyword' },
               max_confidence: { type: 'integer' },
             },
           }

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -601,6 +601,18 @@ const computePlatformMappings = () => {
           date_seen: { type: 'date' },
         },
       },
+      user_confidence_level: {
+        properties: {
+          max_confidence: { type: 'integer' },
+          overrides: {
+            type: 'nested',
+            properties: {
+              entity_type: { type: 'text' },
+              max_confidence: { type: 'integer' },
+            },
+          }
+        },
+      },
       timestamp: {
         type: 'date',
       },

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -891,9 +891,6 @@ const rebuildAndMergeInputFromExistingData = (rawInput, instance) => {
   if (isDictionaryAttribute(key) && isNotEmptyField(R.head(value))) { // Only allow full cleanup
     throw UnsupportedError('Dictionary attribute cant be updated directly', { rawInput });
   }
-  if (!isMultiple && isObjectAttribute(key)) {
-    throw UnsupportedError('Object update only available for array attributes', { rawInput });
-  }
   // region rebuild input values consistency
   if (key.includes('.')) {
     // In case of dict attributes, patching the content is possible through first level path

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1,4 +1,5 @@
 import bcrypt from 'bcryptjs';
+import nconf from 'nconf';
 import { authenticator } from 'otplib';
 import * as R from 'ramda';
 import { uniq } from 'ramda';
@@ -76,6 +77,33 @@ const AUTH_BEARER = 'Bearer';
 const AUTH_BASIC = 'BasicAuth';
 export const TAXIIAPI = 'TAXIIAPI';
 const PLATFORM_ORGANIZATION = 'settings_platform_organization';
+
+export const userConfidenceSchema = {
+  type: 'object',
+  properties: {
+    max_confidence: { type: 'number' },
+    overrides: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          entity_type: { type: 'string' },
+          max_confidence: { type: 'number' }
+        },
+        required: ['entity_type', 'max_confidence']
+      }
+    }
+  },
+  required: ['max_confidence', 'overrides']
+};
+
+/**
+ map: {
+ type: "object",
+ required: [],
+ additionalProperties: {type: "number"},
+ },
+ */
 
 const roleSessionRefresh = async (context, user, roleId) => {
   // Get all groups that have this role
@@ -498,6 +526,7 @@ export const addUser = async (context, user, newUser) => {
     R.assoc('account_status', newUser.account_status ? newUser.account_status : DEFAULT_ACCOUNT_STATUS),
     R.assoc('account_lock_after_date', newUser.account_lock_after_date),
     R.assoc('unit_system', newUser.unit_system),
+    R.assoc('user_confidence_level', { max_confidence: nconf.get('app:user_confidence_level_default') ?? 100, overrides: [] }),
     R.dissoc('roles')
   )(newUser);
   const { element, isCreation } = await createEntity(context, user, userToCreate, ENTITY_TYPE_USER, { complete: true });

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -97,14 +97,6 @@ export const userConfidenceSchema = {
   required: ['max_confidence', 'overrides']
 };
 
-/**
- map: {
- type: "object",
- required: [],
- additionalProperties: {type: "number"},
- },
- */
-
 const roleSessionRefresh = async (context, user, roleId) => {
   // Get all groups that have this role
   const groupsRoles = await listAllRelations(context, user, RELATION_HAS_ROLE, { toId: roleId, fromTypes: [ENTITY_TYPE_GROUP] });

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3351,6 +3351,12 @@ export type Cluster = {
   instances_number: Scalars['Int']['output'];
 };
 
+export type ConfidenceLevelOverride = {
+  __typename?: 'ConfidenceLevelOverride';
+  entity_type: Scalars['String']['output'];
+  max_confidence: Scalars['Int']['output'];
+};
+
 export type Connector = BasicObject & InternalObject & {
   __typename?: 'Connector';
   active?: Maybe<Scalars['Boolean']['output']>;
@@ -25393,6 +25399,7 @@ export type User = BasicObject & InternalObject & {
   theme?: Maybe<Scalars['String']['output']>;
   unit_system?: Maybe<UnitSystem>;
   updated_at: Scalars['DateTime']['output'];
+  user_confidence_level: UserConfidenceLevel;
   user_email: Scalars['String']['output'];
 };
 
@@ -25827,6 +25834,12 @@ export type UserAgentStixCoreRelationshipsDistributionArgs = {
 export type UserAgentAddInput = {
   file?: InputMaybe<Scalars['Upload']['input']>;
   value?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UserConfidenceLevel = {
+  __typename?: 'UserConfidenceLevel';
+  max_confidence: Scalars['Int']['output'];
+  overrides: Array<ConfidenceLevelOverride>;
 };
 
 export type UserConnection = {
@@ -27307,6 +27320,7 @@ export type ResolversTypes = ResolversObject<{
   CityEdge: ResolverTypeWrapper<Omit<CityEdge, 'node'> & { node: ResolversTypes['City'] }>;
   CityEditMutations: ResolverTypeWrapper<Omit<CityEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversTypes['City']>, contextPatch?: Maybe<ResolversTypes['City']>, fieldPatch?: Maybe<ResolversTypes['City']>, relationAdd?: Maybe<ResolversTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversTypes['City']> }>;
   Cluster: ResolverTypeWrapper<Cluster>;
+  ConfidenceLevelOverride: ResolverTypeWrapper<ConfidenceLevelOverride>;
   Connector: ResolverTypeWrapper<Connector>;
   ConnectorConfig: ResolverTypeWrapper<ConnectorConfig>;
   ConnectorConfiguration: ResolverTypeWrapper<ConnectorConfiguration>;
@@ -27896,6 +27910,7 @@ export type ResolversTypes = ResolversObject<{
   UserAddInput: UserAddInput;
   UserAgent: ResolverTypeWrapper<Omit<UserAgent, 'cases' | 'containers' | 'createdBy' | 'groupings' | 'indicators' | 'notes' | 'objectOrganization' | 'observedData' | 'opinions' | 'reports' | 'stixCoreRelationships'> & { cases?: Maybe<ResolversTypes['CaseConnection']>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, indicators?: Maybe<ResolversTypes['IndicatorConnection']>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectOrganization?: Maybe<ResolversTypes['OrganizationConnection']>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']> }>;
   UserAgentAddInput: UserAgentAddInput;
+  UserConfidenceLevel: ResolverTypeWrapper<UserConfidenceLevel>;
   UserConnection: ResolverTypeWrapper<Omit<UserConnection, 'edges'> & { edges: Array<ResolversTypes['UserEdge']> }>;
   UserEdge: ResolverTypeWrapper<Omit<UserEdge, 'node'> & { node: ResolversTypes['User'] }>;
   UserEditMutations: ResolverTypeWrapper<Omit<UserEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'organizationAdd' | 'organizationDelete' | 'relationDelete' | 'tokenRenew'> & { contextClean?: Maybe<ResolversTypes['User']>, contextPatch?: Maybe<ResolversTypes['User']>, fieldPatch?: Maybe<ResolversTypes['User']>, organizationAdd?: Maybe<ResolversTypes['User']>, organizationDelete?: Maybe<ResolversTypes['User']>, relationDelete?: Maybe<ResolversTypes['User']>, tokenRenew?: Maybe<ResolversTypes['User']> }>;
@@ -28029,6 +28044,7 @@ export type ResolversParentTypes = ResolversObject<{
   CityEdge: Omit<CityEdge, 'node'> & { node: ResolversParentTypes['City'] };
   CityEditMutations: Omit<CityEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversParentTypes['City']>, contextPatch?: Maybe<ResolversParentTypes['City']>, fieldPatch?: Maybe<ResolversParentTypes['City']>, relationAdd?: Maybe<ResolversParentTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversParentTypes['City']> };
   Cluster: Cluster;
+  ConfidenceLevelOverride: ConfidenceLevelOverride;
   Connector: Connector;
   ConnectorConfig: ConnectorConfig;
   ConnectorConfiguration: ConnectorConfiguration;
@@ -28536,6 +28552,7 @@ export type ResolversParentTypes = ResolversObject<{
   UserAddInput: UserAddInput;
   UserAgent: Omit<UserAgent, 'cases' | 'containers' | 'createdBy' | 'groupings' | 'indicators' | 'notes' | 'objectOrganization' | 'observedData' | 'opinions' | 'reports' | 'stixCoreRelationships'> & { cases?: Maybe<ResolversParentTypes['CaseConnection']>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, indicators?: Maybe<ResolversParentTypes['IndicatorConnection']>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectOrganization?: Maybe<ResolversParentTypes['OrganizationConnection']>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']> };
   UserAgentAddInput: UserAgentAddInput;
+  UserConfidenceLevel: UserConfidenceLevel;
   UserConnection: Omit<UserConnection, 'edges'> & { edges: Array<ResolversParentTypes['UserEdge']> };
   UserEdge: Omit<UserEdge, 'node'> & { node: ResolversParentTypes['User'] };
   UserEditMutations: Omit<UserEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'organizationAdd' | 'organizationDelete' | 'relationDelete' | 'tokenRenew'> & { contextClean?: Maybe<ResolversParentTypes['User']>, contextPatch?: Maybe<ResolversParentTypes['User']>, fieldPatch?: Maybe<ResolversParentTypes['User']>, organizationAdd?: Maybe<ResolversParentTypes['User']>, organizationDelete?: Maybe<ResolversParentTypes['User']>, relationDelete?: Maybe<ResolversParentTypes['User']>, tokenRenew?: Maybe<ResolversParentTypes['User']> };
@@ -29648,6 +29665,12 @@ export type CityEditMutationsResolvers<ContextType = any, ParentType extends Res
 
 export type ClusterResolvers<ContextType = any, ParentType extends ResolversParentTypes['Cluster'] = ResolversParentTypes['Cluster']> = ResolversObject<{
   instances_number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ConfidenceLevelOverrideResolvers<ContextType = any, ParentType extends ResolversParentTypes['ConfidenceLevelOverride'] = ResolversParentTypes['ConfidenceLevelOverride']> = ResolversObject<{
+  entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  max_confidence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -36189,6 +36212,7 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   theme?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit_system?: Resolver<Maybe<ResolversTypes['UnitSystem']>, ParentType, ContextType>;
   updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  user_confidence_level?: Resolver<ResolversTypes['UserConfidenceLevel'], ParentType, ContextType>;
   user_email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -36294,6 +36318,12 @@ export type UserAgentResolvers<ContextType = any, ParentType extends ResolversPa
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type UserConfidenceLevelResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserConfidenceLevel'] = ResolversParentTypes['UserConfidenceLevel']> = ResolversObject<{
+  max_confidence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  overrides?: Resolver<Array<ResolversTypes['ConfidenceLevelOverride']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -36792,6 +36822,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   CityEdge?: CityEdgeResolvers<ContextType>;
   CityEditMutations?: CityEditMutationsResolvers<ContextType>;
   Cluster?: ClusterResolvers<ContextType>;
+  ConfidenceLevelOverride?: ConfidenceLevelOverrideResolvers<ContextType>;
   Connector?: ConnectorResolvers<ContextType>;
   ConnectorConfig?: ConnectorConfigResolvers<ContextType>;
   ConnectorConfiguration?: ConnectorConfigurationResolvers<ContextType>;
@@ -37176,6 +37207,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   User?: UserResolvers<ContextType>;
   UserAccount?: UserAccountResolvers<ContextType>;
   UserAgent?: UserAgentResolvers<ContextType>;
+  UserConfidenceLevel?: UserConfidenceLevelResolvers<ContextType>;
   UserConnection?: UserConnectionResolvers<ContextType>;
   UserEdge?: UserEdgeResolvers<ContextType>;
   UserEditMutations?: UserEditMutationsResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/migrations/1703150526503-user-confidence-level.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1703150526503-user-confidence-level.js
@@ -10,7 +10,7 @@ export const up = async (next) => {
         overrides: {
           type: 'nested',
           properties: {
-            entity_type: { type: 'text' },
+            entity_type: { type: 'keyword' },
             max_confidence: { type: 'integer' },
           },
         }

--- a/opencti-platform/opencti-graphql/src/migrations/1703150526503-user-confidence-level.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1703150526503-user-confidence-level.js
@@ -1,0 +1,54 @@
+import { elUpdateByQueryForMigration, elUpdateIndicesMappings } from '../database/engine';
+import { READ_INDEX_INTERNAL_OBJECTS } from '../database/utils';
+import { DatabaseError } from '../config/errors';
+
+export const up = async (next) => {
+  await elUpdateIndicesMappings({
+    user_confidence_level: {
+      properties: {
+        max_confidence: { type: 'integer' },
+        overrides: {
+          type: 'nested',
+          properties: {
+            entity_type: { type: 'text' },
+            max_confidence: { type: 'integer' },
+          },
+        }
+      },
+    },
+  });
+
+  // set all user's confidence level to 100, no override
+  const updateQuery = {
+    script: {
+      params: {
+        user_confidence_level: {
+          max_confidence: 100,
+          overrides: [],
+        },
+      },
+      source: 'ctx._source.user_confidence_level = params.user_confidence_level;',
+    },
+    query: {
+      bool: {
+        must: [
+          { term: { 'entity_type.keyword': { value: 'User' } } },
+        ],
+      },
+    },
+  };
+
+  await elUpdateByQueryForMigration(
+    '[MIGRATION] Adding default user confidence = 100',
+    READ_INDEX_INTERNAL_OBJECTS,
+    updateQuery,
+  ).catch((err) => {
+    throw DatabaseError('Error updating elastic', { error: err });
+  });
+
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -23,6 +23,7 @@ import {
   ENTITY_TYPE_HISTORY
 } from '../../schema/internalObject';
 import { settingsMessages } from '../../domain/settings';
+import { userConfidenceSchema } from '../../domain/user';
 
 const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
   [ENTITY_TYPE_SETTINGS]: [
@@ -93,6 +94,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'description', type: 'string', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },
     { name: 'firstname', type: 'string', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },
     { name: 'lastname', type: 'string', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },
+    { name: 'user_confidence_level', type: 'object', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, schemaDef: userConfidenceSchema },
     { name: 'theme', type: 'string', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },
     { name: 'language', type: 'string', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },
     { name: 'external', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false },

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -62,13 +62,13 @@ export const validateAndFormatSchemaAttribute = (
         }
       }
       if (isObjectAttribute(attributeName)) {
-        // current limitation: field patch is only possible with arrays
-        if (editInput.object_path && !attributeDefinition.multiple) {
-          throw ValidationError(attributeName, { message: `Attribute ${attributeName} is not multiple, object_path cannot be used`, data: editInput });
-        }
-
         let validationValues = editInput.value;
         if (editInput.object_path) {
+          // current limitation: field patch is only possible with arrays
+          if (!attributeDefinition.multiple) {
+            throw ValidationError(attributeName, { message: `Attribute ${attributeName} is not multiple, object_path cannot be used`, data: editInput });
+          }
+
           // If object path is setup, controlling the field is much harder.
           // Concept here is to apply the partial operation and check if the result comply to the schema
           const pointers = JSONPath({ json: initial, resultType: 'pointer', path: `${editInput.key}${editInput.object_path}` });

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -62,6 +62,11 @@ export const validateAndFormatSchemaAttribute = (
         }
       }
       if (isObjectAttribute(attributeName)) {
+        // current limitation: field patch is only possible with arrays
+        if (editInput.object_path && !attributeDefinition.multiple) {
+          throw ValidationError(attributeName, { message: `Attribute ${attributeName} is not multiple, object_path cannot be used`, data: editInput });
+        }
+
         let validationValues = editInput.value;
         if (editInput.object_path) {
           // If object path is setup, controlling the field is much harder.
@@ -79,7 +84,7 @@ export const validateAndFormatSchemaAttribute = (
         } else {
           // object not multiple, only one value to check
           if (validationValues.length > 1) {
-            throw ValidationError(attributeName, { message: 'Object is not multiple but has more than 1 value', data: { attribute: attributeName } });
+            throw ValidationError(attributeName, { message: `Attribute ${attributeName} cannot be multiple`, data: editInput });
           }
           valid = validate(validationValues[0]);
         }

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -71,7 +71,15 @@ export const validateAndFormatSchemaAttribute = (
           const patchedInstance = jsonpatch.applyPatch(R.clone(initial), patch).newDocument as any;
           validationValues = patchedInstance[editInput.key];
         }
-        const valid = validate(validationValues);
+
+        let valid = false;
+        if (attributeDefinition.multiple) {
+          // schema is supposedly type=array
+          valid = validate(validationValues);
+        } else {
+          // schema is supposedly type=object, no multiple values provided
+          valid = validate(validationValues[0]);
+        }
         if (!valid) {
           throw ValidationError(attributeName, { message: 'The Object schema is not valid', data: validate.errors });
         }

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -74,10 +74,13 @@ export const validateAndFormatSchemaAttribute = (
 
         let valid = false;
         if (attributeDefinition.multiple) {
-          // schema is supposedly type=array
+          // type=object && multiple -> it's an array than can be validated as-is
           valid = validate(validationValues);
         } else {
-          // schema is supposedly type=object, no multiple values provided
+          // object not multiple, only one value to check
+          if (validationValues.length > 1) {
+            throw ValidationError(attributeName, { message: 'Object is not multiple but has more than 1 value', data: { attribute: attributeName } });
+          }
           valid = validate(validationValues[0]);
         }
         if (!valid) {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/threatActorIndividual-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/threatActorIndividual-test.ts
@@ -343,8 +343,6 @@ describe('Threat actor individual resolver standard behavior', () => {
     expect(threatActorIndividual.height).toHaveLength(2);
     expect(threatActorIndividual.height[0]).toEqual(expectedHeights[1]); // 183
     expect(threatActorIndividual.height[1]).toEqual(expectedHeights[3]); // 190
-
-
   });
   it('should update partial height', async () => {
     const HEIGHT_EDIT = gql`


### PR DESCRIPTION
### Proposed changes

* new attribute `user_confidence_level `with default value and overrides per entity
* default confidence is set from platform settings (default to 100)
* elastic mapping as nested, to query overrides properly
* new migration script to add the mapping and update all users with default confidence

### Related issues

* #4304 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This Chunk 1 addresses the data model and align the database. 
New users are created with defaut (100) confidence to match current behavior ; old users are migrated with same value.