### PR TITLE
[frontend/backend] Filter stix domain object on Data & Search UI and check type in tasks (#5308)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -17,7 +17,7 @@ import useEntityToggle from '../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 import useAuth from '../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../utils/hooks/useEnterpriseEdition';
-import { emptyFilterGroup } from '../../utils/filters/filtersUtils';
+import { emptyFilterGroup, injectEntityTypeFilterInFilterGroup } from '../../utils/filters/filtersUtils';
 import { decodeSearchKeyword, handleSearchByKeyword } from '../../utils/SearchUtils';
 import { useFormatter } from '../../components/i18n';
 
@@ -62,6 +62,8 @@ const Search = () => {
     searchStixCoreObjectsLinesQuery,
     { ...paginationOptions, search: searchTerm },
   );
+
+  const toolBarFilters = injectEntityTypeFilterInFilterGroup(filters, 'Stix-Core-Object');
 
   const handleSearch = (searchKeyword: string) => {
     handleSearchByKeyword(searchKeyword, 'knowledge', history);
@@ -180,8 +182,8 @@ const Search = () => {
               deSelectedElements={deSelectedElements}
               numberOfSelectedElements={numberOfSelectedElements}
               selectAll={selectAll}
-              filters={filters}
-              search={paginationOptions.search}
+              filters={toolBarFilters}
+              search={searchTerm}
               handleClearSelectedElements={handleClearSelectedElements}
             />
           </React.Suspense>

--- a/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
@@ -13,7 +13,7 @@ import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useEntityToggle from '../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, injectEntityTypeFilterInFilterGroup } from '../../../utils/filters/filtersUtils';
 
 const LOCAL_STORAGE_KEY = 'entities';
 
@@ -55,6 +55,7 @@ const Entities = () => {
     entitiesStixDomainObjectsLinesQuery,
     paginationOptions,
   );
+  const toolBarFilters = injectEntityTypeFilterInFilterGroup(filters, 'Stix-Domain-Object');
   const renderLines = () => {
     const isRuntimeSort = isRuntimeFieldEnable() ?? false;
     const dataColumns = {
@@ -164,7 +165,7 @@ const Entities = () => {
                 numberOfSelectedElements={numberOfSelectedElements}
                 selectAll={selectAll}
                 search={searchTerm}
-                filters={filters}
+                filters={toolBarFilters}
                 handleClearSelectedElements={handleClearSelectedElements}
               />
             </React.Suspense>

--- a/opencti-platform/opencti-front/src/utils/Localization.js
+++ b/opencti-platform/opencti-front/src/utils/Localization.js
@@ -9225,6 +9225,7 @@ const i18n = {
       entity_All: 'All entities',
       'entity_Stix-Domain-Object': 'Entity',
       'entity_Stix-Domain-Objects': 'Entities',
+      'entity_Stix-Core-Object': 'Entity and observable',
       'entity_Stix-Core-Objects': 'Entities and observables',
       'entity_Stix-Core-Relationship': 'Relationships',
       'entity_stix-core-relationship': 'Relationships',

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -141,7 +141,7 @@ const computeQueryTaskElements = async (context, user, task) => {
   // Apply the actions for each element
   for (let elementIndex = 0; elementIndex < elements.length; elementIndex += 1) {
     const element = elements[elementIndex];
-    if (!task_excluded_ids.includes(element.node.id)) {
+    if (!task_excluded_ids.includes(element.node.id) && isTaskEnabledEntity(element.node.entity_type)) {
       processingElements.push({ element: element.node, next: element.cursor });
     }
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* [frontend] Select stix domain object as minimum filter on the Data screen.
* [frontend] Fix scope for global search background tasks (search term and filters)
* [backend] check element type before processing in query tasks (same as actual check in list task).

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5308

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
