### PR TITLE
[backend] Fix ignoring boolean value when false in csv mapper (#5300)

### DIFF
--- a/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
@@ -135,7 +135,7 @@ const handleDirectAttribute = (attributeKey: string, column: AttributeColumn, in
     throw UnsupportedError('Invalid attribute', { key: attributeKey, type: entity_type });
   }
   const computedValue = computeValue(value, column, attributeDef);
-  if (computedValue) {
+  if (computedValue !== null && computedValue !== undefined) {
     input[attributeKey] = computedValue;
   }
 };

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
@@ -165,8 +165,10 @@ describe('CSV-PARSER', () => {
     const bundle = await bundleProcess(testContext, ADMIN_USER, filPath, csvMapperMalware);
     const { objects } = bundle;
 
-    expect(objects.length).toBe(2);
+    expect(objects.length).toBe(4);
     expect(objects[0].is_family).toBe(true);
     expect(objects[1].is_family).toBe(false);
+    expect(objects[2].is_family).toBe(true);
+    expect(objects[3].is_family).toBe(true);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
@@ -167,7 +167,6 @@ describe('CSV-PARSER', () => {
 
     expect(objects.length).toBe(2);
     expect(objects[0].is_family).toBe(true);
-    expect(objects.length).toBe(2);
     expect(objects[1].is_family).toBe(false);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-parser-test.js
@@ -12,6 +12,7 @@ import { csvMapperMockSimpleSighting } from './simple-sighting-test/csv-mapper-m
 import { bundleProcess } from '../../../src/parser/csv-bundler';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { csvMapperMockSimpleSkipLine } from './simple-skip-line-test/csv-mapper-mock-simple-skip-line';
+import { csvMapperMalware } from './entities-with-booleans/mapper';
 
 describe('CSV-HELPER', () => {
   it('Column name to idx', async () => {
@@ -157,5 +158,16 @@ describe('CSV-PARSER', () => {
       .toBeNull();
     expect(threatActorWithTypes.threat_actor_types.length)
       .toBe(2);
+  });
+
+  it('Parse CSV - manage boolean values', async () => {
+    const filPath = './tests/02-integration/05-parser/entities-with-booleans/malwares.csv';
+    const bundle = await bundleProcess(testContext, ADMIN_USER, filPath, csvMapperMalware);
+    const { objects } = bundle;
+
+    expect(objects.length).toBe(2);
+    expect(objects[0].is_family).toBe(true);
+    expect(objects.length).toBe(2);
+    expect(objects[1].is_family).toBe(false);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/malwares.csv
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/malwares.csv
@@ -1,0 +1,4 @@
+name,is_family
+Vador,True
+Emotet,False
+Gerard,

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/malwares.csv
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/malwares.csv
@@ -1,4 +1,6 @@
 name,is_family
 Vador,True
 Emotet,False
+Le Pinguin, yes
+Octopus, 1
 Gerard,

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/mapper.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/entities-with-booleans/mapper.ts
@@ -1,0 +1,31 @@
+import { type BasicStoreEntityCsvMapper, CsvMapperRepresentationType } from '../../../../src/modules/internal/csvMapper/csvMapper-types';
+import { ENTITY_TYPE_MALWARE } from '../../../../src/schema/stixDomainObject';
+
+export const csvMapperMalware: Partial<BasicStoreEntityCsvMapper> = {
+  id: 'mapper-malware',
+  has_header: true,
+  separator: ',',
+  representations: [
+    {
+      id: 'representation01',
+      type: CsvMapperRepresentationType.entity,
+      target: {
+        entity_type: ENTITY_TYPE_MALWARE,
+      },
+      attributes: [
+        {
+          key: 'name',
+          column: {
+            column_name: 'A',
+          },
+        },
+        {
+          key: 'is_family',
+          column: {
+            column_name: 'B',
+          },
+        },
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
### Proposed changes

* Change a condition when validating the csv file data that ignored boolean false values

### Related issues

* #5300 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
