### PR TITLE
[frontend] add the ability to edit user_confidence_level (#4304)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_lines/ListLinesContent.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLinesContent.jsx
@@ -268,7 +268,7 @@ class ListLinesContent extends Component {
                           registerChild(ref);
                         }}
                         autoHeight={true}
-                        height={height}
+                        height={height || 0}
                         onRowsRendered={onRowsRendered}
                         isScrolling={isScrolling}
                         onScroll={onChildScroll}

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -19,8 +19,10 @@ const useStyles = makeStyles(() => ({
 }));
 
 interface ConfidenceFieldProps {
+  name?: string;
+  label?: string;
   variant?: string;
-  onSubmit?: (name: string, value: string | number | number[]) => void;
+  onSubmit?: (name: string, value: string) => void;
   onFocus?: (name: string, value: string) => void;
   editContext?:
   | readonly ({
@@ -34,6 +36,8 @@ interface ConfidenceFieldProps {
 }
 
 const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
+  name = 'confidence',
+  label,
   variant,
   onFocus,
   onSubmit,
@@ -43,6 +47,8 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   disabled,
 }) => {
   const { t } = useFormatter();
+  const finalLabel = label || t('Confidence level');
+
   const classes = useStyles();
   return (
     <Alert
@@ -58,9 +64,9 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
         containerstyle={containerStyle}
         fullWidth={true}
         entityType={entityType}
-        attributeName="confidence"
-        name={'confidence'}
-        label={t('Confidence level')}
+        attributeName={name}
+        name={name}
+        label={finalLabel}
         onFocus={onFocus}
         onSubmit={onSubmit}
         editContext={editContext}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
-import { pick } from 'ramda';
 import * as Yup from 'yup';
 import MenuItem from '@mui/material/MenuItem';
 import ConfidenceField from '@components/common/form/ConfidenceField';
@@ -110,27 +109,17 @@ UserEditionOverviewComponentProps
   const objectOrganization = convertOrganizations(user);
 
   const initialValues = {
-    // extract flat attributes
-    ...pick(
-      [
-        'name',
-        'user_email',
-        'firstname',
-        'lastname',
-        'language',
-        'api_token',
-        'objectOrganization',
-        'description',
-        'account_status',
-        'account_lock_after_date',
-      ],
-      {
-        ...user,
-        objectOrganization,
-      },
-    ),
-    // extract object attribute
+    name: user.name,
+    user_email: user.user_email,
+    firstname: user.firstname,
+    lastname: user.lastname,
+    language: user.language,
+    api_token: user.api_token,
+    description: user.description,
+    account_status: user.account_status,
+    account_lock_after_date: user.account_lock_after_date,
     max_confidence: user.user_confidence_level.max_confidence,
+    objectOrganization,
   };
 
   const handleChangeFocus = (name: string) => {


### PR DESCRIPTION
### Proposed changes

* Edit user's confidence level from the user edition panel, overview tab
* Only users with SET_ACCESS capability will see this field

### Related issues

* #4304 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Overrides are taken into account in the code (not changed when editing the global confidence level) but are not editable for now. This is out of scope.