### PR TITLE
[frontend] copy required static files to make PDF lib work

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -129,6 +129,7 @@
     "typescript": "5.3.3",
     "vite": "5.0.10",
     "vite-plugin-relay": "2.0.0",
+    "vite-plugin-static-copy": "^1.0.0",
     "vitest": "1.0.4"
   },
   "engines": {

--- a/opencti-platform/opencti-front/vite.config.mts
+++ b/opencti-platform/opencti-front/vite.config.mts
@@ -2,6 +2,7 @@ import { createLogger, defineConfig, transformWithEsbuild } from 'vite';
 import react from '@vitejs/plugin-react';
 import * as path from 'node:path';
 import relay from 'vite-plugin-relay';
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 // to avoid multiple reload when discovering new dependencies after a going on a lazy (not precedently) loaded route we pre optmize these dependencies
 
@@ -182,6 +183,14 @@ export default defineConfig({
   customLogger: logger,
 
   plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'src/static/ext/*',
+          dest: 'static/ext'
+        }
+      ]
+    }),
     {
       name: 'html-transform',
       enforce: "pre",
@@ -190,8 +199,8 @@ export default defineConfig({
         return html.replace(/%BASE_PATH%/g, basePath)
           .replace(/%APP_TITLE%/g, "OpenCTI Dev")
           .replace(/%APP_DESCRIPTION%/g, "OpenCTI Development platform")
-          .replace(/%APP_FAVICON%/g, `${basePath}/src/static/ext/favicon.png`)
-          .replace(/%APP_MANIFEST%/g, `${basePath}/src/static/ext/manifest.json`)
+          .replace(/%APP_FAVICON%/g, `${basePath}/static/ext/favicon.png`)
+          .replace(/%APP_MANIFEST%/g, `${basePath}/static/ext/manifest.json`)
       }
     },
     {

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -10501,7 +10501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:11.2.0":
+"fs-extra@npm:11.2.0, fs-extra@npm:^11.1.0":
   version: 11.2.0
   resolution: "fs-extra@npm:11.2.0"
   dependencies:
@@ -14850,6 +14850,7 @@ __metadata:
     uuid: 9.0.1
     vite: 5.0.10
     vite-plugin-relay: 2.0.0
+    vite-plugin-static-copy: ^1.0.0
     vitest: 1.0.4
     yup: 1.3.3
   languageName: unknown
@@ -19902,6 +19903,20 @@ __metadata:
     babel-plugin-relay: ^14.1.0
     vite: ">=2.0.0"
   checksum: 123ee9ae0b0da51669a1698f6478e32725971522ccf90b77af678566cb2c23602a687a8caadac6ab25516937d9ff80a77ccae7b8e8a6b4c4f7170b5f5977fc0e
+  languageName: node
+  linkType: hard
+
+"vite-plugin-static-copy@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "vite-plugin-static-copy@npm:1.0.0"
+  dependencies:
+    chokidar: ^3.5.3
+    fast-glob: ^3.2.11
+    fs-extra: ^11.1.0
+    picocolors: ^1.0.0
+  peerDependencies:
+    vite: ^5.0.0
+  checksum: 93fd2167e356b50d1d29f7f8809bb63ef078437f9e13bdaa2fedb1fde73b7488d87ccf1a8115c7616f94327ccbd9188c074a23c18d1264e513aa6f1eb9e10ce9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* [vite only] copy some static files the same way it is already done for the esbuild builder to make pdf lib work in lcoal using vite

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
