### PR TITLE
[frontend] The choice of the type of observable to create is not reset after a "cancel" (#issue/5367)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -337,6 +337,7 @@ const StixCyberObservableCreation = ({
   const onReset = () => {
     if (speeddial) {
       handleClose();
+      setStatus({ open: false, type: null });
     } else {
       localHandleClose();
     }


### PR DESCRIPTION
### Proposed changes

* Update the state on speedial onReset

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5367
