### PR TITLE
[front] Fixing false positive lint issue with banner classes

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/SystemBanners.js
+++ b/opencti-platform/opencti-front/src/public/components/SystemBanners.js
@@ -6,6 +6,10 @@ import { isEmptyField } from '../../utils/utils';
 export const SYSTEM_BANNER_HEIGHT = 20;
 const BANNER_Z_INDEX = 2000;
 
+/* Avoid auto-lint removal using --fix with false positive finding of: */
+/* Styled class is not used in component  custom-rules/classes-rule */
+/* for the banner classes below which are derived in bannerColorClassName() component */
+/* eslint-disable */
 const useStyles = makeStyles(() => ({
   banner: {
     textAlign: 'center',
@@ -27,7 +31,30 @@ const useStyles = makeStyles(() => ({
     padding: '2px 0',
     position: 'relative',
   },
+  /* Avoid auto-lint removal using --fix with false positive finding of: */
+  /* Styled class is not used in component  custom-rules/classes-rule */
+  /* for the banner classes below which are derived in bannerColorClassName() component */
+  bannerGreen: {
+    background: '#00840C',
+  },
+  bannerRed: {
+    background: '#ef0000',
+  },
+  bannerYellow: {
+    background: '#ffff00',
+  },
+  classificationTextGreen: {
+    color: '#ffff00',
+  },
+  classificationTextRed: {
+    color: '#ffffff',
+  },
+  classificationTextYellow: {
+    color: '#000000',
+  },
+  /* end banner classes needing eslint-disable */
 }));
+/* eslint-enable */
 
 const bannerColorClassName = (color, prefix = 'banner') => {
   if (!R.is(String, color)) {


### PR DESCRIPTION

### Proposed changes

* The banner classes are inadvertently flagged by eslint and removed from the SystemBanner module when you pass in the ```--fix``` flag while linting. This causes the banners to lose coloring. This issue was introduced in commit (https://github.com/OpenCTI-Platform/opencti/commit/902c1c7401aabc55af3357d4a468d802fe85045f#diff-15ff25495319f7a99b06e1741547601a23423a1304c93ac9445ee240edd64d31).
* Added eslint-disable flags around the false positive code with a note to explain - why eslint is disabled for this section of code.

![image](https://github.com/OpenCTI-Platform/opencti/assets/132086448/ed314c72-4daf-479a-afff-d6295492bcbf)


### Related issues

None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None
