### PR TITLE
[backend/frontend] Improve search to include a default score criteria (#5397)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.jsx
@@ -45,10 +45,7 @@ const stixCoreObjectContainerTaskAddMutation = graphql`
 
 const stixCoreObjectContainerContainersQuery = graphql`
   query StixCoreObjectContainerContainersQuery($search: String) {
-    containers(
-      search: $search
-      filters: { mode: and, filters: [{ key: "entity_type", values: ["Container"] }], filterGroups: [] }
-    ) {
+    containers(search: $search) {
       edges {
         node {
           id

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2348,6 +2348,7 @@ enum ContainersOrdering {
   x_opencti_workflow_id
   creator
   entity_type
+  _score
 }
 
 type ContainerConnection {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2518,6 +2518,7 @@ enum ContainersOrdering {
   x_opencti_workflow_id
   creator
   entity_type
+  _score
 }
 type ContainerConnection {
   pageInfo: PageInfo!

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3638,6 +3638,7 @@ export type ContainerEditMutationsRelationDeleteArgs = {
 };
 
 export enum ContainersOrdering {
+  Score = '_score',
   Created = 'created',
   CreatedBy = 'createdBy',
   CreatedAt = 'created_at',


### PR DESCRIPTION
See #5397

When user search he expects to have the result ordered by the search score.
The PR does 2 things:
- Remove entity_type unneeded filter for container search
- Add a default scoring ordering if search parameter is specified. This addition will modify the behavior of every screen where you can search for an element by putting in first the better result undependently of the current setup ordering