### PR TITLE
[backend/frontend] Settings platform announcements with recipients are not visible to all admins (#5396)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessageForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessageForm.tsx
@@ -33,7 +33,7 @@ const settingsMessageEditionPatch = graphql`
   ) {
     settingsEdit(id: $id) {
       editMessage(input: $input) {
-        messages {
+        messages_administration {
           ...SettingsMessagesLine_settingsMessage
         }
       }

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 const settingsMessagesFragment = graphql`
   fragment SettingsMessages_settingsMessages on Settings {
-    messages {
+    messages_administration {
       ...SettingsMessagesLine_settingsMessage
     }
   }
@@ -45,7 +45,7 @@ const SettingsMessages = ({
   const messages = useFragment<SettingsMessages_settingsMessages$key>(
     settingsMessagesFragment,
     settings,
-  )?.messages ?? [];
+  )?.messages_administration ?? [];
   const dataColumns: DataColumns = {
     color: {
       label: 'Color',

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesPopover.tsx
@@ -18,7 +18,7 @@ const settingsMessagesPopoverPatch = graphql`
   ) {
     settingsEdit(id: $id) {
       deleteMessage(input: $input) {
-        messages {
+        messages_administration {
           ...SettingsMessagesLine_settingsMessage
         }
       }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1183,6 +1183,7 @@ type Settings implements InternalObject & BasicObject {
   password_policy_min_lowercase: Int
   password_policy_min_uppercase: Int
   messages: [SettingsMessage!]
+  messages_administration: [SettingsMessage!]
   analytics_google_analytics_v4: String
   editContext: [EditUserContext!]
 }

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1060,8 +1060,9 @@ type SettingsMessage {
   dismissible: Boolean!
   updated_at: DateTime!
   color: String
-  recipients: [Member!]
+  recipients: [Member!] @auth(for: [SETTINGS])
 }
+
 type Settings implements InternalObject & BasicObject {
   id: ID!
   standard_id: String! @auth
@@ -1123,6 +1124,7 @@ type Settings implements InternalObject & BasicObject {
   password_policy_min_lowercase: Int @auth
   password_policy_min_uppercase: Int @auth
   messages: [SettingsMessage!] @auth
+  messages_administration: [SettingsMessage!] @auth(for: [SETTINGS])
   analytics_google_analytics_v4: String @auth
   # Technical
   editContext: [EditUserContext!] @auth(for: [SETTINGS])

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -114,7 +114,7 @@ export const settingsEditField = async (context, user, settingsId, input) => {
   return notify(BUS_TOPICS.Settings.EDIT_TOPIC, updatedSettings, user);
 };
 
-export const getMessages = (user, settings) => {
+export const getMessagesFilteredByRecipients = (user, settings) => {
   const messages = JSON.parse(settings.messages ?? '[]');
   return messages.filter(({ recipients }) => {
     // eslint-disable-next-line max-len
@@ -128,8 +128,7 @@ export const settingEditMessage = async (context, user, settingsId, message) => 
     updated_at: now()
   };
   const settings = await getEntityFromCache(context, user, ENTITY_TYPE_SETTINGS);
-  const messages = getMessages(user, settings);
-
+  const messages = JSON.parse(settings.messages ?? '[]');
   const existingIdx = messages.findIndex((m) => m.id === message.id);
   if (existingIdx > -1) {
     messages[existingIdx] = messageToStore;
@@ -146,8 +145,7 @@ export const settingEditMessage = async (context, user, settingsId, message) => 
 
 export const settingDeleteMessage = async (context, user, settingsId, messageId) => {
   const settings = await getEntityFromCache(context, user, ENTITY_TYPE_SETTINGS);
-  const messages = getMessages(user, settings);
-
+  const messages = JSON.parse(settings.messages ?? '[]');
   const existingIdx = messages.findIndex((m) => m.id === messageId);
   if (existingIdx > -1) {
     messages.splice(existingIdx, 1);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -20619,6 +20619,7 @@ export type Settings = BasicObject & InternalObject & {
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   messages?: Maybe<Array<SettingsMessage>>;
+  messages_administration?: Maybe<Array<SettingsMessage>>;
   otp_mandatory?: Maybe<Scalars['Boolean']['output']>;
   parent_types: Array<Scalars['String']['output']>;
   password_policy_max_length?: Maybe<Scalars['Int']['output']>;
@@ -34553,6 +34554,7 @@ export type SettingsResolvers<ContextType = any, ParentType extends ResolversPar
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   messages?: Resolver<Maybe<Array<ResolversTypes['SettingsMessage']>>, ParentType, ContextType>;
+  messages_administration?: Resolver<Maybe<Array<ResolversTypes['SettingsMessage']>>, ParentType, ContextType>;
   otp_mandatory?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   parent_types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   password_policy_max_length?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;


### PR DESCRIPTION
See #5396

Introduce a new API to get messages as admin.
Enforce visibility of admin attribute by annotation