### PR TITLE
[frontend] Remove edit button in an Analyse screen

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
@@ -12,7 +12,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import Drawer from '../../common/drawer/Drawer';
 import inject18n from '../../../../components/i18n';
 import { QueryRenderer, commitMutation } from '../../../../relay/environment';
 import { malwareEditionQuery } from './MalwareEdition';
@@ -135,22 +135,27 @@ class MalwarePopover extends Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <QueryRenderer
-          query={malwareEditionQuery}
-          variables={{ id }}
-          render={({ props }) => {
-            if (props) {
-              return (
-                <MalwareEditionContainer
-                  malware={props.malware}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
-                />
-              );
-            }
-            return <div />;
-          }}
-        />
+        <Drawer
+          title={t('Update a malware')}
+          open={this.state.displayEdit}
+          onClose={this.handleCloseEdit.bind(this)}
+        >
+          <QueryRenderer
+            query={malwareEditionQuery}
+            variables={{ id }}
+            render={({ props }) => {
+              if (props) {
+                return (
+                  <MalwareEditionContainer
+                    malware={props.malware}
+                    handleClose={this.handleCloseEdit.bind(this)}
+                  />
+                );
+              }
+              return <div />;
+            }}
+          />
+        </Drawer>
       </>
     );
   }

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
@@ -135,28 +135,22 @@ class MalwarePopover extends Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Drawer
-          title={t('Update a malware')}
-          open={this.state.displayEdit}
-          onClose={this.handleCloseEdit.bind(this)}
-          variant={DrawerVariant.update}
-        >
-          <QueryRenderer
-            query={malwareEditionQuery}
-            variables={{ id }}
-            render={({ props }) => {
-              if (props) {
-                return (
-                  <MalwareEditionContainer
-                    malware={props.malware}
-                    handleClose={this.handleCloseEdit.bind(this)}
-                  />
-                );
-              }
-              return <div />;
-            }}
-          />
-        </Drawer>
+        <QueryRenderer
+          query={malwareEditionQuery}
+          variables={{ id }}
+          render={({ props }) => {
+            if (props) {
+              return (
+                <MalwareEditionContainer
+                  malware={props.malware}
+                  handleClose={this.handleCloseEdit.bind(this)}
+                  open={this.state.displayEdit}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
       </>
     );
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The Edit button present on an Analyse screen could be removed.

### Related issues

* #5385 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
