### PR TITLE
[backend] Fix widget dashboard if Dynamic from/to result is empty (#5339)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.jsx
@@ -80,6 +80,8 @@ const StixRelationshipsMultiAreaChart = ({
         toTypes: dataSelectionToTypes,
         field: dataSelectionDateAttribute,
         filters,
+        dynamicFrom: selection.dynamicFrom,
+        dynamicTo: selection.dynamicTo,
       };
     });
     let formatter = fsd;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.jsx
@@ -107,6 +107,8 @@ const StixRelationshipsMultiHeatMap = ({
         toTypes: dataSelectionToTypes,
         field: dataSelectionDateAttribute,
         filters,
+        dynamicFrom: selection.dynamicFrom,
+        dynamicTo: selection.dynamicTo,
       };
     });
     return (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.jsx
@@ -43,6 +43,8 @@ const stixRelationshipsRadarsDistributionQuery = graphql`
     $confidences: [Int]
     $search: String
     $filters: FilterGroup
+    $dynamicFrom: FilterGroup
+    $dynamicTo: FilterGroup
   ) {
     stixRelationshipsDistribution(
       field: $field
@@ -64,6 +66,8 @@ const stixRelationshipsRadarsDistributionQuery = graphql`
       confidences: $confidences
       search: $search
       filters: $filters
+      dynamicFrom: $dynamicFrom
+      dynamicTo: $dynamicTo
     ) {
       label
       value
@@ -254,6 +258,8 @@ const StixRelationshipsRadar = ({
       limit: selection.number ?? 10,
       filters: filtersAndOptions?.filters,
       isTo: selection.isTo,
+      dynamicFrom: selection.dynamicFrom,
+      dynamicTo: selection.dynamicTo,
     };
     return (
       <QueryRenderer

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
@@ -43,6 +43,8 @@ const stixRelationshipsTimelineStixRelationshipQuery = graphql`
     $orderBy: StixRelationshipsOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup
+    $dynamicFrom: FilterGroup
+    $dynamicTo: FilterGroup
     $search: String
   ) {
     stixRelationships(
@@ -56,6 +58,8 @@ const stixRelationshipsTimelineStixRelationshipQuery = graphql`
       orderMode: $orderMode
       filters: $filters
       search: $search
+      dynamicFrom: $dynamicFrom
+      dynamicTo: $dynamicTo
     ) {
       edges {
         node {
@@ -1284,6 +1288,8 @@ const StixRelationshipsTimeline = ({
           orderBy: dateAttribute,
           orderMode: 'desc',
           filters,
+          dynamicFrom: selection.dynamicFrom,
+          dynamicTo: selection.dynamicTo,
         }}
         render={({ props }) => {
           if (

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -19,6 +19,8 @@ export const findAll = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (fromIds.length > 0) {
       finalArgs = { ...finalArgs, fromId: args.fromId ? [...fromIds, args.fromId] : fromIds };
+    } else {
+      return { edges: [] };
     }
   } else {
     finalArgs = { ...finalArgs, dynamicFrom: undefined };
@@ -28,6 +30,8 @@ export const findAll = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (toIds.length > 0) {
       finalArgs = { ...finalArgs, toId: args.toId ? [...toIds, args.toId] : toIds };
+    } else {
+      return { edges: [] };
     }
   } else {
     finalArgs = { ...finalArgs, dynamicTo: undefined };
@@ -53,6 +57,8 @@ export const stixRelationshipsDistribution = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (fromIds.length > 0) {
       finalArgs = { ...finalArgs, fromId: args.fromId ? [...fromIds, args.fromId] : fromIds };
+    } else {
+      return [];
     }
   } else {
     finalArgs = { ...finalArgs, dynamicFrom: undefined };
@@ -62,6 +68,8 @@ export const stixRelationshipsDistribution = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (toIds.length > 0) {
       finalArgs = { ...finalArgs, toId: args.toId ? [...toIds, args.toId] : toIds };
+    } else {
+      return [];
     }
   } else {
     finalArgs = { ...finalArgs, dynamicTo: undefined };

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import { batchListThroughGetTo, buildDynamicFilterArgs, deleteElementById, distributionRelations, timeSeriesRelations } from '../database/middleware';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP, ENTITY_TYPE_IDENTITY } from '../schema/general';
 import { buildEntityFilters, listEntities, listRelations, storeLoadById } from '../database/middleware-loader';
-import { READ_INDEX_INFERRED_RELATIONSHIPS, READ_INDEX_STIX_CORE_RELATIONSHIPS, READ_INDEX_STIX_SIGHTING_RELATIONSHIPS } from '../database/utils';
+import { fillTimeSeries, READ_INDEX_INFERRED_RELATIONSHIPS, READ_INDEX_STIX_CORE_RELATIONSHIPS, READ_INDEX_STIX_SIGHTING_RELATIONSHIPS } from '../database/utils';
 import { elCount } from '../database/engine';
 import { RELATION_CREATED_BY, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
@@ -84,6 +84,11 @@ export const stixRelationshipsNumber = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (fromIds.length > 0) {
       finalArgs = { ...finalArgs, fromId: args.fromId ? [...fromIds, args.fromId] : fromIds };
+    } else {
+      return {
+        count: 0,
+        total: 0
+      };
     }
   } else {
     finalArgs = { ...finalArgs, dynamicFrom: undefined };
@@ -93,6 +98,11 @@ export const stixRelationshipsNumber = async (context, user, args) => {
       .then((result) => result.map((n) => n.id));
     if (toIds.length > 0) {
       finalArgs = { ...finalArgs, toId: args.toId ? [...toIds, args.toId] : toIds };
+    } else {
+      return {
+        count: 0,
+        total: 0
+      };
     }
   } else {
     finalArgs = { ...finalArgs, dynamicTo: undefined };
@@ -108,12 +118,15 @@ export const stixRelationshipsNumber = async (context, user, args) => {
 export const stixRelationshipsMultiTimeSeries = async (context, user, args) => {
   return Promise.all(args.timeSeriesParameters.map(async (timeSeriesParameter) => {
     const { dynamicFrom, dynamicTo } = timeSeriesParameter;
+    const { startDate, endDate, interval } = args;
     let finalTimeSeriesParameter = timeSeriesParameter;
     if (isFilterGroupNotEmpty(dynamicFrom)) {
       const fromIds = await listEntities(context, user, [ABSTRACT_STIX_CORE_OBJECT], buildDynamicFilterArgs(dynamicFrom))
         .then((result) => result.map((n) => n.id));
       if (fromIds.length > 0) {
         finalTimeSeriesParameter = { ...finalTimeSeriesParameter, fromId: args.fromId ? [...fromIds, args.fromId] : fromIds };
+      } else {
+        return { data: fillTimeSeries(startDate, endDate, interval, []) };
       }
     } else {
       finalTimeSeriesParameter = { ...finalTimeSeriesParameter, dynamicFrom: undefined };
@@ -123,6 +136,8 @@ export const stixRelationshipsMultiTimeSeries = async (context, user, args) => {
         .then((result) => result.map((n) => n.id));
       if (toIds.length > 0) {
         finalTimeSeriesParameter = { ...finalTimeSeriesParameter, toId: args.toId ? [...toIds, args.toId] : toIds };
+      } else {
+        return { data: fillTimeSeries(startDate, endDate, interval, []) };
       }
     } else {
       finalTimeSeriesParameter = { ...finalTimeSeriesParameter, dynamicTo: undefined };


### PR DESCRIPTION
If the result of the dynamicFrom is empty, the dynamicFrom filter is no longer taken into account.