### PR TITLE
[frontend] Fix filter in report knowledge timeline view

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -675,7 +675,7 @@ export const constructHandleRemoveFilter = (
       ...filters,
       filters: filters.filters.filter((f) => f.key !== k || f.operator !== op), // remove filter with key=k and operator=op
     };
-    return isFilterGroupNotEmpty(newBaseFilters) ? newBaseFilters : undefined;
+    return isFilterGroupNotEmpty(newBaseFilters) ? newBaseFilters : emptyFilterGroup;
   }
   return undefined;
 };


### PR DESCRIPTION
Screen is broken when removing filter :
![image](https://github.com/OpenCTI-Platform/opencti/assets/18297909/3982f7f5-2d94-4c71-938f-7635ad351233)

Step to reproduce :

1.  Report
2. Knowledge
3. Timeline view
4. Add filter
5. Remove filter