### PR TITLE
[frontend] fix link resolution for file export (#5466)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -88,6 +88,7 @@ const RootMalwareAnalysis = () => {
               return (
                 <>
                   <StixDomainObjectHeader
+                    entityType={'Malware-Analysis'}
                     stixDomainObject={malwareAnalysis}
                     PopoverComponent={
                       <MalwareAnalysisPopover id={malwareAnalysisId} />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -485,7 +485,7 @@ const StixDomainObjectHeader = (props) => {
           )}
           <StixCoreObjectFileExport
             id={stixDomainObject.id}
-            type={stixDomainObject.entity_type}
+            type={entityType}
           />
           {isKnowledgeUpdater && (
             <StixCoreObjectContainer elementId={stixDomainObject.id} />

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -94,7 +94,7 @@ const RootAdministrativeAreaComponent = ({
           }}
         >
           <StixDomainObjectHeader
-            entityType="administrativeArea"
+            entityType="Administrative-Area"
             disableSharing={true}
             stixDomainObject={administrativeArea}
             PopoverComponent={

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -88,7 +88,7 @@ const RootCityComponent = ({ queryRef, cityId, link }) => {
           }}
         >
           <StixDomainObjectHeader
-            entityType="city"
+            entityType="City"
             disableSharing={true}
             stixDomainObject={city}
             PopoverComponent={<CityPopover id={city.id} />}

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -90,7 +90,7 @@ const RootCountryComponent = ({ queryRef, countryId, link }) => {
           }}
         >
           <StixDomainObjectHeader
-            entityType="country"
+            entityType="Country"
             disableSharing={true}
             stixDomainObject={country}
             PopoverComponent={<CountryPopover id={country.id} />}

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -101,7 +101,7 @@ class RootCourseOfAction extends Component {
                     }}
                   >
                     <StixDomainObjectHeader
-                      entityType="CourseOfAction"
+                      entityType="Course-Of-Action"
                       disableSharing={true}
                       stixDomainObject={props.courseOfAction}
                       PopoverComponent={<CourseOfActionPopover />}

--- a/opencti-platform/opencti-front/src/utils/Entity.ts
+++ b/opencti-platform/opencti-front/src/utils/Entity.ts
@@ -1,10 +1,10 @@
-export const resolveLink = (type: string): string | null => {
+export const resolveLink = (type = 'unknown'): string | null => {
   switch (type) {
     case 'Dashboard':
-    case 'dashboard':
+    case 'dashboard': // for using resolveLink in workspaces
       return '/dashboard/workspaces/dashboards';
     case 'Investigation':
-    case 'investigation':
+    case 'investigation': // for using resolveLink in workspaces
       return '/dashboard/workspaces/investigations';
     case 'Attack-Pattern':
       return '/dashboard/techniques/attack_patterns';


### PR DESCRIPTION
### Proposed changes

* Make sure all use of `StixDomainObjectHeader` have the right entity type set
* resolveLink utility is now insensitive to capitalization of the entity type, to avoid future typo problems)

### Related issues

* #5466 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
To test, go to a Country knowledge view > export (any format) and hit Create. You should properly redirected to the entity's data tab.
