### PR TITLE
[frontend] fix output ports handling in Playbooks (#5437)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/hooks/useManipulateComponents.js
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/hooks/useManipulateComponents.js
@@ -301,7 +301,6 @@ const useManipulateComponents = (playbook, playbookComponents) => {
     let newNodes = getNodes();
     let newEdges = getEdges();
     const targetNode = getNode(selectedEdge.target);
-    // Add the new node
     const newNode = {
       id: result.nodeId,
       position: { x: targetNode.position.x, y: targetNode.position.y },
@@ -523,8 +522,10 @@ const useManipulateComponents = (playbook, playbookComponents) => {
     setEdges(newEdges);
   };
   const applyDeleteNode = () => {
+    // start by removing the node and the edges that leads to it
     let newNodes = getNodes().filter((n) => n.id !== selectedNode.id);
-    let newEdges = getEdges();
+    let newEdges = getEdges().filter((e) => e.target !== selectedNode.id);
+    // then delete the edges that come out of the node, and all children underneath
     const edgesToDelete = newEdges.filter((n) => n.source === selectedNode.id);
     const result = deleteEdgesAndAllChildren(newNodes, newEdges, edgesToDelete);
     newNodes = result.nodes;
@@ -541,6 +542,7 @@ const useManipulateComponents = (playbook, playbookComponents) => {
     );
     const childPlaceholderId = uuid();
     if (originEdge && otherEdgesToParentNode.length === 1) {
+      // inserting placeholder in place of the node
       newNodes.push({
         id: `${childPlaceholderId}-${originEdge.sourceHandle}`,
         position: {
@@ -559,6 +561,7 @@ const useManipulateComponents = (playbook, playbookComponents) => {
         },
       });
     } else if (otherEdgesToParentNode.length <= 1) {
+      // inserting placeholder of origin (entry point)
       newNodes.push({
         id: 'PLACEHOLDER-ORIGIN',
         type: 'placeholder',
@@ -575,6 +578,8 @@ const useManipulateComponents = (playbook, playbookComponents) => {
       });
     }
     if (parentNode && originEdge && otherEdgesToParentNode.length === 1) {
+      // If the parent node is not the topmost node,
+      // we need a placeholder edge that leads to the placeholder node
       newEdges.push({
         id: `${parentNode.id}-${originEdge.sourceHandle}-${childPlaceholderId}`,
         type: 'placeholder',

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
@@ -55,12 +55,17 @@ const useStyles = makeStyles<Theme>((theme) => ({
     alignItems: 'center',
   },
   handle: {
-    position: 'relative',
-    transform: 'none',
-    left: 'auto',
-    margin: '0 30px 0 30px',
+    position: 'absolute',
   },
 }));
+
+const getHandlePositionStyle = (count: number, index: number, width = 160): React.CSSProperties | undefined => {
+  // we distribute evenly the output ports at the bottom using CSS
+  // we divide our width in N intervals, the N points being at the center of their interval
+  const interval = width / count;
+  const position = index * interval + (interval / 2);
+  return { left: position };
+};
 
 const NodeWorkflow = ({ id, data }: NodeProps) => {
   const classes = useStyles();
@@ -140,7 +145,7 @@ const NodeWorkflow = ({ id, data }: NodeProps) => {
         <Handle type="target" position={Position.Top} isConnectable={false} />
       )}
       <div className={classes.handlesWrapper}>
-        {(data.component?.ports ?? []).map((n: node) => (
+        {(data.component?.ports ?? []).map((n: node, index: number, array: node[]) => (
           <Handle
             key={n.id}
             id={n.id}
@@ -148,6 +153,7 @@ const NodeWorkflow = ({ id, data }: NodeProps) => {
             position={Position.Bottom}
             isConnectable={false}
             className={classes.handle}
+            style={getHandlePositionStyle(array.length, index)}
           />
         ))}
       </div>


### PR DESCRIPTION
### Proposed changes

* when deleting a node in the playbook, also delete the edge that lead to the deleted node (otherwise this "dead" node is kept in the list and impair subsequent calls to the delete algorithm)

### Related issues

* #5437

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

I noticed a UI problem when working on this issue : multiple output ports are poorly displayed, and on top of each other if multiple.
This PR brings an automatic, even distribution of the output ports at the bottom of the node.