### PR TITLE
[backend] Migration rename-workflow-filter-key fail when widgets have empty dataSelection (#5560)

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1701859469408-rename-workflow-filter-key.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1701859469408-rename-workflow-filter-key.js
@@ -191,22 +191,24 @@ export const up = async (next) => {
         for (let i = 0; i < widgetEntries.length; i += 1) {
           const [key, value] = widgetEntries[i];
           const { dataSelection } = value;
-          const newDataSelection = dataSelection.map((selection) => {
-            const { filters = null, dynamicFrom = null, dynamicTo = null } = selection;
-            const newFilters = convertWorkflowFilterKeys(filters, true);
-            const newDynamicFrom = convertWorkflowFilterKeys(dynamicFrom, true);
-            const newDynamicTo = convertWorkflowFilterKeys(dynamicTo, true);
-            return {
-              ...selection,
-              filters: newFilters,
-              dynamicFrom: newDynamicFrom,
-              dynamicTo: newDynamicTo,
+          if (dataSelection) {
+            const newDataSelection = dataSelection.map((selection) => {
+              const { filters = null, dynamicFrom = null, dynamicTo = null } = selection;
+              const newFilters = convertWorkflowFilterKeys(filters, true);
+              const newDynamicFrom = convertWorkflowFilterKeys(dynamicFrom, true);
+              const newDynamicTo = convertWorkflowFilterKeys(dynamicTo, true);
+              return {
+                ...selection,
+                filters: newFilters,
+                dynamicFrom: newDynamicFrom,
+                dynamicTo: newDynamicTo,
+              };
+            });
+            newWidgets[key] = {
+              ...value,
+              dataSelection: newDataSelection,
             };
-          });
-          newWidgets[key] = {
-            ...value,
-            dataSelection: newDataSelection,
-          };
+          }
         }
         const newManifest = {
           ...decodedManifest,


### PR DESCRIPTION
See #5560