### PR TITLE
[frontend] Fix toggle buttons display in headers (#5599)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -22,6 +22,8 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import CircularProgress from '@mui/material/CircularProgress';
 import { makeStyles } from '@mui/styles';
+import Box from '@mui/material/Box';
+import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 import StixCoreObjectSubscribers from '../stix_core_objects/StixCoreObjectSubscribers';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
 import ExportButtons from '../../../../components/ExportButtons';
@@ -69,6 +71,8 @@ const useStyles = makeStyles({
   actions: {
     margin: '-6px 0 0 0',
     float: 'right',
+  },
+  actionButtons: {
     display: 'flex',
   },
   export: {
@@ -738,16 +742,21 @@ const ContainerHeader = (props) => {
     }
   };
 
-  let className = 'containerDefault';
-  if (knowledge) {
-    className = 'containerKnowledge';
+  const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+  // containerDefault style
+  let containerStyle = {
+    marginTop: 0,
+  };
+  if (knowledge || currentMode === 'graph' || currentMode === 'correlation') {
+    // container knowledge / graph style
+    containerStyle = {
+      position: 'absolute',
+      top: 140 + settingsMessagesBannerHeight,
+      right: 24,
+    };
   }
-  if (currentMode === 'graph' || currentMode === 'correlation') {
-    className = 'containerGraph';
-  }
-
   return (
-    <div className={classes[className]}>
+    <Box sx={containerStyle}>
       {!knowledge && (
         <Tooltip
           title={
@@ -874,10 +883,10 @@ const ContainerHeader = (props) => {
         </div>
       )}
       <div className={classes.actions}>
-        {enableQuickSubscription && (
-          <StixCoreObjectSubscribers elementId={container.id} />
-        )}
-        <ToggleButtonGroup size="small" color="secondary" exclusive={false}>
+        <div className={classes.actionButtons}>
+          {enableQuickSubscription && (
+            <StixCoreObjectSubscribers elementId={container.id} />
+          )}
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
             hasAccess={!!enableManageAuthorizedMembers}
@@ -1069,10 +1078,10 @@ const ContainerHeader = (props) => {
               <StixCoreObjectEnrichment stixCoreObjectId={container.id} />
             )}
           </>
-        </ToggleButtonGroup>
+        </div>
       </div>
       <div className="clearfix" />
-    </div>
+    </Box>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -14,7 +14,6 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import ListItemText from '@mui/material/ListItemText';
 import { DialogTitle } from '@mui/material';
@@ -76,6 +75,8 @@ const useStyles = makeStyles(() => ({
   actions: {
     margin: '-6px 0 0 0',
     float: 'right',
+  },
+  actionButtons: {
     display: 'flex',
   },
 }));
@@ -478,10 +479,10 @@ const StixDomainObjectHeader = (props) => {
         </Security>
       )}
       <div className={classes.actions}>
-        {enableQuickSubscription && (
-          <StixCoreObjectSubscribers elementId={stixDomainObject.id} />
-        )}
-        <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
+        <div className={classes.actionButtons}>
+          {enableQuickSubscription && (
+            <StixCoreObjectSubscribers elementId={stixDomainObject.id} />
+          )}
           {disableSharing !== true && (
             <StixCoreObjectSharing
               elementId={stixDomainObject.id}
@@ -502,7 +503,7 @@ const StixDomainObjectHeader = (props) => {
             />
           )}
           <StixCoreObjectEnrichment stixCoreObjectId={stixDomainObject.id} />
-        </ToggleButtonGroup>
+        </div>
       </div>
       <div className="clearfix" />
       {!noAliases && (

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import StixCyberObservablePopover from './StixCyberObservablePopover';
 import { truncate } from '../../../../utils/String';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
@@ -19,6 +18,9 @@ const useStyles = makeStyles(() => ({
   actions: {
     margin: '-6px 0 0 0',
     float: 'right',
+  },
+  actionButtons: {
+    display: 'flex',
   },
 }));
 
@@ -44,7 +46,7 @@ const StixCyberObservableHeaderComponent = ({
         />
       </div>
       <div className={classes.actions}>
-        <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
+        <div className={classes.actionButtons}>
           {disableSharing !== true && (
             <StixCoreObjectSharing
               elementId={stixCyberObservable.id}
@@ -52,7 +54,7 @@ const StixCyberObservableHeaderComponent = ({
             />
           )}
           <StixCoreObjectEnrichment stixCoreObjectId={stixCyberObservable.id} />
-        </ToggleButtonGroup>
+        </div>
       </div>
       <div className="clearfix" />
     </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove toggleButtonGroup in headers since all toggle buttons are independent (replace it with a flex div)
* Fix knowledge graph header display when banner is displayed

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5599

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
