### PR TITLE
[frontend] Unauthorized errors should redirect to Login page (#5608)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -32,8 +32,8 @@ class ErrorBoundaryComponent extends React.Component {
       const types = map((e) => e.name, [...baseErrors, ...retroErrors]);
       // Access error must be forwarded
       if (
-        includes('ForbiddenAccess', types)
-        || includes('AuthRequired', types)
+        includes('FORBIDDEN_ACCESS', types)
+        || includes('AUTH_REQUIRED', types)
       ) {
         // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw this.state.error;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Following #5264 work where there has been a renaming of errors, Fix Error component to handle unauthorized and forbidden errors

### Related issues

* #5608 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

**To test this PR**
- Go to settings => security => users => your user => invalidate its session
- click somewhere else in the app (like "Reports") => you should be redirected to Login page (instead of seeing a "unknown error occurred" message)
