### PR TITLE
[frontend] Unable to create an export of Attack patterns (#5612)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
@@ -69,9 +69,8 @@ const StixDomainObjectAttackPatterns = ({
                 currentView={view}
                 defaultStartTime={defaultStartTime}
                 defaultStopTime={defaultStopTime}
-                handleToggleExports={
-                  disableExport ? null : helpers.handleToggleExports
-                }
+                exportContext={{ entity_type: 'stix-core-relationship' }}
+                handleToggleExports={disableExport ? null : helpers.handleToggleExports}
                 openExports={openExports}
               />
             );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -650,6 +650,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
             open={openExports}
             handleToggle={this.handleToggleExports.bind(this)}
             paginationOptions={paginationOptions}
+            exportContext={{ entity_type: 'stix-core-relationship' }}
           />
         </Security>
         <Security needs={[KNOWLEDGE_KNUPDATE]}>


### PR DESCRIPTION
See #5612

Was du to missing declaration of export context in some components.
This context is mandatory and decide the type of entities that will be exported along the path of the storage