### PR TITLE
Allow to configure node-saml wantAuthnResponseSigned parameter

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -75,6 +75,7 @@ const configurationMapping = {
   signature_algorithm: 'signatureAlgorithm',
   digest_algorithm: 'digestAlgorithm',
   want_assertions_signed: 'wantAssertionsSigned',
+  want_authn_response_signed: 'wantAuthnResponseSigned',
   authn_context: 'authnContext',
   disable_requested_authn_context: 'disableRequestedAuthnContext',
   force_authn: 'forceAuthn',


### PR DESCRIPTION
### Proposed changes

* Allow to configure node-saml's parameter wantAuthnResponseSigned when using env variables

### Checklist

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality

### Further comments

References:
- https://github.com/node-saml/node-saml
- https://github.com/node-saml/passport-saml/discussions/671