### PR TITLE
[frontend] MenuItem component color accessibility changes

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -267,6 +267,18 @@ const ThemeDark = (
         },
       },
     },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            boxShadow: `2px 0 ${EE_COLOR} inset`,
+          },
+          '&.Mui-selected:hover': {
+            boxShadow: `2px 0 ${EE_COLOR} inset`,
+          },
+        },
+      },
+    },
   },
 });
 

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -265,6 +265,23 @@ const ThemeLight = (
         },
       },
     },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          ':hover': {
+            backgroundColor: 'rgba(0,0,0,0.04)',
+          },
+          '&.Mui-selected': {
+            boxShadow: `2px 0 ${EE_COLOR} inset`,
+            backgroundColor: 'rgba(0,102,255,0.08)',
+          },
+          '&.Mui-selected:hover': {
+            boxShadow: `2px 0 ${EE_COLOR} inset`,
+            backgroundColor: 'rgba(0,102,255,0.12)',
+          },
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
### Proposed changes

* Change colors for MenuItem components in light and dark themes for accessibility purposes.
* Light theme: on hover, selected, on hover + selected colors changed. Added a contrasting accent shadow to the left side of selected MenuItems.
* Dark theme: Added a contrasting accent shadow to the left side of selected MenuItems.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
