### PR TITLE
Change the way TAXII ingester paginates requests

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -218,8 +218,13 @@ const taxiiHttpGet = async (ingestion: BasicStoreEntityIngestionTaxii): Promise<
   const httpClient = getHttpClient(httpClientOptions);
   const preparedUri = ingestion.uri.endsWith('/') ? ingestion.uri : `${ingestion.uri}/`;
   const url = `${preparedUri}collections/${ingestion.collection}/objects/`;
-  const next = ingestion.added_after_start ? ingestion.current_state_cursor : null;
-  const params = { next, added_after: ingestion.added_after_start };
+  const next = ingestion.current_state_cursor;
+  // https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107519
+  // If the more property is set to true and the next property is populated then the client can paginate through the remaining records using the next URL parameter along with the
+  // same original query options.
+  // If the more property is set to true and the next property is empty then the client may paginate through the remaining records by using the added_after URL parameter with the
+  // date/time value from the X-TAXII-Date-Added-Last header along with the same original query options.
+  const params = next ? { next } : { added_after: ingestion.added_after_start };
   const { data, headers: resultHeaders } = await httpClient.get(url, { params });
   return { data, addedLast: resultHeaders['x-taxii-date-added-last'] };
 };

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -218,13 +218,13 @@ const taxiiHttpGet = async (ingestion: BasicStoreEntityIngestionTaxii): Promise<
   const httpClient = getHttpClient(httpClientOptions);
   const preparedUri = ingestion.uri.endsWith('/') ? ingestion.uri : `${ingestion.uri}/`;
   const url = `${preparedUri}collections/${ingestion.collection}/objects/`;
-  const next = ingestion.current_state_cursor;
   // https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107519
   // If the more property is set to true and the next property is populated then the client can paginate through the remaining records using the next URL parameter along with the
   // same original query options.
   // If the more property is set to true and the next property is empty then the client may paginate through the remaining records by using the added_after URL parameter with the
   // date/time value from the X-TAXII-Date-Added-Last header along with the same original query options.
-  const params = next ? { next } : { added_after: ingestion.added_after_start };
+  const next = ingestion.current_state_cursor;
+  const params = { next, added_after: ingestion.added_after_start };
   const { data, headers: resultHeaders } = await httpClient.get(url, { params });
   return { data, addedLast: resultHeaders['x-taxii-date-added-last'] };
 };
@@ -241,7 +241,7 @@ const taxiiV21DataHandler: TaxiiHandlerFn = async (context: AuthContext, ingesti
     // Update the state
     await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
       current_state_cursor: data.next ? String(data.next) : undefined,
-      added_after_start: utcDate(addedLast)
+      added_after_start: data.next ? ingestion.added_after_start : utcDate(addedLast)
     });
   } else if (data.objects === undefined) {
     const error = UnknownError('Undefined taxii objects', data);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Extracted from https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107519
*  If the more property is set to true and the next property is populated then the client can paginate through the remaining records using the next URL parameter along with the same original query options.

* If the more property is set to true and the next property is empty then the client may paginate through the remaining records by using the added_after URL parameter with the date/time value from the X-TAXII-Date-Added-Last header along with the same original query options.


### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5681
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
