### PR TITLE
[frontend] Fix report types display if null (#5624)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -142,7 +142,7 @@ const ReportDetailsComponent = (props) => {
               {t('Report types')}
             </Typography>
             <FieldOrEmpty source={report.report_types}>
-              {report.report_types.map((reportType) => (
+              {report.report_types?.map((reportType) => (
                 <Chip
                   key={reportType}
                   classes={{ root: classes.chip }}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Handle report types null otherwise report details page displays an error

### Related issues

* Following #5624 changes

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
