### PR TITLE
[backend] avoid user deletion raising exception when authorized_member is missing (#5580)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -756,11 +756,15 @@ export const meEditField = async (context, user, userId, inputs, password = null
   return userEditField(context, user, userId, inputs);
 };
 
-const isUserTheLastAdmin = (userId, authorized_members) => {
-  const currentUserIsAdmin = authorized_members.some(({ id, access_right }) => id === userId && access_right === 'admin');
-  const anotherUserIsAdmin = authorized_members.some(({ id, access_right }) => id !== userId && access_right === 'admin');
+export const isUserTheLastAdmin = (userId, authorized_members) => {
+  if (authorized_members !== null && authorized_members !== undefined) {
+    const currentUserIsAdmin = authorized_members.some(({ id, access_right }) => id === userId && access_right === 'admin');
+    const anotherUserIsAdmin = authorized_members.some(({ id, access_right }) => id !== userId && access_right === 'admin');
 
-  return currentUserIsAdmin && !anotherUserIsAdmin;
+    return currentUserIsAdmin && !anotherUserIsAdmin;
+  }
+  // if for some reason there is no authorized_member, then nothing prevent from deleting.
+  return false;
 };
 
 export const deleteAllWorkspaceForUser = async (context, authUser, userId) => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-delete-cleanup-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-delete-cleanup-test.ts
@@ -5,7 +5,7 @@ import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
 import type { AuthContext, AuthUser } from '../../../src/types/user';
 import { addNotification, addTrigger, myNotificationsFind, triggerGet } from '../../../src/modules/notification/notification-domain';
 import type { MemberAccessInput, TriggerLiveAddInput, WorkspaceAddInput } from '../../../src/generated/graphql';
-import { addUser, assignGroupToUser, findById as findUserById, userDelete } from '../../../src/domain/user';
+import { addUser, assignGroupToUser, findById as findUserById, isUserTheLastAdmin, userDelete } from '../../../src/domain/user';
 import { addWorkspace, editAuthorizedMembers, findById as findWorkspaceById } from '../../../src/modules/workspace/workspace-domain';
 import type { NotificationAddInput } from '../../../src/modules/notification/notification-types';
 import { TriggerEventType, TriggerType } from '../../../src/generated/graphql';
@@ -146,5 +146,11 @@ describe('Testing user delete on cascade [issue/3720]', () => {
     } catch (e) {
       console.log(JSON.stringify(e));
     }
+  });
+  it('should data without authorized_member not throw exception during user deletion.', async () => {
+    // for some reason this can happend, see https://github.com/OpenCTI-Platform/opencti/issues/5580
+    const isLastAdminResult = isUserTheLastAdmin(ADMIN_USER.id, undefined);
+    expect(true, 'No exception should be raised here').toBe(true);
+    expect(isLastAdminResult, 'An entity without authorized_member data should not block deletion.').toBe(false);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* From this piece of error logs on the issue:
```
{"message":"Cannot read properties of undefined (reading 'some')","name":"TypeError","stack":"TypeError: Cannot read properties of undefined (reading 'some')\n    at isUserTheLastAdmin (/opt/opencti/build/src/domain/user.js:734:49)\n    at /opt/opencti/build/src/domain/user.js:746:34\n    at Array.filter (<anonymous>)\n    at deleteAllWorkspaceForUser (/opt/opencti/build/src/domain/user.js:746:6)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at userDelete (/opt/opencti/build/src/domain/user.js:831:3)"}
```

I think it's because authorized_member is undefined. Not sure why it happen but it should not prevent from user deletion.

- I'm proposing to delete the Workspace when authorized_member is undefined, if you prefer to just skip it (maybe safer) please tell me.

Reproduced with the test **_before changing code_**
![image](https://github.com/OpenCTI-Platform/opencti/assets/3634942/db13cf82-3413-4ea5-a552-94250d85602c)


### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5580

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
