### PR TITLE
[backend] CSV Mapper: internal decay configuration should not be visible on Indicator mapper (#2859)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
@@ -79,6 +79,12 @@ export const INTERNAL_ATTRIBUTES = [
   'x_opencti_cvss_availability_impact',
   'x_opencti_cvss_confidentiality_impact',
   'x_opencti_additional_names',
+  // Decay internal fields on Indicator
+  'decay_next_reaction_date',
+  'decay_base_score',
+  'decay_base_score_date',
+  'decay_history',
+  'decay_applied_rule',
 ];
 
 export const INTERNAL_REFS = [


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove decay internal fields from CSV Mapper configuration screen
![Decay csv mapper mistake](https://github.com/OpenCTI-Platform/opencti/assets/3634942/6405ef13-8453-40fd-b0b0-ad73986c3c26)

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/2859

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
