### PR TITLE
[backend] Invalid TAXII header when collection is exposed to public

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1212,7 +1212,6 @@ enum GroupsOrdering {
   auto_new_marking
   created_at
   updated_at
-  group_confidence_level
 }
 
 type GroupConnection {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7507,7 +7507,6 @@ export enum GroupsOrdering {
   AutoNewMarking = 'auto_new_marking',
   CreatedAt = 'created_at',
   DefaultAssignation = 'default_assignation',
-  GroupConfidenceLevel = 'group_confidence_level',
   Name = 'name',
   UpdatedAt = 'updated_at'
 }

--- a/opencti-platform/opencti-graphql/src/http/httpTaxii.js
+++ b/opencti-platform/opencti-graphql/src/http/httpTaxii.js
@@ -138,6 +138,7 @@ const initTaxiiApi = (app) => {
       const stix = await restCollectionStix(context, user, collection, req.query);
       res.set('X-TAXII-Date-Added-First', getUpdatedAt(R.head(stix.objects)));
       res.set('X-TAXII-Date-Added-Last', getUpdatedAt(R.last(stix.objects)));
+      res.set('Content-Type', TAXII_VERSION);
       res.json(stix);
     } catch (e) {
       const errorDetail = errorConverter(e);

--- a/opencti-platform/opencti-graphql/src/http/httpTaxii.js
+++ b/opencti-platform/opencti-graphql/src/http/httpTaxii.js
@@ -9,6 +9,11 @@ import { BYPASS, executionContext, SYSTEM_USER } from '../utils/access';
 
 const TAXII_VERSION = 'application/taxii+json;version=2.1';
 
+const sendJsonResponse = (res, data) => {
+  res.setHeader('content-type', TAXII_VERSION);
+  res.json(data);
+};
+
 const errorConverter = (e) => {
   const details = R.pipe(R.dissoc('reason'), R.dissoc('http_status'))(e.data);
   return {
@@ -24,7 +29,6 @@ const userHaveAccess = (user) => {
   return capabilities.includes(BYPASS) || capabilities.includes(TAXIIAPI);
 };
 const extractUserFromRequest = async (context, req, res) => {
-  res.setHeader('content-type', TAXII_VERSION);
   // noinspection UnnecessaryLocalVariableJS
   const user = await authenticateUserFromRequest(context, req, res);
   if (!user) {
@@ -70,7 +74,7 @@ const initTaxiiApi = (app) => {
         default: `${getBaseUrl(req)}/taxii2/root`,
         api_roots: [`${getBaseUrl(req)}/taxii2/root`],
       };
-      res.json(discovery);
+      sendJsonResponse(res, discovery);
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -87,7 +91,7 @@ const initTaxiiApi = (app) => {
         max_content_length: 100 * 1024 * 1024, // '100mb'
         versions: [TAXII_VERSION],
       };
-      res.json(rootContent);
+      sendJsonResponse(res, rootContent);
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -99,7 +103,7 @@ const initTaxiiApi = (app) => {
       const context = executionContext('taxii');
       const user = await extractUserFromRequest(context, req, res);
       const collections = await restAllCollections(context, user);
-      res.json({ collections });
+      sendJsonResponse(res, { collections });
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -110,7 +114,7 @@ const initTaxiiApi = (app) => {
     try {
       const context = executionContext('taxii');
       const { collection } = await extractUserAndCollection(context, req, res, id);
-      res.json(restBuildCollection(collection));
+      sendJsonResponse(res, restBuildCollection(collection));
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -124,7 +128,7 @@ const initTaxiiApi = (app) => {
       const manifest = await restCollectionManifest(context, user, collection, req.query);
       res.set('X-TAXII-Date-Added-First', R.head(manifest.objects)?.version);
       res.set('X-TAXII-Date-Added-Last', R.last(manifest.objects)?.version);
-      res.json(manifest);
+      sendJsonResponse(res, manifest);
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -138,8 +142,7 @@ const initTaxiiApi = (app) => {
       const stix = await restCollectionStix(context, user, collection, req.query);
       res.set('X-TAXII-Date-Added-First', getUpdatedAt(R.head(stix.objects)));
       res.set('X-TAXII-Date-Added-Last', getUpdatedAt(R.last(stix.objects)));
-      res.set('Content-Type', TAXII_VERSION);
-      res.json(stix);
+      sendJsonResponse(res, stix);
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -154,7 +157,7 @@ const initTaxiiApi = (app) => {
       const stix = await restCollectionStix(context, user, collection, args);
       res.set('X-TAXII-Date-Added-First', getUpdatedAt(R.head(stix.objects)));
       res.set('X-TAXII-Date-Added-Last', getUpdatedAt(R.last(stix.objects)));
-      res.json(stix);
+      sendJsonResponse(res, stix);
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);
@@ -172,7 +175,7 @@ const initTaxiiApi = (app) => {
       res.set('X-TAXII-Date-Added-First', updatedAt);
       res.set('X-TAXII-Date-Added-Last', updatedAt);
       const versions = data ? [updatedAt] : [];
-      res.json({ versions });
+      sendJsonResponse(res, { versions });
     } catch (e) {
       const errorDetail = errorConverter(e);
       res.status(errorDetail.http_status).send(errorDetail);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set header with mediat type `application/taxii+json` to be aligned with STIX 2.1 standard

![image](https://github.com/OpenCTI-Platform/opencti/assets/75518128/825d1fd1-9522-4f10-8ac0-f0065e19c245)


### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5621

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Expected output
![image](https://github.com/OpenCTI-Platform/opencti/assets/75518128/b560f4e1-aee1-4e6c-a610-ee506b5b9197)
