### PR TITLE
[backend] Fix schema of StixFile where obsContent was also in schema attributes (#5751)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixCyberObservable-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixCyberObservable-registrationAttributes.ts
@@ -120,7 +120,6 @@ const stixCyberObservablesAttributes: { [k: string]: Array<AttributeDefinition> 
     { name: 'atime', label: 'Atime', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_additional_names', label: 'Additional names', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
     { name: 'mime_type', label: 'Mime type', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
-    { name: 'obsContent', label: 'Observable content', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   [ENTITY_HASHED_OBSERVABLE_X509_CERTIFICATE]: [
     hashDefinition,


### PR DESCRIPTION
### Proposed changes

* Remove `obsContent` from schema attributes and keep it only in schema refs

### Related issues

* #5751 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

In my opinion there is also an issue when we want to add Artifacts to a File but I don't think it should be fixed in this issue.
