### PR TITLE
[backend] crop confidence values between 0 and 100

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/grant.js
+++ b/opencti-platform/opencti-graphql/src/domain/grant.js
@@ -5,6 +5,7 @@ import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE } from '../
 import { RELATION_HAS_CAPABILITY } from '../schema/internalRelationship';
 import { generateStandardId } from '../schema/identifier';
 import { publishUserAction } from '../listener/UserActionListener';
+import { cropNumber } from '../utils/math';
 
 export const addCapability = async (context, user, capability) => {
   return createEntity(context, user, capability, ENTITY_TYPE_CAPABILITY);
@@ -41,6 +42,12 @@ export const addGroup = async (context, user, group) => {
     max_confidence: nconf.get('app:group_confidence_level:max_confidence_default') ?? 100,
     overrides: [],
   };
+  // sanitize value between 0 and 100
+  group_confidence_level.max_confidence = cropNumber(group_confidence_level.max_confidence, { min: 0, max: 100 });
+  group_confidence_level.overrides = group_confidence_level.overrides.map((override) => ({
+    entity_type: override.entity_type,
+    max_confidence: cropNumber(override.max_confidence, { min: 0, max: 100 })
+  }));
 
   const groupWithDefaultValues = {
     ...group,

--- a/opencti-platform/opencti-graphql/src/types/group.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/group.d.ts
@@ -1,4 +1,5 @@
 import type { BasicStoreCommon } from './store';
+import type { ConfidenceLevel } from '../generated/graphql';
 
 interface DefaultMarking {
   entity_type: string,
@@ -7,4 +8,5 @@ interface DefaultMarking {
 
 interface Group extends BasicStoreCommon {
   default_marking?: Array<DefaultMarking>;
+  group_confidence_level: ConfidenceLevel
 }

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -1,5 +1,6 @@
 import type { BasicStoreCommon, BasicStoreIdentifier, StoreMarkingDefinition } from './store';
 import type { Group } from './group';
+import type { ConfidenceLevel } from '../generated/graphql';
 
 interface UserRole extends BasicStoreIdentifier {
   name: string;
@@ -41,6 +42,7 @@ interface AuthUser extends BasicStoreIdentifier {
   all_marking: Array<StoreMarkingDefinition>;
   api_token: string;
   account_status: string;
+  user_confidence_level: ConfidenceLevel | null;
 }
 
 interface AuthContext {

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -75,6 +75,10 @@ export const SYSTEM_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const RETENTION_MANAGER_USER: AuthUser = {
@@ -98,6 +102,10 @@ export const RETENTION_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const RULE_MANAGER_USER: AuthUser = {
@@ -121,6 +129,10 @@ export const RULE_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const AUTOMATION_MANAGER_USER: AuthUser = {
@@ -144,6 +156,10 @@ export const AUTOMATION_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const REDACTED_USER: AuthUser = {
@@ -167,6 +183,7 @@ export const REDACTED_USER: AuthUser = {
   api_token: '',
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
+  user_confidence_level: null
 };
 
 export interface AuthorizedMember { id: string, access_right: string }

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -1,0 +1,76 @@
+import { cropNumber } from './math';
+import type { ConfidenceLevelInput, ConfidenceLevelOverrideInput } from '../generated/graphql';
+import { FunctionalError } from '../config/errors';
+import type { AuthUser } from '../types/user';
+
+type EditInputValue = number | ConfidenceLevelInput | ConfidenceLevelOverrideInput;
+
+export const cropMaxConfidenceInEditValue = (value: EditInputValue, object_path?: string) => {
+  let sanitizedValue = value;
+
+  // edited as object_path patching, value might be different depending on the path
+  if (object_path) {
+    // using regexp to accommodate for the optional presence of a leading "/" in object_path
+    if (/(user|group)_confidence_level\/max_confidence$/.test(object_path)) {
+      // object_path ~= "user_confidence_level/max_confidence", value is supposedly a number
+      sanitizedValue = cropNumber(value as number, { min: 0, max: 100 });
+    } else if (/\/overrides\/(\d+)$/.test(object_path)) {
+      // object_path ~= "user_confidence_level/overrides/[n]", value is a ConfidenceLevelOverrideInput
+      sanitizedValue = {
+        entity_type: (value as ConfidenceLevelOverrideInput).entity_type,
+        max_confidence: cropNumber((value as ConfidenceLevelOverrideInput).max_confidence, { min: 0, max: 100 }),
+      };
+    } else if (/\/overrides\/(\d+)\/max_confidence$/.test(object_path)) {
+      // object_path ~= "user_confidence_level/overrides/[n]/max_confidence", value is a number
+      sanitizedValue = cropNumber((value as number), { min: 0, max: 100 });
+    } else {
+      throw FunctionalError('Incorrect use of object_path with a value that does not match the target.', { object_path, value });
+    }
+  } else if ((value as ConfidenceLevelInput).max_confidence !== undefined) {
+    // edited as full object, value is a ConfidenceLevelInput
+    sanitizedValue = {
+      max_confidence: cropNumber((value as ConfidenceLevelInput).max_confidence, { min: 0, max: 100 }),
+      overrides: (value as ConfidenceLevelInput).overrides.map((override) => ({
+        entity_type: override.entity_type,
+        max_confidence: cropNumber(override.max_confidence, { min: 0, max: 100 })
+      }))
+    };
+  }
+
+  return sanitizedValue;
+};
+
+export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
+  // if user has a specific confidence level, it overrides everything and we return it
+  if (user.user_confidence_level) {
+    return {
+      ...user.user_confidence_level,
+      source: user,
+    };
+  }
+
+  // otherwise we get all groups for this user, and select the lowest max_confidence found
+  let minLevel = null;
+  let source = null;
+  if (user.groups) {
+    for (let i = 0; i < user.groups.length; i += 1) {
+      const groupLevel = user.groups[i].group_confidence_level?.max_confidence ?? null;
+      if (minLevel === null || (groupLevel !== null && groupLevel < minLevel)) {
+        minLevel = groupLevel;
+        source = user.groups[i];
+      }
+    }
+  }
+
+  if (minLevel !== null) {
+    return {
+      max_confidence: cropNumber(minLevel, { min: 0, max: 100 }),
+      // TODO: handle overrides and their sources
+      overrides: [],
+      source,
+    };
+  }
+
+  // finally, if this user has no effective confidence level, we can return null
+  return null;
+};

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -24,7 +24,7 @@ export const cropMaxConfidenceInEditValue = (value: EditInputValue, object_path?
       // object_path ~= "user_confidence_level/overrides/[n]/max_confidence", value is a number
       sanitizedValue = cropNumber((value as number), { min: 0, max: 100 });
     } else {
-      throw FunctionalError('Incorrect use of object_path with a value that does not match the target.', { object_path, value });
+      throw FunctionalError('Unhandled object_path for patching a confidence level', { object_path, value });
     }
   } else if ((value as ConfidenceLevelInput).max_confidence !== undefined) {
     // edited as full object, value is a ConfidenceLevelInput

--- a/opencti-platform/opencti-graphql/src/utils/math.ts
+++ b/opencti-platform/opencti-graphql/src/utils/math.ts
@@ -1,0 +1,14 @@
+export const cropNumber = (value: number, options: { min?: number, max?: number }) => {
+  let newValue = value;
+  if (options.min !== undefined) {
+    if (options.max !== undefined && options.min > options.max) {
+      throw Error('Incorrect inputs to cropNumber, min cannot be greater than max');
+    }
+    newValue = Math.max(newValue, options.min);
+  }
+  if (options.max !== undefined) {
+    newValue = Math.min(newValue, options.max);
+  }
+
+  return newValue;
+};

--- a/opencti-platform/opencti-graphql/src/utils/math.ts
+++ b/opencti-platform/opencti-graphql/src/utils/math.ts
@@ -1,8 +1,13 @@
+import { FunctionalError } from '../config/errors';
+
 export const cropNumber = (value: number, options: { min?: number, max?: number }) => {
+  if (!Number.isFinite(value)) {
+    throw FunctionalError('Cannot crop non-finite input value', { value });
+  }
   let newValue = value;
   if (options.min !== undefined) {
     if (options.max !== undefined && options.min > options.max) {
-      throw Error('Incorrect inputs to cropNumber, min cannot be greater than max');
+      throw FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max');
     }
     newValue = Math.max(newValue, options.min);
   }

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { testContext } from '../../utils/testQuery';
-import { checkPasswordInlinePolicy, computeUserEffectiveConfidenceLevel } from '../../../src/domain/user';
+import { checkPasswordInlinePolicy } from '../../../src/domain/user';
 
 describe('password checker', () => {
   it('should no policy applied', async () => {
@@ -73,63 +73,5 @@ describe('password checker', () => {
     };
     expect(checkPasswordInlinePolicy(testContext, policy03, 'julA').length).toBe(1);
     expect(checkPasswordInlinePolicy(testContext, policy03, 'ju!lA').length).toBe(0);
-  });
-});
-
-describe('Effective max confidence level', () => {
-  const group70 = {
-    id: 'group70',
-    group_confidence_level: {
-      max_confidence: 70,
-      overrides: [],
-    }
-  };
-
-  const group80 = {
-    id: 'group80',
-    group_confidence_level: {
-      max_confidence: 70,
-      overrides: [],
-    }
-  };
-
-  it("user's confidence level overrides groups and orgs", async () => {
-    // minimal subset of a real User
-    const userA = {
-      id: 'userA',
-      user_confidence_level: {
-        max_confidence: 30,
-        overrides: [],
-      },
-      groups: [group70, group80],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userA)).toEqual({
-      max_confidence: 30,
-      overrides: [],
-      source: userA,
-    });
-
-    const userB = {
-      id: 'userB',
-      user_confidence_level: null,
-      groups: [group70, group80],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userB)).toEqual({
-      max_confidence: 70,
-      overrides: [],
-      source: group70,
-    });
-
-    const userD = {
-      user_confidence_level: null,
-      groups: [{ group_confidence_level: null }, { group_confidence_level: null }],
-    };
-
-    const userE = {
-      user_confidence_level: null,
-      groups: [],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userD)).toBeNull();
-    expect(computeUserEffectiveConfidenceLevel(userE)).toBeNull();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -94,6 +94,11 @@ describe('Confidence level utilities', () => {
       }
     };
 
+    const groupNull = {
+      id: 'groupNull',
+      group_confidence_level: null
+    };
+
     // minimal subset of a real User
     const userA = {
       id: 'userA',
@@ -120,17 +125,26 @@ describe('Confidence level utilities', () => {
       source: group70,
     });
 
+    const userC = {
+      user_confidence_level: null,
+      groups: [groupNull, group70, groupNull],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userC as unknown as AuthUser)).toEqual({
+      max_confidence: 70,
+      overrides: [],
+      source: group70,
+    });
+
     const userD = {
       user_confidence_level: null,
-      groups: [{ group_confidence_level: null }, { group_confidence_level: null }],
+      groups: [groupNull, groupNull],
     };
+    expect(computeUserEffectiveConfidenceLevel(userD as unknown as AuthUser)).toBeNull();
 
     const userE = {
       user_confidence_level: null,
       groups: [],
     };
-      // ugly typecast to avoid having complete AuthUser objects
-    expect(computeUserEffectiveConfidenceLevel(userD as unknown as AuthUser)).toBeNull();
     expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { computeUserEffectiveConfidenceLevel, cropMaxConfidenceInEditValue } from '../../../src/utils/confidence-level';
+import type { AuthUser } from '../../../src/types/user';
+
+describe('Confidence level utilities', () => {
+  it('sanitizeConfidenceInEditInput should crop value with various min/max inputs', () => {
+    // complete object
+    expect(cropMaxConfidenceInEditValue({ max_confidence: 50, overrides: [] })).toEqual({ max_confidence: 50, overrides: [] });
+    expect(cropMaxConfidenceInEditValue({ max_confidence: 300, overrides: [] })).toEqual({ max_confidence: 100, overrides: [] });
+    expect(cropMaxConfidenceInEditValue({ max_confidence: -300, overrides: [] })).toEqual({ max_confidence: 0, overrides: [] });
+    expect(cropMaxConfidenceInEditValue({ max_confidence: -300, overrides: [{ entity_type: 'Report', max_confidence: 50 }] }))
+      .toEqual({ max_confidence: 0, overrides: [{ entity_type: 'Report', max_confidence: 50 }] });
+    expect(cropMaxConfidenceInEditValue({ max_confidence: 50, overrides: [{ entity_type: 'Report', max_confidence: 500 }] }))
+      .toEqual({ max_confidence: 50, overrides: [{ entity_type: 'Report', max_confidence: 100 }] });
+    expect(cropMaxConfidenceInEditValue({ max_confidence: 50, overrides: [{ entity_type: 'Report', max_confidence: -500 }] }))
+      .toEqual({ max_confidence: 50, overrides: [{ entity_type: 'Report', max_confidence: 0 }] });
+
+    expect(cropMaxConfidenceInEditValue({
+      max_confidence: -50,
+      overrides: [
+        { entity_type: 'Report', max_confidence: 90 },
+        { entity_type: 'Malware', max_confidence: -10 },
+        { entity_type: 'Note', max_confidence: 45 },
+        { entity_type: 'Pokemon', max_confidence: 10000 },
+      ]
+    })).toEqual({
+      max_confidence: 0,
+      overrides: [
+        { entity_type: 'Report', max_confidence: 90 },
+        { entity_type: 'Malware', max_confidence: 0 },
+        { entity_type: 'Note', max_confidence: 45 },
+        { entity_type: 'Pokemon', max_confidence: 100 },
+      ]
+    });
+
+    // complete overrides object
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: 50 }, '/group_confidence_level/overrides/0'))
+      .toEqual({ entity_type: 'Report', max_confidence: 50 });
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: 300 }, '/group_confidence_level/overrides/8'))
+      .toEqual({ entity_type: 'Report', max_confidence: 100 });
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: -300 }, '/group_confidence_level/overrides/7'))
+      .toEqual({ entity_type: 'Report', max_confidence: 0 });
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: 50 }, '/user_confidence_level/overrides/0'))
+      .toEqual({ entity_type: 'Report', max_confidence: 50 });
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: 300 }, '/user_confidence_level/overrides/5'))
+      .toEqual({ entity_type: 'Report', max_confidence: 100 });
+    expect(cropMaxConfidenceInEditValue({ entity_type: 'Report', max_confidence: -300 }, '/user_confidence_level/overrides/3'))
+      .toEqual({ entity_type: 'Report', max_confidence: 0 });
+
+    // max_confidence only
+    expect(cropMaxConfidenceInEditValue(50, '/group_confidence_level/max_confidence')).toEqual(50);
+    expect(cropMaxConfidenceInEditValue(300, '/group_confidence_level/max_confidence')).toEqual(100);
+    expect(cropMaxConfidenceInEditValue(-300, '/group_confidence_level/max_confidence')).toEqual(0);
+    expect(cropMaxConfidenceInEditValue(50, '/user_confidence_level/max_confidence')).toEqual(50);
+    expect(cropMaxConfidenceInEditValue(300, '/user_confidence_level/max_confidence')).toEqual(100);
+    expect(cropMaxConfidenceInEditValue(-300, '/user_confidence_level/max_confidence')).toEqual(0);
+
+    // overrides.max_confidence only
+    expect(cropMaxConfidenceInEditValue(50, '/group_confidence_level/overrides/0/max_confidence')).toEqual(50);
+    expect(cropMaxConfidenceInEditValue(300, '/group_confidence_level/overrides/78/max_confidence')).toEqual(100);
+    expect(cropMaxConfidenceInEditValue(-300, '/group_confidence_level/overrides/9/max_confidence')).toEqual(0);
+    expect(cropMaxConfidenceInEditValue(50, '/user_confidence_level/overrides/8/max_confidence')).toEqual(50);
+    expect(cropMaxConfidenceInEditValue(300, '/user_confidence_level/overrides/0/max_confidence')).toEqual(100);
+    expect(cropMaxConfidenceInEditValue(-300, '/user_confidence_leve/overrides/41/max_confidence')).toEqual(0);
+  });
+
+  it('computeUserEffectiveConfidenceLevel should correctly compute the effective level', async () => {
+    const group70 = {
+      id: 'group70',
+      group_confidence_level: {
+        max_confidence: 70,
+        overrides: [],
+      }
+    };
+
+    const group80 = {
+      id: 'group80',
+      group_confidence_level: {
+        max_confidence: 70,
+        overrides: [],
+      }
+    };
+
+    // minimal subset of a real User
+    const userA = {
+      id: 'userA',
+      user_confidence_level: {
+        max_confidence: 30,
+        overrides: [],
+      },
+      groups: [group70, group80],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userA as unknown as AuthUser)).toEqual({
+      max_confidence: 30,
+      overrides: [],
+      source: userA,
+    });
+
+    const userB = {
+      id: 'userB',
+      user_confidence_level: null,
+      groups: [group70, group80],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userB as unknown as AuthUser)).toEqual({
+      max_confidence: 70,
+      overrides: [],
+      source: group70,
+    });
+
+    const userD = {
+      user_confidence_level: null,
+      groups: [{ group_confidence_level: null }, { group_confidence_level: null }],
+    };
+
+    const userE = {
+      user_confidence_level: null,
+      groups: [],
+    };
+      // ugly typecast to avoid having complete AuthUser objects
+    expect(computeUserEffectiveConfidenceLevel(userD as unknown as AuthUser)).toBeNull();
+    expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { cropNumber } from '../../../src/utils/math';
+import { FunctionalError } from '../../../src/config/errors';
 
 describe('Math utilities: cropNumber', () => {
   it('should crop value with various min/max inputs', () => {
@@ -15,6 +16,11 @@ describe('Math utilities: cropNumber', () => {
 
     expect(cropNumber(50, { })).toEqual(50);
 
-    expect(() => cropNumber(50, { min: 100, max: 10 })).toThrowError('Incorrect inputs to cropNumber, min cannot be greater than max');
+    expect(() => cropNumber(50, { min: 100, max: 10 }))
+      .toThrow(FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max'));
+    expect(() => cropNumber(NaN, { min: 10, max: 80 }))
+      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: NaN }));
+    expect(() => cropNumber({ some: 'object' } as unknown as number, { min: 10, max: 80 }))
+      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: { some: 'object' } }));
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { cropNumber } from '../../../src/utils/math';
+
+describe('Math utilities: cropNumber', () => {
+  it('should crop value with various min/max inputs', () => {
+    expect(cropNumber(50, { min: 10, max: 100 })).toEqual(50);
+    expect(cropNumber(50, { min: 60, max: 100 })).toEqual(60);
+    expect(cropNumber(50, { min: 10, max: 30 })).toEqual(30);
+
+    expect(cropNumber(50, { min: 10 })).toEqual(50);
+    expect(cropNumber(50, { min: 60 })).toEqual(60);
+
+    expect(cropNumber(50, { max: 60 })).toEqual(50);
+    expect(cropNumber(50, { max: 30 })).toEqual(30);
+
+    expect(cropNumber(50, { })).toEqual(50);
+
+    expect(() => cropNumber(50, { min: 100, max: 10 })).toThrowError('Incorrect inputs to cropNumber, min cannot be greater than max');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -14,6 +14,7 @@ import type { StoreMarkingDefinition } from '../../src/types/store';
 import { generateStandardId, MARKING_TLP_AMBER, MARKING_TLP_AMBER_STRICT, MARKING_TLP_GREEN } from '../../src/schema/identifier';
 import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE, ENTITY_TYPE_USER } from '../../src/schema/internalObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../src/modules/organization/organization-types';
+import type { ConfidenceLevel } from '../../src/generated/graphql';
 // endregion
 
 export const SYNC_RAW_START_REMOTE_URI = conf.get('app:sync_raw_start_remote_uri');
@@ -105,7 +106,8 @@ interface Group {
   id: string,
   name: string,
   markings: string[],
-  roles: Role[]
+  roles: Role[],
+  group_confidence_level: ConfidenceLevel
 }
 
 export const GREEN_GROUP: Group = {
@@ -113,12 +115,20 @@ export const GREEN_GROUP: Group = {
   name: 'GREEN GROUP',
   markings: [MARKING_TLP_GREEN],
   roles: [ROLE_PARTICIPATE],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 export const AMBER_GROUP: Group = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER GROUP' }),
   name: 'AMBER GROUP',
   markings: [MARKING_TLP_AMBER],
   roles: [ROLE_EDITOR],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const AMBER_STRICT_GROUP: Group = {
@@ -126,6 +136,10 @@ export const AMBER_STRICT_GROUP: Group = {
   name: 'AMBER STRICT GROUP',
   markings: [MARKING_TLP_AMBER_STRICT],
   roles: [ROLE_SECURITY],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 // Organization
@@ -147,7 +161,8 @@ interface User {
   roles?: Role[],
   organizations?: Organization[],
   groups: Group[],
-  client: AxiosInstance
+  client: AxiosInstance,
+  user_confidence_level?: ConfidenceLevel
 }
 
 export const ADMIN_USER: AuthUser = {
@@ -170,7 +185,11 @@ export const ADMIN_USER: AuthUser = {
   origin: { referer: 'test', user_id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f' },
   api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e84',
   account_status: ACCOUNT_STATUS_ACTIVE,
-  account_lock_after_date: undefined
+  account_lock_after_date: undefined,
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 const TESTING_USERS: User[] = [];
 export const USER_PARTICIPATE: User = {
@@ -439,7 +458,11 @@ export const buildStandardUser = (allowedMarkings: markingType[], allMarkings?: 
     origin: { referer: 'test', user_id: '98ec0c6a-13ce-5e39-b486-354fe4a7084f' },
     api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e85',
     account_status: ACCOUNT_STATUS_ACTIVE,
-    account_lock_after_date: undefined
+    account_lock_after_date: undefined,
+    user_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    }
   };
 };
 


### PR DESCRIPTION
## Description
Closes #5759

This PR handles bad user input

I've split the code into utilities function with unit tests that should cover every possible cases.

### Test cases

For each of these cases, the values can be tested as < 0, between 0 and 100 and above 100, to verify cropping is correct.

* user creation, with `user_confidence level`
* user edition with complete `user_max_confidence_level` payload
* user edition with partial `user_max_confidence_level` payload > max_confidence value
* user edition with partial `user_max_confidence_level` payload > complete overrides value
* user edition with partial `user_max_confidence_level` payload > overrides.max_confidence value
* group creation, with `group_confidence level`
* group edition with complete `group_confidence ` payload
* group edition with partial `group_confidence ` payload > max_confidence value
* group edition with partial `group_confidence ` payload > complete overrides value
* group edition with partial `group_confidence ` payload > overrides.max_confidence value

Error cases
* group edition with a bad `object_path` > throws "Unhandled object_path for patching a confidence level"
* group edition with a correct `object_path` but value is mistyped > throws "Cannot crop non-finite input value"


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Here are some test queries / payloads for the playground.

[confidence-queries.txt](https://github.com/OpenCTI-Platform/opencti/files/14114617/confidence-queries.txt)

