### PR TITLE
[frontend] Hide Indicator decay manager from managers list (#2859)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
@@ -960,7 +960,8 @@ const Settings = () => {
                     </Typography>
                     <Paper classes={{ root: classes.paper }} variant="outlined">
                       <List style={{ marginTop: -20 }}>
-                        {modules.map((module) => {
+                        {/* TODO remove Decay feature flag */}
+                        {modules.filter((module) => module.id !== 'INDICATOR_DECAY_MANAGER').map((module) => {
                           const isEeModule = ['ACTIVITY_MANAGER', 'PLAYBOOK_MANAGER', 'FILE_INDEX_MANAGER'].includes(module.id);
                           let status = module.enable;
                           if (!isEnterpriseEdition && isEeModule) {


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove indicator decay manager from list displayed in settings

### Related issues

* Indicator decay manager was displayed even if it's feature flagged for now

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

