### PR TITLE
[backend] crop effective confidence level in [0-100]

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -69,6 +69,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organ
 import { ENTITY_TYPE_WORKSPACE } from '../modules/workspace/workspace-types';
 import { extractFilterKeys } from '../utils/filtering/filtering-utils';
 import { testFilterGroup, testStringFilter } from '../utils/filtering/boolean-logic-engine';
+import { computeUserEffectiveConfidenceLevel } from '../utils/confidence-level';
 
 const BEARER = 'Bearer ';
 const BASIC = 'Basic ';
@@ -1135,6 +1136,7 @@ const buildSessionUser = (origin, impersonate, provider, settings) => {
     account_lock_after_date: user.account_lock_after_date,
     unit_system: user.unit_system,
     groups: user.groups,
+    user_confidence_level: user.user_confidence_level,
     roles: user.roles,
     impersonate: impersonate !== undefined,
     impersonate_user_id: impersonate !== undefined ? origin.id : null,
@@ -1220,7 +1222,7 @@ export const buildCompleteUser = async (context, client) => {
   const default_hidden_types = uniq(defaultHiddenTypesGroups.concat(defaultHiddenTypesOrgs));
 
   // effective confidence level
-  const effective_confidence_level = computeUserEffectiveConfidenceLevel({ ...client, groups, organizations });
+  const effective_confidence_level = computeUserEffectiveConfidenceLevel({ ...client, groups });
 
   return {
     ...client,
@@ -1460,39 +1462,6 @@ export const userEditContext = async (context, user, userId, input) => {
 // endregion
 
 export const getUserEffectiveConfidenceLevel = async (userId, context) => {
-  const user = await findById(context, context.user, userId);
+  const user = await findById(context, context.user, userId); // this returns a complete user, with groups
   return computeUserEffectiveConfidenceLevel(user);
-};
-
-export const computeUserEffectiveConfidenceLevel = (user) => {
-  // if user has a specific confidence level, it overrides everything and we return it
-  if (user.user_confidence_level) {
-    return {
-      ...user.user_confidence_level,
-      source: user,
-    };
-  }
-
-  // otherwise we get all groups for this user, and select the lowest max_confidence found
-  let minLevel = null;
-  let source = null;
-  for (let i = 0; i < user.groups.length; i += 1) {
-    const groupLevel = user.groups[i].group_confidence_level?.max_confidence ?? null;
-    if (minLevel === null || (groupLevel !== null && groupLevel < minLevel)) {
-      minLevel = groupLevel;
-      source = user.groups[i];
-    }
-  }
-
-  if (minLevel !== null) {
-    return {
-      max_confidence: minLevel,
-      // TODO: handle overrides and their sources
-      overrides: [],
-      source,
-    };
-  }
-
-  // finally, if this user has no effective confidence level, we can return null
-  return null;
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1136,7 +1136,6 @@ const buildSessionUser = (origin, impersonate, provider, settings) => {
     account_lock_after_date: user.account_lock_after_date,
     unit_system: user.unit_system,
     groups: user.groups,
-    user_confidence_level: user.user_confidence_level,
     roles: user.roles,
     impersonate: impersonate !== undefined,
     impersonate_user_id: impersonate !== undefined ? origin.id : null,

--- a/opencti-platform/opencti-graphql/src/types/group.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/group.d.ts
@@ -1,4 +1,5 @@
 import type { BasicStoreCommon } from './store';
+import type { ConfidenceLevel } from '../generated/graphql';
 
 interface DefaultMarking {
   entity_type: string,
@@ -7,4 +8,5 @@ interface DefaultMarking {
 
 interface Group extends BasicStoreCommon {
   default_marking?: Array<DefaultMarking>;
+  group_confidence_level: ConfidenceLevel
 }

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -1,5 +1,6 @@
 import type { BasicStoreCommon, BasicStoreIdentifier, StoreMarkingDefinition } from './store';
 import type { Group } from './group';
+import type { ConfidenceLevel } from '../generated/graphql';
 
 interface UserRole extends BasicStoreIdentifier {
   name: string;
@@ -41,6 +42,8 @@ interface AuthUser extends BasicStoreIdentifier {
   all_marking: Array<StoreMarkingDefinition>;
   api_token: string;
   account_status: string;
+  effective_confidence_level: ConfidenceLevel | null;
+  user_confidence_level: ConfidenceLevel | null;
 }
 
 interface AuthContext {

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -75,6 +75,14 @@ export const SYSTEM_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  effective_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
 };
 
 export const RETENTION_MANAGER_USER: AuthUser = {
@@ -98,6 +106,14 @@ export const RETENTION_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  effective_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
 };
 
 export const RULE_MANAGER_USER: AuthUser = {
@@ -121,6 +137,14 @@ export const RULE_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  effective_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
 };
 
 export const AUTOMATION_MANAGER_USER: AuthUser = {
@@ -144,6 +168,14 @@ export const AUTOMATION_MANAGER_USER: AuthUser = {
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
   administrated_organizations: [],
+  effective_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
 };
 
 export const REDACTED_USER: AuthUser = {
@@ -167,6 +199,8 @@ export const REDACTED_USER: AuthUser = {
   api_token: '',
   account_lock_after_date: undefined,
   account_status: ACCOUNT_STATUS_ACTIVE,
+  effective_confidence_level: null,
+  user_confidence_level: null,
 };
 
 export interface AuthorizedMember { id: string, access_right: string }

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -1,0 +1,44 @@
+import type { AuthUser } from '../types/user';
+import { cropNumber } from './math';
+
+export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
+  // if user has a specific confidence level, it overrides everything and we return it
+  if (user.user_confidence_level) {
+    return {
+      // we make sure the levels are cropped in between 0-100
+      // other values were possibly injected in octi <6.0 though API calls
+      max_confidence: cropNumber(user.user_confidence_level.max_confidence, { min: 0, max: 100 }),
+      overrides: user.user_confidence_level.overrides.map((override) => ({
+        max_confidence: cropNumber(override.max_confidence, { min: 0, max: 100 }),
+        entity_type: override.entity_type,
+      })),
+      source: user,
+    };
+  }
+
+  // otherwise we get all groups for this user, and select the lowest max_confidence found
+  let minLevel = null;
+  let source = null;
+  if (user.groups) {
+    for (let i = 0; i < user.groups.length; i += 1) {
+      // groups were not migrated when introducing group_confidence_level, so group_confidence_level might be null
+      const groupLevel = user.groups[i].group_confidence_level?.max_confidence ?? null;
+      if (groupLevel !== null && (minLevel === null || groupLevel < minLevel)) {
+        minLevel = groupLevel;
+        source = user.groups[i];
+      }
+    }
+  }
+
+  if (minLevel !== null) {
+    return {
+      max_confidence: cropNumber(minLevel, { min: 0, max: 100 }),
+      // TODO: handle overrides and their sources
+      overrides: [],
+      source,
+    };
+  }
+
+  // finally, if this user has no effective confidence level, we can return null
+  return null;
+};

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -7,9 +7,9 @@ export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
     return {
       // we make sure the levels are cropped in between 0-100
       // other values were possibly injected in octi <6.0 though API calls
-      max_confidence: cropNumber(user.user_confidence_level.max_confidence, { min: 0, max: 100 }),
+      max_confidence: cropNumber(user.user_confidence_level.max_confidence, 0, 100),
       overrides: user.user_confidence_level.overrides.map((override) => ({
-        max_confidence: cropNumber(override.max_confidence, { min: 0, max: 100 }),
+        max_confidence: cropNumber(override.max_confidence, 0, 100),
         entity_type: override.entity_type,
       })),
       source: user,
@@ -32,7 +32,7 @@ export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
 
   if (minLevel !== null) {
     return {
-      max_confidence: cropNumber(minLevel, { min: 0, max: 100 }),
+      max_confidence: cropNumber(minLevel, 0, 100),
       // TODO: handle overrides and their sources
       overrides: [],
       source,

--- a/opencti-platform/opencti-graphql/src/utils/math.ts
+++ b/opencti-platform/opencti-graphql/src/utils/math.ts
@@ -1,0 +1,19 @@
+import { FunctionalError } from '../config/errors';
+
+export const cropNumber = (value: number, options: { min?: number, max?: number }) => {
+  if (!Number.isFinite(value)) {
+    throw FunctionalError('Cannot crop non-finite input value', { value });
+  }
+  let newValue = value;
+  if (options.min !== undefined) {
+    if (options.max !== undefined && options.min > options.max) {
+      throw FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max');
+    }
+    newValue = Math.max(newValue, options.min);
+  }
+  if (options.max !== undefined) {
+    newValue = Math.min(newValue, options.max);
+  }
+
+  return newValue;
+};

--- a/opencti-platform/opencti-graphql/src/utils/math.ts
+++ b/opencti-platform/opencti-graphql/src/utils/math.ts
@@ -1,19 +1,12 @@
 import { FunctionalError } from '../config/errors';
 
-export const cropNumber = (value: number, options: { min?: number, max?: number }) => {
-  if (!Number.isFinite(value)) {
-    throw FunctionalError('Cannot crop non-finite input value', { value });
+export const cropNumber = (value: number, min: number, max: number) => {
+  if (!Number.isFinite(value) || !Number.isFinite(min) || !Number.isFinite(max)) {
+    throw FunctionalError('Cannot process non-finite input');
   }
-  let newValue = value;
-  if (options.min !== undefined) {
-    if (options.max !== undefined && options.min > options.max) {
-      throw FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max');
-    }
-    newValue = Math.max(newValue, options.min);
-  }
-  if (options.max !== undefined) {
-    newValue = Math.min(newValue, options.max);
+  if (min > max) {
+    throw FunctionalError('min cannot be greater than max');
   }
 
-  return newValue;
+  return Math.max(Math.min(value, max), min);
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { testContext } from '../../utils/testQuery';
-import { checkPasswordInlinePolicy, computeUserEffectiveConfidenceLevel } from '../../../src/domain/user';
+import { checkPasswordInlinePolicy } from '../../../src/domain/user';
 
 describe('password checker', () => {
   it('should no policy applied', async () => {
@@ -73,63 +73,5 @@ describe('password checker', () => {
     };
     expect(checkPasswordInlinePolicy(testContext, policy03, 'julA').length).toBe(1);
     expect(checkPasswordInlinePolicy(testContext, policy03, 'ju!lA').length).toBe(0);
-  });
-});
-
-describe('Effective max confidence level', () => {
-  const group70 = {
-    id: 'group70',
-    group_confidence_level: {
-      max_confidence: 70,
-      overrides: [],
-    }
-  };
-
-  const group80 = {
-    id: 'group80',
-    group_confidence_level: {
-      max_confidence: 70,
-      overrides: [],
-    }
-  };
-
-  it("user's confidence level overrides groups and orgs", async () => {
-    // minimal subset of a real User
-    const userA = {
-      id: 'userA',
-      user_confidence_level: {
-        max_confidence: 30,
-        overrides: [],
-      },
-      groups: [group70, group80],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userA)).toEqual({
-      max_confidence: 30,
-      overrides: [],
-      source: userA,
-    });
-
-    const userB = {
-      id: 'userB',
-      user_confidence_level: null,
-      groups: [group70, group80],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userB)).toEqual({
-      max_confidence: 70,
-      overrides: [],
-      source: group70,
-    });
-
-    const userD = {
-      user_confidence_level: null,
-      groups: [{ group_confidence_level: null }, { group_confidence_level: null }],
-    };
-
-    const userE = {
-      user_confidence_level: null,
-      groups: [],
-    };
-    expect(computeUserEffectiveConfidenceLevel(userD)).toBeNull();
-    expect(computeUserEffectiveConfidenceLevel(userE)).toBeNull();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { computeUserEffectiveConfidenceLevel } from '../../../src/utils/confidence-level';
+import type { AuthUser } from '../../../src/types/user';
+
+describe('Confidence level utilities', () => {
+  it('computeUserEffectiveConfidenceLevel should correctly compute the effective level', async () => {
+    const group70 = {
+      id: 'group70',
+      group_confidence_level: {
+        max_confidence: 70,
+        overrides: [],
+      }
+    };
+
+    const group80 = {
+      id: 'group80',
+      group_confidence_level: {
+        max_confidence: 70,
+        overrides: [],
+      }
+    };
+
+    const groupNull = {
+      id: 'groupNull',
+      group_confidence_level: null
+    };
+
+    // minimal subset of a real User
+    const userA = {
+      id: 'userA',
+      user_confidence_level: {
+        max_confidence: 30,
+        overrides: [],
+      },
+      groups: [group70, group80],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userA as unknown as AuthUser)).toEqual({
+      max_confidence: 30,
+      overrides: [],
+      source: userA,
+    });
+
+    const userB = {
+      id: 'userB',
+      user_confidence_level: null,
+      groups: [group70, group80],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userB as unknown as AuthUser)).toEqual({
+      max_confidence: 70,
+      overrides: [],
+      source: group70,
+    });
+
+    const userC = {
+      user_confidence_level: null,
+      groups: [groupNull, group70, groupNull],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userC as unknown as AuthUser)).toEqual({
+      max_confidence: 70,
+      overrides: [],
+      source: group70,
+    });
+
+    const userD = {
+      user_confidence_level: null,
+      groups: [groupNull, groupNull],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userD as unknown as AuthUser)).toBeNull();
+
+    const userE = {
+      user_confidence_level: null,
+      groups: [],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
@@ -4,23 +4,17 @@ import { FunctionalError } from '../../../src/config/errors';
 
 describe('Math utilities: cropNumber', () => {
   it('should crop value with various min/max inputs', () => {
-    expect(cropNumber(50, { min: 10, max: 100 })).toEqual(50);
-    expect(cropNumber(50, { min: 60, max: 100 })).toEqual(60);
-    expect(cropNumber(50, { min: 10, max: 30 })).toEqual(30);
+    expect(cropNumber(50, 10, 100)).toEqual(50);
+    expect(cropNumber(50, 60, 100)).toEqual(60);
+    expect(cropNumber(50, 10, 30)).toEqual(30);
 
-    expect(cropNumber(50, { min: 10 })).toEqual(50);
-    expect(cropNumber(50, { min: 60 })).toEqual(60);
-
-    expect(cropNumber(50, { max: 60 })).toEqual(50);
-    expect(cropNumber(50, { max: 30 })).toEqual(30);
-
-    expect(cropNumber(50, { })).toEqual(50);
-
-    expect(() => cropNumber(50, { min: 100, max: 10 }))
-      .toThrow(FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max'));
-    expect(() => cropNumber(NaN, { min: 10, max: 80 }))
-      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: NaN }));
-    expect(() => cropNumber({ some: 'object' } as unknown as number, { min: 10, max: 80 }))
-      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: { some: 'object' } }));
+    expect(() => cropNumber(50, 100, 10))
+      .toThrow(FunctionalError('min cannot be greater than max'));
+    expect(() => cropNumber(NaN, 10, 80))
+      .toThrow(FunctionalError('Cannot process non-finite input'));
+    expect(() => cropNumber(50, NaN, 80))
+      .toThrow(FunctionalError('Cannot process non-finite input'));
+    expect(() => cropNumber(50, 10, NaN))
+      .toThrow(FunctionalError('Cannot process non-finite input'));
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/math-test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { cropNumber } from '../../../src/utils/math';
+import { FunctionalError } from '../../../src/config/errors';
+
+describe('Math utilities: cropNumber', () => {
+  it('should crop value with various min/max inputs', () => {
+    expect(cropNumber(50, { min: 10, max: 100 })).toEqual(50);
+    expect(cropNumber(50, { min: 60, max: 100 })).toEqual(60);
+    expect(cropNumber(50, { min: 10, max: 30 })).toEqual(30);
+
+    expect(cropNumber(50, { min: 10 })).toEqual(50);
+    expect(cropNumber(50, { min: 60 })).toEqual(60);
+
+    expect(cropNumber(50, { max: 60 })).toEqual(50);
+    expect(cropNumber(50, { max: 30 })).toEqual(30);
+
+    expect(cropNumber(50, { })).toEqual(50);
+
+    expect(() => cropNumber(50, { min: 100, max: 10 }))
+      .toThrow(FunctionalError('Incorrect inputs to cropNumber, min cannot be greater than max'));
+    expect(() => cropNumber(NaN, { min: 10, max: 80 }))
+      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: NaN }));
+    expect(() => cropNumber({ some: 'object' } as unknown as number, { min: 10, max: 80 }))
+      .toThrow(FunctionalError('Cannot crop non-finite input value', { value: { some: 'object' } }));
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/group-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/group-test.js
@@ -188,7 +188,7 @@ describe('Group resolver standard behavior', () => {
   });
   it('should list groups', async () => {
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
-    expect(queryResult.data.groups.edges.length).toEqual(8);
+    expect(queryResult.data.groups.edges.length).toEqual(7);
   });
   it('should update group', async () => {
     const UPDATE_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/group-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/group-test.js
@@ -32,6 +32,7 @@ const READ_QUERY = gql`
 
 describe('Group resolver standard behavior', () => {
   let groupInternalId; // the one we will use in all tests
+  const groupsToDeleteIds = []; // keep track for deletion at the end of the tests
   it('should group created', async () => {
     const CREATE_QUERY = gql`
       mutation GroupAdd($input: GroupAddInput!) {
@@ -40,7 +41,11 @@ describe('Group resolver standard behavior', () => {
           name
           description
           group_confidence_level { 
-            max_confidence 
+            max_confidence
+            overrides {
+              entity_type
+              max_confidence
+            }
           }
         }
       }
@@ -53,7 +58,7 @@ describe('Group resolver standard behavior', () => {
         group_confidence_level: { max_confidence: 50, overrides: [] },
       },
     };
-    const group = await queryAsAdmin({
+    let group = await queryAsAdmin({
       query: CREATE_QUERY,
       variables: GROUP_TO_CREATE,
     });
@@ -63,6 +68,22 @@ describe('Group resolver standard behavior', () => {
     expect(group.data.groupAdd.group_confidence_level.max_confidence).toEqual(50);
     // we will use this one in all the subsequent tests
     groupInternalId = group.data.groupAdd.id;
+    groupsToDeleteIds.push(group.data.groupAdd.id);
+
+    // create some more with different configuration of confidence level
+    const GROUP_TO_CREATE_WITH_OVERRIDES = {
+      input: {
+        name: 'Group with overrides',
+        description: 'Group description',
+        group_confidence_level: { max_confidence: 50, overrides: [{ entity_type: 'Report', max_confidence: 80 }] },
+      },
+    };
+    group = await queryAsAdmin({
+      query: CREATE_QUERY,
+      variables: GROUP_TO_CREATE_WITH_OVERRIDES,
+    });
+    expect(group.data.groupAdd.group_confidence_level.overrides[0]).toEqual({ entity_type: 'Report', max_confidence: 80 });
+    groupsToDeleteIds.push(group.data.groupAdd.id);
   });
 
   describe('dashboard preferences', () => {
@@ -167,7 +188,7 @@ describe('Group resolver standard behavior', () => {
   });
   it('should list groups', async () => {
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
-    expect(queryResult.data.groups.edges.length).toEqual(6);
+    expect(queryResult.data.groups.edges.length).toEqual(8);
   });
   it('should update group', async () => {
     const UPDATE_QUERY = gql`
@@ -185,6 +206,60 @@ describe('Group resolver standard behavior', () => {
       variables: { id: groupInternalId, input: { key: 'name', value: ['Group - test'] } },
     });
     expect(queryResult.data.groupEdit.fieldPatch.name).toEqual('Group - test');
+  });
+  it('should update group confidence level', async () => {
+    const UPDATE_QUERY = gql`
+      mutation GroupEdit($id: ID!, $input: [EditInput]!) {
+        groupEdit(id: $id) {
+          fieldPatch(input: $input) {
+            id
+            group_confidence_level {
+              max_confidence
+              overrides { 
+                max_confidence 
+                entity_type 
+              }
+            }
+          }
+        }
+      }
+    `;
+    const group_confidence_level = {
+      max_confidence: 30,
+      overrides: [{ entity_type: 'Report', max_confidence: 50 }],
+    };
+    let queryResult = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: {
+        id: groupInternalId,
+        input: { key: 'group_confidence_level', value: [group_confidence_level] }
+      },
+    });
+    expect(queryResult.data.groupEdit.fieldPatch.group_confidence_level).toEqual(group_confidence_level);
+
+    // update by patching
+    queryResult = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: {
+        id: groupInternalId,
+        input: { key: 'group_confidence_level', object_path: '/group_confidence_level/max_confidence', value: [87] }
+      },
+    });
+    expect(queryResult.data.groupEdit.fieldPatch.group_confidence_level).toEqual({
+      max_confidence: 87,
+      overrides: [{ entity_type: 'Report', max_confidence: 50 }], // unchanged!
+    });
+    queryResult = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: {
+        id: groupInternalId,
+        input: { key: 'group_confidence_level', object_path: '/group_confidence_level/overrides/0/max_confidence', value: [63] }
+      },
+    });
+    expect(queryResult.data.groupEdit.fieldPatch.group_confidence_level).toEqual({
+      max_confidence: 87, // unchanged!
+      overrides: [{ entity_type: 'Report', max_confidence: 63 }],
+    });
   });
   it('should context patch group', async () => {
     const CONTEXT_PATCH_QUERY = gql`
@@ -344,14 +419,17 @@ describe('Group resolver standard behavior', () => {
         }
       }
     `;
-    // Delete the group
-    await queryAsAdmin({
-      query: DELETE_QUERY,
-      variables: { id: groupInternalId },
-    });
-    // Verify is no longer found
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: groupInternalId } });
-    expect(queryResult).not.toBeNull();
-    expect(queryResult.data.group).toBeNull();
+    // Delete the groups
+    for (let i = 0; i < groupsToDeleteIds.length; i++) {
+      const groupId = groupsToDeleteIds[i];
+      await queryAsAdmin({
+        query: DELETE_QUERY,
+        variables: { id: groupId },
+      });
+      // Verify is no longer found
+      const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: groupInternalId } });
+      expect(queryResult).not.toBeNull();
+      expect(queryResult.data.group).toBeNull();
+    }
   });
 });

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -184,7 +184,15 @@ export const ADMIN_USER: AuthUser = {
   origin: { referer: 'test', user_id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f' },
   api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e84',
   account_status: ACCOUNT_STATUS_ACTIVE,
-  account_lock_after_date: undefined
+  account_lock_after_date: undefined,
+  effective_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  },
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 const TESTING_USERS: User[] = [];
 export const USER_PARTICIPATE: User = {
@@ -453,7 +461,15 @@ export const buildStandardUser = (allowedMarkings: markingType[], allMarkings?: 
     origin: { referer: 'test', user_id: '98ec0c6a-13ce-5e39-b486-354fe4a7084f' },
     api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e85',
     account_status: ACCOUNT_STATUS_ACTIVE,
-    account_lock_after_date: undefined
+    account_lock_after_date: undefined,
+    effective_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    },
+    user_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    }
   };
 };
 

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -14,6 +14,7 @@ import type { StoreMarkingDefinition } from '../../src/types/store';
 import { generateStandardId, MARKING_TLP_AMBER, MARKING_TLP_AMBER_STRICT, MARKING_TLP_GREEN } from '../../src/schema/identifier';
 import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE, ENTITY_TYPE_USER } from '../../src/schema/internalObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../src/modules/organization/organization-types';
+import type { ConfidenceLevel } from '../../src/generated/graphql';
 // endregion
 
 export const SYNC_RAW_START_REMOTE_URI = conf.get('app:sync_raw_start_remote_uri');
@@ -105,7 +106,8 @@ interface Group {
   id: string,
   name: string,
   markings: string[],
-  roles: Role[]
+  roles: Role[],
+  group_confidence_level: ConfidenceLevel
 }
 
 export const GREEN_GROUP: Group = {
@@ -113,12 +115,20 @@ export const GREEN_GROUP: Group = {
   name: 'GREEN GROUP',
   markings: [MARKING_TLP_GREEN],
   roles: [ROLE_PARTICIPATE],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 export const AMBER_GROUP: Group = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER GROUP' }),
   name: 'AMBER GROUP',
   markings: [MARKING_TLP_AMBER],
   roles: [ROLE_EDITOR],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 export const AMBER_STRICT_GROUP: Group = {
@@ -126,6 +136,10 @@ export const AMBER_STRICT_GROUP: Group = {
   name: 'AMBER STRICT GROUP',
   markings: [MARKING_TLP_AMBER_STRICT],
   roles: [ROLE_SECURITY],
+  group_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 
 // Organization
@@ -147,7 +161,8 @@ interface User {
   roles?: Role[],
   organizations?: Organization[],
   groups: Group[],
-  client: AxiosInstance
+  client: AxiosInstance,
+  user_confidence_level?: ConfidenceLevel
 }
 
 export const ADMIN_USER: AuthUser = {
@@ -170,7 +185,11 @@ export const ADMIN_USER: AuthUser = {
   origin: { referer: 'test', user_id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f' },
   api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e84',
   account_status: ACCOUNT_STATUS_ACTIVE,
-  account_lock_after_date: undefined
+  account_lock_after_date: undefined,
+  user_confidence_level: {
+    max_confidence: 100,
+    overrides: [],
+  }
 };
 const TESTING_USERS: User[] = [];
 export const USER_PARTICIPATE: User = {
@@ -439,7 +458,11 @@ export const buildStandardUser = (allowedMarkings: markingType[], allMarkings?: 
     origin: { referer: 'test', user_id: '98ec0c6a-13ce-5e39-b486-354fe4a7084f' },
     api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e85',
     account_status: ACCOUNT_STATUS_ACTIVE,
-    account_lock_after_date: undefined
+    account_lock_after_date: undefined,
+    user_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    }
   };
 };
 

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -162,7 +162,6 @@ interface User {
   organizations?: Organization[],
   groups: Group[],
   client: AxiosInstance,
-  user_confidence_level?: ConfidenceLevel
 }
 
 export const ADMIN_USER: AuthUser = {
@@ -185,11 +184,7 @@ export const ADMIN_USER: AuthUser = {
   origin: { referer: 'test', user_id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f' },
   api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e84',
   account_status: ACCOUNT_STATUS_ACTIVE,
-  account_lock_after_date: undefined,
-  user_confidence_level: {
-    max_confidence: 100,
-    overrides: [],
-  }
+  account_lock_after_date: undefined
 };
 const TESTING_USERS: User[] = [];
 export const USER_PARTICIPATE: User = {
@@ -458,11 +453,7 @@ export const buildStandardUser = (allowedMarkings: markingType[], allMarkings?: 
     origin: { referer: 'test', user_id: '98ec0c6a-13ce-5e39-b486-354fe4a7084f' },
     api_token: 'd434ce02-e58e-4cac-8b4c-42bf16748e85',
     account_status: ACCOUNT_STATUS_ACTIVE,
-    account_lock_after_date: undefined,
-    user_confidence_level: {
-      max_confidence: 100,
-      overrides: [],
-    }
+    account_lock_after_date: undefined
   };
 };
 


### PR DESCRIPTION
Closes https://github.com/OpenCTI-Platform/opencti/issues/5759

### Proposed changes

* `user_effective_level` is cropped between [0-100] on computation, that's all
* no cropping when adding/editing the confidence values of users and groups. Thus we cannot trust them for now (this might be addressed in #5696 as part of a new validation against schema, including such numerical constraints)
* adding confidence information to the internal user in context ; for use internnaly
* built-in users have a confidence level now (all to 100 so they can do their job correctly).
* updated test base to improve coverage

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This PR replaces #5768 