### PR TITLE
[backend] extend our vitest config for easier dev process

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -19,9 +19,10 @@
     "start-cluster": "NODE_ENV=cluster node build/back.js",
     "serv": "node build/back.js",
     "insert:dev": "node build/script-insert-dataset.js",
-    "test:dev": "vitest watch --config vitest.config.dev.ts",
-    "test:dev-init-only": "ONLY_PLATFORM_INIT=1 vitest run --config vitest.config.dev.ts tests/02-integration/00-inject/loader-test.js",
-    "test:dev-no-cleanup": "SKIP_CLEANUP_PLATFORM_AT_START=1 vitest watch --config vitest.config.dev.ts",
+    "test:dev:init": "INIT_TEST_PLATFORM=true vitest run --config vitest.config.dev.ts --testNamePattern=\"Should import creation succeed\" tests/02-integration/00-inject/loader-test.js",
+    "test:dev:resume": "SKIP_CLEANUP_PLATFORM=true vitest run --config vitest.config.dev.ts",
+    "test:dev": "vitest run --config vitest.config.dev.ts",
+    "test:watch": "vitest watch --config vitest.config.dev.ts",
     "test": "vitest --silent run --config vitest.config.test.ts --coverage"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -19,9 +19,10 @@
     "start-cluster": "NODE_ENV=cluster node build/back.js",
     "serv": "node build/back.js",
     "insert:dev": "node build/script-insert-dataset.js",
-    "test:dev:init": "INIT_TEST_PLATFORM=true vitest run --config vitest.config.dev.ts --testNamePattern=\"Should import creation succeed\" tests/02-integration/00-inject/loader-test.js",
+    "test:dev:init": "INIT_TEST_PLATFORM=true vitest run --config vitest.config.dev.ts --testNamePattern=\"Should import creation succeed\" tests/02-integration/00-inject/loader-test.ts",
     "test:dev:resume": "SKIP_CLEANUP_PLATFORM=true vitest run --config vitest.config.dev.ts",
     "test:dev": "vitest run --config vitest.config.dev.ts",
+    "test:watch:resume": "SKIP_CLEANUP_PLATFORM=true vitest watch --config vitest.config.dev.ts",
     "test:watch": "vitest watch --config vitest.config.dev.ts",
     "test": "vitest --silent run --config vitest.config.test.ts --coverage"
   },

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -20,6 +20,8 @@
     "serv": "node build/back.js",
     "insert:dev": "node build/script-insert-dataset.js",
     "test:dev": "vitest watch --config vitest.config.dev.ts",
+    "test:dev-init-only": "ONLY_PLATFORM_INIT=1 vitest run --config vitest.config.dev.ts tests/02-integration/00-inject/loader-test.js",
+    "test:dev-no-cleanup": "SKIP_CLEANUP_PLATFORM_AT_START=1 vitest watch --config vitest.config.dev.ts",
     "test": "vitest --silent run --config vitest.config.test.ts --coverage"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/tests/02-integration/00-inject/loader-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/00-inject/loader-test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { ADMIN_USER, API_TOKEN, API_URI, FIVE_MINUTES, PYTHON_PATH, testContext } from '../../utils/testQuery';
 import { execChildPython } from '../../../src/python/pythonBridge';
 
-const importOpts = [API_URI, API_TOKEN, './tests/data/DATA-TEST-STIX2_v2.json'];
+const importOpts: string[] = [API_URI, API_TOKEN, './tests/data/DATA-TEST-STIX2_v2.json'];
 
 describe('Database provision', () => {
   it('Should import creation succeed', async () => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-mapper-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-mapper-test.js
@@ -64,11 +64,8 @@ const mapData = async (fileName, mapper, user = ADMIN_USER) => {
  * /!\
  * To run those tests, we need the data injected by loader-test.
  * So if you want to run only this file follow the steps below:
- * - run 'yarn test:dev loader-test' to inject data in your DB,
- * - after test is done, stop the run,
- * - comment the line 'await elDeleteIndices(...);' in globalSetup.js (DO NOT COMMIT THIS CHANGES),
- * - comment the line 'await createTestUsers();' in globalSetup.js (DO NOT COMMIT THIS CHANGES),
- * - run 'yarn test:dev csv-mapper-test' should be ok
+ * - run 'yarn test:dev:init" to set up a seeded test DB
+ * - run 'yarn test:dev:resume csv-mapper-test'
  */
 describe('CSV-MAPPER', () => {
   let individual;

--- a/opencti-platform/opencti-graphql/tests/utils/globalSetup.js
+++ b/opencti-platform/opencti-graphql/tests/utils/globalSetup.js
@@ -18,29 +18,54 @@ import { executionContext } from '../../src/utils/access';
 import { initializeData } from '../../src/database/data-initialization';
 import { shutdownModules, startModules } from '../../src/managers';
 
-const testPlatformStart = async () => {
+/**
+ * Vitest setup is configurable with environment variables, as you can see in our package.json scripts
+ *   ONLY_PLATFORM_INIT=1 > cleanup the test platform, removing elastic indices, and setup it again
+ *   SKIP_CLEANUP_PLATFORM_AT_START=1 > skip cleanup, and directly start the platform
+ *
+ * run yarn test:dev-init-only to cleanup and reinit a test platform (it also provision the data)
+ * run yarn test:dev-no-cleanup <file-pattern> to run directly some tests without cleanup and init of the test platform
+ */
+
+const { ONLY_PLATFORM_INIT, SKIP_CLEANUP_PLATFORM_AT_START } = process.env;
+
+const initializePlatform = async () => {
   const context = executionContext('platform_test_initialization');
-  logApp.info('[OPENCTI] Starting platform');
+  console.log('🚀 [vitest-global-setup] initializing platform');
+  const stopTime = new Date().getTime();
+
+  await initializeInternalQueues();
+  await initializeBucket();
+  await initializeSchema();
+  await initializeData(context, true);
+  await initializeAdminUser(context);
+  await initDefaultNotifiers(context);
+  console.log(`🚀 [vitest-global-setup] Platform initialized in ${new Date().getTime() - stopTime} ms`);
+};
+
+const testPlatformStart = async () => {
+  const stopTime = new Date().getTime();
+  console.log('🚀 [vitest-global-setup] Starting platform');
   try {
     // Check all dependencies access
     await searchEngineInit();
     // Init the cache manager
     await cacheManager.start();
-    // Init the platform default
-    await initializeInternalQueues();
-    await initializeBucket();
-    await initializeSchema();
-    await initializeData(context, true);
-    await initializeAdminUser(context);
-    await initDefaultNotifiers(context);
+    // Init the platform default if it was cleaned up
+    if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+      await initializePlatform();
+    }
     // Init the modules
     await startModules();
+    console.log(`🚀 [vitest-global-setup] Platform started in ${new Date().getTime() - stopTime} ms`);
   } catch (e) {
     logApp.error(e);
     process.exit(1);
   }
 };
+
 const testPlatformStop = async () => {
+  console.log('🚀 [vitest-global-setup] stopping platform');
   const stopTime = new Date().getTime();
   // Shutdown the cache manager
   await cacheManager.shutdown();
@@ -48,10 +73,12 @@ const testPlatformStop = async () => {
   await shutdownModules();
   // Shutdown the redis clients
   await shutdownRedisClients();
-  logApp.info(`[OPENCTI] Platform stopped ${new Date().getTime() - stopTime} ms`);
+  console.log(`🚀 [vitest-global-setup] Platform stopped in ${new Date().getTime() - stopTime} ms`);
 };
 
 const platformClean = async () => {
+  console.log('🚀 [vitest-global-setup] cleaning up platform');
+  const stopTime = new Date().getTime();
   // Delete the bucket
   await deleteBucket();
   // Delete all rabbitmq queues
@@ -63,15 +90,38 @@ const platformClean = async () => {
   const testRedisClient = createRedisClient('reset');
   await testRedisClient.del('stream.opencti');
   testRedisClient.disconnect();
+  console.log(`🚀 [vitest-global-setup] Platform cleaned up in ${new Date().getTime() - stopTime} ms`);
 };
 
 export async function setup() {
-  // Platform cleanup before executing tests
-  await platformClean();
+  if (ONLY_PLATFORM_INIT) {
+    console.log('🚀 [vitest-global-setup] only running test platform initialization');
+    const stopTime = new Date().getTime();
+    await platformClean();
+    await testPlatformStart();
+    await wait(15000); // Wait 15 secs for complete platform start
+    console.log('🚀 [vitest-global-setup] creating test users');
+    await createTestUsers();
+    console.log(`🚀 [vitest-global-setup] Test Platform initialization done in ${new Date().getTime() - stopTime} ms`);
+    return;
+  }
+
+  if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+    // Platform cleanup before executing tests
+    console.log('🚀 [vitest-global-setup] Cleaning up test platform...');
+    await platformClean();
+  } else {
+    console.log('🚀 [vitest-global-setup] ⚠️ skipping platform cleanup and setup - database state is the same as your last run ⚠️');
+  }
   // Start the platform
   await testPlatformStart();
-  await wait(15000); // Wait 15 secs for complete platform start
-  await createTestUsers();
+
+  // setup tests users
+  if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+    await wait(15000); // Wait 15 secs for complete platform start
+    console.log('🚀 [vitest-global-setup] Creating test users...');
+    await createTestUsers();
+  }
 }
 
 export async function teardown() {

--- a/opencti-platform/opencti-graphql/tests/utils/globalSetup.js
+++ b/opencti-platform/opencti-graphql/tests/utils/globalSetup.js
@@ -20,18 +20,18 @@ import { shutdownModules, startModules } from '../../src/managers';
 
 /**
  * Vitest setup is configurable with environment variables, as you can see in our package.json scripts
- *   ONLY_PLATFORM_INIT=1 > cleanup the test platform, removing elastic indices, and setup it again
- *   SKIP_CLEANUP_PLATFORM_AT_START=1 > skip cleanup, and directly start the platform
+ *   INIT_TEST_PLATFORM=1 > cleanup the test platform, removing elastic indices, and setup it again
+ *   SKIP_CLEANUP_PLATFORM=1 > skip cleanup, and directly start the platform
  *
  * run yarn test:dev-init-only to cleanup and reinit a test platform (it also provision the data)
  * run yarn test:dev-no-cleanup <file-pattern> to run directly some tests without cleanup and init of the test platform
  */
 
-const { ONLY_PLATFORM_INIT, SKIP_CLEANUP_PLATFORM_AT_START } = process.env;
+const { INIT_TEST_PLATFORM, SKIP_CLEANUP_PLATFORM } = process.env;
 
 const initializePlatform = async () => {
   const context = executionContext('platform_test_initialization');
-  console.log('🚀 [vitest-global-setup] initializing platform');
+  logApp.info('[vitest-global-setup] initializing platform');
   const stopTime = new Date().getTime();
 
   await initializeInternalQueues();
@@ -40,24 +40,24 @@ const initializePlatform = async () => {
   await initializeData(context, true);
   await initializeAdminUser(context);
   await initDefaultNotifiers(context);
-  console.log(`🚀 [vitest-global-setup] Platform initialized in ${new Date().getTime() - stopTime} ms`);
+  logApp.info(`[vitest-global-setup] Platform initialized in ${new Date().getTime() - stopTime} ms`);
 };
 
 const testPlatformStart = async () => {
   const stopTime = new Date().getTime();
-  console.log('🚀 [vitest-global-setup] Starting platform');
+  logApp.info('[vitest-global-setup] Starting platform');
   try {
     // Check all dependencies access
     await searchEngineInit();
     // Init the cache manager
     await cacheManager.start();
     // Init the platform default if it was cleaned up
-    if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+    if (!SKIP_CLEANUP_PLATFORM) {
       await initializePlatform();
     }
     // Init the modules
     await startModules();
-    console.log(`🚀 [vitest-global-setup] Platform started in ${new Date().getTime() - stopTime} ms`);
+    logApp.info(`[vitest-global-setup] Platform started in ${new Date().getTime() - stopTime} ms`);
   } catch (e) {
     logApp.error(e);
     process.exit(1);
@@ -65,7 +65,7 @@ const testPlatformStart = async () => {
 };
 
 const testPlatformStop = async () => {
-  console.log('🚀 [vitest-global-setup] stopping platform');
+  logApp.info('[vitest-global-setup] stopping platform');
   const stopTime = new Date().getTime();
   // Shutdown the cache manager
   await cacheManager.shutdown();
@@ -73,11 +73,11 @@ const testPlatformStop = async () => {
   await shutdownModules();
   // Shutdown the redis clients
   await shutdownRedisClients();
-  console.log(`🚀 [vitest-global-setup] Platform stopped in ${new Date().getTime() - stopTime} ms`);
+  logApp.info(`[vitest-global-setup] Platform stopped in ${new Date().getTime() - stopTime} ms`);
 };
 
 const platformClean = async () => {
-  console.log('🚀 [vitest-global-setup] cleaning up platform');
+  logApp.info('[vitest-global-setup] cleaning up platform');
   const stopTime = new Date().getTime();
   // Delete the bucket
   await deleteBucket();
@@ -90,36 +90,36 @@ const platformClean = async () => {
   const testRedisClient = createRedisClient('reset');
   await testRedisClient.del('stream.opencti');
   testRedisClient.disconnect();
-  console.log(`🚀 [vitest-global-setup] Platform cleaned up in ${new Date().getTime() - stopTime} ms`);
+  logApp.info(`[vitest-global-setup] Platform cleaned up in ${new Date().getTime() - stopTime} ms`);
 };
 
 export async function setup() {
-  if (ONLY_PLATFORM_INIT) {
-    console.log('🚀 [vitest-global-setup] only running test platform initialization');
+  if (INIT_TEST_PLATFORM) {
+    logApp.info('[vitest-global-setup] only running test platform initialization');
     const stopTime = new Date().getTime();
     await platformClean();
     await testPlatformStart();
     await wait(15000); // Wait 15 secs for complete platform start
-    console.log('🚀 [vitest-global-setup] creating test users');
+    logApp.info('[vitest-global-setup] creating test users');
     await createTestUsers();
-    console.log(`🚀 [vitest-global-setup] Test Platform initialization done in ${new Date().getTime() - stopTime} ms`);
+    logApp.info(`[vitest-global-setup] Test Platform initialization done in ${new Date().getTime() - stopTime} ms`);
     return;
   }
 
-  if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+  if (!SKIP_CLEANUP_PLATFORM) {
     // Platform cleanup before executing tests
-    console.log('🚀 [vitest-global-setup] Cleaning up test platform...');
+    logApp.info('[vitest-global-setup] Cleaning up test platform...');
     await platformClean();
   } else {
-    console.log('🚀 [vitest-global-setup] ⚠️ skipping platform cleanup and setup - database state is the same as your last run ⚠️');
+    logApp.info('[vitest-global-setup] !!! skipping platform cleanup and setup - database state is the same as your last run !!!');
   }
   // Start the platform
   await testPlatformStart();
 
   // setup tests users
-  if (!SKIP_CLEANUP_PLATFORM_AT_START) {
+  if (!SKIP_CLEANUP_PLATFORM) {
     await wait(15000); // Wait 15 secs for complete platform start
-    console.log('🚀 [vitest-global-setup] Creating test users...');
+    logApp.info('[vitest-global-setup] Creating test users...');
     await createTestUsers();
   }
 }

--- a/opencti-platform/opencti-graphql/tests/utils/globalSetup.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/globalSetup.ts
@@ -85,7 +85,7 @@ const platformClean = async () => {
   await deleteQueues(testContext, ADMIN_USER);
   // Remove all elastic indices
   const indices = await elPlatformIndices();
-  await elDeleteIndices(indices.map((i) => i.index));
+  await elDeleteIndices(indices.map((i: { index: number }) => i.index));
   // Delete redis streams
   const testRedisClient = createRedisClient('reset');
   await testRedisClient.del('stream.opencti');
@@ -93,14 +93,15 @@ const platformClean = async () => {
   logApp.info(`[vitest-global-setup] Platform cleaned up in ${new Date().getTime() - stopTime} ms`);
 };
 
-const waitPlatformIsAlive = async () => {
+const waitPlatformIsAlive = async (): Promise<true> => {
   const isAlive = await isPlatformAlive();
   if (!isAlive) {
     logApp.info('[vitest-global-setup] ping platform ...');
     await wait(1000);
-    return await waitPlatformIsAlive();
+    return waitPlatformIsAlive();
   }
   logApp.info('[vitest-global-setup] platform is alive');
+  return true;
 };
 
 export async function setup() {

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -473,6 +473,20 @@ export const buildStandardUser = (allowedMarkings: markingType[], allMarkings?: 
   };
 };
 
+// TODO: use a real healthcheck query
+const HEALTHCHECK_QUERY = `
+  query {
+    about {
+      version
+    }
+  }
+`;
+
+export const isPlatformAlive = async () => {
+  const { data } = await adminQuery(HEALTHCHECK_QUERY, { });
+  return !!data?.about.version;
+};
+
 export const serverFromUser = (user = ADMIN_USER) => {
   return new ApolloServer({
     schema: createSchema(),

--- a/opencti-platform/opencti-graphql/vitest.config.test.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.test.ts
@@ -10,7 +10,7 @@ export const buildTestConfig = (include: string[]) => defineConfig({
     include,
     testTimeout: 1200000,
     teardownTimeout: 20000,
-    globalSetup: ['./tests/utils/globalSetup.js'],
+    globalSetup: ['./tests/utils/globalSetup.ts'],
     setupFiles: ['./tests/utils/testSetup.js'],
     coverage: {
       provider: 'v8',

--- a/opencti-platform/opencti-graphql/vitest.config.test.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.test.ts
@@ -41,4 +41,3 @@ export const buildTestConfig = (include: string[]) => defineConfig({
 });
 
 export default buildTestConfig(['tests/**/*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);
-// export default buildTestConfig(['tests/(02)-*/**/(loader|filterGroup|workspace)*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);


### PR DESCRIPTION
Improved our tooling to be able to run dev tests locally quickly.

the `globalSetup` for vitest has been refactored and can be piloted by 2 env variables, `INIT_TEST_PLATFORM` and `SKIP_CLEANUP_PLATFORM`. We make use of these variables in new yarn scripts:
* run `yarn test:dev:init` to cleanup your test DB, start a platform, run the loader tests that populates the database. This command won't run any other test.
* once initialized this way,  run `yarn test:dev:resume <name-of-a-test-file.js>` to run the specified test file only, the DB won't be cleaned up after run
* ... or  run `yarn test:watch:resume <name-of-a-test-file.js>` to run in watch mode

This makes developing integration tests much quicker and without having to tweak some config files locally.

As for unit tests, I would still advise to use the vitest integration in the IDE. Nothing beats that as it just won't start a platform, useless for unit tests.

The previous commands still exists ; 
* `yarn test:dev` for 1 complete run (cleanup/setup/all tests suites)
* `yarn test:watch` for a complete execution in watch mode
* `yarn test` unchanged, used by CI to run once in silent with coverage