### PR TITLE
[backend] enforce user max confidence on create/delete/update/upsert (#5697)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectPopover.jsx
@@ -224,7 +224,6 @@ class ContainerStixCoreObjectPopover extends Component {
         }
       },
       onCompleted: () => {
-        this.submitDeleteMapping();
         this.handleCloseDelete();
         const newSelectedElements = R.omit([toId], selectedElements);
         setSelectedElements?.(newSelectedElements);

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -807,6 +807,12 @@ const WorkbenchFileContentComponent = ({
                 history.push('/dashboard/data/import');
               }
             },
+            onError: ({ res }) => {
+              MESSAGING$.notifyError(res.errors?.[0]?.message || t_i18n('An unknown error has occurred! Please try again later.'));
+              setSubmitting(false);
+              resetForm();
+              setDisplayValidate(false);
+            },
           });
         }, 2000);
       },

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -38,7 +38,7 @@ import StixItemLabels from '../../../../../components/StixItemLabels';
 import StixItemMarkings from '../../../../../components/StixItemMarkings';
 import SwitchField from '../../../../../components/SwitchField';
 import TextField from '../../../../../components/TextField';
-import { APP_BASE_PATH, commitMutation, MESSAGING$, QueryRenderer } from '../../../../../relay/environment';
+import { APP_BASE_PATH, commitMutation, handleError, MESSAGING$, QueryRenderer } from '../../../../../relay/environment';
 import { observableValue, resolveIdentityClass, resolveIdentityType, resolveLink, resolveLocationType, resolveThreatActorType } from '../../../../../utils/Entity';
 import { defaultKey, defaultValue } from '../../../../../utils/Graph';
 import useAttributes from '../../../../../utils/hooks/useAttributes';
@@ -807,8 +807,8 @@ const WorkbenchFileContentComponent = ({
                 history.push('/dashboard/data/import');
               }
             },
-            onError: ({ res }) => {
-              MESSAGING$.notifyError(res.errors?.[0]?.message || t_i18n('An unknown error has occurred! Please try again later.'));
+            onError: (error) => {
+              handleError(error);
               setSubmitting(false);
               resetForm();
               setDisplayValidate(false);

--- a/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
@@ -392,7 +392,7 @@ const TasksList = ({ data }) => {
               <Button
                 style={{ position: 'absolute', right: 10, top: 10 }}
                 variant={task.errors.length > 0 ? 'contained' : 'outlined'}
-                color={'secondary'}
+                color={'error'}
                 disabled={task.errors.length === 0}
                 onClick={() => handleOpenErrors(task.errors)}
                 size="small"

--- a/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
@@ -391,8 +391,9 @@ const TasksList = ({ data }) => {
               </Grid>
               <Button
                 style={{ position: 'absolute', right: 10, top: 10 }}
-                variant="contained"
-                color="secondary"
+                variant={task.errors.length > 0 ? 'contained' : 'outlined'}
+                color={'secondary'}
+                disabled={task.errors.length === 0}
                 onClick={() => handleOpenErrors(task.errors)}
                 size="small"
               >

--- a/opencti-platform/opencti-front/src/relay/environment.jsx
+++ b/opencti-platform/opencti-front/src/relay/environment.jsx
@@ -5,7 +5,6 @@ import { debounce } from 'rxjs/operators';
 import React, { Component } from 'react';
 import { commitLocalUpdate as CLU, commitMutation as CM, QueryRenderer as QR, requestSubscription as RS, fetchQuery as FQ } from 'react-relay';
 import * as PropTypes from 'prop-types';
-import { map, isEmpty, filter, pathOr, isNil } from 'ramda';
 import { urlMiddleware, RelayNetworkLayer } from 'react-relay-network-modern';
 import * as R from 'ramda';
 import uploadMiddleware from './uploadMiddleware';
@@ -29,7 +28,7 @@ export class ApplicationError extends Error {
 }
 
 // Network
-const isEmptyPath = isNil(window.BASE_PATH) || isEmpty(window.BASE_PATH);
+const isEmptyPath = R.isNil(window.BASE_PATH) || R.isEmpty(window.BASE_PATH);
 const contextPath = isEmptyPath || window.BASE_PATH === '/' ? '' : window.BASE_PATH;
 export const APP_BASE_PATH = isEmptyPath || contextPath.startsWith('/') ? contextPath : `/${contextPath}`;
 
@@ -89,10 +88,10 @@ QueryRenderer.propTypes = {
   query: PropTypes.object,
 };
 
-const buildErrorMessages = (error) => map(
+const buildErrorMessages = (error) => R.map(
   (e) => ({
     type: 'error',
-    text: pathOr(e.message, ['data', 'reason'], e),
+    text: R.pathOr(e.message, ['data', 'reason'], e),
   }),
   error.res.errors,
 );
@@ -126,11 +125,11 @@ export const commitMutation = ({
   onError: (error) => {
     if (setSubmitting) setSubmitting(false);
     if (error && error.res && error.res.errors) {
-      const authRequired = filter(
-        (e) => pathOr(e.message, ['data', 'type'], e) === 'authentication',
+      const authRequired = R.filter(
+        (e) => R.pathOr(e.message, ['data', 'type'], e) === 'authentication',
         error.res.errors,
       );
-      if (!isEmpty(authRequired)) {
+      if (!R.isEmpty(authRequired)) {
         MESSAGING$.notifyError('Unauthorized action, please refresh your browser');
       } else if (onError) {
         const messages = buildErrorMessages(error);
@@ -157,10 +156,10 @@ export const handleErrorInForm = (error, setErrors) => {
         formattedError.data.message || formattedError.data.reason,
     });
   } else {
-    const messages = map(
+    const messages = R.map(
       (e) => ({
         type: 'error',
-        text: pathOr(e.message, ['data', 'reason'], e),
+        text: R.pathOr(e.message, ['data', 'reason'], e),
       }),
       error.res.errors,
     );
@@ -170,10 +169,10 @@ export const handleErrorInForm = (error, setErrors) => {
 
 export const handleError = (error) => {
   if (error && error.res && error.res.errors) {
-    const messages = map(
+    const messages = R.map(
       (e) => ({
         type: 'error',
-        text: pathOr(e.message, ['data', 'message'], e),
+        text: R.pathOr(e.message, ['data', 'message'], e),
       }),
       error.res.errors,
     );

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2667,10 +2667,7 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
 
   // when creating stix ref, we must check confidence on from side (this count has modifying this element itself)
   if (isStixRefRelationship(relationshipType)) {
-    const fromSideHasConfidenceAttribute = schemaAttributesDefinition.getAttribute(from.entity_type, 'confidence');
-    if (fromSideHasConfidenceAttribute) {
-      controlUserConfidenceAgainstElement(user, from);
-    }
+    controlUserConfidenceAgainstElement(user, from);
   }
 
   // check if user has "edit" access on from and to
@@ -3204,16 +3201,10 @@ export const internalDeleteElementById = async (context, user, id, opts = {}) =>
     throw AlreadyDeletedError({ id });
   }
   // region confidence control
-  const hasConfidenceAttribute = schemaAttributesDefinition.getAttribute(element.entity_type, 'confidence');
-  if (hasConfidenceAttribute) {
-    controlUserConfidenceAgainstElement(user, element);
-  }
+  controlUserConfidenceAgainstElement(user, element);
   // when deleting stix ref, we must check confidence on from side (this count has modifying this element itself)
   if (isStixRefRelationship(element.entity_type)) {
-    const fromSideHasConfidenceAttribute = schemaAttributesDefinition.getAttribute(element.from.entity_type, 'confidence');
-    if (fromSideHasConfidenceAttribute) {
-      controlUserConfidenceAgainstElement(user, element.from);
-    }
+    controlUserConfidenceAgainstElement(user, element.from);
   }
   // endregion
   // Prevent individual deletion if linked to a user

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2474,14 +2474,15 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
           }
         }
       } else { // not multiple
+        // If expected data is different from current data...
         const currentData = element[relDef.databaseName];
-        const updatable = isUpsertSynchro || (isInputWithData && isEmptyField(currentData)) || isConfidenceMatch;
-        // If expected data is different from current data
-        // And data can be updated:
+        const isInputDifferentFromCurrent = !R.equals(currentData, patchInputData?.internal_id);
+        // ... and data can be updated:
         //   forced synchro
         //   OR the field was null -> better than nothing !
         //   OR the confidence matches -> new value is "better" than existing value
-        if (!R.equals(currentData, patchInputData) && updatable) {
+        const updatable = isUpsertSynchro || (isInputWithData && isEmptyField(currentData)) || isConfidenceMatch;
+        if (isInputDifferentFromCurrent && updatable) {
           inputs.push({ key: inputField, value: [patchInputData] });
         }
       }

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2672,7 +2672,6 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
       controlUserConfidenceAgainstElement(user, from);
     }
   }
-  // endregion
 
   // check if user has "edit" access on from and to
   if (!validateUserAccessOperation(user, from, 'edit') || !validateUserAccessOperation(user, to, 'edit')) {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1857,7 +1857,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
         const { value: targetsCreated } = meta[metaIndex];
         const targetCreated = R.head(targetsCreated);
         // If asking for a real change
-        if (currentValue?.standard_id !== targetCreated?.internal_id && currentValue?.id !== targetCreated?.internal_id) {
+        if (currentValue?.id !== targetCreated?.internal_id) {
           // Delete the current relation
           if (currentValue?.standard_id) {
             const currentRels = await listAllRelations(context, user, relType, { fromId: initial.id });
@@ -2476,7 +2476,7 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
       } else { // not multiple
         // If expected data is different from current data...
         const currentData = element[relDef.databaseName];
-        const isInputDifferentFromCurrent = !R.equals(currentData, patchInputData?.internal_id);
+        const isInputDifferentFromCurrent = !R.equals(currentData, patchInputData);
         // ... and data can be updated:
         //   forced synchro
         //   OR the field was null -> better than nothing !
@@ -2779,10 +2779,8 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
         });
       }
       // TODO Handling merging relation when updating to prevent multiple relations finding
-      existingRelationship = R.head(filteredRelations);
-      // We can use the resolved input from/to to complete the element
-      existingRelationship.from = from;
-      existingRelationship.to = to;
+      // resolve all refs so we can upsert properly
+      existingRelationship = await storeLoadByIdWithRefs(context, user, R.head(filteredRelations).internal_id);
     }
     // endregion
     if (existingRelationship) {

--- a/opencti-platform/opencti-graphql/src/domain/file.js
+++ b/opencti-platform/opencti-graphql/src/domain/file.js
@@ -12,6 +12,7 @@ import { supportedMimeTypes } from '../modules/managerConfiguration/managerConfi
 import { SYSTEM_USER } from '../utils/access';
 import { isEmptyField, isNotEmptyField, READ_INDEX_FILES } from '../database/utils';
 import { getStats } from '../database/engine';
+import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 
 export const buildOptionsFromFileManager = async (context) => {
   let importPaths = ['import/'];
@@ -71,6 +72,12 @@ export const askJobImport = async (context, user, args) => {
   const entityId = bypassEntityId || file.metaData.entity_id;
   const opts = { manual: true, connectorId, configuration, bypassValidation };
   const entity = await internalLoadById(context, user, entityId);
+
+  // This is a manual request for import, we have to check confidence and throw on error
+  if (entity) {
+    controlUserConfidenceAgainstElement(user, entity);
+  }
+
   const connectors = await uploadJobImport(context, user, file.id, file.metaData.mimetype, entityId, opts);
   const entityName = entityId ? extractEntityRepresentativeName(entity) : 'global';
   const entityType = entityId ? entity.entity_type : 'global';

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -129,6 +129,10 @@ export const groupEditField = async (context, user, groupId, input) => {
     message: `updates \`${input.map((i) => i.key).join(', ')}\` for group \`${element.name}\``,
     context_data: { id: groupId, entity_type: ENTITY_TYPE_GROUP, input }
   });
+  // on editing the group confidence level, all memebers might have changed their effective level
+  if (input.find((i) => i.key === 'group_confidence_level')) {
+    await groupSessionRefresh(context, user, groupId);
+  }
   return notify(BUS_TOPICS[ENTITY_TYPE_GROUP].EDIT_TOPIC, element, user);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1171,6 +1171,7 @@ const buildSessionUser = (origin, impersonate, provider, settings) => {
       definition_type: m.definition_type,
     })),
     session_version: PLATFORM_VERSION,
+    effective_confidence_level: user.effective_confidence_level,
     ...user.provider_metadata
   };
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -658,6 +658,10 @@ export const userEditField = async (context, user, userId, rawInputs) => {
       inputs.push({ key: 'account_status', value: [ACCOUNT_STATUS_EXPIRED] });
       await killUserSessions(userId);
     }
+    if (input.key === 'user_confidence_level') {
+      // user's effective level might have changed, we need to refresh session info
+      await userSessionRefresh(userId);
+    }
     inputs.push(input);
   }
   const { element } = await updateAttribute(context, user, userId, ENTITY_TYPE_USER, inputs);

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1441,6 +1441,10 @@ export const initAdmin = async (context, email, password, tokenValue) => {
       description: 'Principal admin account',
       api_token: tokenValue,
       password,
+      user_confidence_level: {
+        max_confidence: 100,
+        overrides: [],
+      },
     };
     await addUser(context, SYSTEM_USER, userToCreate);
     await userSessionRefresh(OPENCTI_ADMIN_UUID);

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1470,5 +1470,8 @@ export const userEditContext = async (context, user, userId, input) => {
 
 export const getUserEffectiveConfidenceLevel = async (userId, context) => {
   const user = await findById(context, context.user, userId); // this returns a complete user, with groups
+  if (!user) {
+    throw FunctionalError('User not found', { user_id: userId });
+  }
   return computeUserEffectiveConfidenceLevel(user);
 };

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -421,7 +421,7 @@ const executeProcessing = async (context, user, job) => {
             await executeUnshare(context, user, actionContext, element);
           }
         } catch (err) {
-          errors.push({ id: element.id, message: `${err.message} - ${err.data?.reason ?? err.reason}` });
+          errors.push({ id: element.id, message: `${err.message} - ${err.data?.reason ?? err.reason ?? 'no reason provided'}` });
         }
       }
     }

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -137,6 +137,7 @@ const computeQueryTaskElements = async (context, user, task) => {
   const { actions, task_position, task_filters, task_search = null, task_excluded_ids = [] } = task;
   const processingElements = [];
   // Fetch the information
+  // note that the query is filtered to allow only elements with matching confidence level
   const data = await executeTaskQuery(context, user, task_filters, task_search, task_position);
   // const expectedNumber = data.pageInfo.globalCount;
   const elements = data.edges;

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -4,6 +4,8 @@ import { isEmptyField, isNotEmptyField } from '../database/utils';
 import { FunctionalError } from '../config/errors';
 import { logApp } from '../config/conf';
 import { schemaAttributesDefinition } from '../schema/schema-attributes';
+import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../generated/graphql';
+import { isFilterGroupNotEmpty } from './filtering/filtering-utils';
 
 type ObjectWithConfidence = {
   id: string,
@@ -145,7 +147,7 @@ export const adaptUpdateInputsConfidence = <T extends ObjectWithConfidence>(user
   // if the initial element does not have any confidence prior to this update, and we are not setting one now
   // then we force the element confidence to the user's confidence
   const hasConfidenceAttribute = schemaAttributesDefinition.getAttribute(element.entity_type, 'confidence');
-  if (hasConfidenceAttribute && isNotEmptyField(element.confidence) && inputsArray.length > 0 && !hasConfidenceInput) {
+  if (hasConfidenceAttribute && isEmptyField(element.confidence) && inputsArray.length > 0 && !hasConfidenceInput) {
     newInputs.push({ key: 'confidence', value: [userMaxConfidenceLevel.toString()] });
   }
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -91,6 +91,22 @@ describe('Confidence level utilities', () => {
         .not.toThrowError();
       expect(() => controlUserConfidenceAgainstElement(makeUser(null), makeElement(30)))
         .toThrowError('User has no effective max confidence level and cannot update this element');
+      expect(() => controlUserConfidenceAgainstElement(makeUser(50), {
+        id: 'object_no_confidence',
+        entity_type: 'Artifact',
+      })).not.toThrowError();
+      expect(() => controlUserConfidenceAgainstElement(makeUser(null), {
+        id: 'object_no_confidence',
+        entity_type: 'Artifact',
+      })).not.toThrowError(); // existence of user level is not even checked
+    });
+    it('on any element (noThrow)', () => {
+      expect(controlUserConfidenceAgainstElement(makeUser(50), makeElement(30), true)).toEqual(true);
+      expect(controlUserConfidenceAgainstElement(makeUser(30), makeElement(50), true)).toEqual(false);
+      expect(controlUserConfidenceAgainstElement(makeUser(50), makeElement(null), true)).toEqual(true);
+      expect(controlUserConfidenceAgainstElement(makeUser(null), makeElement(30), true)).toEqual(false);
+      expect(controlUserConfidenceAgainstElement(makeUser(50), { id: 'object_no_confidence', entity_type: 'Artifact' }, true)).toEqual(true);
+      expect(controlUserConfidenceAgainstElement(makeUser(null), { id: 'object_no_confidence', entity_type: 'Artifact' }, true)).toEqual(true);
     });
     it('on create input', () => {
       expect(controlCreateInputWithUserConfidence(makeUser(50), makeElement(30))).toEqual({

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -1,20 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import {
+  adaptUpdateInputsConfidence,
   computeUserEffectiveConfidenceLevel,
   controlCreateInputWithUserConfidence,
-  controlUserConfidenceAgainstElement,
   controlUpsertInputWithUserConfidence,
-  adaptUpdateInputsConfidence
+  controlUserConfidenceAgainstElement,
+  adaptFiltersWithUserConfidence
 } from '../../../src/utils/confidence-level';
 import type { AuthUser } from '../../../src/types/user';
+import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../../../src/generated/graphql';
+
+const makeUser = (confidence: number | null) => ({
+  id: `user_${confidence}`,
+  effective_confidence_level: confidence ? { max_confidence: confidence } : null
+} as AuthUser);
+
+const makeGroup = (confidence: number | null) => ({
+  id: `group_${confidence}`,
+  group_confidence_level: confidence ? { max_confidence: confidence, overrides: [] } : null
+});
+
+const makeElement = (confidence?: number | null) => ({
+  id: `object_${confidence}`,
+  entity_type: 'Report',
+  confidence,
+});
 
 describe('Confidence level utilities', () => {
   it('computeUserEffectiveConfidenceLevel should correctly compute the effective level', async () => {
-    const makeGroup = (confidence: number | null) => ({
-      id: `group_${confidence}`,
-      group_confidence_level: confidence ? { max_confidence: confidence, overrides: [] } : null
-    });
-
     const group70 = makeGroup(70);
     const group80 = makeGroup(80);
     const groupNull = makeGroup(null);
@@ -67,109 +80,119 @@ describe('Confidence level utilities', () => {
     };
     expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
   });
+
   describe('Control confidence', () => {
-    const makeUser = (confidence: number | null) => ({
-      id: `user_${confidence}`,
-      effective_confidence_level: confidence ? { max_confidence: confidence } : null
-    } as AuthUser);
-
-    const makeObject = (confidence?: number | null) => ({
-      id: `object_${confidence}`,
-      entity_type: 'Report',
-      confidence,
-    });
-
     it('on any element', () => {
-      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeObject(30)))
+      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeElement(30)))
         .not.toThrowError();
-      expect(() => controlUserConfidenceAgainstElement(makeUser(30), makeObject(50)))
+      expect(() => controlUserConfidenceAgainstElement(makeUser(30), makeElement(50)))
         .toThrowError('User effective max confidence level is insufficient to update this element');
-      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeObject(null)))
+      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeElement(null)))
         .not.toThrowError();
-      expect(() => controlUserConfidenceAgainstElement(makeUser(null), makeObject(30)))
+      expect(() => controlUserConfidenceAgainstElement(makeUser(null), makeElement(30)))
         .toThrowError('User has no effective max confidence level and cannot update this element');
     });
-
     it('on create input', () => {
-      expect(controlCreateInputWithUserConfidence(makeUser(50), makeObject(30))).toEqual({
+      expect(controlCreateInputWithUserConfidence(makeUser(50), makeElement(30))).toEqual({
         confidenceLevelToApply: 30,
       });
-      expect(controlCreateInputWithUserConfidence(makeUser(30), makeObject(50))).toEqual({
+      expect(controlCreateInputWithUserConfidence(makeUser(30), makeElement(50))).toEqual({
         confidenceLevelToApply: 30,
       });
-      expect(controlCreateInputWithUserConfidence(makeUser(30), makeObject(null))).toEqual({
+      expect(controlCreateInputWithUserConfidence(makeUser(30), makeElement(null))).toEqual({
         confidenceLevelToApply: 30,
       });
-      expect(() => controlCreateInputWithUserConfidence(makeUser(null), makeObject(50)))
+      expect(() => controlCreateInputWithUserConfidence(makeUser(null), makeElement(50)))
         .toThrowError('User has no effective max confidence level and cannot create this element');
     });
-
     it('on upsert input', () => {
-      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(30), makeObject(10)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeElement(30), makeElement(10)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 30,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(10), makeObject(30)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeElement(10), makeElement(30)))
         .toEqual({
           isConfidenceMatch: false,
           confidenceLevelToApply: 10,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(50), makeObject(10)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeElement(50), makeElement(10)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 30,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(10), makeObject(50)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeElement(10), makeElement(50)))
         .toEqual({
           isConfidenceMatch: false,
           confidenceLevelToApply: 10,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeObject(50), makeObject(30)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeElement(50), makeElement(30)))
         .toEqual({
           isConfidenceMatch: false,
           confidenceLevelToApply: 10,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeObject(30), makeObject(50)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeElement(30), makeElement(50)))
         .toEqual({
           isConfidenceMatch: false,
           confidenceLevelToApply: 10,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(null), makeObject(30)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeElement(null), makeElement(30)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 50,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(null), makeObject(50)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeElement(null), makeElement(50)))
         .toEqual({
           isConfidenceMatch: false,
           confidenceLevelToApply: 30,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(30), makeObject(null)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeElement(30), makeElement(null)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 30,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(50), makeObject(null)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeElement(50), makeElement(null)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 30,
         });
-      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(null), makeObject(null)))
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeElement(null), makeElement(null)))
         .toEqual({
           isConfidenceMatch: true,
           confidenceLevelToApply: 30,
         });
-      expect(() => controlUpsertInputWithUserConfidence(makeUser(null), makeObject(30), makeObject(50)))
+      expect(() => controlUpsertInputWithUserConfidence(makeUser(null), makeElement(30), makeElement(50)))
         .toThrowError('User has no effective max confidence level and cannot update this element');
     });
+  });
 
-    it('', () => {
-      const makeConfidenceInput = (confidence: number) => ({
-        key: 'confidence',
-        value: [confidence.toString()],
-      });
-      adaptUpdateInputsConfidence(makeUser(50), makeConfidenceInput(10), makeObject(30));
+  it('adaptUpdateInputsConfidence should adapt correctly input payload', () => {
+    const makeConfidenceInput = (confidence: number) => ({
+      key: 'confidence',
+      value: [confidence.toString()],
     });
+    const otherInput = {
+      key: 'description',
+      value: ['some text'],
+    };
+
+    expect(adaptUpdateInputsConfidence(makeUser(50), makeConfidenceInput(30), makeElement(10)))
+      .toEqual([{ key: 'confidence', value: ['30'] }]);
+    expect(adaptUpdateInputsConfidence(makeUser(50), makeConfidenceInput(10), makeElement(30)))
+      .toEqual([{ key: 'confidence', value: ['10'] }]);
+    expect(adaptUpdateInputsConfidence(makeUser(30), makeConfidenceInput(50), makeElement(10)))
+      .toEqual([{ key: 'confidence', value: ['30'] }]); // capped
+    expect(adaptUpdateInputsConfidence(makeUser(30), makeConfidenceInput(10), makeElement(50)))
+      .toEqual([{ key: 'confidence', value: ['10'] }]); // this function does not control against element!
+    expect(adaptUpdateInputsConfidence(makeUser(10), makeConfidenceInput(50), makeElement(30)))
+      .toEqual([{ key: 'confidence', value: ['10'] }]); // capped / this function does not control against element!
+    expect(adaptUpdateInputsConfidence(makeUser(10), makeConfidenceInput(30), makeElement(50)))
+      .toEqual([{ key: 'confidence', value: ['10'] }]); // capped / this function does not control against element!
+    expect(adaptUpdateInputsConfidence(makeUser(10), otherInput, makeElement(50)))
+      .toEqual([otherInput]); // no need to inject confidence
+    expect(adaptUpdateInputsConfidence(makeUser(10), otherInput, makeElement(null)))
+      .toEqual([otherInput, { key: 'confidence', value: ['10'] }]); // inject user's confidence
+    expect(adaptUpdateInputsConfidence(makeUser(10), makeConfidenceInput(30), makeElement(null)))
+      .toEqual([{ key: 'confidence', value: ['10'] }]); // capped / no need to inject user's confidence
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -1,29 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { computeUserEffectiveConfidenceLevel } from '../../../src/utils/confidence-level';
+import {
+  computeUserEffectiveConfidenceLevel,
+  controlCreateInputWithUserConfidence,
+  controlUserConfidenceAgainstElement,
+  controlUpsertInputWithUserConfidence,
+  adaptUpdateInputsConfidence
+} from '../../../src/utils/confidence-level';
 import type { AuthUser } from '../../../src/types/user';
 
 describe('Confidence level utilities', () => {
   it('computeUserEffectiveConfidenceLevel should correctly compute the effective level', async () => {
-    const group70 = {
-      id: 'group70',
-      group_confidence_level: {
-        max_confidence: 70,
-        overrides: [],
-      }
-    };
+    const makeGroup = (confidence: number | null) => ({
+      id: `group_${confidence}`,
+      group_confidence_level: confidence ? { max_confidence: confidence, overrides: [] } : null
+    });
 
-    const group80 = {
-      id: 'group80',
-      group_confidence_level: {
-        max_confidence: 70,
-        overrides: [],
-      }
-    };
-
-    const groupNull = {
-      id: 'groupNull',
-      group_confidence_level: null
-    };
+    const group70 = makeGroup(70);
+    const group80 = makeGroup(80);
+    const groupNull = makeGroup(null);
 
     // minimal subset of a real User
     const userA = {
@@ -72,5 +66,110 @@ describe('Confidence level utilities', () => {
       groups: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
+  });
+  describe('Control confidence', () => {
+    const makeUser = (confidence: number | null) => ({
+      id: `user_${confidence}`,
+      effective_confidence_level: confidence ? { max_confidence: confidence } : null
+    } as AuthUser);
+
+    const makeObject = (confidence?: number | null) => ({
+      id: `object_${confidence}`,
+      entity_type: 'Report',
+      confidence,
+    });
+
+    it('on any element', () => {
+      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeObject(30)))
+        .not.toThrowError();
+      expect(() => controlUserConfidenceAgainstElement(makeUser(30), makeObject(50)))
+        .toThrowError('User effective max confidence level is insufficient to update this element');
+      expect(() => controlUserConfidenceAgainstElement(makeUser(50), makeObject(null)))
+        .not.toThrowError();
+      expect(() => controlUserConfidenceAgainstElement(makeUser(null), makeObject(30)))
+        .toThrowError('User has no effective max confidence level and cannot update this element');
+    });
+
+    it('on create input', () => {
+      expect(controlCreateInputWithUserConfidence(makeUser(50), makeObject(30))).toEqual({
+        confidenceLevelToApply: 30,
+      });
+      expect(controlCreateInputWithUserConfidence(makeUser(30), makeObject(50))).toEqual({
+        confidenceLevelToApply: 30,
+      });
+      expect(controlCreateInputWithUserConfidence(makeUser(30), makeObject(null))).toEqual({
+        confidenceLevelToApply: 30,
+      });
+      expect(() => controlCreateInputWithUserConfidence(makeUser(null), makeObject(50)))
+        .toThrowError('User has no effective max confidence level and cannot create this element');
+    });
+
+    it('on upsert input', () => {
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(30), makeObject(10)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 30,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(10), makeObject(30)))
+        .toEqual({
+          isConfidenceMatch: false,
+          confidenceLevelToApply: 10,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(50), makeObject(10)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 30,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(10), makeObject(50)))
+        .toEqual({
+          isConfidenceMatch: false,
+          confidenceLevelToApply: 10,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeObject(50), makeObject(30)))
+        .toEqual({
+          isConfidenceMatch: false,
+          confidenceLevelToApply: 10,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(10), makeObject(30), makeObject(50)))
+        .toEqual({
+          isConfidenceMatch: false,
+          confidenceLevelToApply: 10,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(null), makeObject(30)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 50,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(null), makeObject(50)))
+        .toEqual({
+          isConfidenceMatch: false,
+          confidenceLevelToApply: 30,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(50), makeObject(30), makeObject(null)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 30,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(50), makeObject(null)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 30,
+        });
+      expect(controlUpsertInputWithUserConfidence(makeUser(30), makeObject(null), makeObject(null)))
+        .toEqual({
+          isConfidenceMatch: true,
+          confidenceLevelToApply: 30,
+        });
+      expect(() => controlUpsertInputWithUserConfidence(makeUser(null), makeObject(30), makeObject(50)))
+        .toThrowError('User has no effective max confidence level and cannot update this element');
+    });
+
+    it('', () => {
+      const makeConfidenceInput = (confidence: number) => ({
+        key: 'confidence',
+        value: [confidence.toString()],
+      });
+      adaptUpdateInputsConfidence(makeUser(50), makeConfidenceInput(10), makeObject(30));
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -162,7 +162,7 @@ describe('Confidence level utilities', () => {
           confidenceLevelToApply: 30,
         });
       expect(() => controlUpsertInputWithUserConfidence(makeUser(null), makeElement(30), makeElement(50)))
-        .toThrowError('User has no effective max confidence level and cannot update this element');
+        .toThrowError('User has no effective max confidence level and cannot upsert this element');
     });
   });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -195,4 +195,39 @@ describe('Confidence level utilities', () => {
     expect(adaptUpdateInputsConfidence(makeUser(10), makeConfidenceInput(30), makeElement(null)))
       .toEqual([{ key: 'confidence', value: ['10'] }]); // capped / no need to inject user's confidence
   });
+
+  it('getConfidenceFilterForUser shall produce correct filters', () => {
+    const emptyFilterGroup: FilterGroup = {
+      mode: FilterMode.And,
+      filterGroups: [],
+      filters: [],
+    };
+    const exampleFilterGroup: FilterGroup = {
+      mode: FilterMode.Or,
+      filterGroups: [],
+      filters: [
+        { key: ['name'], operator: FilterOperator.Contains, mode: FilterMode.Or, values: ['aa', 'bb', 'cc'] },
+        { key: ['score'], operator: FilterOperator.Gte, mode: FilterMode.And, values: [70] }
+      ],
+    };
+    const filter50: Filter = {
+      mode: FilterMode.And,
+      operator: FilterOperator.Lte,
+      key: ['confidence'],
+      values: [50]
+    };
+
+    expect(adaptFiltersWithUserConfidence(makeUser(50), emptyFilterGroup))
+      .toEqual({
+        mode: FilterMode.And,
+        filters: [filter50],
+        filterGroups: []
+      });
+    expect(adaptFiltersWithUserConfidence(makeUser(50), exampleFilterGroup))
+      .toEqual({
+        mode: FilterMode.And,
+        filters: [filter50],
+        filterGroups: [exampleFilterGroup]
+      });
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
@@ -38,7 +38,7 @@ describe('File storage file listing', () => {
     let file = head(list.edges).node;
     expect(file.id).toEqual(exportFileId(malware));
     expect(file.name).toEqual(exportFileName);
-    expect(file.size).toEqual(10692);
+    expect(file.size).toEqual(10700);
     expect(file.metaData).not.toBeNull();
     expect(file.metaData.encoding).toEqual('7bit');
     expect(file.metaData.filename).toEqual(exportFileName.replace(/\s/g, '%20'));
@@ -48,7 +48,7 @@ describe('File storage file listing', () => {
     expect(list.edges.length).toEqual(1);
     file = head(list.edges).node;
     expect(file.id).toEqual(importFileId);
-    expect(file.size).toEqual(10692);
+    expect(file.size).toEqual(10700);
     expect(file.name).toEqual(exportFileName);
   });
   it('should all file listing', async () => {
@@ -68,7 +68,7 @@ describe('File storage file listing', () => {
     files = await allFilesForPaths(testContext, ADMIN_USER, ['export/Malware'], { entity_id: 'unknow_id' });
     expect(files.length).toEqual(0);
     // maxFileSize filtering
-    files = await allFilesForPaths(testContext, ADMIN_USER, ['export/Malware'], { maxFileSize: 10692 });
+    files = await allFilesForPaths(testContext, ADMIN_USER, ['export/Malware'], { maxFileSize: 10700 });
     expect(files.length).toEqual(1);
     files = await allFilesForPaths(testContext, ADMIN_USER, ['export/Malware'], { maxFileSize: 1692 });
     expect(files.length).toEqual(0);
@@ -102,7 +102,7 @@ describe('File storage file listing', () => {
     expect(file).not.toBeNull();
     expect(file.id).toEqual(exportFileId(malware));
     expect(file.name).toEqual(exportFileName);
-    expect(file.size).toEqual(10692);
+    expect(file.size).toEqual(10700);
   });
   it('should delete file', async () => {
     const malware = await elLoadById(testContext, ADMIN_USER, 'malware--faa5b705-cf44-4e50-8472-29e5fec43c3c');

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -245,7 +245,7 @@ describe('Relations listing', () => {
     expect(stixCoreRelationships.edges.length).toEqual(24);
     const stixRefRelationships = await listRelations(testContext, ADMIN_USER, 'stix-ref-relationship');
     expect(stixRefRelationships).not.toBeNull();
-    expect(stixRefRelationships.edges.length).toEqual(125);
+    expect(stixRefRelationships.edges.length).toEqual(124);
   });
   it('should list relations with roles', async () => {
     const stixRelations = await listRelations(testContext, ADMIN_USER, 'uses', {
@@ -1213,6 +1213,7 @@ describe('Elements upsert behaviors', () => {
     });
     expect(malware.confidence).toEqual(11);
     expect(malware.objectMarking[0].standard_id).toEqual(greenMarking);
+    // in case of marking, the highest rank is kept so we'll have only one
 
     // Upsert forcing the synchronization
     const syncContext = { ...testContext, synchronizedUpsert: true };

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -745,6 +745,7 @@ describe('Upsert and merge entities', () => {
       description: 'MALWARE_TEST DESCRIPTION',
       stix_id: 'malware--907bb632-e3c2-52fa-b484-cf166a7d377e',
       objectMarking: [clearMarking, mitreMarking],
+      confidence: 15, // not set, it would fallback to user's confidence which is 100
     };
     const createdMalware = await addMalware(testContext, ADMIN_USER, malware);
     expect(createdMalware).not.toBeNull();
@@ -755,7 +756,11 @@ describe('Upsert and merge entities', () => {
     expect(loadMalware).not.toBeNull();
     expect(loadMalware['object-marking'].length).toEqual(2);
     // Upsert TLP by name
-    let upMalware = { name: 'MALWARE_TEST', objectMarking: [testMarking] };
+    let upMalware = {
+      name: 'MALWARE_TEST',
+      objectMarking: [testMarking],
+      confidence: 15,
+    };
     let upsertedMalware = await addMalware(testContext, ADMIN_USER, upMalware);
     expect(upsertedMalware).not.toBeNull();
     expect(upsertedMalware.id).toEqual(createdMalware.id);
@@ -768,7 +773,7 @@ describe('Upsert and merge entities', () => {
       description: 'MALWARE_TEST NEW',
       stix_id: 'malware--907bb632-e3c2-52fa-b484-cf166a7d377e',
       aliases: ['NEW MALWARE ALIAS'],
-      confidence: 90,
+      confidence: 90, // 90 > 15, so it's upserted
     };
     upsertedMalware = await addMalware(testContext, ADMIN_USER, upMalware);
     expect(upsertedMalware.name).toEqual('NEW NAME');

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/taxii-filtering-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/taxii-filtering-test.js
@@ -272,7 +272,7 @@ describe('Complex filters combinations, behavior tested on taxii collections', (
       filters: [{
         key: 'confidence',
         values: ['90'],
-        operator: 'gte',
+        operator: 'eq',
       }],
       filterGroups: [{
         mode: 'and',
@@ -368,8 +368,8 @@ describe('Complex filters combinations, behavior tested on taxii collections', (
     taxiiCollection = await storeLoadById(testContext, ADMIN_USER, taxiiInternalId, ENTITY_TYPE_TAXII_COLLECTION);
     const { edges: results6 } = await collectionQuery(testContext, ADMIN_USER, taxiiCollection, {});
     edgeIds = results6.map((e) => e.node.internal_id);
-    expect(edgeIds.length).toEqual(1);
-    expect(edgeIds[0]).toEqual(city3InternalId);
+    expect(edgeIds.length).toEqual(2); // City3 + Heitzing in DATA_STIX2_v2 (no confidence so inserted with user's confidence which is 100)
+    expect(edgeIds[1]).toEqual(city3InternalId);
     // --- 07. filters with keys that require a conversion --- //
     // objectMarking = marking1
     await changeTaxiiFilters({

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -42,7 +42,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['campaign'].length).toBe(7);
       expect(updateEventsByTypes['relationship'].length).toBe(8);
       expect(updateEventsByTypes['identity'].length).toBe(11);
-      expect(updateEventsByTypes['malware'].length).toBe(13);
+      expect(updateEventsByTypes['malware'].length).toBe(15);
       expect(updateEventsByTypes['intrusion-set'].length).toBe(4);
       expect(updateEventsByTypes['data-component'].length).toBe(2);
       expect(updateEventsByTypes['location'].length).toBe(12);
@@ -65,7 +65,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(132);
+      expect(updateEvents.length).toBe(134);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
@@ -1,15 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import {
-  ADMIN_USER,
-  API_TOKEN,
-  API_URI,
-  FIFTEEN_MINUTES,
-  PYTHON_PATH, queryAsAdmin,
-  RAW_EVENTS_SIZE,
-  SYNC_RAW_START_REMOTE_URI,
-  testContext,
-} from '../../utils/testQuery';
+import { ADMIN_USER, API_TOKEN, API_URI, FIFTEEN_MINUTES, PYTHON_PATH, queryAsAdmin, RAW_EVENTS_SIZE, SYNC_RAW_START_REMOTE_URI, testContext } from '../../utils/testQuery';
 import { execChildPython } from '../../../src/python/pythonBridge';
 import { checkPostSyncContent, checkPreSyncContent } from '../sync-utils';
 import { elAggregationCount } from '../../../src/database/engine';
@@ -80,12 +71,12 @@ describe('Database sync raw', () => {
       expect(vocabRemoved.map((v) => v.name)).toEqual([]);
       expect(vocabAdded.map((v) => v.name)).toEqual([]);
 
-      const plop = await elAggregationCount(testContext, ADMIN_USER, READ_DATA_INDICES, { types: ['Stix-Object'], field: 'entity_type' });
-      const maaaap = new Map(plop.map((i) => [i.label, i.value]));
-      expect(maaaap.get('Indicator')).toEqual(28);
-      expect(maaaap.get('Malware')).toEqual(27);
-      expect(maaaap.get('Label')).toEqual(13);
-      expect(maaaap.get('Vocabulary')).toEqual(335);
+      const counters = await elAggregationCount(testContext, ADMIN_USER, READ_DATA_INDICES, { types: ['Stix-Object'], field: 'entity_type' });
+      const countersMap = new Map(counters.map((i) => [i.label, i.value]));
+      expect(countersMap.get('Indicator')).toEqual(28);
+      expect(countersMap.get('Malware')).toEqual(27);
+      expect(countersMap.get('Label')).toEqual(13);
+      expect(countersMap.get('Vocabulary')).toEqual(335);
 
       // Post check
       await checkPostSyncContent(SYNC_RAW_START_REMOTE_URI, objectMap, relMap, initStixReport);

--- a/opencti-platform/opencti-graphql/tests/05-rules/observe-sighting-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/observe-sighting-test.js
@@ -49,10 +49,13 @@ describe('Observed sighting rule', () => {
         x_opencti_detection: false,
         start_time: '2020-01-10T00:00:00.000Z',
         stop_time: '2020-02-20T00:00:00.000Z',
-        confidence: 100,
+        confidence: 50,
         relationship_type: RELATION_BASED_ON,
         objectMarking: [TLP_CLEAR_ID],
       });
+      // base: OBSERVED_FILE sighted in ANSSI (confidence 100)
+      // Create relation CBRICKSDOC based on OBSERVED_FILE (confidence 50)
+      // inferred: CBRICKSDOC sighted in ANSII
       const afterLiveRelations = await fetchInferences();
       expect(afterLiveRelations.length).toBe(1);
       const cbrickToAnssi = await inferenceLookup(afterLiveRelations, CBRICKSDOC, ANSSI, STIX_SIGHTING_RELATIONSHIP);
@@ -61,7 +64,7 @@ describe('Observed sighting rule', () => {
       expect(cbrickToAnssi.first_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToAnssi.last_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToAnssi.attribute_count).toBe(1);
-      expect(cbrickToAnssi.confidence).toBe(0);
+      expect(cbrickToAnssi.confidence).toBe(100); // RULE_MANAGER_USER has confidence 100
       expect(cbrickToAnssi.i_inference_weight).toBe(1);
       expect((cbrickToAnssi.object_marking_refs || []).length).toBe(0);
       // Change the organization
@@ -86,7 +89,7 @@ describe('Observed sighting rule', () => {
       expect(cbrickToMitreRescan.first_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToMitreRescan.last_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToMitreRescan.attribute_count).toBe(1);
-      expect(cbrickToMitreRescan.confidence).toBe(0);
+      expect(cbrickToMitreRescan.confidence).toBe(100);
       expect(cbrickToMitreRescan.i_inference_weight).toBe(1);
       expect((cbrickToMitreRescan.object_marking_refs || []).length).toBe(0);
       // Cleanup

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 942;
+export const RAW_EVENTS_SIZE = 944;
 export const SYNC_LIVE_EVENTS_SIZE = 594;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -334,13 +334,10 @@ class Consumer(Thread):  # pylint: disable=too-many-instance-attributes
         except Exception as ex:  # pylint: disable=broad-except
             error = str(ex)
             error_msg = traceback.format_exc()
-            if (
-                "LOCK_ERROR" in error_msg
-                and self.processing_count < MAX_PROCESSING_COUNT
-            ):
+            if "LOCK_ERROR" in error_msg:
                 bundles_lock_error_counter.add(1)
                 # Platform is under heavy load:
-                # wait for unlock & retry almost indefinitely.
+                # wait for unlock & retry indefinitely.
                 sleep_jitter = round(random.uniform(10, 30), 2)
                 time.sleep(sleep_jitter)
                 self.data_handler(connection, channel, delivery_tag, data)


### PR DESCRIPTION
Addresses backend part for #5697

### Proposed changes
The code changes are quite limited, but are located in critical places. They have a lot of impact.

If a user has no effective confidence level due to a bad configuration of the groups, a `LockTimeoutError` is thrown (a special kind of error that causes worker to retry infinitely - this way no message is lost).
We expect this error to disappear in the future (it's a manual migration for admins), and want to limit the _soon-to-be-dead_ code that handles it.

Legit errors are thrown on create, update or upsert. There are a lot of edge cases depending on the ingestion pipeline being used, but here are the main principles:
* a failed confidence control should throw an error on direct, manual operations (user action / api call)
* a failed confidence control during an automated operation (like auto-enrichment or background tasks) should not throw error (the operation is simply not done and the whole process continues)
* on create, confidence level of created entity cannot be higher than user's level. If not, the value is capped automatically (no error thrown, only a log warning).
* on create, if confidence is not provided we use the user's level ; which is 100 in all our tests. Before, it felt back to 0, so I had to mitigate the impact on the test base.
* on update, if user has insufficient confidence level compared to the element, an error is thrown
* on delete, if user has insufficient confidence level compared to the element, an error is thrown

On upsert (connectors, feeds, etc.) this is a lot trickier, I advise to read the code changes carefully.
One impactful change is that, if the input data has a higher confidence than the current element, fields are updated.
Before, it was not the case for refs (like createdBy).

The new confidence control enlighted several issues and tricky bugs that were silent until now, so we had to fix them too.


### Related issues

* #5697

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality