### PR TITLE
[backend/frontend] Introduce dev flags to deactivate feature in ongoing development

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/CustomizationMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/CustomizationMenu.tsx
@@ -1,9 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import NavToolbarMenu, { MenuEntry } from '../common/menus/NavToolbarMenu';
-import useHelper from '../../../utils/hooks/useHelper';
 
 const CustomizationMenu: FunctionComponent = () => {
-  const { isFeatureEnable } = useHelper();
   const entries: MenuEntry[] = [
     {
       path: '/dashboard/settings/customization/entity_types',
@@ -21,10 +19,6 @@ const CustomizationMenu: FunctionComponent = () => {
       path: '/dashboard/settings/customization/retention',
       label: 'Retention policies',
     },
-    ...(isFeatureEnable('INDICATOR_DECAY') ? [{
-      path: '/dashboard/settings/customization/decay',
-      label: 'Decay rules',
-    }] : []),
   ];
   return <NavToolbarMenu entries={entries} />;
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/CustomizationMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/CustomizationMenu.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent } from 'react';
 import NavToolbarMenu, { MenuEntry } from '../common/menus/NavToolbarMenu';
+import useHelper from '../../../utils/hooks/useHelper';
 
 const CustomizationMenu: FunctionComponent = () => {
+  const { isFeatureEnable } = useHelper();
   const entries: MenuEntry[] = [
     {
       path: '/dashboard/settings/customization/entity_types',
@@ -19,6 +21,10 @@ const CustomizationMenu: FunctionComponent = () => {
       path: '/dashboard/settings/customization/retention',
       label: 'Retention policies',
     },
+    ...(isFeatureEnable('INDICATOR_DECAY') ? [{
+      path: '/dashboard/settings/customization/decay',
+      label: 'Decay rules',
+    }] : []),
   ];
   return <NavToolbarMenu entries={entries} />;
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
@@ -960,8 +960,7 @@ const Settings = () => {
                     </Typography>
                     <Paper classes={{ root: classes.paper }} variant="outlined">
                       <List style={{ marginTop: -20 }}>
-                        {/* TODO remove Decay feature flag */}
-                        {modules.filter((module) => module.id !== 'INDICATOR_DECAY_MANAGER').map((module) => {
+                        {modules.map((module) => {
                           const isEeModule = ['ACTIVITY_MANAGER', 'PLAYBOOK_MANAGER', 'FILE_INDEX_MANAGER'].includes(module.id);
                           let status = module.enable;
                           if (!isEnterpriseEdition && isEeModule) {
@@ -972,9 +971,7 @@ const Settings = () => {
                               <ListItemText primary={t_i18n(module.id)} />
                               <ItemBoolean
                                 variant="inList"
-                                label={
-                                  module.enable ? t_i18n('Enabled') : t_i18n('Disabled')
-                                }
+                                label={module.enable ? t_i18n('Enabled') : t_i18n('Disabled')}
                                 status={status}
                               />
                             </ListItem>

--- a/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
+++ b/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
@@ -36,7 +36,7 @@ const isFeatureEnable = (
 ) => {
   const flags = settings.platform_feature_flags ?? [];
   const feature = flags.find((f) => f.id === id);
-  return feature !== undefined && feature.enable === true;
+  return feature === undefined || feature.enable === true;
 };
 
 const isModuleEnable = (

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -94,6 +94,7 @@
   "https_proxy": "",
   "no_proxy": "",
   "https_proxy_ca": [],
+  "disabled_dev_features": ["INDICATOR_DECAY"],
   "https_proxy_reject_unauthorized": false,
   "relations_deduplication": {
     "past_days": 30,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -4,6 +4,7 @@
     "base_path": "",
     "base_url": "http://localhost:4000/",
     "enabled": true,
+    "disabled_dev_features": ["INDICATOR_DECAY"],
     "https_cert": {
       "ca": [],
       "key": null,
@@ -94,7 +95,6 @@
   "https_proxy": "",
   "no_proxy": "",
   "https_proxy_ca": [],
-  "disabled_dev_features": ["INDICATOR_DECAY"],
   "https_proxy_reject_unauthorized": false,
   "relations_deduplication": {
     "past_days": 30,

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -2,6 +2,7 @@
   "app": {
     "port": 4010,
     "performance_logger": false,
+    "disabled_dev_features": [],
     "sync_raw_start_remote_uri": "http://localhost:4200/graphql",
     "sync_live_start_remote_uri": "http://localhost:4200/graphql",
     "sync_direct_start_remote_uri": "http://localhost:4200/graphql",

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -535,4 +535,13 @@ export const setStoppingState = (state) => {
   platformState.stopping = state;
 };
 
+export const DISABLED_FEATURE_FLAGS = nconf.get('disabled_dev_features') ?? [];
+export const isFeatureEnabled = (feature) => {
+  const isActivated = DISABLED_FEATURE_FLAGS.length === 0 || !DISABLED_FEATURE_FLAGS.includes(feature);
+  if (!isActivated) {
+    logApp.info('[FEATURE-FLAG] Deactivated feature still in development', { feature });
+  }
+  return isActivated;
+};
+
 export default nconf;

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -535,7 +535,7 @@ export const setStoppingState = (state) => {
   platformState.stopping = state;
 };
 
-export const DISABLED_FEATURE_FLAGS = nconf.get('disabled_dev_features') ?? [];
+export const DISABLED_FEATURE_FLAGS = nconf.get('app:disabled_dev_features') ?? [];
 export const isFeatureEnabled = (feature) => {
   const isActivated = DISABLED_FEATURE_FLAGS.length === 0 || !DISABLED_FEATURE_FLAGS.includes(feature);
   if (!isActivated) {

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -2,7 +2,7 @@ import { getHeapStatistics } from 'node:v8';
 import nconf from 'nconf';
 import * as R from 'ramda';
 import { createEntity, listAllThings, loadEntity, patchAttribute, updateAttribute } from '../database/middleware';
-import conf, { ACCOUNT_STATUSES, BUS_TOPICS, ENABLED_DEMO_MODE, getBaseUrl, PLATFORM_VERSION } from '../config/conf';
+import conf, { ACCOUNT_STATUSES, BUS_TOPICS, DISABLED_FEATURE_FLAGS, ENABLED_DEMO_MODE, getBaseUrl, PLATFORM_VERSION } from '../config/conf';
 import { delEditContext, getClusterInstances, getRedisVersion, notify, setEditContext } from '../database/redis';
 import { isRuntimeSortEnable, searchEngineVersion } from '../database/engine';
 import { getRabbitMQVersion } from '../database/rabbitmq';
@@ -68,6 +68,7 @@ export const getSettings = async (context) => {
     platform_map_tile_server_light: nconf.get('app:map_tile_server_light'),
     platform_feature_flags: [
       { id: 'RUNTIME_SORTING', enable: isRuntimeSortEnable() },
+      ...(DISABLED_FEATURE_FLAGS.map((feature) => ({ id: feature, enable: false })))
     ],
   };
 };

--- a/opencti-platform/opencti-graphql/src/manager/indicatorDecayManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/indicatorDecayManager.ts
@@ -2,8 +2,8 @@ import { type ManagerDefinition, registerManager } from './managerModule';
 import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { findIndicatorsForDecay, updateIndicatorDecayScore } from '../modules/indicator/indicator-domain';
+import { INDICATOR_DECAY_FEATURE_FLAG } from '../modules/indicator/indicator-types';
 
-const INDICATOR_DECAY = 'INDICATOR_DECAY';
 const INDICATOR_DECAY_MANAGER_ENABLED = booleanConf('indicator_decay_manager:enabled', false);
 const INDICATOR_DECAY_MANAGER_KEY = conf.get('indicator_decay_manager:lock_key') || 'indicator_decay_manager_lock';
 const SCHEDULE_TIME = conf.get('indicator_decay_manager:interval') || 60000; // 1 minute
@@ -52,6 +52,6 @@ const INDICATOR_DECAY_MANAGER_DEFINITION: ManagerDefinition = {
   }
 };
 
-if (isFeatureEnabled(INDICATOR_DECAY)) {
+if (isFeatureEnabled(INDICATOR_DECAY_FEATURE_FLAG)) {
   registerManager(INDICATOR_DECAY_MANAGER_DEFINITION);
 }

--- a/opencti-platform/opencti-graphql/src/manager/indicatorDecayManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/indicatorDecayManager.ts
@@ -1,8 +1,9 @@
 import { type ManagerDefinition, registerManager } from './managerModule';
-import conf, { booleanConf, logApp } from '../config/conf';
+import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { findIndicatorsForDecay, updateIndicatorDecayScore } from '../modules/indicator/indicator-domain';
 
+const INDICATOR_DECAY = 'INDICATOR_DECAY';
 const INDICATOR_DECAY_MANAGER_ENABLED = booleanConf('indicator_decay_manager:enabled', false);
 const INDICATOR_DECAY_MANAGER_KEY = conf.get('indicator_decay_manager:lock_key') || 'indicator_decay_manager_lock';
 const SCHEDULE_TIME = conf.get('indicator_decay_manager:interval') || 60000; // 1 minute
@@ -51,4 +52,6 @@ const INDICATOR_DECAY_MANAGER_DEFINITION: ManagerDefinition = {
   }
 };
 
-registerManager(INDICATOR_DECAY_MANAGER_DEFINITION);
+if (isFeatureEnabled(INDICATOR_DECAY)) {
+  registerManager(INDICATOR_DECAY_MANAGER_DEFINITION);
+}

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-types.ts
@@ -5,6 +5,7 @@ import type { BasicStoreEntity, StoreEntity } from '../../types/store';
 import type { DecayHistory } from './decay-domain';
 import type { DecayRule } from '../../generated/graphql';
 
+export const INDICATOR_DECAY_FEATURE_FLAG = 'INDICATOR_DECAY';
 export const ENTITY_TYPE_INDICATOR = 'Indicator';
 
 // Indicator Specific Properties

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -1,8 +1,9 @@
 import { type ModuleDefinition, registerDefinition } from '../../schema/module';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
-import { ENTITY_TYPE_INDICATOR, type StixIndicator, type StoreEntityIndicator } from './indicator-types';
+import { ENTITY_TYPE_INDICATOR, INDICATOR_DECAY_FEATURE_FLAG, type StixIndicator, type StoreEntityIndicator } from './indicator-types';
 import convertIndicatorToStix from './indicator-converter';
 import { killChainPhases, objectOrganization } from '../../schema/stixRefRelationship';
+import { isFeatureEnabled } from '../../config/conf';
 
 const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator> = {
   type: {
@@ -92,4 +93,6 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
   converter: convertIndicatorToStix
 };
 
-registerDefinition(INDICATOR_DEFINITION);
+if (isFeatureEnabled(INDICATOR_DECAY_FEATURE_FLAG)) {
+  registerDefinition(INDICATOR_DEFINITION);
+}

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -4,6 +4,7 @@ import { ENTITY_TYPE_INDICATOR, INDICATOR_DECAY_FEATURE_FLAG, type StixIndicator
 import convertIndicatorToStix from './indicator-converter';
 import { killChainPhases, objectOrganization } from '../../schema/stixRefRelationship';
 import { isFeatureEnabled } from '../../config/conf';
+import type { AttributeDefinition } from '../../schema/attribute-definition';
 
 const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator> = {
   type: {
@@ -31,59 +32,61 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
     { name: 'x_opencti_detection', label: 'Detection', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_main_observable_type', label: 'Main observable type', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_mitre_platforms', label: 'Platforms', type: 'string', format: 'short', mandatoryType: 'customizable', editDefault: true, multiple: true, upsert: true, isFilterable: true },
-    {
-      name: 'decay_next_reaction_date',
-      type: 'date',
-      mandatoryType: 'no',
-      editDefault: false,
-      multiple: false,
-      upsert: false,
-      label: 'Decay next reaction date',
-      isFilterable: false
-    },
-    {
-      name: 'decay_base_score',
-      type: 'numeric',
-      mandatoryType: 'no',
-      editDefault: true,
-      multiple: false,
-      upsert: true,
-      label: 'Decay base score',
-      isFilterable: true,
-      precision: 'integer',
-    },
-    {
-      name: 'decay_base_score_date',
-      type: 'date',
-      mandatoryType: 'no',
-      editDefault: true,
-      multiple: false,
-      upsert: true,
-      label: 'Decay base score date',
-      isFilterable: false,
-    },
-    {
-      name: 'decay_history',
-      type: 'object',
-      mandatoryType: 'no',
-      editDefault: false,
-      multiple: true,
-      upsert: false,
-      label: 'Decay history',
-      isFilterable: false,
-      format: 'flat'
-    },
-    {
-      name: 'decay_applied_rule',
-      type: 'object',
-      mandatoryType: 'no',
-      editDefault: false,
-      multiple: false,
-      upsert: false,
-      label: 'Decay applied rule',
-      isFilterable: false,
-      format: 'flat'
-    },
+    ...(isFeatureEnabled(INDICATOR_DECAY_FEATURE_FLAG) ? [
+      {
+        name: 'decay_next_reaction_date',
+        type: 'date',
+        mandatoryType: 'no',
+        editDefault: false,
+        multiple: false,
+        upsert: false,
+        label: 'Decay next reaction date',
+        isFilterable: false
+      },
+      {
+        name: 'decay_base_score',
+        type: 'numeric',
+        mandatoryType: 'no',
+        editDefault: true,
+        multiple: false,
+        upsert: true,
+        label: 'Decay base score',
+        isFilterable: true,
+        precision: 'integer',
+      },
+      {
+        name: 'decay_base_score_date',
+        type: 'date',
+        mandatoryType: 'no',
+        editDefault: true,
+        multiple: false,
+        upsert: true,
+        label: 'Decay base score date',
+        isFilterable: false,
+      },
+      {
+        name: 'decay_history',
+        type: 'object',
+        mandatoryType: 'no',
+        editDefault: false,
+        multiple: true,
+        upsert: false,
+        label: 'Decay history',
+        isFilterable: false,
+        format: 'flat'
+      },
+      {
+        name: 'decay_applied_rule',
+        type: 'object',
+        mandatoryType: 'no',
+        editDefault: false,
+        multiple: false,
+        upsert: false,
+        label: 'Decay applied rule',
+        isFilterable: false,
+        format: 'flat'
+      }
+    ] as AttributeDefinition[] : []),
   ],
   relations: [],
   relationsRefs: [objectOrganization, killChainPhases],
@@ -93,6 +96,4 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
   converter: convertIndicatorToStix
 };
 
-if (isFeatureEnabled(INDICATOR_DECAY_FEATURE_FLAG)) {
-  registerDefinition(INDICATOR_DEFINITION);
-}
+registerDefinition(INDICATOR_DEFINITION);


### PR DESCRIPTION
This PR aims to introduce a dev configuration to disable features that are currently in development but not ready yet.
That's will ease the merging of large feature but providing simple tools to hide the feature.

In this PR you will find a example of Decay indicator feature deactivation.
- Deactivation of the manager registration
- Deactivation of the module registration
- Deactivation of a frontend specific menu