### PR TITLE
[backend] Indicators created with same name should not be deduplicated (#5819)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -9,7 +9,7 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
     id: 'indicator',
     name: ENTITY_TYPE_INDICATOR,
     category: ABSTRACT_STIX_DOMAIN_OBJECT,
-    aliased: true
+    aliased: false
   },
   identifier: {
     definition: {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove aliased true on indicator module (added when refactoring indicator domain in module)

### Related issues

* #5819 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
