### PR TITLE
[frontend] Added 'application/vnd.ms-excel' as an accepted MIME type in csv mapper

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperTestDialog.tsx
@@ -98,6 +98,7 @@ const CsvMapperTestDialog: FunctionComponent<CsvMapperTestDialogProps> = ({
           <CustomFileUploader
             setFieldValue={(field, v) => onChange(field, v)}
             label={'Your testing file limited to 100 lines (csv only, max 1MB)'}
+            // we also accept application/vnd.ms-excel type because that's how csv's seem to be seen as under WindowsOS + Firefox browser
             acceptMimeTypes={'text/csv,application/vnd.ms-excel'}
             // we limit the file size so the upload does not take too long for a simple test
             sizeLimit={1000000}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperTestDialog.tsx
@@ -43,7 +43,7 @@ const CsvMapperTestDialog: FunctionComponent<CsvMapperTestDialogProps> = ({
 
   const onChange = async (field: string, v: string | File | undefined) => {
     if (field === 'file' && v instanceof File) {
-      if (v.type === 'text/csv') {
+      if (v.type === 'text/csv' || v.type === 'application/vnd.ms-excel') {
         const fileValue = await v.text();
         setValue(fileValue);
       } else {
@@ -98,7 +98,7 @@ const CsvMapperTestDialog: FunctionComponent<CsvMapperTestDialogProps> = ({
           <CustomFileUploader
             setFieldValue={(field, v) => onChange(field, v)}
             label={'Your testing file limited to 100 lines (csv only, max 1MB)'}
-            acceptMimeTypes={'text/csv'}
+            acceptMimeTypes={'text/csv,application/vnd.ms-excel'}
             // we limit the file size so the upload does not take too long for a simple test
             sizeLimit={1000000}
           />


### PR DESCRIPTION
### Proposed changes

* This is the implementation of the fix proposed by [@lndrtrbn ] to the issue.

### Related issues

* #5854 

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The drawback of thix fix is that it might confuse users by giving them the option to select .xls files to import.

An other possible fix would have been to drop the checking of the MIME type when importing the csv, and only check for the .csv file extension, but I'm not sure what all the impacts of not checking for the MIME type might be.
