### PR TITLE
[frontend] Fixed remaining links from old /dashboard/data/connectors address to new /dashboard/data/ingestion/connectors

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.jsx
@@ -187,7 +187,7 @@ class ConnectorComponent extends Component {
       },
       onCompleted: () => {
         this.handleCloseDelete();
-        this.props.history.push('/dashboard/data/connectors');
+        this.props.history.push('/dashboard/data/ingestion/connectors');
       },
     });
   }

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -197,7 +197,7 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
       },
       onCompleted: () => {
         MESSAGING$.notifySuccess('The connector has been cleared');
-        history.push('/dashboard/data/connectors');
+        history.push('/dashboard/data/ingestion/connectors');
       },
       updater: undefined,
       optimisticResponse: undefined,

--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportContent.jsx
@@ -393,7 +393,7 @@ class ImportContentComponent extends Component {
                     return (
                       <ListItemButton
                         component={Link}
-                        to={`/dashboard/data/connectors/${connector.id}`}
+                        to={`/dashboard/data/ingestion/connectors/${connector.id}`}
                         key={connector.id}
                         dense={true}
                         divider={true}


### PR DESCRIPTION
### Proposed changes

Some links to the old /dashboard/data/connectors endpoint were remaining. I changed it to the new /dashboard/data/ingestion/connectors address

### Related issues

* #5868 


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality


### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
