### PR TITLE
[frontend] Confidence Level logic enforced in the platform (User) (#5697)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2560,7 +2560,6 @@
   "Max Confidence Level:": "Max. Konfidenzniveau:",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "Bitte überprüfen Sie die Gültigkeit des ausgewählten CSV-Mappers für die angegebene URL.",
   "Only successful tests allow the ingestion creation.": "Nur erfolgreiche Tests ermöglichen die Erstellung der Aufnahme.",
-  "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
   "Request for takedown date": "Antrag auf Übernahmedatum",
   "Enable AI powered platform": "KI-gestützte Plattform aktivieren",
   "To use AI, please enable it in the configuration of your platform.": "Um AI zu nutzen, aktivieren Sie es bitte in der Konfiguration Ihrer Plattform.",
@@ -2663,4 +2662,7 @@
   "Delete public dashboard": "Öffentliches Dashboard löschen",
   "Are you sure you want to delete this public dashboard?": "Sind Sie sicher, dass Sie dieses öffentliche Dashboard löschen möchten?",
   "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert."
+  "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
+  "Your maximum confidence level is insufficient to edit this object.": "Dein maximales Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
+  "You need a maximum confidence level to edit objects in the platform.": "Du benötigst ein maximales Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."
 }

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2663,6 +2663,6 @@
   "Are you sure you want to delete this public dashboard?": "Sind Sie sicher, dass Sie dieses öffentliche Dashboard löschen möchten?",
   "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert.",
   "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
-  "Your maximum confidence level is insufficient to edit this object.": "Dein maximales Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
-  "You need a maximum confidence level to edit objects in the platform.": "Du benötigst ein maximales Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."
+  "Your confidence level is insufficient to edit this object.": "Dein Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
+  "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."
 }

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2661,7 +2661,7 @@
   "Disable public dashboard": "Öffentliches Dashboard deaktivieren",
   "Delete public dashboard": "Öffentliches Dashboard löschen",
   "Are you sure you want to delete this public dashboard?": "Sind Sie sicher, dass Sie dieses öffentliche Dashboard löschen möchten?",
-  "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert."
+  "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert.",
   "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
   "Your maximum confidence level is insufficient to edit this object.": "Dein maximales Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
   "You need a maximum confidence level to edit objects in the platform.": "Du benötigst ein maximales Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2662,5 +2662,7 @@
   "AI Powered": "AI Powered",
   "Missing token": "Missing token",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.",
-  "Accept": "Accept"
+  "Accept": "Accept",
+  "Your maximum confidence level is insufficient to edit this object.": "Your maximum confidence level is insufficient to edit this object.",
+  "You need a maximum confidence level to edit objects in the platform.": "You need a maximum confidence level to edit objects in the platform."
 }

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2663,6 +2663,6 @@
   "Missing token": "Missing token",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.",
   "Accept": "Accept",
-  "Your maximum confidence level is insufficient to edit this object.": "Your maximum confidence level is insufficient to edit this object.",
-  "You need a maximum confidence level to edit objects in the platform.": "You need a maximum confidence level to edit objects in the platform."
+  "Your confidence level is insufficient to edit this object.": "Your confidence level is insufficient to edit this object.",
+  "You need a confidence level to edit objects in the platform.": "You need a confidence level to edit objects in the platform."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2568,7 +2568,6 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user’s groups.": "El nivel de confianza máximo se define actualmente a nivel de usuario. Anula el nivel de confianza máximo de los grupos de usuarios.",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "Por favor, verifique la validez del asignador CSV seleccionado para la URL proporcionada.",
   "Only successful tests allow the ingestion creation.": "Sólo las pruebas exitosas permiten la creación de la ingesta.",
-  "Only successful tests allow the ingestion edition.": "Sólo las pruebas exitosas permiten la edición de ingesta.",
   "Request for takedown date": "Fecha de solicitud de retirada",
   "Enable AI powered platform": "Habilitar plataforma con IA",
   "To use AI, please enable it in the configuration of your platform.": "Para utilizar la IA, por favor, habilítela en la configuración de su plataforma.",
@@ -2667,4 +2666,6 @@
   "Delete public dashboard": "Borrar panel público",
   "Are you sure you want to delete this public dashboard?": "¿Está seguro de que desea eliminar este panel público?",
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán."
+  "Your maximum confidence level is insufficient to edit this object.": "Tu nivel máximo de confianza es insuficiente para editar este objeto.",
+  "You need a maximum confidence level to edit objects in the platform.": "Necesitas un nivel máximo de confianza para editar objetos en la plataforma."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2666,6 +2666,6 @@
   "Delete public dashboard": "Borrar panel público",
   "Are you sure you want to delete this public dashboard?": "¿Está seguro de que desea eliminar este panel público?",
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
-  "Your maximum confidence level is insufficient to edit this object.": "Tu nivel máximo de confianza es insuficiente para editar este objeto.",
-  "You need a maximum confidence level to edit objects in the platform.": "Necesitas un nivel máximo de confianza para editar objetos en la plataforma."
+  "Your confidence level is insufficient to edit this object.": "Tu nivel de confianza es insuficiente para editar este objeto.",
+  "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2665,7 +2665,7 @@
   "Disable public dashboard": "Desactivar panel público",
   "Delete public dashboard": "Borrar panel público",
   "Are you sure you want to delete this public dashboard?": "¿Está seguro de que desea eliminar este panel público?",
-  "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán."
+  "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
   "Your maximum confidence level is insufficient to edit this object.": "Tu nivel máximo de confianza es insuficiente para editar este objeto.",
   "You need a maximum confidence level to edit objects in the platform.": "Necesitas un nivel máximo de confianza para editar objetos en la plataforma."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2574,7 +2574,6 @@
   "Delete public dashboard": "Supprimer le tableau de bord public",
   "Are you sure you want to delete this public dashboard?": "Êtes-vous sûr de vouloir supprimer ce tableau de bord public ?",
   "A public dashboard is a snapshot...": "Un tableau de bord public est un instantané d'un tableau de bord privé à un moment précis. Si vous modifiez le tableau de bord privé, les tableaux de bord publics déjà créés ne seront pas modifiés.",
-  "Home": "Accueil",
   "Request for takedown date": "Date de la demande de démontage",
   "Enable AI powered platform": "Activer la plateforme alimentée par l'IA",
   "To use AI, please enable it in the configuration of your platform.": "Pour utiliser l'IA, veuillez l'activer dans la configuration de votre plateforme.",
@@ -2663,6 +2662,6 @@
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "L'IA générative est une fonction bêta, car nous sommes en train d'affiner nos modèles. Pensez à vérifier les informations importantes.",
   "Accept": "Accepter",
   "Home": "Accueil",
-  "Your maximum confidence level is insufficient to edit this object.": "Votre niveau de confiance maximum est insuffisant pour éditer cet objet.",
-  "You need a maximum confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance maximum pour éditer des objets sur la plateforme."
+  "Your confidence level is insufficient to edit this object.": "Votre niveau de confiance est insuffisant pour éditer cet objet.",
+  "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2564,7 +2564,6 @@
   "Copy link": "Copier le lien",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "Veuillez vérifier la validité du mappeur CSV sélectionné pour l'URL donnée.",
   "Only successful tests allow the ingestion creation.": "Seuls les tests réussis permettent la création de l'ingestion.",
-  "Only successful tests allow the ingestion edition.": "Seuls les tests réussis permettent l'édition de l'ingestion.",
   "Public dashboards": "Tableaux de bord publics",
   "Existing public dashboards": "Tableaux de bord publics existants",
   "No public dashboard created yet": "Aucun tableau de bord public n'a encore été créé",
@@ -2662,5 +2661,8 @@
   "AI Powered": "AI Powered",
   "Missing token": "Jeton manquant",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "L'IA générative est une fonction bêta, car nous sommes en train d'affiner nos modèles. Pensez à vérifier les informations importantes.",
-  "Accept": "Accepter"
+  "Accept": "Accepter",
+  "Home": "Accueil",
+  "Your maximum confidence level is insufficient to edit this object.": "Votre niveau de confiance maximum est insuffisant pour éditer cet objet.",
+  "You need a maximum confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance maximum pour éditer des objets sur la plateforme."
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2564,7 +2564,6 @@
   "Copy link": "リンクをコピー",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "指定された URL に対して選択した CSV マッパーが有効であることを確認してください。",
   "Only successful tests allow the ingestion creation.": "成功したテストのみが取り込みの作成を許可します。",
-  "Only successful tests allow the ingestion edition.": "テストが成功した場合のみ、インジェスト エディションが許可されます。",
   "Public dashboards": "公開ダッシュボード",
   "Existing public dashboards": "既存の公開ダッシュボード",
   "No public dashboard created yet": "まだ作成されていない公開ダッシュボード",
@@ -2662,5 +2661,7 @@
   "AI Powered": "AI搭載",
   "Missing token": "トークンの紛失",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "ジェネレーティブAIは現在モデルを微調整しているベータ機能です。重要な情報を確認してください。",
-  "Accept": "受け入れる"
+  "Accept": "受け入れる",
+  "Your maximum confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
+  "You need a maximum confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。"
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2662,6 +2662,6 @@
   "Missing token": "トークンの紛失",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "ジェネレーティブAIは現在モデルを微調整しているベータ機能です。重要な情報を確認してください。",
   "Accept": "受け入れる",
-  "Your maximum confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
-  "You need a maximum confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。"
+  "Your confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
+  "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。"
 }

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2564,7 +2564,6 @@
   "Copy link": "复制链接",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "请验证给定 URL 所选 CSV 映射器的有效性。",
   "Only successful tests allow the ingestion creation.": "只有成功的测试才允许创建摄取。",
-  "Only successful tests allow the ingestion edition.": "只有成功的测试才允许摄取版本。",
   "Public dashboards": "公共仪表板",
   "Existing public dashboards": "现有公共仪表盘",
   "No public dashboard created yet": "尚未创建公共仪表盘",
@@ -2662,5 +2661,7 @@
   "AI Powered": "人工智能技术",
   "Missing token": "丢失的令牌",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "生成式人工智能是一项测试功能，因为我们目前正在对模型进行微调。请考虑检查重要信息。",
-  "Accept": "接受"
+  "Accept": "接受",
+  "Your maximum confidence level is insufficient to edit this object.": "编辑此对象需要更高的最大信心水平。",
+  "You need a maximum confidence level to edit objects in the platform.": "在平台上编辑对象需要最高信心水平。"
 }

--- a/opencti-platform/opencti-front/src/components/AlertConfidenceForEntity.tsx
+++ b/opencti-platform/opencti-front/src/components/AlertConfidenceForEntity.tsx
@@ -23,7 +23,7 @@ const AlertConfidenceForEntity: React.FC<AlertConfidenceForEntityProps> = ({ ent
       variant="outlined"
       style={{ marginTop: 20, marginBottom: 20 }}
     >
-      {t_i18n('Your maximum confidence level is insufficient to edit this object.')}
+      {t_i18n('Your confidence level is insufficient to edit this object.')}
     </Alert>
   );
 };

--- a/opencti-platform/opencti-front/src/components/AlertConfidenceForEntity.tsx
+++ b/opencti-platform/opencti-front/src/components/AlertConfidenceForEntity.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import useConfidenceLevel from '../utils/hooks/useConfidenceLevel';
+import { useFormatter } from './i18n';
+
+type AlertConfidenceForEntityProps = {
+  entity: {
+    confidence?: number | null
+  }
+};
+
+const AlertConfidenceForEntity: React.FC<AlertConfidenceForEntityProps> = ({ entity }) => {
+  const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
+
+  if (checkConfidenceForEntity(entity)) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity="warning"
+      variant="outlined"
+      style={{ marginTop: 20, marginBottom: 20 }}
+    >
+      {t_i18n('Your maximum confidence level is insufficient to edit this object.')}
+    </Alert>
+  );
+};
+
+export default AlertConfidenceForEntity;

--- a/opencti-platform/opencti-front/src/components/InputSliderField.tsx
+++ b/opencti-platform/opencti-front/src/components/InputSliderField.tsx
@@ -4,7 +4,6 @@ import { Grid, MenuItem, Select, SelectChangeEvent, Slider } from '@mui/material
 import SimpleTextField from './SimpleTextField';
 import { SubscriptionFocus } from './Subscription';
 import { buildScaleLevel, useLevel } from '../utils/hooks/useScale';
-import useConfidenceLevel from '../utils/hooks/useConfidenceLevel';
 
 interface InputSliderFieldProps {
   label: string;
@@ -21,11 +20,10 @@ interface InputSliderFieldProps {
   entityType: string;
   attributeName: string;
   disabled?: boolean;
+  maxLimit?: number;
 }
 
-const InputSliderField: FunctionComponent<
-InputSliderFieldProps & FieldProps
-> = ({
+const InputSliderField: FunctionComponent<InputSliderFieldProps & FieldProps> = ({
   form: { setFieldValue },
   field: { name, value },
   label,
@@ -36,18 +34,19 @@ InputSliderFieldProps & FieldProps
   entityType,
   attributeName,
   disabled,
+  maxLimit,
 }) => {
-  const { effectiveConfidenceLevel } = useConfidenceLevel();
   const {
     level: { color },
-    marks,
+    marks: defaultMarks,
     scale,
   } = useLevel(entityType, attributeName, value);
   const min = scale?.min ? scale.min.value : 0;
   const defaultMaxValue = scale?.max ? scale.max.value : 0;
-  const max = effectiveConfidenceLevel
-    ? effectiveConfidenceLevel.max_confidence
+  const max = maxLimit !== undefined && Number.isFinite(maxLimit) && maxLimit <= defaultMaxValue
+    ? maxLimit
     : defaultMaxValue;
+  const marks = defaultMarks.filter((mark) => mark.value <= max);
   const sliderStyle = {
     color,
     '& .MuiSlider-rail': {

--- a/opencti-platform/opencti-front/src/components/InputSliderField.tsx
+++ b/opencti-platform/opencti-front/src/components/InputSliderField.tsx
@@ -4,6 +4,7 @@ import { Grid, MenuItem, Select, SelectChangeEvent, Slider } from '@mui/material
 import SimpleTextField from './SimpleTextField';
 import { SubscriptionFocus } from './Subscription';
 import { buildScaleLevel, useLevel } from '../utils/hooks/useScale';
+import useConfidenceLevel from '../utils/hooks/useConfidenceLevel';
 
 interface InputSliderFieldProps {
   label: string;
@@ -36,13 +37,17 @@ InputSliderFieldProps & FieldProps
   attributeName,
   disabled,
 }) => {
+  const { effectiveConfidenceLevel } = useConfidenceLevel();
   const {
     level: { color },
     marks,
     scale,
   } = useLevel(entityType, attributeName, value);
   const min = scale?.min ? scale.min.value : 0;
-  const max = scale?.max ? scale.max.value : 0;
+  const defaultMaxValue = scale?.max ? scale.max.value : 0;
+  const max = effectiveConfidenceLevel
+    ? effectiveConfidenceLevel.max_confidence
+    : defaultMaxValue;
   const sliderStyle = {
     color,
     '& .MuiSlider-rail': {
@@ -68,7 +73,7 @@ InputSliderFieldProps & FieldProps
               label={label}
               onSubmit={onSubmit}
               onFocus={onFocus}
-              disabled={disabled}
+              disabled={disabled || value > max}
               helpertext={
                 <SubscriptionFocus context={editContext} fieldName={name} />
               }
@@ -80,7 +85,7 @@ InputSliderFieldProps & FieldProps
               labelId={name}
               value={currentLevel.level.value?.toString() ?? ''}
               onChange={updateFromSelect}
-              disabled={disabled}
+              disabled={disabled || value > max}
               sx={{ marginTop: 2 }} // to align field with the number input, that has a label
             >
               {marks.map((mark, i: number) => {
@@ -107,7 +112,7 @@ InputSliderFieldProps & FieldProps
           valueLabelDisplay="off"
           size="small"
           valueLabelFormat={() => currentLevel.level.label}
-          disabled={disabled}
+          disabled={disabled || value > max}
         />
       </>
     );

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -78,6 +78,9 @@ const rootPrivateQuery = graphql`
       theme
       user_email
       individual_id
+      effective_confidence_level {
+        max_confidence
+      }
       capabilities {
         name
       }

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -91,6 +91,9 @@ const rootPrivateQuery = graphql`
       }
       default_time_field
       default_hidden_types
+      effective_confidence_level {
+        max_confidence
+      }
       default_marking {
         entity_type
         values {

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,6 +19,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const groupingMutationFieldPatch = graphql`
   mutation GroupingEditionOverviewFieldPatchMutation(
@@ -82,6 +84,7 @@ const groupingMutationRelationDelete = graphql`
 const GroupingEditionOverviewComponent = (props) => {
   const { grouping, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -191,6 +194,15 @@ const GroupingEditionOverviewComponent = (props) => {
       }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
+            {(!checkConfidenceForEntity(grouping) && (
+              <Alert severity="warning" variant="outlined"
+                style={{ marginTop: 20, marginBottom: 20 }}
+              >
+                {t_i18n(
+                  'Your maximum confidence level is insufficient to edit this object.',
+                )}
+              </Alert>
+            ))}
             <Field
               component={TextField}
               name="name"

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -19,7 +18,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const groupingMutationFieldPatch = graphql`
   mutation GroupingEditionOverviewFieldPatchMutation(
@@ -84,7 +83,6 @@ const groupingMutationRelationDelete = graphql`
 const GroupingEditionOverviewComponent = (props) => {
   const { grouping, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -194,15 +192,7 @@ const GroupingEditionOverviewComponent = (props) => {
       }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
-            {(!checkConfidenceForEntity(grouping) && (
-              <Alert severity="warning" variant="outlined"
-                style={{ marginTop: 20, marginBottom: 20 }}
-              >
-                {t_i18n(
-                  'Your maximum confidence level is insufficient to edit this object.',
-                )}
-              </Alert>
-            ))}
+            <AlertConfidenceForEntity entity={grouping} />
             <Field
               component={TextField}
               name="name"

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
@@ -4,6 +4,12 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
+import {
+  malwareAnalysisEditionOverviewFocus,
+  malwareAnalysisMutationRelationAdd,
+  malwareAnalysisMutationRelationDelete,
+} from '@components/analyses/malware_analyses/MalwareAnalysisEditionOverview';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CommitMessage from '../../common/form/CommitMessage';
@@ -12,11 +18,12 @@ import { useFormatter } from '../../../../components/i18n';
 import { Option } from '../../common/form/ReferenceField';
 import { MalwareAnalysisEditionDetails_malwareAnalysis$key } from './__generated__/MalwareAnalysisEditionDetails_malwareAnalysis.graphql';
 import { MalwareAnalysisEditionDetailsFocusMutation } from './__generated__/MalwareAnalysisEditionDetailsFocusMutation.graphql';
-import { MalwareAnalysisEditionDetailsFieldPatchMutation as FieldPatchMutation } from './__generated__/MalwareAnalysisEditionDetailsFieldPatchMutation.graphql';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import { RelayError } from '../../../../relay/relayTypes';
 import { MESSAGING$ } from '../../../../relay/environment';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionDetailsFieldPatchMutation(
@@ -50,6 +57,14 @@ export const malwareAnalysisEditionDetailsFragment = graphql`
         analysis_engine_version
         analysis_definition_version
         modules
+        confidence
+        objectMarking {
+          id
+          definition_type
+          definition
+          x_opencti_order
+          x_opencti_color
+        }
     }
 `;
 interface MalwareAnalysisEditionDetailsProps {
@@ -69,6 +84,7 @@ interface MalwareAnalysisEditionFormValues {
 // eslint-disable-next-line max-len
 const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDetailsProps> = ({ malwareAnalysisRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     configuration_version: Yup.string().nullable(),
     analysis_started: Yup.date().nullable(),
@@ -80,9 +96,20 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
   const malwareAnalysisDetailsValidator = useSchemaCreationValidation('Malware-Analysis', basicShape);
   const malwareAnalysis = useFragment(malwareAnalysisEditionDetailsFragment, malwareAnalysisRef);
 
-  const [commitFieldPatch] = useMutation<FieldPatchMutation>(malwareAnalysisMutationFieldPatch);
   const [commitEditionDetailsFocus] = useMutation<MalwareAnalysisEditionDetailsFocusMutation>(malwareAnalysisEditionDetailsFocus);
 
+  const queries = {
+    fieldPatch: malwareAnalysisMutationFieldPatch,
+    relationAdd: malwareAnalysisMutationRelationAdd,
+    relationDelete: malwareAnalysisMutationRelationDelete,
+    editionFocus: malwareAnalysisEditionOverviewFocus,
+  };
+  const editor = useFormEditor(
+    malwareAnalysis as GenericData,
+    enableReferences,
+    queries,
+    malwareAnalysisDetailsValidator,
+  );
   const handleChangeFocus = (name: string) => {
     commitEditionDetailsFocus({
       variables: {
@@ -100,7 +127,7 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
       malwareAnalysisDetailsValidator
         .validateAt(name, { [name]: value })
         .then(() => {
-          commitFieldPatch({
+          editor.fieldPatch({
             variables: {
               id: malwareAnalysis.id,
               input: [{ key: name, value: [finalValue ?? ''] }],
@@ -117,7 +144,7 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
       malwareAnalysisDetailsValidator
         .validateAt(name, { [name]: value })
         .then(() => {
-          commitFieldPatch({
+          editor.fieldPatch({
             variables: {
               id: malwareAnalysis.id,
               input: [{ key: name, value: finalValue }],
@@ -138,7 +165,7 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
       modules: values.modules?.split('\n') ?? [],
     }).map(([key, value]) => ({ key, value: adaptFieldValue(value) }));
 
-    commitFieldPatch({
+    editor.fieldPatch({
       variables: {
         id: malwareAnalysis.id,
         input: inputValues,
@@ -178,6 +205,15 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
         values,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(malwareAnalysis) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="configuration_version"

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import {
   malwareAnalysisEditionOverviewFocus,
   malwareAnalysisMutationRelationAdd,
@@ -22,8 +21,8 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import { RelayError } from '../../../../relay/relayTypes';
 import { MESSAGING$ } from '../../../../relay/environment';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionDetailsFieldPatchMutation(
@@ -84,7 +83,6 @@ interface MalwareAnalysisEditionFormValues {
 // eslint-disable-next-line max-len
 const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDetailsProps> = ({ malwareAnalysisRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     configuration_version: Yup.string().nullable(),
     analysis_started: Yup.date().nullable(),
@@ -205,15 +203,7 @@ const MalwareAnalysisEditionDetails: FunctionComponent<MalwareAnalysisEditionDet
         values,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(malwareAnalysis) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={malwareAnalysis} />
           <Field
             component={TextField}
             name="configuration_version"

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -21,6 +22,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionOverviewFieldPatchMutation(
@@ -45,7 +47,7 @@ export const malwareAnalysisEditionOverviewFocus = graphql`
     }
 `;
 
-const malwareAnalysisMutationRelationAdd = graphql`
+export const malwareAnalysisMutationRelationAdd = graphql`
     mutation MalwareAnalysisEditionOverviewRelationAddMutation(
         $id: ID!
         $input: StixRefRelationshipAddInput!
@@ -59,7 +61,7 @@ const malwareAnalysisMutationRelationAdd = graphql`
     }
 `;
 
-const malwareAnalysisMutationRelationDelete = graphql`
+export const malwareAnalysisMutationRelationDelete = graphql`
     mutation MalwareAnalysisEditionOverviewRelationDeleteMutation(
         $id: ID!
         $toId: StixRef!
@@ -123,6 +125,7 @@ interface MalwareAnalysisEditionFormValues {
 // eslint-disable-next-line max-len
 const MalwareAnalysisEditionOverview: FunctionComponent<MalwareAnalysisEditionOverviewProps> = ({ malwareAnalysisRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     result_name: Yup.string().required(t_i18n('This field is required')),
     product: Yup.string().required(t_i18n('This field is required')),
@@ -213,6 +216,15 @@ const MalwareAnalysisEditionOverview: FunctionComponent<MalwareAnalysisEditionOv
         values,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(malwareAnalysis) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="product"

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -22,7 +21,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionOverviewFieldPatchMutation(
@@ -125,7 +124,6 @@ interface MalwareAnalysisEditionFormValues {
 // eslint-disable-next-line max-len
 const MalwareAnalysisEditionOverview: FunctionComponent<MalwareAnalysisEditionOverviewProps> = ({ malwareAnalysisRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     result_name: Yup.string().required(t_i18n('This field is required')),
     product: Yup.string().required(t_i18n('This field is required')),
@@ -216,15 +214,7 @@ const MalwareAnalysisEditionOverview: FunctionComponent<MalwareAnalysisEditionOv
         values,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(malwareAnalysis) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={malwareAnalysis} />
           <Field
             component={TextField}
             name="product"

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -22,6 +23,7 @@ import { NoteEditionOverview_note$data } from './__generated__/NoteEditionOvervi
 import SliderField from '../../../../components/SliderField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const noteMutationFieldPatch = graphql`
   mutation NoteEditionOverviewFieldPatchMutation(
@@ -86,6 +88,7 @@ const NoteEditionOverviewComponent: FunctionComponent<
 NoteEditionOverviewProps
 > = ({ note, context }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const basicShape = {
@@ -155,6 +158,15 @@ NoteEditionOverviewProps
     >
       {({ setFieldValue }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(note) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={DateTimePickerField}
             name="created"

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -23,7 +22,7 @@ import { NoteEditionOverview_note$data } from './__generated__/NoteEditionOvervi
 import SliderField from '../../../../components/SliderField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const noteMutationFieldPatch = graphql`
   mutation NoteEditionOverviewFieldPatchMutation(
@@ -88,7 +87,6 @@ const NoteEditionOverviewComponent: FunctionComponent<
 NoteEditionOverviewProps
 > = ({ note, context }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const basicShape = {
@@ -158,15 +156,7 @@ NoteEditionOverviewProps
     >
       {({ setFieldValue }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(note) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={note} />
           <Field
             component={DateTimePickerField}
             name="created"

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -15,6 +16,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import useGranted, { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const opinionMutationFieldPatch = graphql`
     mutation OpinionEditionOverviewFieldPatchMutation(
@@ -72,6 +74,7 @@ const opinionMutationRelationDelete = graphql`
 const OpinionEditionOverviewComponent = (props) => {
   const { opinion, context } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const basicShape = {
     opinion: Yup.string().required(t_i18n('This field is required')),
@@ -126,6 +129,15 @@ const OpinionEditionOverviewComponent = (props) => {
       {({ setFieldValue }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
+            {(!checkConfidenceForEntity(opinion) && (
+              <Alert severity="warning" variant="outlined"
+                style={{ marginTop: 20, marginBottom: 20 }}
+              >
+                {t_i18n(
+                  'Your maximum confidence level is insufficient to edit this object.',
+                )}
+              </Alert>
+            ))}
             <OpenVocabField
               label={t_i18n('Opinion')}
               type="opinion-ov"

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -16,7 +15,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import useGranted, { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const opinionMutationFieldPatch = graphql`
     mutation OpinionEditionOverviewFieldPatchMutation(
@@ -74,7 +73,6 @@ const opinionMutationRelationDelete = graphql`
 const OpinionEditionOverviewComponent = (props) => {
   const { opinion, context } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const basicShape = {
     opinion: Yup.string().required(t_i18n('This field is required')),
@@ -129,15 +127,7 @@ const OpinionEditionOverviewComponent = (props) => {
       {({ setFieldValue }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
-            {(!checkConfidenceForEntity(opinion) && (
-              <Alert severity="warning" variant="outlined"
-                style={{ marginTop: 20, marginBottom: 20 }}
-              >
-                {t_i18n(
-                  'Your maximum confidence level is insufficient to edit this object.',
-                )}
-              </Alert>
-            ))}
+            <AlertConfidenceForEntity entity={opinion} />
             <OpenVocabField
               label={t_i18n('Opinion')}
               type="opinion-ov"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -50,6 +50,7 @@ export const reportCreationMutation = graphql`
       name
       description
       entity_type
+      confidence
       parent_types
       ...ReportLine_node
     }

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { buildDate, parse } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -22,6 +23,7 @@ import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const reportMutationFieldPatch = graphql`
   mutation ReportEditionOverviewFieldPatchMutation(
@@ -86,6 +88,7 @@ const reportMutationRelationDelete = graphql`
 const ReportEditionOverviewComponent = (props) => {
   const { report, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -209,6 +212,15 @@ const ReportEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(report) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { buildDate, parse } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -23,7 +22,7 @@ import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const reportMutationFieldPatch = graphql`
   mutation ReportEditionOverviewFieldPatchMutation(
@@ -88,7 +87,6 @@ const reportMutationRelationDelete = graphql`
 const ReportEditionOverviewComponent = (props) => {
   const { report, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -212,15 +210,7 @@ const ReportEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(report) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={report} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,6 +19,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const channelMutationFieldPatch = graphql`
   mutation ChannelEditionOverviewFieldPatchMutation(
@@ -78,6 +80,7 @@ const channelMutationRelationDelete = graphql`
 const ChannelEditionOverviewComponent = (props) => {
   const { channel, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -180,6 +183,15 @@ const ChannelEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(channel) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -19,7 +18,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const channelMutationFieldPatch = graphql`
   mutation ChannelEditionOverviewFieldPatchMutation(
@@ -80,7 +79,6 @@ const channelMutationRelationDelete = graphql`
 const ChannelEditionOverviewComponent = (props) => {
   const { channel, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -183,15 +181,7 @@ const ChannelEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(channel) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={channel} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { createFragmentContainer, graphql, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
+import { malwareEditionOverviewFocus, malwareMutationRelationAdd, malwareMutationRelationDelete } from './MalwareEditionOverview';
 import { isNone, useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import OpenVocabField from '../../common/form/OpenVocabField';
@@ -10,6 +12,9 @@ import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const malwareMutationFieldPatch = graphql`
   mutation MalwareEditionDetailsFieldPatchMutation(
@@ -41,22 +46,37 @@ const malwareEditionDetailsFocus = graphql`
   }
 `;
 
-const malwareValidation = (t) => Yup.object().shape({
-  first_seen: Yup.date().nullable().typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
-  last_seen: Yup.date().nullable()
-    .min(Yup.ref('first_seen'), "The last seen date can't be before first seen date")
-    .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
-  architecture_execution_envs: Yup.array().nullable(),
-  implementation_languages: Yup.array().nullable(),
-  capabilities: Yup.array().nullable(),
-  references: Yup.array().required(t('This field is required')),
-});
-
 const MalwareEditionDetailsComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
+  const basicShape = {
+    first_seen: Yup.date().nullable().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    last_seen: Yup.date().nullable()
+      .min(Yup.ref('first_seen'), "The last seen date can't be before first seen date")
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    architecture_execution_envs: Yup.array().nullable(),
+    implementation_languages: Yup.array().nullable(),
+    capabilities: Yup.array().nullable(),
+    references: Yup.array().required(t_i18n('This field is required')),
+  };
+  const malwareValidator = useSchemaEditionValidation(
+    'Malware',
+    basicShape,
+  );
+  const queries = {
+    fieldPatch: malwareMutationFieldPatch,
+    relationAdd: malwareMutationRelationAdd,
+    relationDelete: malwareMutationRelationDelete,
+    editionFocus: malwareEditionOverviewFocus,
+  };
+  const editor = useFormEditor(
+    malware,
+    enableReferences,
+    queries,
+    malwareValidator,
+  );
 
-  const [commitFieldPatch] = useMutation(malwareMutationFieldPatch);
   const [commitEditionDetailsFocus] = useMutation(malwareEditionDetailsFocus);
 
   const handleChangeFocus = (name) => commitEditionDetailsFocus({
@@ -79,7 +99,7 @@ const MalwareEditionDetailsComponent = (props) => {
       last_seen: values.last_seen ? parse(values.last_seen).format() : null,
     }).map(([key, value]) => ({ key, value: adaptFieldValue(value) }));
 
-    commitFieldPatch({
+    editor.fieldPatch({
       variables: {
         id: malware.id,
         input: inputValues,
@@ -95,7 +115,7 @@ const MalwareEditionDetailsComponent = (props) => {
 
   const handleSubmitField = (name, value) => {
     if (!enableReferences) {
-      commitFieldPatch({
+      editor.fieldPatch({
         variables: {
           id: malware.id,
           input: { key: name, value: value || '' },
@@ -117,7 +137,7 @@ const MalwareEditionDetailsComponent = (props) => {
     <Formik
       enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={malwareValidation(t_i18n)}
+      validationSchema={malwareValidator}
       onSubmit={onSubmit}
     >
       {({
@@ -129,6 +149,15 @@ const MalwareEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(malware) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={DateTimePickerField}
             name="first_seen"
@@ -219,6 +248,7 @@ export default createFragmentContainer(MalwareEditionDetailsComponent, {
         architecture_execution_envs
         implementation_languages
         capabilities
+        confidence
       }
     `,
 });

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { createFragmentContainer, graphql, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { malwareEditionOverviewFocus, malwareMutationRelationAdd, malwareMutationRelationDelete } from './MalwareEditionOverview';
 import { isNone, useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -14,7 +13,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const malwareMutationFieldPatch = graphql`
   mutation MalwareEditionDetailsFieldPatchMutation(
@@ -49,7 +48,6 @@ const malwareEditionDetailsFocus = graphql`
 const MalwareEditionDetailsComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     first_seen: Yup.date().nullable().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     last_seen: Yup.date().nullable()
@@ -149,15 +147,7 @@ const MalwareEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(malware) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={malware} />
           <Field
             component={DateTimePickerField}
             name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -21,7 +20,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import SwitchField from '../../../../components/SwitchField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const malwareMutationFieldPatch = graphql`
   mutation MalwareEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ export const malwareMutationRelationDelete = graphql`
 const MalwareEditionOverviewComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -191,15 +189,7 @@ const MalwareEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(malware) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={malware} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -20,6 +21,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import SwitchField from '../../../../components/SwitchField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const malwareMutationFieldPatch = graphql`
   mutation MalwareEditionOverviewFieldPatchMutation(
@@ -51,7 +53,7 @@ export const malwareEditionOverviewFocus = graphql`
   }
 `;
 
-const malwareMutationRelationAdd = graphql`
+export const malwareMutationRelationAdd = graphql`
   mutation MalwareEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -66,7 +68,7 @@ const malwareMutationRelationAdd = graphql`
   }
 `;
 
-const malwareMutationRelationDelete = graphql`
+export const malwareMutationRelationDelete = graphql`
   mutation MalwareEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -83,6 +85,7 @@ const malwareMutationRelationDelete = graphql`
 const MalwareEditionOverviewComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -188,6 +191,15 @@ const MalwareEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(malware) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -19,6 +20,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const toolMutationFieldPatch = graphql`
   mutation ToolEditionOverviewFieldPatchMutation(
@@ -82,6 +84,7 @@ const toolMutationRelationDelete = graphql`
 const ToolEditionOverviewComponent = (props) => {
   const { tool, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -188,6 +191,15 @@ const ToolEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(tool) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -20,7 +19,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const toolMutationFieldPatch = graphql`
   mutation ToolEditionOverviewFieldPatchMutation(
@@ -84,7 +83,6 @@ const toolMutationRelationDelete = graphql`
 const ToolEditionOverviewComponent = (props) => {
   const { tool, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -191,15 +189,7 @@ const ToolEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(tool) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={tool} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
@@ -130,15 +130,7 @@ const VulnerabilityEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(vulnerability) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={vulnerability} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
@@ -130,6 +130,15 @@ const VulnerabilityEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(vulnerability) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"
@@ -260,6 +269,7 @@ export default createFragmentContainer(VulnerabilityEditionDetailsComponent, {
         x_opencti_cvss_integrity_impact
         x_opencti_cvss_availability_impact
         x_opencti_cvss_confidentiality_impact
+        confidence
       }
     `,
 });

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionDetails.jsx
@@ -13,6 +13,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const vulnerabilityMutationFieldPatch = graphql`
   mutation VulnerabilityEditionDetailsFieldPatchMutation(

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -17,6 +18,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const vulnerabilityMutationFieldPatch = graphql`
   mutation VulnerabilityEditionOverviewFieldPatchMutation(
@@ -83,6 +85,7 @@ export const vulnerabilityMutationRelationDelete = graphql`
 const VulnerabilityEditionOverviewComponent = (props) => {
   const { vulnerability, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -186,6 +189,15 @@ const VulnerabilityEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(vulnerability) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,7 +17,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const vulnerabilityMutationFieldPatch = graphql`
   mutation VulnerabilityEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ export const vulnerabilityMutationRelationDelete = graphql`
 const VulnerabilityEditionOverviewComponent = (props) => {
   const { vulnerability, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -189,15 +187,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(vulnerability) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={vulnerability} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -4,7 +4,6 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -26,7 +25,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseIncidentEditionOverview_case$key } from './__generated__/CaseIncidentEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const caseIncidentMutationFieldPatch = graphql`
   mutation CaseIncidentEditionOverviewCaseFieldPatchMutation(
@@ -170,7 +169,6 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseIncidentEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -269,15 +267,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(caseData) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={caseData} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -25,6 +26,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseIncidentEditionOverview_case$key } from './__generated__/CaseIncidentEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const caseIncidentMutationFieldPatch = graphql`
   mutation CaseIncidentEditionOverviewCaseFieldPatchMutation(
@@ -168,6 +170,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseIncidentEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -266,6 +269,15 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(caseData) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -4,7 +4,6 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -26,7 +25,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseRfiEditionOverview_case$key } from './__generated__/CaseRfiEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const caseRfiMutationFieldPatch = graphql`
   mutation CaseRfiEditionOverviewCaseFieldPatchMutation(
@@ -169,7 +168,6 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseRfiEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -268,15 +266,7 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(caseData) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={caseData} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -25,6 +26,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseRfiEditionOverview_case$key } from './__generated__/CaseRfiEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const caseRfiMutationFieldPatch = graphql`
   mutation CaseRfiEditionOverviewCaseFieldPatchMutation(
@@ -167,6 +169,7 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseRfiEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -265,6 +268,15 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(caseData) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -4,7 +4,6 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -26,7 +25,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseRftEditionOverview_case$key } from './__generated__/CaseRftEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const caseRftMutationFieldPatch = graphql`
   mutation CaseRftEditionOverviewCaseFieldPatchMutation(
@@ -169,7 +168,6 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseRftEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -268,15 +266,7 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(caseData) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={caseData} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -25,6 +26,7 @@ import { Option } from '../../common/form/ReferenceField';
 import StatusField from '../../common/form/StatusField';
 import { CaseRftEditionOverview_case$key } from './__generated__/CaseRftEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const caseRftMutationFieldPatch = graphql`
   mutation CaseRftEditionOverviewCaseFieldPatchMutation(
@@ -167,6 +169,7 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const caseData = useFragment(caseRftEditionOverviewFragment, caseRef);
 
   const basicShape = {
@@ -265,6 +268,15 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(caseData) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
@@ -23,7 +22,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const feedbackMutationFieldPatch = graphql`
   mutation FeedbackEditionOverviewFieldPatchMutation(
@@ -149,7 +148,6 @@ const FeedbackEditionOverviewComponent: FunctionComponent<
 FeedbackEditionOverviewProps
 > = ({ feedbackRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const feedbackData = useFragment(feedbackEditionOverviewFragment, feedbackRef);
 
   const basicShape = {
@@ -247,15 +245,7 @@ FeedbackEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(feedbackData) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={feedbackData} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
@@ -22,6 +23,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const feedbackMutationFieldPatch = graphql`
   mutation FeedbackEditionOverviewFieldPatchMutation(
@@ -147,6 +149,7 @@ const FeedbackEditionOverviewComponent: FunctionComponent<
 FeedbackEditionOverviewProps
 > = ({ feedbackRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const feedbackData = useFragment(feedbackEditionOverviewFragment, feedbackRef);
 
   const basicShape = {
@@ -244,6 +247,15 @@ FeedbackEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(feedbackData) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -5,6 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import InputSliderField from '../../../../components/InputSliderField';
 import { useFormatter } from '../../../../components/i18n';
 import { GenericContext } from '../model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const useStyles = makeStyles(() => ({
   alert: {
@@ -45,6 +46,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   const { t_i18n } = useFormatter();
   const finalLabel = label || t_i18n('Confidence level');
   const classes = useStyles();
+  const { effectiveConfidenceLevel } = useConfidenceLevel();
   return (
     <Alert
       classes={{ root: classes.alert, message: classes.message }}
@@ -66,6 +68,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
         onSubmit={onSubmit}
         editContext={editContext}
         disabled={disabled}
+        maxLimit={effectiveConfidenceLevel?.max_confidence ?? 0}
       />
     </Alert>
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
@@ -8,6 +8,7 @@ import { Close } from '@mui/icons-material';
 import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { buildDate, formatDate } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -32,6 +33,7 @@ import {
 import { Option } from '../form/ReferenceField';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
@@ -205,6 +207,7 @@ Omit<StixCoreRelationshipEditionOverviewProps, 'queryRef'>
   const stixCoreRelationshipType = 'stix-core-relationship';
 
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const classes = useStyles();
   const enableReferences = useIsEnforceReference(stixCoreRelationshipType);
 
@@ -331,6 +334,15 @@ Omit<StixCoreRelationshipEditionOverviewProps, 'queryRef'>
             dirty,
           }) => (
             <Form style={{ margin: '20px 0 20px 0' }}>
+              {(!checkConfidenceForEntity(stixCoreRelationship) && (
+                <Alert severity="warning" variant="outlined"
+                  style={{ marginTop: 20, marginBottom: 20 }}
+                >
+                  {t_i18n(
+                    'Your maximum confidence level is insufficient to edit this object.',
+                  )}
+                </Alert>
+              ))}
               <ConfidenceField
                 variant="edit"
                 onFocus={editor.changeFocus}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
@@ -8,7 +8,6 @@ import { Close } from '@mui/icons-material';
 import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { buildDate, formatDate } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/MarkdownField';
@@ -33,7 +32,7 @@ import {
 import { Option } from '../form/ReferenceField';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
@@ -207,7 +206,6 @@ Omit<StixCoreRelationshipEditionOverviewProps, 'queryRef'>
   const stixCoreRelationshipType = 'stix-core-relationship';
 
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const classes = useStyles();
   const enableReferences = useIsEnforceReference(stixCoreRelationshipType);
 
@@ -334,15 +332,7 @@ Omit<StixCoreRelationshipEditionOverviewProps, 'queryRef'>
             dirty,
           }) => (
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(stixCoreRelationship) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={stixCoreRelationship} />
               <ConfidenceField
                 variant="edit"
                 onFocus={editor.changeFocus}

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Event.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Event.jsx
@@ -36,7 +36,6 @@ class EventComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={event}
-              displayConfidence={false}
             />
           </Grid>
           <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -7,6 +7,7 @@ import { graphql, useMutation } from 'react-relay';
 import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -45,6 +46,7 @@ const eventMutation = graphql`
       standard_id
       name
       description
+      confidence
       entity_type
       parent_types
       ...EventLine_node
@@ -57,6 +59,7 @@ const EVENT_TYPE = 'Event';
 interface EventAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   event_types: string[];
   start_time: Date | null;
   stop_time: Date | null;
@@ -89,6 +92,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),
     start_time: Yup.date()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
@@ -110,6 +114,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
       name: values.name,
       description: values.description,
       event_types: values.event_types,
+      confidence: parseInt(String(values.confidence), 10),
       start_time: values.start_time ? parse(values.start_time).format() : null,
       stop_time: values.stop_time ? parse(values.stop_time).format() : null,
       createdBy: values.createdBy?.value,
@@ -146,6 +151,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
     description: '',
     event_types: [],
     start_time: null,
+    confidence: undefined,
     stop_time: null,
     createdBy: defaultCreatedBy,
     objectMarking: defaultMarkingDefinitions ?? [],
@@ -207,6 +213,10 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               fullWidth: true,
               style: { marginTop: 20 },
             }}
+          />
+          <ConfidenceField
+            entityType="Event"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -79,6 +80,7 @@ const EventEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),
     start_time: Yup.date().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')).nullable(),
     stop_time: Yup.date()
@@ -105,6 +107,7 @@ const EventEditionOverviewComponent = (props) => {
       R.dissoc('message'),
       R.dissoc('references'),
       R.assoc('createdBy', values.createdBy?.value),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
       R.assoc('start_time', parse(values.start_time).format()),
       R.assoc('stop_time', parse(values.stop_time).format()),
@@ -158,6 +161,7 @@ const EventEditionOverviewComponent = (props) => {
       'description',
       'start_time',
       'stop_time',
+      'confidence',
       'createdBy',
       'objectMarking',
       'x_opencti_workflow_id',
@@ -247,6 +251,14 @@ const EventEditionOverviewComponent = (props) => {
               ),
             }}
           />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Event"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
+          />
           {event.workflowEnabled && (
           <StatusField
             name="x_opencti_workflow_id"
@@ -302,6 +314,7 @@ export default createFragmentContainer(EventEditionOverviewComponent, {
         event_types
         description
         start_time
+        confidence
         stop_time
         createdBy {
           ... on Identity {

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -21,7 +20,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const eventMutationFieldPatch = graphql`
   mutation EventEditionOverviewFieldPatchMutation(
@@ -78,7 +77,6 @@ const eventMutationRelationDelete = graphql`
 const EventEditionOverviewComponent = (props) => {
   const { event, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -186,15 +184,7 @@ const EventEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(event) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={event} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -20,6 +21,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const eventMutationFieldPatch = graphql`
   mutation EventEditionOverviewFieldPatchMutation(
@@ -76,6 +78,7 @@ const eventMutationRelationDelete = graphql`
 const EventEditionOverviewComponent = (props) => {
   const { event, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -183,6 +186,15 @@ const EventEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(event) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Individual.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Individual.jsx
@@ -39,8 +39,6 @@ class IndividualComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={individual}
-              displayConfidence={false}
-              displayReliability={false}
             />
           </Grid>
           {viewAs === 'knowledge' && (

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -42,6 +43,7 @@ const individualMutation = graphql`
       id
       standard_id
       name
+      confidence
       description
       entity_type
       parent_types
@@ -55,6 +57,7 @@ const INDIVIDUAL_TYPE = 'Individual';
 interface IndividualAddInput {
   name: string
   description: string
+  confidence: number | undefined
   x_opencti_reliability: string | undefined
   createdBy: Option | undefined
   objectMarking: Option[]
@@ -87,6 +90,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
       .required(t_i18n('This field is required')),
     description: Yup.string()
       .nullable(),
+    confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
   };
@@ -104,6 +108,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
       description: values.description,
       x_opencti_reliability: values.x_opencti_reliability,
       createdBy: values.createdBy?.value,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map((v) => v.value),
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -138,6 +143,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
       name: '',
       description: '',
       x_opencti_reliability: undefined,
+      confidence: undefined,
       createdBy: defaultCreatedBy,
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
@@ -176,6 +182,10 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
           multiline={true}
           rows="4"
           style={{ marginTop: 20 }}
+        />
+        <ConfidenceField
+          entityType="Individual"
+          containerStyle={fieldSpacingContainerStyle}
         />
         <OpenVocabField
           label={t_i18n('Reliability')}

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -87,6 +88,7 @@ const IndividualEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
@@ -108,6 +110,7 @@ const IndividualEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -163,6 +166,7 @@ const IndividualEditionOverviewComponent = (props) => {
       'x_opencti_reliability',
       'createdBy',
       'objectMarking',
+      'confidence',
       'x_opencti_workflow_id',
     ]),
   )(individual);
@@ -207,6 +211,14 @@ const IndividualEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
               }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Individual"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={TextField}
@@ -289,6 +301,7 @@ export default createFragmentContainer(IndividualEditionOverviewComponent, {
         name
         description
         contact_information
+        confidence
         x_opencti_reliability
         createdBy {
           ... on Identity {

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -19,7 +18,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const individualMutationFieldPatch = graphql`
   mutation IndividualEditionOverviewFieldPatchMutation(
@@ -86,7 +85,6 @@ const individualMutationRelationDelete = graphql`
 const IndividualEditionOverviewComponent = (props) => {
   const { individual, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -188,15 +186,7 @@ const IndividualEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(individual) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={individual} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,6 +19,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const individualMutationFieldPatch = graphql`
   mutation IndividualEditionOverviewFieldPatchMutation(
@@ -84,6 +86,7 @@ const individualMutationRelationDelete = graphql`
 const IndividualEditionOverviewComponent = (props) => {
   const { individual, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -185,6 +188,15 @@ const IndividualEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(individual) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Organization.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Organization.jsx
@@ -39,8 +39,6 @@ class OrganizationComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={organization}
-              displayConfidence={false}
-              displayReliability={false}
             />
           </Grid>
           {viewAs === 'knowledge' && (

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -45,6 +46,7 @@ const organizationMutation = graphql`
       id
       standard_id
       name
+      confidence
       description
       entity_type
       parent_types
@@ -58,6 +60,7 @@ const ORGANIZATION_TYPE = 'Organization';
 interface OrganizationAddInput {
   name: string
   description: string
+  confidence: number | undefined
   x_opencti_reliability: string | undefined
   x_opencti_organization_type: string | undefined
   createdBy: Option | undefined
@@ -91,6 +94,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       .required(t_i18n('This field is required')),
     description: Yup.string()
       .nullable(),
+    confidence: Yup.number().nullable(),
     x_opencti_organization_type: Yup.string()
       .nullable(),
     x_opencti_reliability: Yup.string()
@@ -111,6 +115,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       x_opencti_reliability: values.x_opencti_reliability,
       x_opencti_organization_type: values.x_opencti_organization_type,
       createdBy: values.createdBy?.value,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map((v) => v.value),
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -147,6 +152,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       x_opencti_reliability: undefined,
       x_opencti_organization_type: undefined,
       createdBy: defaultCreatedBy,
+      confidence: undefined,
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
       externalReferences: [],
@@ -184,6 +190,10 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
           multiline={true}
           rows="4"
           style={fieldSpacingContainerStyle}
+        />
+        <ConfidenceField
+          entityType="Organization"
+          containerStyle={fieldSpacingContainerStyle}
         />
         { /* TODO Improve customization (vocab with letter range) 2662 */}
         <OpenVocabField

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -6,6 +6,7 @@ import { OrganizationEditionOverview_organization$data } from '@components/entit
 import { OrganizationEditionContainer_organization$data } from '@components/entities/organizations/__generated__/OrganizationEditionContainer_organization.graphql';
 import { FormikConfig } from 'formik/dist/types';
 import { Option } from '@components/common/form/ReferenceField';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import makeStyles from '@mui/styles/makeStyles';
@@ -110,6 +111,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -207,6 +209,15 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
         dirty,
       }) => (
         <Form className={classes.formContainer}>
+          {(!checkConfidenceForEntity(organization) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -6,7 +6,6 @@ import { OrganizationEditionOverview_organization$data } from '@components/entit
 import { OrganizationEditionContainer_organization$data } from '@components/entities/organizations/__generated__/OrganizationEditionContainer_organization.graphql';
 import { FormikConfig } from 'formik/dist/types';
 import { Option } from '@components/common/form/ReferenceField';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import makeStyles from '@mui/styles/makeStyles';
@@ -111,7 +110,6 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -209,15 +207,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
         dirty,
       }) => (
         <Form className={classes.formContainer}>
-          {(!checkConfidenceForEntity(organization) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={organization} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -6,6 +6,7 @@ import { OrganizationEditionOverview_organization$data } from '@components/entit
 import { OrganizationEditionContainer_organization$data } from '@components/entities/organizations/__generated__/OrganizationEditionContainer_organization.graphql';
 import { FormikConfig } from 'formik/dist/types';
 import { Option } from '@components/common/form/ReferenceField';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import makeStyles from '@mui/styles/makeStyles';
 import TextField from '../../../../components/TextField';
@@ -113,6 +114,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_organization_type: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
@@ -231,6 +233,14 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
               <SubscriptionFocus context={context} fieldName="description" />
               }
           />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Organization"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
+          />
           <Field
             component={TextField}
             variant="standard"
@@ -323,6 +333,7 @@ export default createFragmentContainer(OrganizationEditionOverviewComponent, {
         id
         name
         description
+        confidence
         contact_information
         x_opencti_organization_type
         x_opencti_reliability

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -6,9 +6,9 @@ import { OrganizationEditionOverview_organization$data } from '@components/entit
 import { OrganizationEditionContainer_organization$data } from '@components/entities/organizations/__generated__/OrganizationEditionContainer_organization.graphql';
 import { FormikConfig } from 'formik/dist/types';
 import { Option } from '@components/common/form/ReferenceField';
-import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import makeStyles from '@mui/styles/makeStyles';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -23,6 +23,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const useStyles = makeStyles(() => ({
   formContainer: {

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Sector.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Sector.jsx
@@ -36,7 +36,6 @@ class SectorComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={sector}
-              displayConfidence={false}
             />
           </Grid>
           <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -44,6 +45,7 @@ const sectorMutation = graphql`
       description
       entity_type
       parent_types
+      confidence
       isSubSector
       objectMarking {
         id
@@ -75,6 +77,7 @@ const SECTOR_TYPE = 'Sector';
 interface SectorAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
   objectLabel: Option[];
@@ -107,6 +110,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
       .required(t_i18n('This field is required')),
     description: Yup.string()
       .nullable(),
+    confidence: Yup.number().nullable(),
   };
   const sectorValidator = useSchemaCreationValidation(SECTOR_TYPE, basicShape);
 
@@ -123,6 +127,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
       name: values.name,
       description: values.description,
       createdBy: values.createdBy?.value,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map((v) => v.value),
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -156,6 +161,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
     {
       name: inputValue ?? '',
       description: '',
+      confidence: undefined,
       createdBy: defaultCreatedBy,
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
@@ -195,6 +201,10 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Sector"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -17,6 +18,7 @@ import StatusField from '../../common/form/StatusField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const sectorMutationFieldPatch = graphql`
   mutation SectorEditionOverviewFieldPatchMutation(
@@ -80,6 +82,7 @@ const sectorMutationRelationDelete = graphql`
 const SectorEditionOverviewComponent = (props) => {
   const { sector, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -180,6 +183,15 @@ const SectorEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(sector) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,7 +17,7 @@ import StatusField from '../../common/form/StatusField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const sectorMutationFieldPatch = graphql`
   mutation SectorEditionOverviewFieldPatchMutation(
@@ -82,7 +81,6 @@ const sectorMutationRelationDelete = graphql`
 const SectorEditionOverviewComponent = (props) => {
   const { sector, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -183,15 +181,7 @@ const SectorEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(sector) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={sector} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -83,6 +84,7 @@ const SectorEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
   };
@@ -102,6 +104,7 @@ const SectorEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -156,6 +159,7 @@ const SectorEditionOverviewComponent = (props) => {
       'references',
       'description',
       'createdBy',
+      'confidence',
       'objectMarking',
       'x_opencti_workflow_id',
     ]),
@@ -201,6 +205,14 @@ const SectorEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
               }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Sector"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           {sector.workflowEnabled && (
           <StatusField
@@ -256,6 +268,7 @@ export default createFragmentContainer(SectorEditionOverviewComponent, {
         name
         description
         isSubSector
+        confidence
         createdBy {
           ... on Identity {
             id

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/System.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/System.jsx
@@ -42,8 +42,6 @@ class SystemComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={system}
-              displayConfidence={false}
-              displayReliability={false}
             />
           </Grid>
           {viewAs === 'knowledge' && (

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -43,6 +44,7 @@ const systemMutation = graphql`
       standard_id
       name
       description
+      confidence
       entity_type
       parent_types
       ...SystemLine_node
@@ -55,6 +57,7 @@ const SYSTEM_TYPE = 'System';
 interface SystemAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   x_opencti_reliability: string | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
@@ -88,6 +91,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
       .required(t_i18n('This field is required')),
     description: Yup.string()
       .nullable(),
+    confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
   };
@@ -108,6 +112,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
       description: values.description,
       x_opencti_reliability: values.x_opencti_reliability,
       createdBy: values.createdBy?.value,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map((v) => v.value),
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -141,6 +146,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
     {
       name: inputValue ?? '',
       description: '',
+      confidence: undefined,
       x_opencti_reliability: undefined,
       createdBy: defaultCreatedBy,
       objectMarking: defaultMarkingDefinitions ?? [],
@@ -181,6 +187,10 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="System"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <OpenVocabField
             label={t_i18n('Reliability')}

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,6 +19,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const systemMutationFieldPatch = graphql`
   mutation SystemEditionOverviewFieldPatchMutation(
@@ -81,6 +83,7 @@ const systemMutationRelationDelete = graphql`
 const SystemEditionOverviewComponent = (props) => {
   const { system, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -183,6 +186,15 @@ const SystemEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(system) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -84,6 +85,7 @@ const SystemEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
@@ -105,6 +107,7 @@ const SystemEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -160,6 +163,7 @@ const SystemEditionOverviewComponent = (props) => {
       'x_opencti_reliability',
       'createdBy',
       'objectMarking',
+      'confidence',
       'x_opencti_workflow_id',
     ]),
   )(system);
@@ -205,6 +209,14 @@ const SystemEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
               }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="System"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={TextField}
@@ -286,6 +298,7 @@ export default createFragmentContainer(SystemEditionOverviewComponent, {
         id
         name
         description
+        confidence
         contact_information
         x_opencti_reliability
         createdBy {

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -19,7 +18,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const systemMutationFieldPatch = graphql`
   mutation SystemEditionOverviewFieldPatchMutation(
@@ -83,7 +82,6 @@ const systemMutationRelationDelete = graphql`
 const SystemEditionOverviewComponent = (props) => {
   const { system, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -186,15 +184,7 @@ const SystemEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(system) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={system} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { isNone, useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -15,6 +16,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { IncidentEditionDetails_incident$key } from './__generated__/IncidentEditionDetails_incident.graphql';
 import { parse } from '../../../../utils/Time';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionDetailsFieldPatchMutation(
@@ -54,6 +56,7 @@ const incidentEditionDetailsFragment = graphql`
     source
     objective
     is_inferred
+    confidence
   }
 `;
 
@@ -89,6 +92,7 @@ const IncidentEditionDetails: FunctionComponent<
 IncidentEditionDetailsProps
 > = ({ incidentRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const incident = useFragment(incidentEditionDetailsFragment, incidentRef);
   const isInferred = incident.is_inferred;
@@ -176,6 +180,15 @@ IncidentEditionDetailsProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(incident) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={DateTimePickerField}
             name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { isNone, useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -16,7 +15,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { IncidentEditionDetails_incident$key } from './__generated__/IncidentEditionDetails_incident.graphql';
 import { parse } from '../../../../utils/Time';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionDetailsFieldPatchMutation(
@@ -92,7 +91,6 @@ const IncidentEditionDetails: FunctionComponent<
 IncidentEditionDetailsProps
 > = ({ incidentRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const incident = useFragment(incidentEditionDetailsFragment, incidentRef);
   const isInferred = incident.is_inferred;
@@ -180,15 +178,7 @@ IncidentEditionDetailsProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(incident) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={incident} />
           <Field
             component={DateTimePickerField}
             name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -23,6 +24,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionOverviewFieldPatchMutation(
@@ -154,6 +156,7 @@ const IncidentEditionOverviewComponent: FunctionComponent<
 IncidentEditionOverviewProps
 > = ({ incidentRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const incident = useFragment(incidentEditionOverviewFragment, incidentRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -255,6 +258,15 @@ IncidentEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(incident) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -24,7 +23,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionOverviewFieldPatchMutation(
@@ -156,7 +155,6 @@ const IncidentEditionOverviewComponent: FunctionComponent<
 IncidentEditionOverviewProps
 > = ({ incidentRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const incident = useFragment(incidentEditionOverviewFragment, incidentRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -258,15 +256,7 @@ IncidentEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(incident) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={incident} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,6 +19,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 export const observedDataMutationFieldPatch = graphql`
   mutation ObservedDataEditionOverviewFieldPatchMutation(
@@ -83,6 +85,7 @@ const observedDataMutationRelationDelete = graphql`
 const ObservedDataEditionOverviewComponent = (props) => {
   const { observedData, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     first_observed: Yup.date()
@@ -203,6 +206,15 @@ const ObservedDataEditionOverviewComponent = (props) => {
       }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
+            {(!checkConfidenceForEntity(observedData) && (
+              <Alert severity="warning" variant="outlined"
+                style={{ marginTop: 20, marginBottom: 20 }}
+              >
+                {t_i18n(
+                  'Your maximum confidence level is insufficient to edit this object.',
+                )}
+              </Alert>
+            ))}
             <Field
               component={DateTimePickerField}
               name="first_observed"

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -19,7 +18,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 export const observedDataMutationFieldPatch = graphql`
   mutation ObservedDataEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ const observedDataMutationRelationDelete = graphql`
 const ObservedDataEditionOverviewComponent = (props) => {
   const { observedData, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     first_observed: Yup.date()
@@ -206,15 +204,7 @@ const ObservedDataEditionOverviewComponent = (props) => {
       }) => (
         <div>
           <Form style={{ margin: '20px 0 20px 0' }}>
-            {(!checkConfidenceForEntity(observedData) && (
-              <Alert severity="warning" variant="outlined"
-                style={{ marginTop: 20, marginBottom: 20 }}
-              >
-                {t_i18n(
-                  'Your maximum confidence level is insufficient to edit this object.',
-                )}
-              </Alert>
-            ))}
+            <AlertConfidenceForEntity entity={observedData} />
             <Field
               component={DateTimePickerField}
               name="first_observed"

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -8,7 +8,6 @@ import { Close } from '@mui/icons-material';
 import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { buildDate, formatDate } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -34,7 +33,7 @@ import {
 import CommitMessage from '../../common/form/CommitMessage';
 import type { Theme } from '../../../../components/Theme';
 import { StixSightingRelationshipEditionOverviewQuery } from './__generated__/StixSightingRelationshipEditionOverviewQuery.graphql';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
@@ -206,7 +205,6 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
   const stixSightingRelationshipType = 'stix-sighting-relationship';
 
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const classes = useStyles();
   const enableReferences = useIsEnforceReference(stixSightingRelationshipType);
 
@@ -309,15 +307,7 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
         >
           {({ submitForm, isSubmitting, setFieldValue, values, isValid, dirty }) => (
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(stixSightingRelationship) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={stixSightingRelationship} />
               <Field
                 component={TextField}
                 variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -8,6 +8,7 @@ import { Close } from '@mui/icons-material';
 import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { buildDate, formatDate } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -33,6 +34,7 @@ import {
 import CommitMessage from '../../common/form/CommitMessage';
 import type { Theme } from '../../../../components/Theme';
 import { StixSightingRelationshipEditionOverviewQuery } from './__generated__/StixSightingRelationshipEditionOverviewQuery.graphql';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
@@ -204,6 +206,7 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
   const stixSightingRelationshipType = 'stix-sighting-relationship';
 
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const classes = useStyles();
   const enableReferences = useIsEnforceReference(stixSightingRelationshipType);
 
@@ -306,6 +309,15 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
         >
           {({ submitForm, isSubmitting, setFieldValue, values, isValid, dirty }) => (
             <Form style={{ margin: '20px 0 20px 0' }}>
+              {(!checkConfidenceForEntity(stixSightingRelationship) && (
+                <Alert severity="warning" variant="outlined"
+                  style={{ marginTop: 20, marginBottom: 20 }}
+                >
+                  {t_i18n(
+                    'Your maximum confidence level is insufficient to edit this object.',
+                  )}
+                </Alert>
+              ))}
               <Field
                 component={TextField}
                 variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeArea.tsx
@@ -104,7 +104,6 @@ const AdministrativeArea = ({
         <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
           <StixDomainObjectOverview
             stixDomainObject={administrativeArea}
-            displayConfidence={false}
           />
         </Grid>
         <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -43,6 +44,7 @@ const administrativeAreaMutation = graphql`
       standard_id
       name
       description
+      confidence
       entity_type
       parent_types
       ...AdministrativeAreaLine_node
@@ -55,6 +57,7 @@ interface AdministrativeAreaAddInput {
   description: string;
   latitude: string;
   longitude: string;
+  confidence: number | undefined
   createdBy: Option | undefined;
   objectMarking: Option[];
   objectLabel: Option[];
@@ -86,6 +89,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -107,6 +111,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
       latitude: parseFloat(values.latitude),
       longitude: parseFloat(values.longitude),
       description: values.description,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map(({ value }) => value),
       objectLabel: values.objectLabel.map(({ value }) => value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -138,6 +143,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
       description: '',
       latitude: '',
       longitude: '',
+      confidence: undefined,
       createdBy: defaultCreatedBy,
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
@@ -170,6 +176,10 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
             multiline={true}
             rows={4}
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Administrative-Area"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -87,6 +88,7 @@ export const administrativeAreaEditionOverviewFragment = graphql`
     description
     latitude
     longitude
+    confidence
     createdBy {
       ... on Identity {
         id
@@ -145,6 +147,7 @@ AdministrativeAreaEditionOverviewProps
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -219,6 +222,7 @@ AdministrativeAreaEditionOverviewProps
     description: administrativeArea.description,
     latitude: administrativeArea.latitude,
     longitude: administrativeArea.longitude,
+    confidence: administrativeArea.confidence,
     createdBy: convertCreatedBy(administrativeArea),
     objectMarking: convertMarkings(administrativeArea),
     x_opencti_workflow_id: convertStatus(t_i18n, administrativeArea) as Option,
@@ -265,6 +269,14 @@ AdministrativeAreaEditionOverviewProps
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Administrative-Area"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -20,6 +21,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const administrativeAreaMutationFieldPatch = graphql`
   mutation AdministrativeAreaEditionOverviewFieldPatchMutation(
@@ -140,6 +142,7 @@ AdministrativeAreaEditionOverviewProps
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const administrativeArea = useFragment(
     administrativeAreaEditionOverviewFragment,
     administrativeAreaRef,
@@ -244,6 +247,15 @@ AdministrativeAreaEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(administrativeArea) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -21,7 +20,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const administrativeAreaMutationFieldPatch = graphql`
   mutation AdministrativeAreaEditionOverviewFieldPatchMutation(
@@ -142,7 +141,6 @@ AdministrativeAreaEditionOverviewProps
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const administrativeArea = useFragment(
     administrativeAreaEditionOverviewFragment,
     administrativeAreaRef,
@@ -247,15 +245,7 @@ AdministrativeAreaEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(administrativeArea) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={administrativeArea} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/City.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/City.tsx
@@ -97,7 +97,6 @@ const City = ({ cityData }: { cityData: City_city$key }) => {
         <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
           <StixDomainObjectOverview
             stixDomainObject={city}
-            displayConfidence={false}
           />
         </Grid>
         <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -42,6 +43,7 @@ const cityMutation = graphql`
       name
       description
       entity_type
+      confidence
       parent_types
       ...CityLine_node
     }
@@ -53,6 +55,7 @@ interface CityAddInput {
   description: string;
   latitude: string;
   longitude: string;
+  confidence: number | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
   objectLabel: Option[];
@@ -83,6 +86,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -101,6 +105,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
       description: values.description,
       latitude: parseFloat(values.latitude),
       longitude: parseFloat(values.longitude),
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map(({ value }) => value),
       objectLabel: values.objectLabel.map(({ value }) => value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -130,6 +135,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
     description: '',
     latitude: '',
     longitude: '',
+    confidence: undefined,
     createdBy: defaultCreatedBy,
     objectMarking: defaultMarkingDefinitions ?? [],
     objectLabel: [],
@@ -160,6 +166,10 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
             multiline={true}
             rows={4}
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="City"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -5,7 +5,6 @@ import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import ConfidenceField from '@components/common/form/ConfidenceField';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -21,7 +20,7 @@ import { CityEditionOverview_city$key } from './__generated__/CityEditionOvervie
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const cityMutationFieldPatch = graphql`
   mutation CityEditionOverviewFieldPatchMutation(
@@ -138,7 +137,6 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const city = useFragment(cityEditionOverviewFragment, cityRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -234,15 +232,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(city) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={city} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -84,6 +85,7 @@ export const cityEditionOverviewFragment = graphql`
     id
     name
     description
+    confidence
     latitude
     longitude
     createdBy {
@@ -138,6 +140,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -204,6 +207,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
   const initialValues = {
     name: city.name,
     description: city.description,
+    confidence: city.confidence,
     latitude: city.latitude,
     longitude: city.longitude,
     references: [],
@@ -252,6 +256,14 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="City"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import ConfidenceField from '@components/common/form/ConfidenceField';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -20,6 +21,7 @@ import { CityEditionOverview_city$key } from './__generated__/CityEditionOvervie
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const cityMutationFieldPatch = graphql`
   mutation CityEditionOverviewFieldPatchMutation(
@@ -136,6 +138,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const city = useFragment(cityEditionOverviewFragment, cityRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -231,6 +234,15 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(city) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Country.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Country.tsx
@@ -117,7 +117,6 @@ const CountryComponent = ({
         <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
           <StixDomainObjectOverview
             stixDomainObject={country}
-            displayConfidence={false}
           />
         </Grid>
         <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
@@ -8,6 +8,7 @@ import { FormikConfig } from 'formik/dist/types';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import CustomFileUploader from '@components/common/files/CustomFileUploader';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -40,6 +41,7 @@ const countryMutation = graphql`
       id
       standard_id
       name
+      confidence
       description
       entity_type
       parent_types
@@ -51,6 +53,7 @@ const countryMutation = graphql`
 interface CountryAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
   objectLabel: Option[];
@@ -81,6 +84,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
   };
   const countryValidator = useSchemaCreationValidation(
     COUNTRY_TYPE,
@@ -94,6 +98,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
     const input: CountryCreationMutation$variables['input'] = {
       name: values.name,
       description: values.description,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map(({ value }) => value),
       objectLabel: values.objectLabel.map(({ value }) => value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -121,6 +126,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
   const initialValues = useDefaultValues<CountryAddInput>(COUNTRY_TYPE, {
     name: '',
     description: '',
+    confidence: undefined,
     createdBy: defaultCreatedBy,
     objectMarking: defaultMarkingDefinitions ?? [],
     objectLabel: [],
@@ -152,6 +158,10 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Country"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -20,6 +21,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const countryMutationFieldPatch = graphql`
   mutation CountryEditionOverviewFieldPatchMutation(
@@ -134,6 +136,7 @@ const CountryEditionOverviewComponent: FunctionComponent<
 CountryEditionOverviewProps
 > = ({ countryRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const country = useFragment(countryEditionOverviewFragment, countryRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -227,6 +230,15 @@ CountryEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(country) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -85,6 +86,7 @@ const countryEditionOverviewFragment = graphql`
     id
     name
     description
+    confidence
     createdBy {
       ... on Identity {
         id
@@ -121,6 +123,7 @@ interface CountryEditionOverviewProps {
 interface CountryEditionFormValues {
   name: string;
   description: string | null;
+  confidence: number | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
   x_opencti_workflow_id: Option;
@@ -136,6 +139,7 @@ CountryEditionOverviewProps
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
   };
@@ -161,6 +165,7 @@ CountryEditionOverviewProps
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -207,6 +212,7 @@ CountryEditionOverviewProps
     name: country.name,
     description: country.description ?? '',
     references: [],
+    confidence: country.confidence,
     createdBy: convertCreatedBy(country) as Option,
     objectMarking: convertMarkings(country),
     x_opencti_workflow_id: convertStatus(t_i18n, country) as Option,
@@ -252,6 +258,14 @@ CountryEditionOverviewProps
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Country"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           {country?.workflowEnabled && (
             <StatusField

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -21,7 +20,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const countryMutationFieldPatch = graphql`
   mutation CountryEditionOverviewFieldPatchMutation(
@@ -136,7 +135,6 @@ const CountryEditionOverviewComponent: FunctionComponent<
 CountryEditionOverviewProps
 > = ({ countryRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const country = useFragment(countryEditionOverviewFragment, countryRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -230,15 +228,7 @@ CountryEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(country) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={country} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Position.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Position.tsx
@@ -70,7 +70,6 @@ const PositionComponent: FunctionComponent<PositionComponentProps> = ({
         <Grid item={true} xs={4} style={{ paddingTop: 10 }}>
           <StixDomainObjectOverview
             stixDomainObject={position}
-            displayConfidence={false}
           />
         </Grid>
         <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -42,6 +43,7 @@ const positionMutation = graphql`
       standard_id
       name
       description
+      confidence
       entity_type
       parent_types
       ...PositionLine_node
@@ -54,6 +56,7 @@ const POSITION_TYPE = 'Position';
 interface PositionAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   latitude: string;
   longitude: string;
   street_address: string;
@@ -86,6 +89,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -109,6 +113,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
     const input: PositionCreationMutation$variables['input'] = {
       name: values.name,
       description: values.description,
+      confidence: parseInt(String(values.confidence), 10),
       latitude: parseFloat(values.latitude),
       longitude: parseFloat(values.longitude),
       street_address: values.street_address,
@@ -144,6 +149,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
   const initialValues = useDefaultValues(POSITION_TYPE, {
     name: '',
     description: '',
+    confidence: undefined,
     latitude: '',
     longitude: '',
     street_address: '',
@@ -179,6 +185,10 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
             multiline={true}
             rows={4}
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Position"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,7 +17,7 @@ import StatusField from '../../common/form/StatusField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const positionMutationFieldPatch = graphql`
   mutation PositionEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ const positionMutationRelationDelete = graphql`
 const PositionEditionOverviewComponent = (props) => {
   const { position, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
@@ -200,15 +198,8 @@ const PositionEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(position) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}          <Field
+          <AlertConfidenceForEntity entity={position} />
+          <Field
             component={TextField}
             variant="standard"
             name="name"
@@ -219,7 +210,7 @@ const PositionEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
             }
-                       />
+          />
           <Field
             component={MarkdownField}
             name="description"

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -85,6 +86,7 @@ const PositionEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
+    confidence: Yup.number().nullable(),
     latitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
@@ -117,6 +119,7 @@ const PositionEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -172,6 +175,7 @@ const PositionEditionOverviewComponent = (props) => {
       'longitude',
       'street_address',
       'postal_code',
+      'confidence',
       'createdBy',
       'objectMarking',
       'x_opencti_workflow_id',
@@ -218,6 +222,14 @@ const PositionEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Position"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={TextField}
@@ -330,6 +342,7 @@ export default createFragmentContainer(PositionEditionOverviewComponent, {
       longitude
       street_address
       postal_code
+      confidence
       description
       createdBy {
         ... on Identity {

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -17,6 +18,7 @@ import StatusField from '../../common/form/StatusField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const positionMutationFieldPatch = graphql`
   mutation PositionEditionOverviewFieldPatchMutation(
@@ -83,6 +85,7 @@ const positionMutationRelationDelete = graphql`
 const PositionEditionOverviewComponent = (props) => {
   const { position, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
@@ -197,7 +200,15 @@ const PositionEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          <Field
+          {(!checkConfidenceForEntity(position) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}          <Field
             component={TextField}
             variant="standard"
             name="name"
@@ -208,7 +219,7 @@ const PositionEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
             }
-          />
+                       />
           <Field
             component={MarkdownField}
             name="description"

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Region.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Region.tsx
@@ -108,7 +108,6 @@ const RegionComponent = ({ regionData }: { regionData: Region_region$key }) => {
         <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
           <StixDomainObjectOverview
             stixDomainObject={region}
-            displayConfidence={false}
           />
         </Grid>
         <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
@@ -8,6 +8,7 @@ import { FormikConfig } from 'formik/dist/types';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import CustomFileUploader from '@components/common/files/CustomFileUploader';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -40,6 +41,7 @@ const regionMutation = graphql`
       id
       standard_id
       name
+      confidence
       description
       entity_type
       parent_types
@@ -51,6 +53,7 @@ const regionMutation = graphql`
 interface RegionAddInput {
   name: string;
   description: string;
+  confidence: number | undefined;
   createdBy: Option | undefined;
   objectMarking: Option[];
   objectLabel: Option[];
@@ -82,6 +85,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
   };
   const regionValidator = useSchemaCreationValidation(REGION_TYPE, basicShape);
   const [commit] = useMutation(regionMutation);
@@ -93,6 +97,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
     const input: RegionCreationMutation$variables['input'] = {
       name: values.name,
       description: values.description,
+      confidence: parseInt(String(values.confidence), 10),
       objectMarking: values.objectMarking.map(({ value }) => value),
       objectLabel: values.objectLabel.map(({ value }) => value),
       externalReferences: values.externalReferences.map(({ value }) => value),
@@ -120,6 +125,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
   const initialValues = useDefaultValues(REGION_TYPE, {
     name: inputValue ?? '',
     description: '',
+    confidence: undefined,
     createdBy: defaultCreatedBy,
     objectMarking: defaultMarkingDefinitions ?? [],
     objectLabel: [],
@@ -152,6 +158,10 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Region"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import * as R from 'ramda';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -85,6 +86,7 @@ const regionEditionOverviewFragment = graphql`
     id
     name
     description
+    confidence
     createdBy {
       ... on Identity {
         id
@@ -122,6 +124,7 @@ interface RegionEditionFormValues {
   name: string;
   description: string | null;
   createdBy: Option | undefined;
+  confidence: number | undefined;
   objectMarking: Option[];
   x_opencti_workflow_id: Option;
   message?: string;
@@ -136,6 +139,7 @@ RegionEdititionOverviewProps
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
   };
@@ -163,6 +167,7 @@ RegionEdititionOverviewProps
       R.dissoc('references'),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
       R.toPairs,
       R.map((n) => ({
@@ -206,6 +211,7 @@ RegionEdititionOverviewProps
   const initialValues = {
     name: region.name,
     description: region.description,
+    confidence: region.confidence,
     createdBy: convertCreatedBy(region),
     objectMarking: convertMarkings(region),
     x_opencti_workflow_id: convertStatus(t_i18n, region) as Option,
@@ -252,6 +258,14 @@ RegionEdititionOverviewProps
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Region"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           {region.workflowEnabled && (
             <StatusField

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -4,7 +4,6 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -21,7 +20,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const regionMutationFieldPatch = graphql`
   mutation RegionEditionOverviewFieldPatchMutation(
@@ -136,7 +135,6 @@ const RegionEditionOverviewComponent: FunctionComponent<
 RegionEdititionOverviewProps
 > = ({ regionRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const region = useFragment(regionEditionOverviewFragment, regionRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -230,15 +228,7 @@ RegionEdititionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(region) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={region} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import ConfidenceField from '@components/common/form/ConfidenceField';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -20,6 +21,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const regionMutationFieldPatch = graphql`
   mutation RegionEditionOverviewFieldPatchMutation(
@@ -134,6 +136,7 @@ const RegionEditionOverviewComponent: FunctionComponent<
 RegionEdititionOverviewProps
 > = ({ regionRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const region = useFragment(regionEditionOverviewFragment, regionRef);
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -227,6 +230,15 @@ RegionEdititionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(region) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -4,7 +4,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -24,7 +23,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const indicatorMutationFieldPatch = graphql`
   mutation IndicatorEditionOverviewFieldPatchMutation(
@@ -83,7 +82,6 @@ const IndicatorEditionOverviewComponent = ({
   enableReferences,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -227,15 +225,7 @@ const IndicatorEditionOverviewComponent = ({
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(indicator) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={indicator} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -4,6 +4,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -23,6 +24,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const indicatorMutationFieldPatch = graphql`
   mutation IndicatorEditionOverviewFieldPatchMutation(
@@ -81,6 +83,7 @@ const IndicatorEditionOverviewComponent = ({
   enableReferences,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -224,6 +227,15 @@ const IndicatorEditionOverviewComponent = ({
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(indicator) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -25,7 +24,7 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import { InfrastructureEditionOverview_infrastructure$key } from './__generated__/InfrastructureEditionOverview_infrastructure.graphql';
 import { Option } from '../../common/form/ReferenceField';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const infrastructureMutationFieldPatch = graphql`
   mutation InfrastructureEditionOverviewFieldPatchMutation(
@@ -157,7 +156,6 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const infrastructure = useFragment(infrastructureEditionOverviewFragment, infrastructureData);
 
   const basicShape = {
@@ -271,15 +269,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(infrastructure) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={infrastructure} />
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -24,6 +25,7 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import { InfrastructureEditionOverview_infrastructure$key } from './__generated__/InfrastructureEditionOverview_infrastructure.graphql';
 import { Option } from '../../common/form/ReferenceField';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const infrastructureMutationFieldPatch = graphql`
   mutation InfrastructureEditionOverviewFieldPatchMutation(
@@ -155,6 +157,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const infrastructure = useFragment(infrastructureEditionOverviewFragment, infrastructureData);
 
   const basicShape = {
@@ -268,6 +271,15 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(infrastructure) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
@@ -130,7 +130,6 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
         editContext={editContext}
         disabled={!switchValue || disabled}
         variant="edit"
-        maxLimit={effectiveConfidenceLevel?.max_confidence ?? 0}
       />
     </Alert>
   );

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
@@ -11,7 +11,6 @@ import { useFormatter } from '../../../../components/i18n';
 import UserConfidenceLevel from './UserConfidenceLevel';
 import type { Theme } from '../../../../components/Theme';
 import SwitchField from '../../../../components/SwitchField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const useStyles = makeStyles((theme: Theme) => ({
   alert: {
@@ -58,7 +57,6 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
   const classes = useStyles();
   const { setFieldValue, initialValues } = useFormikContext<Record<string, boolean>>();
   const [switchValue, setSwitchValue] = useState(Number.isInteger(initialValues[name]));
-  const { effectiveConfidenceLevel } = useConfidenceLevel();
 
   const handleSwitchChange = async () => {
     if (switchValue) {

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
@@ -11,6 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import UserConfidenceLevel from './UserConfidenceLevel';
 import type { Theme } from '../../../../components/Theme';
 import SwitchField from '../../../../components/SwitchField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const useStyles = makeStyles((theme: Theme) => ({
   alert: {
@@ -57,6 +58,7 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
   const classes = useStyles();
   const { setFieldValue, initialValues } = useFormikContext<Record<string, boolean>>();
   const [switchValue, setSwitchValue] = useState(Number.isInteger(initialValues[name]));
+  const { effectiveConfidenceLevel } = useConfidenceLevel();
 
   const handleSwitchChange = async () => {
     if (switchValue) {
@@ -128,6 +130,7 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
         editContext={editContext}
         disabled={!switchValue || disabled}
         variant="edit"
+        maxLimit={effectiveConfidenceLevel?.max_confidence ?? 0}
       />
     </Alert>
   );

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPattern.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPattern.jsx
@@ -39,7 +39,6 @@ class AttackPatternComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={attackPattern}
-              displayConfidence={false}
             />
           </Grid>
           <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
@@ -7,6 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -211,6 +212,10 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Attack-Pattern"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <KillChainPhasesField
             name="killChainPhases"

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionDetails.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { attackPatternMutationRelationAdd, attackPatternMutationRelationDelete } from './AttackPatternEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -12,9 +11,9 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const attackPatternMutationFieldPatch = graphql`
   mutation AttackPatternEditionDetailsFieldPatchMutation(
@@ -52,7 +51,6 @@ export const attackPatternEditionDetailsFocus = graphql`
 const AttackPatternEditionDetailsComponent = (props) => {
   const { attackPattern, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     x_mitre_platforms: Yup.array(),
@@ -165,15 +163,7 @@ const AttackPatternEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(attackPattern) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={attackPattern} />
           <OpenVocabField
             label={t_i18n('Platforms')}
             type="platforms_ov"

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -89,6 +90,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
     x_mitre_id: Yup.string().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    confidence: Yup.number().nullable(),
     x_opencti_workflow_id: Yup.object(),
   };
   const attackPatternValidator = useSchemaEditionValidation(
@@ -117,6 +119,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
       R.dissoc('references'),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
       R.assoc('killChainPhases', R.pluck('value', values.killChainPhases)),
       R.toPairs,
@@ -169,6 +172,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
       'description',
       'createdBy',
       'killChainPhases',
+      'confidence',
       'objectMarking',
       'x_opencti_workflow_id',
     ]),
@@ -225,6 +229,14 @@ const AttackPatternEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Attack-Pattern"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <KillChainPhasesField
             name="killChainPhases"
@@ -295,6 +307,7 @@ export default createFragmentContainer(AttackPatternEditionOverviewComponent, {
       name
       x_mitre_id
       description
+      confidence
       createdBy {
         ... on Identity {
           id

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -19,7 +18,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const attackPatternMutationFieldPatch = graphql`
   mutation AttackPatternEditionOverviewFieldPatchMutation(
@@ -86,7 +85,6 @@ export const attackPatternMutationRelationDelete = graphql`
 const AttackPatternEditionOverviewComponent = (props) => {
   const { attackPattern, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -196,15 +194,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(attackPattern) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={attackPattern} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,6 +19,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const attackPatternMutationFieldPatch = graphql`
   mutation AttackPatternEditionOverviewFieldPatchMutation(
@@ -52,7 +54,7 @@ export const attackPatternEditionOverviewFocus = graphql`
   }
 `;
 
-const attackPatternMutationRelationAdd = graphql`
+export const attackPatternMutationRelationAdd = graphql`
   mutation AttackPatternEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -67,7 +69,7 @@ const attackPatternMutationRelationAdd = graphql`
   }
 `;
 
-const attackPatternMutationRelationDelete = graphql`
+export const attackPatternMutationRelationDelete = graphql`
   mutation AttackPatternEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -84,6 +86,7 @@ const attackPatternMutationRelationDelete = graphql`
 const AttackPatternEditionOverviewComponent = (props) => {
   const { attackPattern, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -193,6 +196,15 @@ const AttackPatternEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(attackPattern) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfAction.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfAction.jsx
@@ -39,7 +39,6 @@ class CourseOfActionComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={courseOfAction}
-              displayConfidence={false}
             />
           </Grid>
           <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
@@ -13,6 +13,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import CustomFileUploader from '@components/common/files/CustomFileUploader';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -60,6 +61,7 @@ const courseOfActionMutation = graphql`
       description
       entity_type
       parent_types
+      confidence
       ...CourseOfActionLine_node
     }
   }
@@ -107,6 +109,7 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
       .required(t_i18n('This field is required')),
     description: Yup.string()
       .nullable(),
+    confidence: Yup.number().nullable(),
   };
   const courseOfActionValidator = useSchemaCreationValidation(
     COURSE_OF_ACTION_TYPE,
@@ -202,6 +205,10 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Course-Of-Action"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -86,6 +87,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    confidence: Yup.number().nullable(),
     x_opencti_threat_hunting: Yup.string().nullable(),
     x_opencti_log_sources: Yup.string().nullable(),
     x_mitre_id: Yup.string().nullable(),
@@ -116,6 +118,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -180,6 +183,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
       'x_opencti_log_sources',
       'createdBy',
       'objectMarking',
+      'confidence',
       'x_opencti_workflow_id',
       'x_mitre_id',
     ]),
@@ -236,6 +240,14 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Course-Of-Action"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           <Field
             component={MarkdownField}
@@ -327,6 +339,7 @@ export default createFragmentContainer(CourseOfActionEditionOverviewComponent, {
       id
       name
       description
+      confidence
       x_opencti_threat_hunting
       x_opencti_log_sources
       x_mitre_id

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -17,6 +18,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const courseOfActionMutationFieldPatch = graphql`
   mutation CourseOfActionEditionOverviewFieldPatchMutation(
@@ -83,6 +85,7 @@ const courseOfActionMutationRelationDelete = graphql`
 const CourseOfActionEditionOverviewComponent = (props) => {
   const { courseOfAction, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -204,6 +207,15 @@ const CourseOfActionEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(courseOfAction) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,7 +17,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const courseOfActionMutationFieldPatch = graphql`
   mutation CourseOfActionEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ const courseOfActionMutationRelationDelete = graphql`
 const CourseOfActionEditionOverviewComponent = (props) => {
   const { courseOfAction, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -207,15 +205,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(courseOfAction) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={courseOfAction} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -20,7 +19,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { adaptFieldValue } from '../../../../utils/String';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const dataComponentMutationFieldPatch = graphql`
   mutation DataComponentEditionOverviewFieldPatchMutation(
@@ -140,7 +139,6 @@ const DataComponentEditionOverview: FunctionComponent<
 DataComponentEditionOverviewComponentProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const dataComponent = useFragment(DataComponentEditionOverviewFragment, data);
 
@@ -247,15 +245,7 @@ DataComponentEditionOverviewComponentProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(dataComponent) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={dataComponent} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -19,6 +20,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { adaptFieldValue } from '../../../../utils/String';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const dataComponentMutationFieldPatch = graphql`
   mutation DataComponentEditionOverviewFieldPatchMutation(
@@ -138,6 +140,7 @@ const DataComponentEditionOverview: FunctionComponent<
 DataComponentEditionOverviewComponentProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const dataComponent = useFragment(DataComponentEditionOverviewFragment, data);
 
@@ -244,6 +247,15 @@ DataComponentEditionOverviewComponentProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(dataComponent) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -22,7 +21,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { dataComponentEditionOverviewFocus } from '../data_components/DataComponentEditionOverview';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const dataSourceMutationFieldPatch = graphql`
   mutation DataSourceEditionOverviewFieldPatchMutation(
@@ -147,7 +146,6 @@ const DataSourceEditionOverview: FunctionComponent<
 DataSourceEditionOverviewProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const dataSource = useFragment(dataSourceEditionOverviewFragment, data);
 
   const basicShape = {
@@ -258,15 +256,7 @@ DataSourceEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(dataSource) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={dataSource} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -21,6 +22,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { dataComponentEditionOverviewFocus } from '../data_components/DataComponentEditionOverview';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const dataSourceMutationFieldPatch = graphql`
   mutation DataSourceEditionOverviewFieldPatchMutation(
@@ -145,6 +147,7 @@ const DataSourceEditionOverview: FunctionComponent<
 DataSourceEditionOverviewProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const dataSource = useFragment(dataSourceEditionOverviewFragment, data);
 
   const basicShape = {
@@ -255,6 +258,15 @@ DataSourceEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(dataSource) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Narrative.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Narrative.jsx
@@ -39,7 +39,6 @@ class NarrativeComponent extends Component {
           <Grid item={true} xs={6} style={{ paddingTop: 10 }}>
             <StixDomainObjectOverview
               stixDomainObject={narrative}
-              displayConfidence={false}
             />
           </Grid>
           <Grid item={true} xs={6} style={{ marginTop: 30 }}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -12,6 +12,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -61,6 +62,7 @@ const narrativeMutation = graphql`
       entity_type
       parent_types
       isSubNarrative
+      confidence
       objectMarking {
         id
         definition_type
@@ -208,6 +210,10 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
             multiline={true}
             rows="4"
             style={{ marginTop: 20 }}
+          />
+          <ConfidenceField
+            entityType="Narratives"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -84,6 +85,7 @@ const NarrativeEditionOverviewComponent = (props) => {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    confidence: Yup.number().nullable(),
     x_opencti_workflow_id: Yup.object(),
   };
   const narrativeValidator = useSchemaEditionValidation(
@@ -110,6 +112,7 @@ const NarrativeEditionOverviewComponent = (props) => {
     const inputValues = R.pipe(
       R.dissoc('message'),
       R.dissoc('references'),
+      R.assoc('confidence', parseInt(values.confidence, 10)),
       R.assoc('createdBy', values.createdBy?.value),
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
       R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
@@ -165,6 +168,7 @@ const NarrativeEditionOverviewComponent = (props) => {
       'description',
       'createdBy',
       'objectMarking',
+      'confidence',
       'x_opencti_workflow_id',
     ]),
   )(narrative);
@@ -208,6 +212,14 @@ const NarrativeEditionOverviewComponent = (props) => {
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
             }
+          />
+          <ConfidenceField
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            entityType="Narratives"
+            containerStyle={fieldSpacingContainerStyle}
+            editContext={context}
+            variant="edit"
           />
           {narrative.workflowEnabled && (
             <StatusField
@@ -265,6 +277,7 @@ export default createFragmentContainer(NarrativeEditionOverviewComponent, {
       id
       name
       description
+      confidence
       createdBy {
         ... on Identity {
           id

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -17,6 +18,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const narrativeMutationFieldPatch = graphql`
   mutation NarrativeEditionOverviewFieldPatchMutation(
@@ -80,6 +82,7 @@ const narrativeMutationRelationDelete = graphql`
 const NarrativeEditionOverviewComponent = (props) => {
   const { narrative, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -188,6 +191,15 @@ const NarrativeEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(narrative) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,7 +17,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const narrativeMutationFieldPatch = graphql`
   mutation NarrativeEditionOverviewFieldPatchMutation(
@@ -82,7 +81,6 @@ const narrativeMutationRelationDelete = graphql`
 const NarrativeEditionOverviewComponent = (props) => {
   const { narrative, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -191,15 +189,7 @@ const NarrativeEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(narrative) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={narrative} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { campaignEditionOverviewFocus, campaignMutationRelationAdd, campaignMutationRelationDelete } from './CampaignEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -13,9 +12,9 @@ import { buildDate, parse } from '../../../../utils/Time';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionDetailsFieldPatchMutation(
@@ -50,7 +49,6 @@ const campaignEditionDetailsFocus = graphql`
 const CampaignEditionDetailsComponent = (props) => {
   const { campaign, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     first_seen: Yup.date()
@@ -163,15 +161,7 @@ const CampaignEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(campaign) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={campaign} />
           <Field
             component={DateTimePickerField}
             name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
@@ -3,6 +3,8 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
+import { campaignEditionOverviewFocus, campaignMutationRelationAdd, campaignMutationRelationDelete } from './CampaignEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -11,6 +13,9 @@ import { buildDate, parse } from '../../../../utils/Time';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import useFormEditor from '../../../../utils/hooks/useFormEditor';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionDetailsFieldPatchMutation(
@@ -42,20 +47,38 @@ const campaignEditionDetailsFocus = graphql`
   }
 `;
 
-const campaignValidation = (t) => Yup.object().shape({
-  first_seen: Yup.date()
-    .nullable()
-    .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
-  last_seen: Yup.date()
-    .nullable()
-    .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
-  objective: Yup.string().nullable(),
-  references: Yup.array(),
-});
-
 const CampaignEditionDetailsComponent = (props) => {
   const { campaign, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
+
+  const basicShape = {
+    first_seen: Yup.date()
+      .nullable()
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    last_seen: Yup.date()
+      .nullable()
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    objective: Yup.string().nullable(),
+    references: Yup.array(),
+  };
+  const campaignValidator = useSchemaEditionValidation(
+    'Campaign',
+    basicShape,
+  );
+
+  const queries = {
+    fieldPatch: campaignMutationFieldPatch,
+    addRelation: campaignMutationRelationAdd,
+    deleteRelation: campaignMutationRelationDelete,
+    editionFocus: campaignEditionOverviewFocus,
+  };
+  const editor = useFormEditor(
+    campaign,
+    enableReferences,
+    queries,
+    campaignValidator,
+  );
 
   const handleChangeFocus = (name) => commitMutation({
     mutation: campaignEditionDetailsFocus,
@@ -87,8 +110,7 @@ const CampaignEditionDetailsComponent = (props) => {
         value: adaptFieldValue(n[1]),
       })),
     )(values);
-    commitMutation({
-      mutation: campaignMutationFieldPatch,
+    editor.fieldPatch({
       variables: {
         id: campaign.id,
         input: inputValues,
@@ -106,11 +128,10 @@ const CampaignEditionDetailsComponent = (props) => {
 
   const handleSubmitField = (name, value) => {
     if (!enableReferences) {
-      campaignValidation(t_i18n)
+      campaignValidator
         .validateAt(name, { [name]: value })
         .then(() => {
-          commitMutation({
-            mutation: campaignMutationFieldPatch,
+          editor.fieldPatch({
             variables: {
               id: campaign.id,
               input: { key: name, value: value || '' },
@@ -130,7 +151,7 @@ const CampaignEditionDetailsComponent = (props) => {
     <Formik
       enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={campaignValidation(t_i18n)}
+      validationSchema={campaignValidator}
       onSubmit={onSubmit}
     >
       {({
@@ -142,6 +163,15 @@ const CampaignEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(campaign) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={DateTimePickerField}
             name="first_seen"
@@ -208,6 +238,7 @@ export default createFragmentContainer(CampaignEditionDetailsComponent, {
       first_seen
       last_seen
       objective
+      confidence
     }
   `,
 });

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -17,6 +18,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionOverviewFieldPatchMutation(
@@ -51,7 +53,7 @@ export const campaignEditionOverviewFocus = graphql`
   }
 `;
 
-const campaignMutationRelationAdd = graphql`
+export const campaignMutationRelationAdd = graphql`
   mutation CampaignEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -66,7 +68,7 @@ const campaignMutationRelationAdd = graphql`
   }
 `;
 
-const campaignMutationRelationDelete = graphql`
+export const campaignMutationRelationDelete = graphql`
   mutation CampaignEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -83,6 +85,7 @@ const campaignMutationRelationDelete = graphql`
 const CampaignEditionOverviewComponent = (props) => {
   const { campaign, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -181,6 +184,15 @@ const CampaignEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(campaign) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,7 +17,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ export const campaignMutationRelationDelete = graphql`
 const CampaignEditionOverviewComponent = (props) => {
   const { campaign, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -184,15 +182,7 @@ const CampaignEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(campaign) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={campaign} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import { intrusionSetEditionOverviewFocus, intrusionSetMutationRelationAdd, intrusionSetMutationRelationDelete } from './IntrusionSetEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -15,9 +14,9 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const intrusionSetMutationFieldPatch = graphql`
   mutation IntrusionSetEditionDetailsFieldPatchMutation(
@@ -55,7 +54,6 @@ const intrusionSetEditionDetailsFocus = graphql`
 const IntrusionSetEditionDetailsComponent = (props) => {
   const { intrusionSet, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     first_seen: Yup.date()
@@ -196,15 +194,7 @@ const IntrusionSetEditionDetailsComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(intrusionSet) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={intrusionSet} />
           <Field
             component={DateTimePickerField}
             name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
-import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -18,7 +17,7 @@ import StatusField from '../../common/form/StatusField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const intrusionSetMutationFieldPatch = graphql`
   mutation IntrusionSetEditionOverviewFieldPatchMutation(
@@ -85,7 +84,6 @@ export const intrusionSetMutationRelationDelete = graphql`
 const IntrusionSetEditionOverviewComponent = (props) => {
   const { intrusionSet, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -193,15 +191,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(intrusionSet) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={intrusionSet} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -17,6 +18,7 @@ import StatusField from '../../common/form/StatusField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const intrusionSetMutationFieldPatch = graphql`
   mutation IntrusionSetEditionOverviewFieldPatchMutation(
@@ -51,7 +53,7 @@ export const intrusionSetEditionOverviewFocus = graphql`
   }
 `;
 
-const intrusionSetMutationRelationAdd = graphql`
+export const intrusionSetMutationRelationAdd = graphql`
   mutation IntrusionSetEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -66,7 +68,7 @@ const intrusionSetMutationRelationAdd = graphql`
   }
 `;
 
-const intrusionSetMutationRelationDelete = graphql`
+export const intrusionSetMutationRelationDelete = graphql`
   mutation IntrusionSetEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -83,6 +85,7 @@ const intrusionSetMutationRelationDelete = graphql`
 const IntrusionSetEditionOverviewComponent = (props) => {
   const { intrusionSet, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
 
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
@@ -190,6 +193,15 @@ const IntrusionSetEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(intrusionSet) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionDetails.jsx
@@ -3,7 +3,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import * as Yup from 'yup';
 import * as R from 'ramda';
 import { Field, Form, Formik } from 'formik';
-import Alert from '@mui/material/Alert';
 import { ThreatActorGroupEditionOverviewFocus, ThreatActorGroupMutationRelationAdd, ThreatActorGroupMutationRelationDelete } from './ThreatActorGroupEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -15,9 +14,9 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const ThreatActorGroupMutationFieldPatch = graphql`
   mutation ThreatActorGroupEditionDetailsFieldPatchMutation(
@@ -59,7 +58,6 @@ const ThreatActorGroupEditionDetailsComponent = ({
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     first_seen: Yup.date()
       .nullable()
@@ -210,15 +208,7 @@ const ThreatActorGroupEditionDetailsComponent = ({
         }) => (
           <div>
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(threatActorGroup) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={threatActorGroup} />
               <Field
                 component={DateTimePickerField}
                 name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -3,7 +3,6 @@ import * as R from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -19,7 +18,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const ThreatActorGroupMutationFieldPatch = graphql`
   mutation ThreatActorGroupEditionOverviewFieldPatchMutation(
@@ -86,7 +85,6 @@ export const ThreatActorGroupMutationRelationDelete = graphql`
 const ThreatActorGroupEditionOverviewComponent = (props) => {
   const { threatActorGroup, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     threat_actor_types: Yup.array().nullable(),
@@ -196,15 +194,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(threatActorGroup) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={threatActorGroup} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -3,6 +3,7 @@ import * as R from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -18,6 +19,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const ThreatActorGroupMutationFieldPatch = graphql`
   mutation ThreatActorGroupEditionOverviewFieldPatchMutation(
@@ -52,7 +54,7 @@ export const ThreatActorGroupEditionOverviewFocus = graphql`
   }
 `;
 
-const ThreatActorGroupMutationRelationAdd = graphql`
+export const ThreatActorGroupMutationRelationAdd = graphql`
   mutation ThreatActorGroupEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -67,7 +69,7 @@ const ThreatActorGroupMutationRelationAdd = graphql`
   }
 `;
 
-const ThreatActorGroupMutationRelationDelete = graphql`
+export const ThreatActorGroupMutationRelationDelete = graphql`
   mutation ThreatActorGroupEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -84,6 +86,7 @@ const ThreatActorGroupMutationRelationDelete = graphql`
 const ThreatActorGroupEditionOverviewComponent = (props) => {
   const { threatActorGroup, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const basicShape = {
     name: Yup.string().min(2).required(t_i18n('This field is required')),
     threat_actor_types: Yup.array().nullable(),
@@ -193,6 +196,15 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(threatActorGroup) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import * as Yup from 'yup';
 import { Form, Formik } from 'formik';
 import { graphql, useFragment } from 'react-relay';
-import Alert from '@mui/material/Alert';
 import {
   ThreatActorIndividualEditionOverviewFocus,
   ThreatActorIndividualMutationRelationDelete,
@@ -18,9 +17,9 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { ThreatActorIndividualEditionBiographics_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionBiographics_ThreatActorIndividual.graphql';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const threatActorIndividualEditionBiographicsFocus = graphql`
   mutation ThreatActorIndividualEditionBiographicsFocusMutation(
@@ -85,7 +84,6 @@ ThreatActorIndividualEditionBiographicsComponentProps
   context,
 }: ThreatActorIndividualEditionBiographicsComponentProps) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const { heightsConverterLoad, weightsConverterLoad } = useUserMetric();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionBiographicsFragment,
@@ -169,15 +167,7 @@ ThreatActorIndividualEditionBiographicsComponentProps
         }) => (
           <div>
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(threatActorIndividual) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={threatActorIndividual} />
               <OpenVocabField
                 name="eye_color"
                 label={t_i18n('Eye Color')}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import * as Yup from 'yup';
 import { Form, Formik } from 'formik';
 import { graphql, useFragment } from 'react-relay';
+import Alert from '@mui/material/Alert';
+import {
+  ThreatActorIndividualEditionOverviewFocus,
+  ThreatActorIndividualMutationRelationDelete,
+  threatActorIndividualRelationAddMutation,
+} from '@components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview';
 import { GenericContext } from '../../common/model/GenericContextModel';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';
@@ -12,6 +18,9 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { ThreatActorIndividualEditionBiographics_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionBiographics_ThreatActorIndividual.graphql';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 
 const threatActorIndividualEditionBiographicsFocus = graphql`
   mutation ThreatActorIndividualEditionBiographicsFocusMutation(
@@ -51,19 +60,16 @@ const threatActorIndividualEditionBiographicsFragment = graphql`
       date_seen
       measure
     }
+    confidence
+    objectMarking {
+      id
+      definition_type
+      definition
+      x_opencti_order
+      x_opencti_color
+    }
   }
 `;
-
-const threatActorIndividualValidation = (t: (s: string) => string) => Yup.object().shape({
-  eye_color: Yup.string()
-    .nullable()
-    .typeError(t('The value must be a string')),
-  hair_color: Yup.string()
-    .nullable()
-    .typeError(t('The value must be a string')),
-  weight: Yup.array(),
-  height: Yup.array(),
-});
 
 interface ThreatActorIndividualEditionBiographicsComponentProps {
   threatActorIndividualRef: ThreatActorIndividualEditionBiographics_ThreatActorIndividual$key;
@@ -79,10 +85,39 @@ ThreatActorIndividualEditionBiographicsComponentProps
   context,
 }: ThreatActorIndividualEditionBiographicsComponentProps) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const { heightsConverterLoad, weightsConverterLoad } = useUserMetric();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionBiographicsFragment,
     threatActorIndividualRef,
+  );
+
+  const basicShape = {
+    eye_color: Yup.string()
+      .nullable()
+      .typeError(t_i18n('The value must be a string')),
+    hair_color: Yup.string()
+      .nullable()
+      .typeError(t_i18n('The value must be a string')),
+    weight: Yup.array(),
+    height: Yup.array(),
+  };
+  const threatActorIndividualValidator = useSchemaEditionValidation(
+    'Threat-Actor-Individual',
+    basicShape,
+  );
+
+  const queries = {
+    fieldPatch: threatActorIndividualMutationFieldPatch,
+    relationAdd: threatActorIndividualRelationAddMutation,
+    relationDelete: ThreatActorIndividualMutationRelationDelete,
+    editionFocus: ThreatActorIndividualEditionOverviewFocus,
+  };
+  const editor = useFormEditor(
+    threatActorIndividual as GenericData,
+    enableReferences,
+    queries,
+    threatActorIndividualValidator,
   );
 
   const handleChangeFocus = (name: string) => commitMutation({
@@ -96,12 +131,10 @@ ThreatActorIndividualEditionBiographicsComponentProps
     },
   });
   const handleSubmitField = (name: string, value: string | string[]) => {
-    threatActorIndividualValidation(t_i18n)
+    threatActorIndividualValidator
       .validateAt(name, { [name]: value })
       .then(() => {
-        commitMutation({
-          ...defaultCommitMutation,
-          mutation: threatActorIndividualMutationFieldPatch,
+        editor.fieldPatch({
           variables: {
             id: threatActorIndividual.id,
             input: { key: name, value },
@@ -123,7 +156,7 @@ ThreatActorIndividualEditionBiographicsComponentProps
       <Formik
         enableReinitialize={true}
         initialValues={initialValues}
-        validationSchema={threatActorIndividualValidation(t_i18n)}
+        validationSchema={threatActorIndividualValidator}
         onSubmit={() => {}}
       >
         {({
@@ -136,6 +169,15 @@ ThreatActorIndividualEditionBiographicsComponentProps
         }) => (
           <div>
             <Form style={{ margin: '20px 0 20px 0' }}>
+              {(!checkConfidenceForEntity(threatActorIndividual) && (
+                <Alert severity="warning" variant="outlined"
+                  style={{ marginTop: 20, marginBottom: 20 }}
+                >
+                  {t_i18n(
+                    'Your maximum confidence level is insufficient to edit this object.',
+                  )}
+                </Alert>
+              ))}
               <OpenVocabField
                 name="eye_color"
                 label={t_i18n('Eye Color')}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
@@ -4,7 +4,6 @@ import { graphql, useFragment } from 'react-relay';
 import * as Yup from 'yup';
 import CountryField from '@components/common/form/CountryField';
 import { Option } from '@components/common/form/ReferenceField';
-import Alert from '@mui/material/Alert';
 import {
   ThreatActorIndividualEditionOverviewFocus,
   ThreatActorIndividualMutationRelationDelete,
@@ -23,9 +22,9 @@ import { EditOperation } from './__generated__/ThreatActorIndividualEditionDetai
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { isEmptyField } from '../../../../utils/utils';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const threatActorIndividualEditionDemographicsFocus = graphql`
   mutation ThreatActorIndividualEditionDemographicsFocusMutation(
@@ -88,7 +87,6 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
   context,
 }: ThreatActorIndividualEditionDemographicsComponentProps) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionDemographicsFragment,
     threatActorIndividualRef,
@@ -187,15 +185,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
         {({ submitForm, isSubmitting, setFieldValue, isValid, dirty }) => (
           <div>
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(threatActorIndividual) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={threatActorIndividual} />
               <CountryField
                 id="PlaceOfBirth"
                 name="bornIn"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment, useMutation } from 'react-relay';
 import * as Yup from 'yup';
 import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import {
   ThreatActorIndividualMutationRelationDelete,
   threatActorIndividualRelationAddMutation,
@@ -22,8 +21,8 @@ import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorIndividualEditionDetails_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionDetails_ThreatActorIndividual.graphql';
 import { ThreatActorIndividualEditionDetailsFocusMutation } from './__generated__/ThreatActorIndividualEditionDetailsFocusMutation.graphql';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const threatActorIndividualMutationFieldPatch = graphql`
   mutation ThreatActorIndividualEditionDetailsFieldPatchMutation(
@@ -97,7 +96,6 @@ const ThreatActorIndividualEditionDetailsComponent: FunctionComponent<
 ThreatActorIndividualEditionDetailsProps
 > = ({ threatActorIndividualRef, context, enableReferences, handleClose }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionDetailsFragment,
     threatActorIndividualRef,
@@ -247,15 +245,7 @@ ThreatActorIndividualEditionDetailsProps
         }) => (
           <div>
             <Form style={{ margin: '20px 0 20px 0' }}>
-              {(!checkConfidenceForEntity(threatActorIndividual) && (
-                <Alert severity="warning" variant="outlined"
-                  style={{ marginTop: 20, marginBottom: 20 }}
-                >
-                  {t_i18n(
-                    'Your maximum confidence level is insufficient to edit this object.',
-                  )}
-                </Alert>
-              ))}
+              <AlertConfidenceForEntity entity={threatActorIndividual} />
               <Field
                 component={DateTimePickerField}
                 name="first_seen"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
+import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -21,6 +22,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorIndividualEditionOverview_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionOverview_ThreatActorIndividual.graphql';
 import { GenericContext } from '../../common/model/GenericContextModel';
+import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
 const ThreatActorIndividualMutationFieldPatch = graphql`
   mutation ThreatActorIndividualEditionOverviewFieldPatchMutation(
@@ -52,7 +54,7 @@ export const ThreatActorIndividualEditionOverviewFocus = graphql`
   }
 `;
 
-const threatActorIndividualRelationAddMutation = graphql`
+export const threatActorIndividualRelationAddMutation = graphql`
   mutation ThreatActorIndividualEditionOverviewRelationAddMutation(
     $id: ID!
     $input: StixRefRelationshipAddInput!
@@ -65,7 +67,7 @@ const threatActorIndividualRelationAddMutation = graphql`
   }
 `;
 
-const ThreatActorIndividualMutationRelationDelete = graphql`
+export const ThreatActorIndividualMutationRelationDelete = graphql`
   mutation ThreatActorIndividualEditionOverviewRelationDeleteMutation(
     $id: ID!
     $toId: StixRef!
@@ -136,6 +138,7 @@ const ThreatActorIndividualEditionOverviewComponent: FunctionComponent<
 ThreatActorIndividualEditionOverviewProps
 > = ({ threatActorIndividualRef, enableReferences, handleClose, context }) => {
   const { t_i18n } = useFormatter();
+  const { checkConfidenceForEntity } = useConfidenceLevel();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionOverviewFragment,
     threatActorIndividualRef,
@@ -247,6 +250,15 @@ ThreatActorIndividualEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
+          {(!checkConfidenceForEntity(threatActorIndividual) && (
+            <Alert severity="warning" variant="outlined"
+              style={{ marginTop: 20, marginBottom: 20 }}
+            >
+              {t_i18n(
+                'Your maximum confidence level is insufficient to edit this object.',
+              )}
+            </Alert>
+          ))}
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
-import Alert from '@mui/material/Alert';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -22,7 +21,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorIndividualEditionOverview_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionOverview_ThreatActorIndividual.graphql';
 import { GenericContext } from '../../common/model/GenericContextModel';
-import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
+import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const ThreatActorIndividualMutationFieldPatch = graphql`
   mutation ThreatActorIndividualEditionOverviewFieldPatchMutation(
@@ -138,7 +137,6 @@ const ThreatActorIndividualEditionOverviewComponent: FunctionComponent<
 ThreatActorIndividualEditionOverviewProps
 > = ({ threatActorIndividualRef, enableReferences, handleClose, context }) => {
   const { t_i18n } = useFormatter();
-  const { checkConfidenceForEntity } = useConfidenceLevel();
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionOverviewFragment,
     threatActorIndividualRef,
@@ -250,15 +248,7 @@ ThreatActorIndividualEditionOverviewProps
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          {(!checkConfidenceForEntity(threatActorIndividual) && (
-            <Alert severity="warning" variant="outlined"
-              style={{ marginTop: 20, marginBottom: 20 }}
-            >
-              {t_i18n(
-                'Your maximum confidence level is insufficient to edit this object.',
-              )}
-            </Alert>
-          ))}
+          <AlertConfidenceForEntity entity={threatActorIndividual} />
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1457,6 +1457,8 @@ type MeUser implements BasicObject & InternalObject {
   objectOrganization: MeOrganizationConnection
   capabilities: [Capability!]!
   default_hidden_types: [String]!
+  user_confidence_level: ConfidenceLevel
+  effective_confidence_level: EffectiveConfidenceLevel
   allowed_marking: [MarkingDefinition!]
   default_marking: [DefaultMarking!]
   otp_mandatory: Boolean

--- a/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
@@ -3,8 +3,9 @@ import { MESSAGING$ } from '../../relay/environment';
 
 const useConfidenceLevel = () => {
   const { me } = useAuth();
+  const effectiveConfidenceLevel = me?.effective_confidence_level;
+
   const checkConfidenceForEntity = (entity: { confidence?: number | null }, notifyError = false) => {
-    const effectiveConfidenceLevel = me?.effective_confidence_level;
     if (effectiveConfidenceLevel && entity.confidence && effectiveConfidenceLevel.max_confidence < entity.confidence) {
       if (notifyError) {
         MESSAGING$.notifyError('Your maximum confidence level is insufficient to edit this object.');
@@ -18,7 +19,7 @@ const useConfidenceLevel = () => {
     return true;
   };
 
-  return { checkConfidenceForEntity };
+  return { checkConfidenceForEntity, effectiveConfidenceLevel };
 };
 
 export default useConfidenceLevel;

--- a/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
@@ -10,12 +10,12 @@ const useConfidenceLevel = () => {
   const checkConfidenceForEntity = (entity: { confidence?: number | null }, notifyError = false) => {
     if (effectiveConfidenceLevel && entity.confidence && effectiveConfidenceLevel.max_confidence < entity.confidence) {
       if (notifyError) {
-        MESSAGING$.notifyError(t_i18n('Your maximum confidence level is insufficient to edit this object.'));
+        MESSAGING$.notifyError(t_i18n('Your confidence level is insufficient to edit this object.'));
       }
       return false;
     } if (!effectiveConfidenceLevel && entity.confidence) {
       if (notifyError) {
-        MESSAGING$.notifyError(t_i18n('You need a maximum confidence level to edit objects in the platform.'));
+        MESSAGING$.notifyError(t_i18n('You need a confidence level to edit objects in the platform.'));
       } return false;
     }
     return true;

--- a/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
@@ -1,19 +1,21 @@
 import useAuth from './useAuth';
 import { MESSAGING$ } from '../../relay/environment';
+import { useFormatter } from '../../components/i18n';
 
 const useConfidenceLevel = () => {
   const { me } = useAuth();
+  const { t_i18n } = useFormatter();
   const effectiveConfidenceLevel = me.effective_confidence_level;
 
   const checkConfidenceForEntity = (entity: { confidence?: number | null }, notifyError = false) => {
     if (effectiveConfidenceLevel && entity.confidence && effectiveConfidenceLevel.max_confidence < entity.confidence) {
       if (notifyError) {
-        MESSAGING$.notifyError('Your maximum confidence level is insufficient to edit this object.');
+        MESSAGING$.notifyError(t_i18n('Your maximum confidence level is insufficient to edit this object.'));
       }
       return false;
     } if (!effectiveConfidenceLevel && entity.confidence) {
       if (notifyError) {
-        MESSAGING$.notifyError('You need a maximum confidence level to edit objects in the platform.');
+        MESSAGING$.notifyError(t_i18n('You need a maximum confidence level to edit objects in the platform.'));
       } return false;
     }
     return true;

--- a/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
@@ -1,0 +1,24 @@
+import useAuth from './useAuth';
+import { MESSAGING$ } from '../../relay/environment';
+
+const useConfidenceLevel = () => {
+  const { me } = useAuth();
+  const checkConfidenceForEntity = (entity: { confidence?: number | null }, notifyError = false) => {
+    const effectiveConfidenceLevel = me?.effective_confidence_level;
+    if (effectiveConfidenceLevel && entity.confidence && effectiveConfidenceLevel.max_confidence < entity.confidence) {
+      if (notifyError) {
+        MESSAGING$.notifyError('Your maximum confidence level is insufficient to edit this object.');
+      }
+      return false;
+    } if (!effectiveConfidenceLevel && entity.confidence) {
+      if (notifyError) {
+        MESSAGING$.notifyError('You need a maximum confidence level to edit objects in the platform.');
+      } return false;
+    }
+    return true;
+  };
+
+  return { checkConfidenceForEntity };
+};
+
+export default useConfidenceLevel;

--- a/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useConfidenceLevel.ts
@@ -3,7 +3,7 @@ import { MESSAGING$ } from '../../relay/environment';
 
 const useConfidenceLevel = () => {
   const { me } = useAuth();
-  const effectiveConfidenceLevel = me?.effective_confidence_level;
+  const effectiveConfidenceLevel = me.effective_confidence_level;
 
   const checkConfidenceForEntity = (entity: { confidence?: number | null }, notifyError = false) => {
     if (effectiveConfidenceLevel && entity.confidence && effectiveConfidenceLevel.max_confidence < entity.confidence) {

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -9,6 +9,7 @@ import useVocabularyCategory from './useVocabularyCategory';
 import { isEmptyField } from '../utils';
 import { now } from '../Time';
 import { AuthorizedMembers, authorizedMembersToOptions, INPUT_AUTHORIZED_MEMBERS } from '../authorizedMembers';
+import useConfidenceLevel from './useConfidenceLevel';
 
 export const useComputeDefaultValues = () => {
   const { fieldToCategory } = useVocabularyCategory();
@@ -81,6 +82,7 @@ const useDefaultValues = <Values extends FormikValues>(
   notEmptyValues?: Partial<Values>,
 ) => {
   const computeDefaultValues = useComputeDefaultValues();
+  const { effectiveConfidenceLevel } = useConfidenceLevel();
 
   const entitySettings = useEntitySettings(id).at(0);
   if (!entitySettings) {
@@ -115,7 +117,7 @@ const useDefaultValues = <Values extends FormikValues>(
 
   // Default confidence
   if (keys.includes('confidence') && isEmptyField(initialValues.confidence) && isEmptyField(defaultValues.confidence)) {
-    defaultValues.confidence = 75;
+    defaultValues.confidence = effectiveConfidenceLevel?.max_confidence ?? 75;
   }
 
   // Default published

--- a/opencti-platform/opencti-front/src/utils/hooks/useFormEditor.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useFormEditor.ts
@@ -200,6 +200,11 @@ const useFormEditor = (
     commitFieldPatch(args);
   };
 
+  const checkAndCommitChangeField = (name: string, value: number | number[] | string | Date | Option | Option[]) => {
+    if (!checkConfidenceForEntity(data, true)) return;
+    changeField(name, value);
+  };
+
   return {
     changeMarking,
     changeAssignee,
@@ -208,7 +213,7 @@ const useFormEditor = (
     changeKillChainPhases,
     changeExternalReferences,
     changeFocus,
-    changeField,
+    changeField: checkAndCommitChangeField,
     fieldPatch: checkAndCommitFieldPatch,
     changeGrantableGroups,
   };

--- a/opencti-platform/opencti-front/src/utils/hooks/useFormEditor.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useFormEditor.ts
@@ -1,11 +1,14 @@
 import { GraphQLTaggedNode } from 'relay-runtime/lib/query/RelayModernGraphQLTag';
-import { useMutation } from 'react-relay';
+import { useMutation, UseMutationConfig } from 'react-relay';
 import { ObjectSchema, SchemaObjectDescription } from 'yup';
-import { Option } from '../../private/components/common/form/ReferenceField';
+import { MutationParameters } from 'relay-runtime';
+import { Option } from '@components/common/form/ReferenceField';
 import { convertAssignees, convertExternalReferences, convertKillChainPhases, convertMarkings, convertParticipants } from '../edition';
+import useConfidenceLevel from './useConfidenceLevel';
 
 export interface GenericData {
   id: string;
+  confidence?: number;
   readonly objectMarking: {
     readonly edges: ReadonlyArray<{
       readonly node: {
@@ -190,6 +193,13 @@ const useFormEditor = (
     });
   };
 
+  const { checkConfidenceForEntity } = useConfidenceLevel();
+
+  const checkAndCommitFieldPatch = (args: UseMutationConfig<MutationParameters>) => {
+    if (!checkConfidenceForEntity(data, true)) return;
+    commitFieldPatch(args);
+  };
+
   return {
     changeMarking,
     changeAssignee,
@@ -199,7 +209,7 @@ const useFormEditor = (
     changeExternalReferences,
     changeFocus,
     changeField,
-    fieldPatch: commitFieldPatch,
+    fieldPatch: checkAndCommitFieldPatch,
     changeGrantableGroups,
   };
 };

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1389,6 +1389,8 @@ type MeUser implements BasicObject & InternalObject {
   objectOrganization: MeOrganizationConnection
   capabilities: [Capability!]!
   default_hidden_types: [String]!
+  user_confidence_level: ConfidenceLevel
+  effective_confidence_level: EffectiveConfidenceLevel
   allowed_marking: [MarkingDefinition!]
   default_marking: [DefaultMarking!]
   otp_mandatory: Boolean

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -11790,6 +11790,7 @@ export type MeUser = BasicObject & InternalObject & {
   default_marking?: Maybe<Array<DefaultMarking>>;
   default_time_field?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  effective_confidence_level?: Maybe<EffectiveConfidenceLevel>;
   entity_type: Scalars['String']['output'];
   external?: Maybe<Scalars['Boolean']['output']>;
   firstname?: Maybe<Scalars['String']['output']>;
@@ -11807,6 +11808,7 @@ export type MeUser = BasicObject & InternalObject & {
   standard_id: Scalars['String']['output'];
   theme?: Maybe<Scalars['String']['output']>;
   unit_system?: Maybe<UnitSystem>;
+  user_confidence_level?: Maybe<ConfidenceLevel>;
   user_email: Scalars['String']['output'];
 };
 
@@ -33162,6 +33164,7 @@ export type MeUserResolvers<ContextType = any, ParentType extends ResolversParen
   default_marking?: Resolver<Maybe<Array<ResolversTypes['DefaultMarking']>>, ParentType, ContextType>;
   default_time_field?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  effective_confidence_level?: Resolver<Maybe<ResolversTypes['EffectiveConfidenceLevel']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   external?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   firstname?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -33179,6 +33182,7 @@ export type MeUserResolvers<ContextType = any, ParentType extends ResolversParen
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   theme?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit_system?: Resolver<Maybe<ResolversTypes['UnitSystem']>, ParentType, ContextType>;
+  user_confidence_level?: Resolver<Maybe<ResolversTypes['ConfidenceLevel']>, ParentType, ContextType>;
   user_email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -101,6 +101,7 @@ const userResolvers = {
     objectOrganization: (current, args, context) => userOrganizationsPaginated(context, context.user, current.id, args),
     default_dashboards: (current, _, context) => findDefaultDashboards(context, context.user, current),
     default_dashboard: (current, _, context) => findWorskpaceById(context, context.user, current.default_dashboard),
+    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current.id, context),
   },
   UserSession: {
     user: (session, _, context) => creatorLoader.load(session.user_id, context, context.user),


### PR DESCRIPTION
### Proposed changes

* Add Confidence Field missing in several SDO in creation/edition form and overview
* Add a hook to check the confidence level of the user and compare it to each entity confidence level. If the user's confidence level is lower than the entity, then the user CAN'T edit the entity and an alert + error message are display in form.
* Refacto some component to use the check confidence hook with fieldPatch in useFormEditor 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
