### PR TITLE
[backend] Broken attack patterns matrix everywhere (#5841)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -206,7 +206,8 @@
     "engine_selector": "auto",
     "index_creation_pattern": "-000001",
     "search_ignore_throttled": false,
-    "max_pagination_result": 500,
+    "max_pagination_result": 5000,
+    "default_pagination_result": 500,
     "max_bulk_operations": 5000,
     "max_runtime_resolutions": 5000,
     "max_concurrency": 4

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -155,7 +155,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const allowSelfSigned = mappedConfig.allow_self_signed || mappedConfig.allow_self_signed === 'true';
       mappedConfig = R.assoc('tlsOptions', { rejectUnauthorized: !allowSelfSigned }, mappedConfig);
       const ldapOptions = { server: mappedConfig };
-      const ldapStrategy = new LdapStrategy(ldapOptions, async (user, done) => {
+      const ldapStrategy = new LdapStrategy(ldapOptions, (user, done) => {
         logApp.info('[LDAP] Successfully logged', { user });
         const userMail = mappedConfig.mail_attribute ? user[mappedConfig.mail_attribute] : user.mail;
         const userName = mappedConfig.account_attribute ? user[mappedConfig.account_attribute] : user.givenName;

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -893,7 +893,7 @@ const getRuntimeEntities = async (context, user, entityType) => {
   const elements = await elPaginate(context, user, READ_INDEX_STIX_DOMAIN_OBJECTS, {
     types: [entityType],
     first: MAX_RUNTIME_RESOLUTION_SIZE,
-    bypassSizeLimit: true,
+    bypassSizeLimit: true, // ensure that max runtime prevent on ES_MAX_PAGINATION
     connectionFormat: false,
   });
   return R.mergeAll(elements.map((i) => ({ [i.internal_id]: i.name })));

--- a/opencti-platform/opencti-graphql/src/database/file-search.js
+++ b/opencti-platform/opencti-graphql/src/database/file-search.js
@@ -20,7 +20,7 @@ import { RELATION_GRANTED_TO, RELATION_OBJECT_MARKING } from '../schema/stixRefR
 import { buildPagination, cursorToOffset, INDEX_FILES, READ_DATA_INDICES_WITHOUT_INTERNAL, READ_INDEX_FILES } from './utils';
 import { DatabaseError } from '../config/errors';
 import { logApp } from '../config/conf';
-import { buildDataRestrictions, elFindByIds, elIndex, elRawCount, elRawDeleteByQuery, elRawSearch, elRawUpdateByQuery } from './engine';
+import { buildDataRestrictions, elFindByIds, elIndex, elRawCount, elRawDeleteByQuery, elRawSearch, elRawUpdateByQuery, ES_MINIMUM_FIXED_PAGINATION } from './engine';
 
 const buildIndexFileBody = (documentId, file, entity = null) => {
   const documentBody = {
@@ -172,7 +172,7 @@ const elBuildSearchFilesQueryBody = async (context, user, options = {}) => {
   };
 };
 export const elSearchFiles = async (context, user, options = {}) => {
-  const { search = null, first = 20, after, connectionFormat = true, includeContent = false, orderBy = null, orderMode = 'asc' } = options;
+  const { search = null, first = ES_MINIMUM_FIXED_PAGINATION, after, connectionFormat = true, includeContent = false, orderBy = null, orderMode = 'asc' } = options;
   const { fields = [], excludeFields = ['attachment.content'], highlight = true } = options; // results format options
   const searchAfter = after ? cursorToOffset(after) : undefined;
   const body = await elBuildSearchFilesQueryBody(context, user, options);

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -10,7 +10,7 @@ import {
   READ_RELATIONSHIPS_INDICES,
   READ_RELATIONSHIPS_INDICES_WITHOUT_INFERRED
 } from './utils';
-import { elAggregationsList, elCount, elFindByIds, elList, elLoadById, elPaginate, UNIMPACTED_ENTITIES_ROLE } from './engine';
+import { elAggregationsList, elCount, elFindByIds, elList, elLoadById, elPaginate, ES_MINIMUM_FIXED_PAGINATION, UNIMPACTED_ENTITIES_ROLE } from './engine';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_OBJECT, ABSTRACT_STIX_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
 import type { AuthContext, AuthUser } from '../types/user';
 import type {
@@ -286,32 +286,6 @@ export const listRelations = async <T extends StoreProxyRelation>(context: AuthC
   return elPaginate(context, user, indices, paginateArgs);
 };
 
-export const listRelationsFromElement = async <T extends StoreProxyRelation>(context: AuthContext, user: AuthUser, type: string | Array<string>,
-  elementSourceId: string, elementTargetTypes: string[], args: RelationOptions<T> = {}): Promise<Array<T>> => {
-  const opts = {
-    ...args,
-    fromId: elementSourceId,
-    toTypes: elementTargetTypes,
-    first: args.first ?? 10,
-    orderBy: args.orderBy ?? 'created_at',
-    orderMode: args.orderMode ?? OrderingMode.Desc
-  };
-  return listRelations(context, user, type, opts);
-};
-
-export const listRelationsToElement = async <T extends StoreProxyRelation>(context: AuthContext, user: AuthUser, type: string | Array<string>,
-  elementTargetId: string, elementFromTypes: string[], args: RelationOptions<T> = {}): Promise<Array<T>> => {
-  const opts = {
-    ...args,
-    toId: elementTargetId,
-    fromTypes: elementFromTypes,
-    first: args.first ?? 10,
-    orderBy: args.orderBy ?? 'created_at',
-    orderMode: args.orderMode ?? OrderingMode.Desc
-  };
-  return listRelations(context, user, type, opts);
-};
-
 export const listAllRelations = async <T extends StoreProxyRelation>(context: AuthContext, user: AuthUser, type: string | Array<string>,
   args: RelationOptions<T> = {}): Promise<Array<T>> => {
   const { indices = READ_RELATIONSHIPS_INDICES } = args;
@@ -485,7 +459,7 @@ export const listEntitiesThroughRelationsPaginated = async <T extends BasicStore
   };
   const paginateArgs = buildEntityFilters(entityType, {
     ...args,
-    first: args.first ?? 20,
+    first: args.first ?? ES_MINIMUM_FIXED_PAGINATION,
     orderBy: args.orderBy ?? 'created_at',
     orderMode: args.orderMode ?? OrderingMode.Desc,
     filters: connectedFilters

--- a/opencti-platform/opencti-graphql/src/domain/container.js
+++ b/opencti-platform/opencti-graphql/src/domain/container.js
@@ -7,7 +7,7 @@ import { ABSTRACT_BASIC_RELATIONSHIP, ABSTRACT_STIX_REF_RELATIONSHIP, ABSTRACT_S
 import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
 import { buildPagination, READ_ENTITIES_INDICES, READ_INDEX_STIX_DOMAIN_OBJECTS, READ_RELATIONSHIPS_INDICES } from '../database/utils';
 import { now } from '../utils/format';
-import { elCount, elFindByIds, ES_MAX_PAGINATION, MAX_RELATED_CONTAINER_RESOLUTION } from '../database/engine';
+import { elCount, elFindByIds, ES_DEFAULT_PAGINATION, MAX_RELATED_CONTAINER_RESOLUTION } from '../database/engine';
 import { findById as findInvestigationById } from '../modules/workspace/workspace-domain';
 import { stixCoreObjectAddRelations } from './stixCoreObject';
 import { addFilter } from '../utils/filtering/filtering-utils';
@@ -53,7 +53,7 @@ export const objects = async (context, user, containerId, args) => {
     const paginatedElements = {};
     while (hasNextPage) {
       // Force options to prevent connection format and manage search after
-      const paginateOpts = { ...baseOpts, first: args.first ?? ES_MAX_PAGINATION, after: searchAfter };
+      const paginateOpts = { ...baseOpts, first: args.first ?? ES_DEFAULT_PAGINATION, after: searchAfter };
       const currentPagination = await listEntitiesThroughRelationsPaginated(context, user, containerId, RELATION_OBJECT, types, false, paginateOpts);
       const noMoreElements = currentPagination.edges.length === 0 || currentPagination.edges.length < paginateOpts.first;
       if (noMoreElements) {

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -14,6 +14,7 @@ export const buildArgsFromDynamicFilters = async (context, user, args) => {
   const listEntitiesWithFilters = async (filters) => listEntities(context, user, [ABSTRACT_STIX_OBJECT], {
     connectionFormat: false,
     first: MAX_RUNTIME_RESOLUTION_SIZE,
+    bypassSizeLimit: true,
     baseData: true,
     filters
   });

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -14,7 +14,7 @@ export const buildArgsFromDynamicFilters = async (context, user, args) => {
   const listEntitiesWithFilters = async (filters) => listEntities(context, user, [ABSTRACT_STIX_OBJECT], {
     connectionFormat: false,
     first: MAX_RUNTIME_RESOLUTION_SIZE,
-    bypassSizeLimit: true,
+    bypassSizeLimit: true, // ensure that max runtime prevent on ES_MAX_PAGINATION
     baseData: true,
     filters
   });

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import * as R from 'ramda';
-import { elDeleteInstances, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, } from '../database/engine';
+import { elDeleteInstances, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, ES_MINIMUM_FIXED_PAGINATION } from '../database/engine';
 import { generateWorkId } from '../schema/identifier';
 import { INDEX_HISTORY, isNotEmptyField, READ_INDEX_HISTORY } from '../database/utils';
 import { isWorkCompleted, redisDeleteWorks, redisUpdateActionExpectation, redisUpdateWorkFigures } from '../database/redis';
@@ -48,7 +48,7 @@ export const findAll = (context, user, args = {}) => {
 };
 
 export const worksForConnector = async (context, user, connectorId, args = {}) => {
-  const { first = 10, filters = null } = args;
+  const { first = ES_MINIMUM_FIXED_PAGINATION, filters = null } = args;
   const finalFilters = addFilter(filters, 'connector_id', connectorId);
   return elPaginate(context, user, READ_INDEX_HISTORY, {
     type: ENTITY_TYPE_WORK,
@@ -61,7 +61,7 @@ export const worksForConnector = async (context, user, connectorId, args = {}) =
 };
 
 export const worksForSource = async (context, user, sourceId, args = {}) => {
-  const { first = 10, filters = null, type } = args;
+  const { first = ES_MINIMUM_FIXED_PAGINATION, filters = null, type } = args;
   let finalFilters = addFilter(filters, 'event_source_id', sourceId);
   if (type) {
     finalFilters = addFilter(finalFilters, 'event_type', type);


### PR DESCRIPTION
See #5841

For now instead of changing the screen loading way, bring back the pagination window to 5000.
+ some adaptation to respect the other options
+ default pagination to 500  when nothing is specified.