### PR TITLE
[frontend] Decay improvement: remove moment usage, remove zoom on chart (#2859)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/DecayDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/DecayDialog.tsx
@@ -88,11 +88,11 @@ const DecayDialogContent : FunctionComponent<DecayDialogContentProps> = ({ indic
   };
 
   const labelledHistoryList: LabelledDecayHistory[] = [];
-  decayHistory.map((history) => (
+  decayHistory.forEach((history) => (
     labelledHistoryList.push(getDisplayFor(history))
   ));
 
-  decayLivePoints.map((history) => (
+  decayLivePoints.forEach((history) => (
     labelledHistoryList.push(getDisplayFor(history))
   ));
 

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayChart.tsx
@@ -137,9 +137,8 @@ const DecayChart : FunctionComponent<DecayChartProps> = ({ currentScore, decayCu
       toolbar: { show: false },
       type: 'line',
       background: chartBackgroundColor,
-      selection: {
-        enabled: false,
-      },
+      selection: { enabled: false},
+      zoom: { enabled: false }
     },
     xaxis: {
       type: 'datetime',

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayChart.tsx
@@ -137,8 +137,8 @@ const DecayChart : FunctionComponent<DecayChartProps> = ({ currentScore, decayCu
       toolbar: { show: false },
       type: 'line',
       background: chartBackgroundColor,
-      selection: { enabled: false},
-      zoom: { enabled: false }
+      selection: { enabled: false },
+      zoom: { enabled: false },
     },
     xaxis: {
       type: 'datetime',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* moment is deprecated, removing it from i18n file
* remove zoom on Decay chart (or user need to F5 to have the chart back in the screen)

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/2859

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
