### PR TITLE
[frontend] Fix data import redirect from workbench (#5805)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -804,7 +804,7 @@ const WorkbenchFileContentComponent = ({
                 )}/${file.metaData.entity.id}`;
                 history.push(`${entityLink}/files`);
               } else {
-                history.push('/dashboard/import');
+                history.push('/dashboard/data/import');
               }
             },
           });

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFilePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFilePopover.jsx
@@ -86,7 +86,7 @@ class WorkbenchFilePopover extends Component {
           )}/${this.props.file.metaData.entity.id}`;
           this.props.history.push(`${entityLink}/files`);
         } else {
-          this.props.history.push('/dashboard/import');
+          this.props.history.push('/dashboard/data/import');
         }
       },
     });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix redirect to dashboard/data/import since rename of url

### Related issues

* the issue is not released yet and only present on master (& testing) : when you validate or delete an analyst workbench, it will redirect to dashboard/import which doesn't exist anymore (the right url is dashboard/data/import now)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
