### PR TITLE
[frontend] show right navigation menu when some manager are disabled.

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -109,9 +109,12 @@ const IngestionCsv = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
-      </Alert>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
+        </Alert>
+        <IngestionMenu/>
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -109,7 +109,7 @@ const IngestionCsv = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
@@ -58,7 +58,7 @@ const IngestionRss = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
@@ -58,9 +58,12 @@ const IngestionRss = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
-      </Alert>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
+        </Alert>
+        <IngestionMenu/>
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
@@ -63,7 +63,7 @@ const IngestionTaxii = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
@@ -63,9 +63,12 @@ const IngestionTaxii = () => {
   };
   if (!platformModuleHelpers.isIngestionManagerEnable()) {
     return (
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
-      </Alert>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(INGESTION_MANAGER))}
+        </Alert>
+        <IngestionMenu/>
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
@@ -64,7 +64,7 @@ const Sync = () => {
   };
   if (!platformModuleHelpers.isSyncManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(SYNC_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
@@ -64,9 +64,12 @@ const Sync = () => {
   };
   if (!platformModuleHelpers.isSyncManagerEnable()) {
     return (
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(SYNC_MANAGER))}
-      </Alert>
+        <div>
+          <Alert severity="info">
+            {t_i18n(platformModuleHelpers.generateDisableMessage(SYNC_MANAGER))}
+          </Alert>
+          <IngestionMenu/>
+        </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
@@ -64,12 +64,12 @@ const Sync = () => {
   };
   if (!platformModuleHelpers.isSyncManagerEnable()) {
     return (
-        <div>
-          <Alert severity="info">
-            {t_i18n(platformModuleHelpers.generateDisableMessage(SYNC_MANAGER))}
-          </Alert>
-          <IngestionMenu/>
-        </div>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(SYNC_MANAGER))}
+        </Alert>
+        <IngestionMenu/>
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
@@ -46,12 +46,12 @@ const Tasks = () => {
   };
   if (!platformModuleHelpers.isTasksManagerEnable()) {
     return (
-    <div>
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(TASK_MANAGER))}
-      </Alert>
-      <ProcessingMenu />
-    </div>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(TASK_MANAGER))}
+        </Alert>
+        <ProcessingMenu />
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
@@ -46,9 +46,12 @@ const Tasks = () => {
   };
   if (!platformModuleHelpers.isTasksManagerEnable()) {
     return (
+    <div>
       <Alert severity="info">
         {t_i18n(platformModuleHelpers.generateDisableMessage(TASK_MANAGER))}
       </Alert>
+      <ProcessingMenu />
+    </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
@@ -46,7 +46,7 @@ const Tasks = () => {
   };
   if (!platformModuleHelpers.isTasksManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(TASK_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
@@ -56,9 +56,12 @@ const Retention = () => {
   };
   if (!platformModuleHelpers.isRetentionManagerEnable()) {
     return (
+    <div>
       <Alert severity="info">
         {t_i18n(platformModuleHelpers.generateDisableMessage(RETENTION_MANAGER))}
       </Alert>
+      <CustomizationMenu />
+    </div>
     );
   }
   return (

--- a/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
@@ -56,7 +56,7 @@ const Retention = () => {
   };
   if (!platformModuleHelpers.isRetentionManagerEnable()) {
     return (
-      <div>
+      <div className={classes.container}>
         <Alert severity="info">
           {t_i18n(platformModuleHelpers.generateDisableMessage(RETENTION_MANAGER))}
         </Alert>

--- a/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
@@ -56,12 +56,12 @@ const Retention = () => {
   };
   if (!platformModuleHelpers.isRetentionManagerEnable()) {
     return (
-    <div>
-      <Alert severity="info">
-        {t_i18n(platformModuleHelpers.generateDisableMessage(RETENTION_MANAGER))}
-      </Alert>
-      <CustomizationMenu />
-    </div>
+      <div>
+        <Alert severity="info">
+          {t_i18n(platformModuleHelpers.generateDisableMessage(RETENTION_MANAGER))}
+        </Alert>
+        <CustomizationMenu />
+      </div>
     );
   }
   return (

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -178,7 +178,7 @@ describe('Indicator resolver standard behavior', () => {
 
     expect(queryResult.data?.indicator.decay_base_score).toBe(50);
     const startDecayDate: Date = queryResult.data?.indicator.decay_base_score_date;
-    expect(startDecayDate.getTime() / 1000).toBeCloseTo(new Date().getTime() / 1000, 0); // approximately now
+    expect(startDecayDate.getTime() / 10000).toBeCloseTo(new Date().getTime() / 10000, 0); // approximately now
 
     const historyRecords: DecayHistory[] = queryResult.data?.indicator.decay_history;
     expect(historyRecords.length).toBe(1); // just created, should just have creation date


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When a manager is disabled, the right navigation menu is hidden, so it's not possible to navigate to other page like connector.

Example before change:
![Capture d'écran 2024-02-13 174456](https://github.com/OpenCTI-Platform/opencti/assets/3634942/8ee323cd-b413-49d7-a7b9-a325b596e177)

Same screen after change:
![Capture d'écran 2024-02-14 113951](https://github.com/OpenCTI-Platform/opencti/assets/3634942/ba582b12-10c5-4ba8-b2a2-23c0795aaea6)



### Related issues

* No issue as far as I know.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
