### PR TITLE
[backend] Introduce fuzzy search and wildcard prefix options

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -212,6 +212,8 @@
     "engine_selector": "auto",
     "index_creation_pattern": "-000001",
     "search_ignore_throttled": false,
+    "search_wildcard_prefix": false,
+    "search_fuzzy": false,
     "max_pagination_result": 5000,
     "default_pagination_result": 500,
     "max_bulk_operations": 5000,

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -50,7 +50,6 @@ export interface ListFilter<T extends BasicStoreCommon> {
   indices?: Array<string>
   search?: InputMaybe<string> | string | undefined
   useWildcardPrefix?: boolean
-  useWildcardSuffix?: boolean
   first?: number | null
   after?: string | undefined | null
   orderBy?: any


### PR DESCRIPTION
Introduce fuzzy search and wildcard prefix options.
As this kind of default search introduce high usage of elastic and a change in default search behavior, options are disabled by default.

```
  "elasticsearch": {
    ....
    "search_wildcard_prefix": false,
    "search_fuzzy": false,
    ....
  },
```

With search_fuzzy option activated, the search includes words with automatic fuzzy comparison depending on the word size.
With search_wildcard_prefix option activated the search will include words not starting with the word.
