### PR TITLE
[frontend] Systems display in BreadCrumbs

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/Systems.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Systems.tsx
@@ -120,7 +120,7 @@ const Systems = () => {
 
   return (
     <>
-      <Breadcrumbs variant="list" elements={[{ label: t_i18n('Entities') }, { label: t_i18n('Organizations'), current: true }]} />
+      <Breadcrumbs variant="list" elements={[{ label: t_i18n('Entities') }, { label: t_i18n('Systems'), current: true }]} />
       {renderLines()}
       <Security needs={[KNOWLEDGE_KNUPDATE]}>
         <SystemCreation paginationOptions={paginationOptions} />


### PR DESCRIPTION
In the right panel, select Entities>Systems.
The header display is Entites>Organizations (instead of Systems)