### PR TITLE
[backend/frontend] remove 'remove' operation from playbook (#5950)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -231,8 +231,7 @@ const PlaybookAddComponentsContent = ({
                 value: n.value,
                 patch_value: n.value,
               })),
-            )
-                        }
+            )}
           />
         );
       case 'objectLabel':
@@ -248,8 +247,7 @@ const PlaybookAddComponentsContent = ({
                 value: n.value,
                 patch_value: n.label,
               })),
-            )
-                        }
+            )}
           />
         );
       case 'createdBy':
@@ -263,8 +261,7 @@ const PlaybookAddComponentsContent = ({
                 value: value.value,
                 patch_value: value.value,
               },
-            ])
-                        }
+            ])}
           />
         );
       case 'x_opencti_workflow_id':
@@ -278,8 +275,7 @@ const PlaybookAddComponentsContent = ({
                 value: value.value,
                 patch_value: value.value,
               },
-            ])
-                        }
+            ])}
           />
         );
       case 'x_opencti_detection':
@@ -300,19 +296,14 @@ const PlaybookAddComponentsContent = ({
           <Field
             component={TextField}
             disabled={disabled}
-            type={
-                            numberAttributes.includes(actionsInputs[i]?.attribute)
-                              ? 'number'
-                              : 'text'
-                        }
+            type={numberAttributes.includes(actionsInputs[i]?.attribute) ? 'number' : 'text'}
             variant="standard"
             name={`actions-${i}-value`}
             label={t_i18n('Value')}
             fullWidth={true}
             onChange={(_, value) => handleChangeActionInput(i, 'value', [
               { label: value, value, patch_value: value },
-            ])
-                        }
+            ])}
           />
         );
     }
@@ -392,10 +383,7 @@ const PlaybookAddComponentsContent = ({
     });
     const initialValues = currentConfig
       ? {
-        name:
-                    selectedNode?.data?.component?.id === selectedComponent.id
-                      ? selectedNode?.data?.name
-                      : selectedComponent.name,
+        name: selectedNode?.data?.component?.id === selectedComponent.id ? selectedNode?.data?.name : selectedComponent.name,
         ...currentConfig,
       }
       : {
@@ -516,12 +504,7 @@ const PlaybookAddComponentsContent = ({
                                     <Select
                                       variant="standard"
                                       value={actionsInputs[i]?.op}
-                                      onChange={(event) => handleChangeActionInput(
-                                        i,
-                                        'op',
-                                        event.target.value,
-                                      )
-                                      }
+                                      onChange={(event) => handleChangeActionInput(i, 'op', event.target.value)}
                                     >
                                       {(v.items?.properties?.op?.enum ?? ['add, replace, remove']).map((op) => (
                                         <MenuItem key={op} value={op}>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -166,12 +166,6 @@ const PlaybookAddComponentsContent = ({
       ];
     } else if (actionsInputs[i]?.op === 'replace') {
       options = [
-        {
-          label: t_i18n('Marking definitions'),
-          value: 'objectMarking',
-          isMultiple: true,
-        },
-        { label: t_i18n('Labels'), value: 'objectLabel', isMultiple: true },
         { label: t_i18n('Author'), value: 'createdBy', isMultiple: false },
         { label: t_i18n('Confidence'), value: 'confidence', isMultiple: false },
         { label: t_i18n('Score'), value: 'x_opencti_score', isMultiple: false },

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -37,6 +37,7 @@ import SwitchField from '../../../../components/SwitchField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import StatusField from '../../common/form/StatusField';
+import { capitalizeFirstLetter } from '../../../../utils/String';
 import { numberAttributes } from '../../../../utils/hooks/useAttributes';
 import AutocompleteField from '../../../../components/AutocompleteField';
 
@@ -528,15 +529,11 @@ const PlaybookAddComponentsContent = ({
                                       )
                                       }
                                     >
-                                      <MenuItem value="add">
-                                        {t_i18n('Add')}
-                                      </MenuItem>
-                                      <MenuItem value="replace">
-                                        {t_i18n('Replace')}
-                                      </MenuItem>
-                                      <MenuItem value="remove">
-                                        {t_i18n('Remove')}
-                                      </MenuItem>
+                                      {(v.items?.properties?.op?.enum ?? ['add, replace, remove']).map((op) => (
+                                        <MenuItem key={op} value={op}>
+                                          {t_i18n(capitalizeFirstLetter(op))}
+                                        </MenuItem>
+                                      ))}
                                     </Select>
                                   </FormControl>
                                 </Grid>

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -497,7 +497,7 @@ interface UpdateValueConfiguration {
   patch_value: string
 }
 interface UpdateConfiguration extends PlaybookComponentConfiguration {
-  actions: { op: 'add' | 'replace' | 'remove', attribute: string, value: UpdateValueConfiguration[] }[]
+  actions: { op: 'add' | 'replace', attribute: string, value: UpdateValueConfiguration[] }[]
   all: boolean
 }
 const PLAYBOOK_UPDATE_KNOWLEDGE_COMPONENT_SCHEMA: JSONSchemaType<UpdateConfiguration> = {
@@ -508,7 +508,7 @@ const PLAYBOOK_UPDATE_KNOWLEDGE_COMPONENT_SCHEMA: JSONSchemaType<UpdateConfigura
       items: {
         type: 'object',
         properties: {
-          op: { type: 'string', enum: ['add', 'replace', 'remove'] },
+          op: { type: 'string', enum: ['add', 'replace'] },
           attribute: { type: 'string' },
           value: {
             type: 'array',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* operation "remove" is currently not supported by the platform, so we remove it from playbook operations
* display in the frontend action operations supported by the playbook component instead of hardcoded operations (I still kept a fallback on default operations in case the playbook component doesn't provide them)

### Related issues

* #5950 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
