### PR TITLE
[frontend] remove column 'source' from task errors (#5885)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
@@ -479,7 +479,6 @@ const TasksList = ({ data }) => {
                   <TableRow>
                     <TableCell>{t_i18n('Timestamp')}</TableCell>
                     <TableCell>{t_i18n('Message')}</TableCell>
-                    <TableCell>{t_i18n('Source')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -487,7 +486,6 @@ const TasksList = ({ data }) => {
                     <TableRow key={error.timestamp}>
                       <TableCell>{nsdt(error.timestamp)}</TableCell>
                       <TableCell>{error.message}</TableCell>
-                      <TableCell>{error.source}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
`source` is not not queried, not in schema, so always empty

### Proposed changes

* do not show the source column, until we have a proper solution to provide it

### Related issues

* closes #5885 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
