### PR TITLE
[frontend] remove badge in the top bar trigger icon

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -275,13 +275,7 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
                     to="/dashboard/profile/triggers"
                     color={location.pathname === '/dashboard/profile/triggers' ? 'primary' : 'inherit'}
                   >
-                    <Badge
-                      color="secondary"
-                      variant="dot"
-                      invisible={!isNewNotification}
-                    >
-                      <AlarmOnOutlined fontSize="medium" />
-                    </Badge>
+                    <AlarmOnOutlined fontSize="medium" />
                   </IconButton>
                 </Tooltip>
               </>


### PR DESCRIPTION
When there are unread notifications, the badge is present both on the notifcation icon and trigger icon of the topbar. It should only be on the notification icon.