### PR TITLE
[Backend] Enrich model to add update attribute protection

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3196,9 +3196,7 @@ const elUpdateConnectionsOfElement = async (documentId, documentBody) => {
   });
 };
 export const elUpdateElement = async (instance) => {
-  // Update the element it self
   const esData = prepareElementForIndexing(instance);
-  // Set the cache
   const dataToReplace = R.dissoc('representative', esData);
   const replacePromise = elReplace(instance._index, instance.internal_id, { doc: dataToReplace });
   // If entity with a name, must update connections

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1695,9 +1695,6 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
   if ((opts.references ?? []).length > 0 && references.length !== (opts.references ?? []).length) {
     throw FunctionalError('Cant find element references for commit', { id: initial.internal_id, references: opts.references });
   }
-  // Validate input attributes
-  const entitySetting = await getEntitySettingFromCache(context, initial.entity_type);
-  await validateInputUpdate(context, user, initial.entity_type, initial, updates, entitySetting);
   // Endregion
   // Individual check
   const { bypassIndividualUpdate } = opts;
@@ -1735,6 +1732,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
   const updated = mergeInstanceWithUpdateInputs(initial, inputs);
   const keys = R.map((t) => t.key, attributes);
   if (opts.bypassValidation !== true) { // Allow creation directly from the back-end
+    const entitySetting = await getEntitySettingFromCache(context, initial.entity_type);
     const isAllowedToByPass = isUserHasCapability(user, BYPASS_REFERENCE);
     if (!isAllowedToByPass && entitySetting?.enforce_reference) {
       const isNoReferenceKey = noReferenceAttributes.includes(R.head(keys)) && keys.length === 1;
@@ -2004,6 +2002,10 @@ export const updateAttribute = async (context, user, id, type, inputs, opts = {}
   if (!initial) {
     throw FunctionalError('Cant find element to update', { id, type });
   }
+  // Validate input attributes
+  const entitySetting = await getEntitySettingFromCache(context, initial.entity_type);
+  await validateInputUpdate(context, user, initial.entity_type, initial, inputs, entitySetting);
+  // Continue update
   return updateAttributeFromLoadedWithRefs(context, user, initial, inputs, opts);
 };
 

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1354,13 +1354,9 @@ const innerUpdateAttribute = (instance, rawInput) => {
   // Check consistency
   checkAttributeConsistency(instance.entity_type, key);
   const input = rebuildAndMergeInputFromExistingData(rawInput, instance);
-  if (R.isEmpty(input)) return undefined;
-  // const updatedInputs = [input];
-  // // Specific case for Report
-  // if (instance.entity_type === ENTITY_TYPE_CONTAINER_REPORT && key === 'published') {
-  //   const createdInput = { key: 'created', value: input.value };
-  //   updatedInputs.push(createdInput);
-  // }
+  if (R.isEmpty(input)) {
+    return undefined;
+  }
   return input;
 };
 const prepareAttributesForUpdate = (instance, elements, upsert) => {
@@ -1434,10 +1430,7 @@ const prepareAttributesForUpdate = (instance, elements, upsert) => {
     if (input.key === ATTRIBUTE_ALIASES || input.key === ATTRIBUTE_ALIASES_OPENCTI) {
       const filteredValues = input.value.filter((e) => normalizeName(e) !== normalizeName(instance.name));
       const uniqAliases = R.uniqBy((e) => normalizeName(e), filteredValues);
-      return {
-        key: input.key,
-        value: uniqAliases
-      };
+      return { key: input.key, value: uniqAliases };
     }
     // No need to rework the input
     return input;

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2013,6 +2013,11 @@ export const patchAttribute = async (context, user, id, type, patch, opts = {}) 
   const inputs = transformPatchToInput(patch, opts.operations);
   return updateAttribute(context, user, id, type, inputs, opts);
 };
+
+export const patchAttributeFromLoadedWithRefs = async (context, user, initial, patch, opts = {}) => {
+  const inputs = transformPatchToInput(patch, opts.operations);
+  return updateAttributeFromLoadedWithRefs(context, user, initial, inputs, opts);
+};
 // endregion
 
 // region rules
@@ -2085,7 +2090,7 @@ const createRuleDataPatch = (instance) => {
   }
   return patch;
 };
-const upsertEntityRule = async (context, instance, input, opts = {}) => {
+const upsertEntityRule = async (context, user, instance, input, opts = {}) => {
   logApp.info('Upsert inferred entity', { input });
   const { fromRule } = opts;
   const updatedRule = input[fromRule];
@@ -2093,9 +2098,10 @@ const upsertEntityRule = async (context, instance, input, opts = {}) => {
   const ruleInstance = R.mergeRight(instance, rulePatch);
   const innerPatch = createRuleDataPatch(ruleInstance);
   const patch = { ...rulePatch, ...innerPatch };
-  return await patchAttribute(context, RULE_MANAGER_USER, instance.id, instance.entity_type, patch, opts);
+  const element = await storeLoadByIdWithRefs(context, user, instance.internal_id, { type: instance.entity_type });
+  return await patchAttributeFromLoadedWithRefs(context, RULE_MANAGER_USER, element, patch, opts);
 };
-const upsertRelationRule = async (context, instance, input, opts = {}) => {
+const upsertRelationRule = async (context, user, instance, input, opts = {}) => {
   const { fromRule, ruleOverride = false } = opts;
   // 01 - Update the rule
   const updatedRule = input[fromRule];
@@ -2109,7 +2115,8 @@ const upsertRelationRule = async (context, instance, input, opts = {}) => {
   const innerPatch = createRuleDataPatch(ruleInstance);
   const patch = { ...rulePatch, ...innerPatch };
   logApp.info('Upsert inferred relation', { id: instance.id, relation: patch });
-  return await patchAttribute(context, RULE_MANAGER_USER, instance.id, instance.entity_type, patch, opts);
+  const element = await storeLoadByIdWithRefs(context, user, instance.internal_id, { type: instance.entity_type });
+  return await patchAttributeFromLoadedWithRefs(context, RULE_MANAGER_USER, element, patch, opts);
 };
 // endregion
 
@@ -2781,7 +2788,7 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
     if (existingRelationship) {
       // If upsert come from a rule, do a specific upsert.
       if (fromRule) {
-        return await upsertRelationRule(context, existingRelationship, input, { ...opts, locks: participantIds });
+        return await upsertRelationRule(context, user, existingRelationship, input, { ...opts, locks: participantIds });
       }
       // If not upsert the element
       return upsertElement(context, user, existingRelationship, relationshipType, resolvedInput, { ...opts, locks: participantIds });
@@ -3089,7 +3096,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
           throw UnsupportedError('Cant upsert inferred entity. Too many entities resolved', { input, entityIds });
         }
         // If upsert come from a rule, do a specific upsert.
-        return await upsertEntityRule(context, R.head(filteredEntities), input, { ...opts, locks: participantIds });
+        return await upsertEntityRule(context, user, R.head(filteredEntities), input, { ...opts, locks: participantIds });
       }
       if (filteredEntities.length === 1) {
         const upsertEntityOpts = { ...opts, locks: participantIds, bypassIndividualUpdate: true };
@@ -3340,13 +3347,13 @@ export const deleteInferredRuleElement = async (rule, instance, deletedDependenc
       logApp.info('Cleanup inferred element', { rule, id: instance.id });
       const input = { [completeRuleName]: null };
       const upsertOpts = { fromRule, ruleOverride: true };
-      await upsertRelationRule(context, instance, input, upsertOpts);
+      await upsertRelationRule(context, RULE_MANAGER_USER, instance, input, upsertOpts);
     } else {
       logApp.info('Upsert inferred element', { rule, id: instance.id });
       // Rule still have other explanation, update the rule
       const input = { [completeRuleName]: rebuildRuleContent };
       const ruleOpts = { fromRule, ruleOverride: true };
-      await upsertRelationRule(context, instance, input, ruleOpts);
+      await upsertRelationRule(context, RULE_MANAGER_USER, instance, input, ruleOpts);
     }
   } catch (err) {
     if (err.name === ALREADY_DELETED_ERROR) {

--- a/opencti-platform/opencti-graphql/src/modules/attributes/basicRelationship-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/basicRelationship-registrationAttributes.ts
@@ -28,7 +28,7 @@ const basicRelationshipAttributes: Array<AttributeDefinition> = [
   creators,
   { name: 'fromType', label: 'Source entity', type: 'string', format: 'short', editDefault: false, mandatoryType: 'internal', multiple: false, upsert: false, isFilterable: true }, // TODO to remove ?
   { name: 'toType', label: 'Target entity', type: 'string', format: 'short', editDefault: false, mandatoryType: 'internal', multiple: false, upsert: false, isFilterable: true }, // TODO to remove?
-  { name: 'i_inference_weight', label: 'Inference weight', type: 'numeric', precision: 'integer', editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: true },
+  { name: 'i_inference_weight', label: 'Inference weight', type: 'numeric', precision: 'integer', update: false, editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: true },
   {
     name: 'connections',
     label: 'Relations connections',
@@ -38,6 +38,7 @@ const basicRelationshipAttributes: Array<AttributeDefinition> = [
     mandatoryType: 'internal',
     multiple: true,
     upsert: false,
+    update: false,
     isFilterable: true,
     mappings: [
       { ...internalId,

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import { type AttributeDefinition, authorizedMembers, errors, id } from '../../schema/attribute-definition';
+import { type AttributeDefinition, authorizedMembers, errors, id, updatedAt } from '../../schema/attribute-definition';
 import { schemaAttributesDefinition } from '../../schema/schema-attributes';
 import {
   ENTITY_TYPE_CAPABILITY,
@@ -332,6 +332,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'description', label: 'Description', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   [ENTITY_TYPE_CONNECTOR]: [
+    { ...updatedAt, update: true },
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'active', label: 'Status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'auto', label: 'Auto', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -332,7 +332,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'description', label: 'Description', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   [ENTITY_TYPE_CONNECTOR]: [
-    { ...updatedAt, update: true },
+    { ...updatedAt, update: true }, // Allow change of updated_at for connector ping
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'active', label: 'Status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'auto', label: 'Auto', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
@@ -43,7 +43,7 @@ const stixDomainObjectAttributes: Array<AttributeDefinition> = [
   lang,
   confidence,
   revoked,
-  { ...files, update: true },
+  files,
   { name: 'x_opencti_graph_data', label: 'Graph data', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   { name: 'x_opencti_workflow_id', label: 'Workflow status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true }
 ];

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -29,13 +29,12 @@ type BasicDefinition = {
   name: string // name in the database
   label: string // label for front display
   description?: string // Description of the attribute
-  ignoreInCreationForm?: boolean // If this attribute will be part of auto generated creation form in the UI
   multiple: boolean, // If attribute can have multiple values
   mandatoryType: MandatoryType // If attribute is mandatory
   upsert: boolean // If attribute can be upsert by the integration
   isFilterable: boolean // If attribute can be used as a filter key in the UI
   editDefault: boolean // TO CHECK ?????
-  update?: boolean // TO CHECK ?????
+  update?: boolean // If attribute can be updated (null = true)
 };
 
 type BasicObjectDefinition = BasicDefinition & {
@@ -65,12 +64,12 @@ export const id: AttributeDefinition = {
   label: 'Id',
   type: 'string',
   format: 'short',
+  update: false,
   mandatoryType: 'no',
   multiple: false,
   editDefault: false,
   upsert: false,
   isFilterable: false,
-  ignoreInCreationForm: true,
 };
 
 export const internalId: AttributeDefinition = {
@@ -78,6 +77,7 @@ export const internalId: AttributeDefinition = {
   label: 'Internal id',
   type: 'string',
   format: 'short',
+  update: false,
   mandatoryType: 'no',
   editDefault: false,
   multiple: false,
@@ -90,6 +90,7 @@ export const creators: AttributeDefinition = {
   label: 'Creators',
   type: 'string',
   format: 'id',
+  update: false,
   entityTypes: [ENTITY_TYPE_USER],
   mandatoryType: 'no',
   editDefault: false,
@@ -103,6 +104,7 @@ export const standardId: AttributeDefinition = {
   label: 'Id',
   type: 'string',
   format: 'short',
+  update: false,
   mandatoryType: 'internal',
   editDefault: false,
   multiple: false,
@@ -115,6 +117,7 @@ export const iAliasedIds: AttributeDefinition = {
   label: 'Internal aliases',
   type: 'string',
   format: 'short', // Not ID as alias is not really an entity
+  update: false,
   mandatoryType: 'no',
   editDefault: false,
   multiple: true,
@@ -182,6 +185,7 @@ export const parentTypes: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: true,
   upsert: false,
@@ -194,6 +198,7 @@ export const baseType: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -206,6 +211,7 @@ export const entityType: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -218,6 +224,7 @@ export const entityLocationType: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -230,6 +237,7 @@ export const relationshipType: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -242,6 +250,7 @@ export const xOpenctiType: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'no',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -337,6 +346,7 @@ export const createdAt: AttributeDefinition = {
   label: 'Created at',
   type: 'date',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,
@@ -348,6 +358,7 @@ export const updatedAt: AttributeDefinition = {
   type: 'date',
   mandatoryType: 'internal',
   editDefault: false,
+  update: false,
   multiple: false,
   upsert: false,
   isFilterable: true,
@@ -407,6 +418,7 @@ export const identityClass: AttributeDefinition = {
   type: 'string',
   format: 'short',
   mandatoryType: 'no',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -358,7 +358,6 @@ export const updatedAt: AttributeDefinition = {
   type: 'date',
   mandatoryType: 'internal',
   editDefault: false,
-  update: false,
   multiple: false,
   upsert: false,
   isFilterable: true,

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -357,6 +357,7 @@ export const updatedAt: AttributeDefinition = {
   label: 'Updated at',
   type: 'date',
   mandatoryType: 'internal',
+  update: false,
   editDefault: false,
   multiple: false,
   upsert: false,

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -14,6 +14,7 @@ import type { AttributeDefinition } from './attribute-definition';
 import type { EditInput } from '../generated/graphql';
 import { EditOperation } from '../generated/graphql';
 import { utcDate } from '../utils/format';
+import { schemaRelationsRefDefinition } from './schema-relationsRef';
 
 const ajv = new Ajv();
 
@@ -190,7 +191,9 @@ export const validateInputCreation = async (
 const validateUpdatableAttribute = (instanceType: string, input: Record<string, unknown>) => {
   Object.entries(input).forEach(([key]) => {
     const attribute = schemaAttributesDefinition.getAttribute(instanceType, key);
-    if (!attribute || attribute.update === false) {
+    const reference = schemaRelationsRefDefinition.getRelationRef(instanceType, key);
+    const schemaAttribute = attribute || reference;
+    if (!schemaAttribute || schemaAttribute.update === false) {
       throw ValidationError(key, { message: 'You cannot update incompatible attribute' });
     }
   });

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -190,8 +190,8 @@ export const validateInputCreation = async (
 const validateUpdatableAttribute = (instanceType: string, input: Record<string, unknown>) => {
   Object.entries(input).forEach(([key]) => {
     const attribute = schemaAttributesDefinition.getAttribute(instanceType, key);
-    if (attribute?.update === false) {
-      throw ValidationError(attribute.name, { message: `You cannot update ${attribute.name} attribute` });
+    if (!attribute || attribute.update === false) {
+      throw ValidationError(key, { message: 'You cannot update incompatible attribute' });
     }
   });
 };

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -85,12 +85,19 @@ describe('Loaders', () => {
 });
 
 describe('Attribute updater', () => {
-  it.skip('should update fail for unknown attributes', async () => {
+  it('should update fail for protected attributes', async () => {
+    const campaign = await elLoadById(testContext, ADMIN_USER, 'campaign--92d46985-17a6-4610-8be8-cc70c82ed214');
+    const campaignId = campaign.internal_id;
+    const input = { id: '92d46985-17a6-4610-8be8-cc70c82ed214' };
+    const dataPromise = patchAttribute(testContext, ADMIN_USER, campaignId, ENTITY_TYPE_CAMPAIGN, input);
+    expect(dataPromise).rejects.toThrow();
+  });
+  it('should update fail for unknown attributes', async () => {
     const campaign = await elLoadById(testContext, ADMIN_USER, 'campaign--92d46985-17a6-4610-8be8-cc70c82ed214');
     const campaignId = campaign.internal_id;
     const input = { observable_value: 'test' };
-    const { element: update } = await patchAttribute(testContext, ADMIN_USER, campaignId, ENTITY_TYPE_CAMPAIGN, input);
-    expect(update).rejects.toThrow();
+    const dataPromise = patchAttribute(testContext, ADMIN_USER, campaignId, ENTITY_TYPE_CAMPAIGN, input);
+    expect(dataPromise).rejects.toThrow();
   });
   it('should update dont do anything if already the same', async () => {
     const campaign = await elLoadById(testContext, ADMIN_USER, 'campaign--92d46985-17a6-4610-8be8-cc70c82ed214');


### PR DESCRIPTION
Enrich model to add update attribute protection.
That will prevent to modify attribute not correctly related to the entity.