### PR TITLE
[backend/frontend] user's confidence level shall be the highest among user's group(s)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2664,5 +2664,6 @@
   "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert.",
   "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
   "Your confidence level is insufficient to edit this object.": "Dein Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
-  "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."
+  "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "Der Benutzer ist BYPASS-fähig, sein maximales Vertrauensniveau ist auf 100 eingestellt."
 }

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2664,6 +2664,5 @@
   "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert.",
   "Only successful tests allow the ingestion edition.": "Nur erfolgreiche Tests erlauben die Ingestion-Edition.",
   "Your confidence level is insufficient to edit this object.": "Dein Vertrauensniveau ist unzureichend, um dieses Objekt zu bearbeiten.",
-  "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten.",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "Der Benutzer ist BYPASS-fähig, sein maximales Vertrauensniveau ist auf 100 eingestellt."
+  "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten."
 }

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2528,7 +2528,6 @@
   "Unknown configuration error in the platform.": "Unknown configuration error in the platform.",
   "Effective Max Confidence Level:": "Effective Max Confidence Level:",
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "The user has BYPASS capability, their max confidence level is set to 100.",
   "This user has no Max Confidence Level and does not inherit one from groups. Add a group to this user to resolve the issue.": "This user has no Max Confidence Level and does not inherit one from groups. Add a group to this user to resolve the issue.",
   "This user does not inherit a Max Confidence Level from their group. Configure user's groups with a Max Confidence Level.": "This user does not inherit a Max Confidence Level from their group. Configure user's groups with a Max Confidence Level.",
   "This group has no Max Confidence Level defined.": "This group has no Max Confidence Level defined.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2525,6 +2525,7 @@
   "This group does not have a Max Confidence Level, members might not be able to create data.": "This group does not have a Max Confidence Level, members might not be able to create data.",
   "This user has no effective confidence level from the groups assigned.": "This user has no effective confidence level from the groups assigned.",
   "The Max Confidence Level is currently inherited from...": "The Max Confidence Level is currently inherited from the group {link}.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "The user has BYPASS capability, their max confidence level is set to 100.",
   "Unknown configuration error in the platform.": "Unknown configuration error in the platform.",
   "Effective Max Confidence Level:": "Effective Max Confidence Level:",
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2528,6 +2528,7 @@
   "Unknown configuration error in the platform.": "Unknown configuration error in the platform.",
   "Effective Max Confidence Level:": "Effective Max Confidence Level:",
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "The user has BYPASS capability, their max confidence level is set to 100.",
   "This user has no Max Confidence Level and does not inherit one from groups. Add a group to this user to resolve the issue.": "This user has no Max Confidence Level and does not inherit one from groups. Add a group to this user to resolve the issue.",
   "This user does not inherit a Max Confidence Level from their group. Configure user's groups with a Max Confidence Level.": "This user does not inherit a Max Confidence Level from their group. Configure user's groups with a Max Confidence Level.",
   "This group has no Max Confidence Level defined.": "This group has no Max Confidence Level defined.",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2562,10 +2562,6 @@
   "To prevent people seeing all the data...": "Para evitar que los usuarios vean todos los datos del panel público, seleccione una definición de marcado para restringir los datos compartidos.",
   "Max level markings": "Marcas de nivel máximo",
   "Copy link": "Copiar enlace",
-  "Disable link": "Desactivar enlace",
-  "Delete link": "Borrar enlace",
-  "Are you sure you want to delete this dashboard link?": "¿Está seguro de que desea eliminar este enlace del panel de control?",
-  "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user’s groups.": "El nivel de confianza máximo se define actualmente a nivel de usuario. Anula el nivel de confianza máximo de los grupos de usuarios.",
   "Please, verify the validity of the selected CSV mapper for the given URL.": "Por favor, verifique la validez del asignador CSV seleccionado para la URL proporcionada.",
   "Only successful tests allow the ingestion creation.": "Sólo las pruebas exitosas permiten la creación de la ingesta.",
   "Request for takedown date": "Fecha de solicitud de retirada",
@@ -2667,5 +2663,7 @@
   "Are you sure you want to delete this public dashboard?": "¿Está seguro de que desea eliminar este panel público?",
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
   "Your confidence level is insufficient to edit this object.": "Tu nivel de confianza es insuficiente para editar este objeto.",
-  "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma."
+  "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "El usuario tiene capacidad BYPASS, su nivel de confianza máximo está fijado en 100.",
+  "Only successful tests allow the ingestion edition.": "Sólo las pruebas exitosas permiten la edición de ingestión."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2664,6 +2664,5 @@
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
   "Your confidence level is insufficient to edit this object.": "Tu nivel de confianza es insuficiente para editar este objeto.",
   "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma.",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "El usuario tiene capacidad BYPASS, su nivel de confianza máximo está fijado en 100.",
   "Only successful tests allow the ingestion edition.": "Sólo las pruebas exitosas permiten la edición de ingestión."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2664,5 +2664,6 @@
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
   "Your confidence level is insufficient to edit this object.": "Tu nivel de confianza es insuficiente para editar este objeto.",
   "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma.",
-  "Only successful tests allow the ingestion edition.": "Sólo las pruebas exitosas permiten la edición de ingestión."
+  "Only successful tests allow the ingestion edition.": "Sólo las pruebas exitosas permiten la edición de ingestión.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "El usuario tiene capacidad BYPASS, su nivel de confianza máximo está fijado en 100."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2663,5 +2663,7 @@
   "Accept": "Accepter",
   "Home": "Accueil",
   "Your confidence level is insufficient to edit this object.": "Votre niveau de confiance est insuffisant pour éditer cet objet.",
-  "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme."
+  "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "L'utilisateur a la capacité de BYPASS, son niveau de confiance maximum est fixé à 100.",
+  "Only successful tests allow the ingestion edition.": "Seuls les tests réussis permettent l'édition de l'ingestion."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2664,6 +2664,5 @@
   "Home": "Accueil",
   "Your confidence level is insufficient to edit this object.": "Votre niveau de confiance est insuffisant pour éditer cet objet.",
   "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme.",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "L'utilisateur a la capacité de BYPASS, son niveau de confiance maximum est fixé à 100.",
   "Only successful tests allow the ingestion edition.": "Seuls les tests réussis permettent l'édition de l'ingestion."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2664,5 +2664,6 @@
   "Home": "Accueil",
   "Your confidence level is insufficient to edit this object.": "Votre niveau de confiance est insuffisant pour éditer cet objet.",
   "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme.",
-  "Only successful tests allow the ingestion edition.": "Seuls les tests réussis permettent l'édition de l'ingestion."
+  "Only successful tests allow the ingestion edition.": "Seuls les tests réussis permettent l'édition de l'ingestion.",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "L'utilisateur a la capacité de BYPASS, son niveau de confiance maximum est fixé à 100."
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2663,5 +2663,7 @@
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "ジェネレーティブAIは現在モデルを微調整しているベータ機能です。重要な情報を確認してください。",
   "Accept": "受け入れる",
   "Your confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
-  "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。"
+  "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "ユーザーはBYPASS能力を持っており、最大信頼度は100に設定されている。",
+  "Only successful tests allow the ingestion edition.": "成功したテストのみがインジェスト版を許可します。"
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2664,5 +2664,6 @@
   "Accept": "受け入れる",
   "Your confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
   "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。",
-  "Only successful tests allow the ingestion edition.": "成功したテストのみがインジェスト版を許可します。"
+  "Only successful tests allow the ingestion edition.": "成功したテストのみがインジェスト版を許可します。",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "ユーザーはBYPASS能力を持っており、最大信頼度は100に設定されている。"
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2664,6 +2664,5 @@
   "Accept": "受け入れる",
   "Your confidence level is insufficient to edit this object.": "このオブジェクトを編集するためには、最大の自信レベルが不足しています。",
   "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "ユーザーはBYPASS能力を持っており、最大信頼度は100に設定されている。",
   "Only successful tests allow the ingestion edition.": "成功したテストのみがインジェスト版を許可します。"
 }

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2662,7 +2662,6 @@
   "Missing token": "丢失的令牌",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "生成式人工智能是一项测试功能，因为我们目前正在对模型进行微调。请考虑检查重要信息。",
   "Accept": "接受",
-  "The user has BYPASS capability, their max confidence level is set to 100.": "用户具有 BYPASS 功能，其最大置信度设置为 100。",
   "Only successful tests allow the ingestion edition.": "只有成功的测试才允许摄取版本。",
   "Your confidence level is insufficient to edit this object.": "您的置信度不足以编辑此对象。",
   "You need a confidence level to edit objects in the platform.": "编辑平台中的对象需要信任级别。"

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2664,5 +2664,6 @@
   "Accept": "接受",
   "Only successful tests allow the ingestion edition.": "只有成功的测试才允许摄取版本。",
   "Your confidence level is insufficient to edit this object.": "您的置信度不足以编辑此对象。",
-  "You need a confidence level to edit objects in the platform.": "编辑平台中的对象需要信任级别。"
+  "You need a confidence level to edit objects in the platform.": "编辑平台中的对象需要信任级别。",
+  "The user has BYPASS capability, their max confidence level is set to 100.": "用户具有 BYPASS 功能，其最大置信度设置为 100。"
 }

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2662,6 +2662,8 @@
   "Missing token": "丢失的令牌",
   "Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.": "生成式人工智能是一项测试功能，因为我们目前正在对模型进行微调。请考虑检查重要信息。",
   "Accept": "接受",
-  "Your maximum confidence level is insufficient to edit this object.": "编辑此对象需要更高的最大信心水平。",
-  "You need a maximum confidence level to edit objects in the platform.": "在平台上编辑对象需要最高信心水平。"
+  "The user has BYPASS capability, their max confidence level is set to 100.": "用户具有 BYPASS 功能，其最大置信度设置为 100。",
+  "Only successful tests allow the ingestion edition.": "只有成功的测试才允许摄取版本。",
+  "Your confidence level is insufficient to edit this object.": "您的置信度不足以编辑此对象。",
+  "You need a confidence level to edit objects in the platform.": "编辑平台中的对象需要信任级别。"
 }

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
@@ -125,6 +125,7 @@ const GroupCreation = ({ paginationOptions }) => {
               {hasSetAccess && (
                 <ConfidenceField
                   name="group_confidence_level"
+                  label={t_i18n('Max Confidence Level')}
                   entityType="Group"
                   containerStyle={fieldSpacingContainerStyle}
                 />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -550,9 +550,7 @@ const User: FunctionComponent<UserProps> = ({ data }) => {
                   {t_i18n('Max Confidence Level')}
                 </Typography>
                 <div className="clearfix"/>
-                <UserConfidenceLevel
-                  confidenceLevel={user.effective_confidence_level}
-                />
+                <UserConfidenceLevel user={user} />
               </Grid>
             </Grid>
           </Paper>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
@@ -6,6 +6,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import Box from '@mui/material/Box';
 import { useFormatter } from '../../../../components/i18n';
+import useGranted, { BYPASS } from '../../../../utils/hooks/useGranted';
 
 type Data_UserConfidenceLevel = User_user$data['user_confidence_level'];
 type Data_EffectiveConfidenceLevel = User_user$data['effective_confidence_level'];
@@ -16,6 +17,8 @@ type UserConfidenceLevelProps = {
 
 const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLevel }) => {
   const { t_i18n } = useFormatter();
+
+  const isGrantedBypass = useGranted([BYPASS]);
 
   if (!confidenceLevel) {
     return (
@@ -31,6 +34,8 @@ const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLev
 
   const renderSource = () => {
     const source = (confidenceLevel as Data_EffectiveConfidenceLevel)?.source;
+
+    console.log(isGrantedBypass);
 
     // FIXME: if watching the current user's detailed view, the source is {}, hence the check if (source.entity_type && ...) below
     // see warning: The GraphQL server likely violated the globally unique id requirement by returning the same id for different objects.
@@ -59,7 +64,10 @@ const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLev
       return (
         <Tooltip
           sx={{ marginLeft: 1 }}
-          title={t_i18n('The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user\'s groups.')}
+          title={isGrantedBypass
+            ? t_i18n('The user has BYPASS capability, their max confidence level is set to 100.')
+            : t_i18n('The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user\'s groups.')
+          }
         >
           <InformationOutline fontSize={'small'} color={'info'} />
         </Tooltip>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
@@ -6,21 +6,15 @@ import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import Box from '@mui/material/Box';
 import { useFormatter } from '../../../../components/i18n';
-import useGranted, { BYPASS } from '../../../../utils/hooks/useGranted';
-
-type Data_UserConfidenceLevel = User_user$data['user_confidence_level'];
-type Data_EffectiveConfidenceLevel = User_user$data['effective_confidence_level'];
 
 type UserConfidenceLevelProps = {
-  confidenceLevel?: Data_UserConfidenceLevel | Data_EffectiveConfidenceLevel
+  user: Pick<User_user$data, 'user_confidence_level' | 'effective_confidence_level'>
 };
 
-const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLevel }) => {
+const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ user }) => {
   const { t_i18n } = useFormatter();
 
-  const isGrantedBypass = useGranted([BYPASS]);
-
-  if (!confidenceLevel) {
+  if (!user.effective_confidence_level) {
     return (
       <Tooltip
         title={t_i18n("No confidence level found in this user's groups, and no confidence level defined at the user level.")}
@@ -33,9 +27,7 @@ const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLev
   // TODO: add overrides in a tooltip when in use
 
   const renderSource = () => {
-    const source = (confidenceLevel as Data_EffectiveConfidenceLevel)?.source;
-
-    console.log(isGrantedBypass);
+    const source = user.effective_confidence_level?.source;
 
     // FIXME: if watching the current user's detailed view, the source is {}, hence the check if (source.entity_type && ...) below
     // see warning: The GraphQL server likely violated the globally unique id requirement by returning the same id for different objects.
@@ -60,14 +52,18 @@ const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLev
           </Tooltip>
         );
       }
-      // the user himself
+
+      // source is the user himself, most probably by setting at the user level
+      let title = t_i18n('The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user\'s groups.');
+      // ... or if user has BYPASS, it's fixed to 100; check below is a cheap proxy (as we do not have user's capabilities in UserEditionOverview
+      if (!user.user_confidence_level || user.user_confidence_level.max_confidence < 100) {
+        title = t_i18n('The user has BYPASS capability, their max confidence level is set to 100.');
+      }
+
       return (
         <Tooltip
           sx={{ marginLeft: 1 }}
-          title={isGrantedBypass
-            ? t_i18n('The user has BYPASS capability, their max confidence level is set to 100.')
-            : t_i18n('The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user\'s groups.')
-          }
+          title={title}
         >
           <InformationOutline fontSize={'small'} color={'info'} />
         </Tooltip>
@@ -80,7 +76,7 @@ const UserConfidenceLevel: React.FC<UserConfidenceLevelProps> = ({ confidenceLev
 
   return (
     <Box component={'span'} sx={{ display: 'inline-flex', alignItems: 'center' }}>
-      <span>{`${confidenceLevel.max_confidence ?? '-'}`}</span>
+      <span>{`${user.effective_confidence_level.max_confidence ?? '-'}`}</span>
       {renderSource()}
     </Box>
   );

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
@@ -39,7 +39,7 @@ interface UserConfidenceLevelFieldProps {
   | null;
   containerStyle?: Record<string, string | number>;
   disabled?: boolean;
-  currentUser?: UserEditionOverview_user$data; // only for edition
+  user?: UserEditionOverview_user$data; // only for edition
 }
 
 const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps> = ({
@@ -50,7 +50,7 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
   editContext,
   containerStyle,
   disabled,
-  currentUser,
+  user,
 }) => {
   const { t_i18n } = useFormatter();
   const finalLabel = label || t_i18n('Confidence level');
@@ -76,21 +76,21 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
       variant="outlined"
       sx={{ position: 'relative' }}
     >
-      { currentUser && !!currentUser.effective_confidence_level && (
+      { user && !!user.effective_confidence_level && (
         <Box>
           {t_i18n('Effective Max Confidence Level:')}
           &nbsp;
-          <UserConfidenceLevel confidenceLevel={currentUser.effective_confidence_level} />
+          <UserConfidenceLevel user={user} />
         </Box>
       )}
-      { currentUser && currentUser.effective_confidence_level === null && (currentUser.groups?.edges ?? []).length > 0 && (
+      { user && user.effective_confidence_level === null && (user.groups?.edges ?? []).length > 0 && (
         <Box
           sx={{ color: 'error.main' }}
         >
           {t_i18n('This user does not inherit a Max Confidence Level from their group. Configure user\'s groups with a Max Confidence Level.')}
         </Box>
       )}
-      { currentUser && currentUser.effective_confidence_level === null && (currentUser.groups?.edges ?? []).length === 0 && (
+      { user && user.effective_confidence_level === null && (user.groups?.edges ?? []).length === 0 && (
         <Box
           sx={{ color: 'error.main' }}
         >

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEditionOverview.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { createFragmentContainer, graphql, useMutation } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
@@ -379,7 +379,7 @@ UserEditionOverviewComponentProps
               onSubmit={handleSubmitField}
               containerStyle={fieldSpacingContainerStyle}
               editContext={context}
-              currentUser={user}
+              user={user}
             />
           )}
         </Form>

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -6,7 +6,7 @@ import { logApp } from '../config/conf';
 import { schemaAttributesDefinition } from '../schema/schema-attributes';
 import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../generated/graphql';
 import { isFilterGroupNotEmpty } from './filtering/filtering-utils';
-import { BYPASS, isUserHasCapability } from './access';
+import { isBypassUser } from './access';
 
 type ObjectWithConfidence = {
   id: string,
@@ -16,7 +16,7 @@ type ObjectWithConfidence = {
 
 export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
   // if a user has BYPASS capability, we consider a level 100
-  if (isUserHasCapability(user, BYPASS)) {
+  if (isBypassUser(user)) {
     return {
       max_confidence: 100,
       overrides: [],

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -28,23 +28,23 @@ export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
     };
   }
 
-  // otherwise we get all groups for this user, and select the lowest max_confidence found
-  let minLevel = null;
+  // otherwise we get all groups for this user, and select the highest max_confidence found
+  let maxLevel = null;
   let source = null;
   if (user.groups) {
     for (let i = 0; i < user.groups.length; i += 1) {
       // groups were not migrated when introducing group_confidence_level, so group_confidence_level might be null
       const groupLevel = user.groups[i].group_confidence_level?.max_confidence ?? null;
-      if (groupLevel !== null && (minLevel === null || groupLevel < minLevel)) {
-        minLevel = groupLevel;
+      if (groupLevel !== null && (maxLevel === null || groupLevel > maxLevel)) {
+        maxLevel = groupLevel;
         source = user.groups[i];
       }
     }
   }
 
-  if (minLevel !== null) {
+  if (maxLevel !== null) {
     return {
-      max_confidence: cropNumber(minLevel, 0, 100),
+      max_confidence: cropNumber(maxLevel, 0, 100),
       // TODO: handle overrides and their sources
       overrides: [],
       source,

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -6,6 +6,7 @@ import { logApp } from '../config/conf';
 import { schemaAttributesDefinition } from '../schema/schema-attributes';
 import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../generated/graphql';
 import { isFilterGroupNotEmpty } from './filtering/filtering-utils';
+import { BYPASS, isUserHasCapability } from './access';
 
 type ObjectWithConfidence = {
   id: string,
@@ -14,6 +15,15 @@ type ObjectWithConfidence = {
 };
 
 export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
+  // if a user has BYPASS capability, we consider a level 100
+  if (isUserHasCapability(user, BYPASS)) {
+    return {
+      max_confidence: 100,
+      overrides: [],
+      source: user,
+    };
+  }
+
   // if user has a specific confidence level, it overrides everything and we return it
   if (user.user_confidence_level) {
     return {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../src/utils/confidence-level';
 import type { AuthUser } from '../../../src/types/user';
 import { type FilterGroup, FilterMode, FilterOperator } from '../../../src/generated/graphql';
+import { BYPASS } from '../../../src/utils/access';
 
 const makeUser = (confidence: number | null) => ({
   id: `user_${confidence}`,
@@ -40,6 +41,7 @@ describe('Confidence level utilities', () => {
         overrides: [],
       },
       groups: [group70, group80],
+      capabilities: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userA as unknown as AuthUser)).toEqual({
       max_confidence: 30,
@@ -51,6 +53,7 @@ describe('Confidence level utilities', () => {
       id: 'userB',
       user_confidence_level: null,
       groups: [group70, group80],
+      capabilities: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userB as unknown as AuthUser)).toEqual({
       max_confidence: 80,
@@ -61,6 +64,7 @@ describe('Confidence level utilities', () => {
     const userC = {
       user_confidence_level: null,
       groups: [groupNull, group70, groupNull],
+      capabilities: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userC as unknown as AuthUser)).toEqual({
       max_confidence: 70,
@@ -71,14 +75,41 @@ describe('Confidence level utilities', () => {
     const userD = {
       user_confidence_level: null,
       groups: [groupNull, groupNull],
+      capabilities: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userD as unknown as AuthUser)).toBeNull();
 
     const userE = {
       user_confidence_level: null,
       groups: [],
+      capabilities: [],
     };
     expect(computeUserEffectiveConfidenceLevel(userE as unknown as AuthUser)).toBeNull();
+
+    const userF = {
+      user_confidence_level: {
+        max_confidence: 30,
+        overrides: [],
+      },
+      groups: [group70],
+      capabilities: [{ name: BYPASS }],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userF as unknown as AuthUser)).toEqual({
+      max_confidence: 100,
+      overrides: [],
+      source: userF,
+    });
+
+    const userG = {
+      user_confidence_level: null,
+      groups: [group70, group80],
+      capabilities: [{ name: BYPASS }],
+    };
+    expect(computeUserEffectiveConfidenceLevel(userG as unknown as AuthUser)).toEqual({
+      max_confidence: 100,
+      overrides: [],
+      source: userG,
+    });
   });
 
   describe('Control confidence', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -53,9 +53,9 @@ describe('Confidence level utilities', () => {
       groups: [group70, group80],
     };
     expect(computeUserEffectiveConfidenceLevel(userB as unknown as AuthUser)).toEqual({
-      max_confidence: 70,
+      max_confidence: 80,
       overrides: [],
-      source: group70,
+      source: group80,
     });
 
     const userC = {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
@@ -421,10 +421,10 @@ describe('User resolver standard behavior', () => {
       },
     });
     expect(queryResult.data.userEdit.fieldPatch.user_confidence_level).toBeNull;
-    // now effective level is the highest values among the 2 groups
+    // now effective level is the highest values among the 2 groups (default: 100)
     expect(queryResult.data.userEdit.fieldPatch.effective_confidence_level.max_confidence).toEqual(100);
-    expect(queryResult.data.userEdit.fieldPatch.effective_confidence_level.source.id).toEqual(groupInternalId);
   });
+
   it('should add role in group', async () => {
     const ROLE_ADD_QUERY = gql`
       mutation RoleAdd($input: RoleAddInput!) {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
@@ -421,8 +421,8 @@ describe('User resolver standard behavior', () => {
       },
     });
     expect(queryResult.data.userEdit.fieldPatch.user_confidence_level).toBeNull;
-    // now effective level is the group's value
-    expect(queryResult.data.userEdit.fieldPatch.effective_confidence_level.max_confidence).toEqual(60);
+    // now effective level is the highest values among the 2 groups
+    expect(queryResult.data.userEdit.fieldPatch.effective_confidence_level.max_confidence).toEqual(100);
     expect(queryResult.data.userEdit.fieldPatch.effective_confidence_level.source.id).toEqual(groupInternalId);
   });
   it('should add role in group', async () => {


### PR DESCRIPTION
This specific point of the specifications have been rediscussed, as we want to favor consistency in the platform.

To align on how we handle markings or capabilities, we will take the highest max confidence level among the user's group(s) as the user's effective max confidence level.

Note that if a user has a specific level defined, it will overwrite this level from their groups ; this mechanism does not change.

Finally, if the user has `BYPASS` capability, we consider they have a max confidence level to 100, allowing for all modification/creation in the platform.