### PR TITLE
[frontend] fix bad behaviour onBlur Markdown fields (#5943)

### DIFF
--- a/opencti-platform/opencti-front/src/components/MarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/MarkdownField.jsx
@@ -35,15 +35,8 @@ const MarkdownField = (props) => {
     }
   };
   const internalOnBlur = (event) => {
-    const { nodeName } = event.relatedTarget || {};
-    const isOtherMarkdownFieldOnFocus = !!event.relatedTarget?.name;
-    const isHandleMarkdownButton = event.target.nodeName !== 'BUTTON';
-    if (
-      nodeName === 'INPUT'
-      || nodeName === 'DIV'
-      || nodeName === undefined
-      || (nodeName === 'TEXTAREA' && (isOtherMarkdownFieldOnFocus || isHandleMarkdownButton))
-    ) {
+    const isClickOutsideCurrentField = !event.currentTarget.contains(event.relatedTarget);
+    if (isClickOutsideCurrentField) {
       setFieldTouched(name, true);
       if (typeof onSubmit === 'function') {
         onSubmit(name, field.value || '');

--- a/opencti-platform/opencti-front/src/components/MarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/MarkdownField.jsx
@@ -36,11 +36,13 @@ const MarkdownField = (props) => {
   };
   const internalOnBlur = (event) => {
     const { nodeName } = event.relatedTarget || {};
+    const isOtherMarkdownFieldOnFocus = !!event.relatedTarget?.name;
+    const isHandleMarkdownButton = event.target.nodeName !== 'BUTTON';
     if (
       nodeName === 'INPUT'
       || nodeName === 'DIV'
-      || nodeName === 'BUTTON'
       || nodeName === undefined
+      || (nodeName === 'TEXTAREA' && (isOtherMarkdownFieldOnFocus || isHandleMarkdownButton))
     ) {
       setFieldTouched(name, true);
       if (typeof onSubmit === 'function') {


### PR DESCRIPTION
### Proposed changes

- Fix bad behaviour for saving Markdown fields
- Text is not saved when a Markdown formatting button is clicked (Heading, Bold...).
- Text is saved when the field is defocused, with Makdown formatting.
- Saving even when the field is defocused by focusing another Markdown or TextArea field

### Related issues

- #5943 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

- A good example form is on page : Techniques / Courses of Actions / select one / update

### For testing

- Update description text (write "test" for example)
- click on title button => Expected : Markdown form field content is updating ("### test"), but not description on overview / details / description
- click outside Markdown field => Expected : saving description, and display on overview / details / description
- try the same, when clicking outside, try focusing other form input, other markdown field (Threat hunting techniques), other textarea field (Log sources), etc => Expected : saving description, and display on overview / details / description