### PR TITLE
[backend] CSV Mapper - fix how to retrieve entity settings (#6034)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
@@ -61,6 +61,7 @@ export const INTERNAL_ATTRIBUTES = [
   'authorized_authorities',
   'precision',
   'pattern_version',
+  'connections',
   // X - Mitre
   'x_mitre_permissions_required',
   'x_mitre_detection',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change how we retrieve the entity settings to be able to fetch parent type when necessary (for stix core relationships)

### Related issues

* #6034 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Use the function `getEntitySettingFromCache` instead of directly calling the cache with `getEntitiesListFromCache` because the first one manage the fact to fetch entity settings from parent type which is not the case with the second one. So need to readapt the code to work with this function.
