### PR TITLE
[backend/frontend] Fix malware analyses pagination error on submission date if null (#6054)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
@@ -88,8 +88,7 @@ MalwareAnalysisFormProps
   const basicShape = {
     result_name: Yup.string().required(t_i18n('This field is required')),
     product: Yup.string().required(t_i18n('This field is required')),
-    submitted: Yup.date()
-      .required(t_i18n('This field is required'))
+    submitted: Yup.date().nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     confidence: Yup.number(),
   };

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
@@ -127,7 +127,7 @@ const MalwareAnalysisEditionOverview: FunctionComponent<MalwareAnalysisEditionOv
   const basicShape = {
     result_name: Yup.string().required(t_i18n('This field is required')),
     product: Yup.string().required(t_i18n('This field is required')),
-    submitted: Yup.date().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    submitted: Yup.date().nullable().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     confidence: Yup.number(),
     result: Yup.string().nullable(),
     version: Yup.string().nullable(),

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -2369,6 +2369,10 @@ const elQueryBodyBuilder = async (context, user, options) => {
       const orderKeyword = isDateOrNumber || orderCriteria.startsWith('_') ? orderCriteria : `${orderCriteria}.keyword`;
       if (orderKeyword === '_score') {
         ordering = R.append({ [orderKeyword]: scoreSearchOrder }, ordering);
+      } else if (isDateAttribute(orderCriteria)) {
+        // sorting on null dates results to an error, one way to fix it is to use missing: 0
+        // see https://github.com/elastic/elasticsearch/issues/81960
+        ordering = R.append({ [orderKeyword]: { order: orderMode, missing: 0 } }, ordering);
       } else {
         const order = { [orderKeyword]: { order: orderMode, missing: '_last' } };
         ordering = R.append(order, ordering);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -416,6 +416,26 @@ describe('Elasticsearch pagination', () => {
     expect(data).not.toBeNull();
     expect(data.edges.length).toEqual(1);
   });
+  it('should entity paginate domain objects sort by published', async () => {
+    const data = await elPaginate(testContext, ADMIN_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
+      orderBy: 'published',
+      first: 20,
+      orderMode: 'desc',
+    });
+    expect(data).not.toBeNull();
+    expect(data.edges.length).toEqual(20);
+    expect(data.pageInfo.endCursor).toBeDefined();
+
+    const { endCursor } = data.pageInfo;
+    const nextPage = await elPaginate(testContext, ADMIN_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
+      orderBy: 'published',
+      first: 20,
+      orderMode: 'desc',
+      after: endCursor,
+    });
+    expect(nextPage).not.toBeNull();
+    expect(nextPage.edges.length).toBeGreaterThan(1);
+  });
   it('should entity paginate with single type', async () => {
     // first = 200, after, types = null, filters = null, search = null,
     // orderBy = null, orderMode = 'asc',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use missing: 0 for dates fixes the issue with sorting
* set submitted to nullable in malware creation and edition
* add test

### Related issues

* #6054

To reproduce the issue locally, you need to create more than 25 malware analyses with at least one without a submitted date. You can also export malware analyses from testing platform and import them on your local platform.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
