### PR TITLE
[backend/frontend] entity_type filter available for abstract types

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -670,7 +670,7 @@ const useSearchEntities = ({
         case 'fromTypes':
         case 'toTypes':
         case 'type':
-          if (
+          if ( // case not abstract types
             availableEntityTypes
             && !availableEntityTypes.includes('Stix-Cyber-Observable')
             && !availableEntityTypes.includes('Stix-Domain-Object')
@@ -694,8 +694,9 @@ const useSearchEntities = ({
               }))
               .sort((a, b) => a.label.localeCompare(b.label));
             unionSetEntities(filterKey, entitiesTypes);
-          } else {
+          } else { // case abstract types
             let result = [] as EntityWithLabelValue[];
+            // push the observables
             if (
               !availableEntityTypes
               || availableEntityTypes.includes('Stix-Core-Object')
@@ -715,6 +716,7 @@ const useSearchEntities = ({
                 },
               ];
             }
+            // push the stix domain objects
             if (
               !availableEntityTypes
               || availableEntityTypes.includes('Stix-Core-Object')
@@ -734,6 +736,7 @@ const useSearchEntities = ({
                 ...result,
               ];
             }
+            // push the relationship types
             if (
               !availableEntityTypes
               || availableEntityTypes.includes('stix-core-relationship')

--- a/opencti-platform/opencti-front/tests_e2e/filters/addFilter.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/filters/addFilter.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "../fixtures/baseFixtures";
+import { FiltersUtils } from '../model/filters.pageModel';
+
+test('Add a new filter in the observables list and check the filter is still present when we come back to the page', async ({ page }) => {
+  await page.goto('/dashboard/observations/observables');
+  const filterUtils = new FiltersUtils(page);
+  await filterUtils.addFilter('Entity type', 'Artifact');
+  await expect(page.getByRole('button', { name: 'Entity type = Artifact' })).toBeVisible();
+  await page.goto('/dashboard/');
+  await page.goto('/dashboard/observations/observables');
+  await expect(page.getByRole('button', { name: 'Entity type = Artifact' })).toBeVisible();
+});

--- a/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+
+export class FiltersUtils {
+  constructor(private page: Page) {
+  }
+  async addFilter(filterKey: string, filterLabel: string) {
+    await this.page.getByLabel('Add filter').click();
+    await this.page.getByRole('option', { name: filterKey }).click();
+    await this.page.getByLabel(filterKey).click();
+    await this.page.getByLabel(filterLabel).getByRole('checkbox').check();
+    await this.page.locator('.MuiPopover-root > .MuiBackdrop-root').click();
+  }
+  
+}

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/filterKeysSchema-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/filterKeysSchema-test.ts
@@ -16,7 +16,7 @@ import { ENTITY_TYPE_NOTIFICATION, ENTITY_TYPE_TRIGGER } from '../../../src/modu
 import { ENTITY_HASHED_OBSERVABLE_ARTIFACT, ENTITY_HASHED_OBSERVABLE_STIX_FILE, ENTITY_HASHED_OBSERVABLE_X509_CERTIFICATE } from '../../../src/schema/stixCyberObservable';
 import { ENTITY_TYPE_CONTAINER_CASE } from '../../../src/modules/case/case-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../../../src/modules/grouping/grouping-types';
-import { ALIAS_FILTER, CONNECTED_TO_INSTANCE_FILTER, CONTEXT_OBJECT_LABEL_FILTER, INSTANCE_REGARDING_OF } from '../../../src/utils/filtering/filtering-constants';
+import { ALIAS_FILTER, CONNECTED_TO_INSTANCE_FILTER, CONTEXT_OBJECT_LABEL_FILTER, INSTANCE_REGARDING_OF, TYPE_FILTER } from '../../../src/utils/filtering/filtering-constants';
 import { ENTITY_TYPE_HISTORY } from '../../../src/schema/internalObject';
 
 describe('Filter keys schema generation testing', async () => {
@@ -156,6 +156,13 @@ describe('Filter keys schema generation testing', async () => {
     expect(filterDefinition?.multiple).toEqual(true);
     expect(filterDefinition?.elementsForFilterValuesSearch.length).toEqual(1);
     expect(filterDefinition?.elementsForFilterValuesSearch[0]).toEqual(ABSTRACT_STIX_CORE_OBJECT);
+    // 'entity_type' filter for abstract types only
+    filterDefinition = filterKeysSchema.get(ABSTRACT_STIX_CORE_OBJECT)?.get(TYPE_FILTER);
+    expect(filterDefinition?.type).toEqual('string');
+    filterDefinition = filterKeysSchema.get(ABSTRACT_STIX_CYBER_OBSERVABLE)?.get(TYPE_FILTER);
+    expect(filterDefinition?.type).toEqual('string');
+    filterDefinition = filterKeysSchema.get(ENTITY_TYPE_MALWARE)?.get(TYPE_FILTER);
+    expect(filterDefinition).toBeUndefined();
   });
   it('should construct correct filter definition for abstract entity types', () => {
     // Containers


### PR DESCRIPTION
Issue (on testing only) : entity_type filter not available in Data>Entities, Observations>Observables, Global Search