### PR TITLE
[backend] Based on relationship should inherit markings & restrictions when created from Indicators or observables (#6068)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -31,7 +31,7 @@ import {
   isStixCyberObservableHashedObservable,
   stixCyberObservableOptions
 } from '../schema/stixCyberObservable';
-import { ABSTRACT_STIX_CYBER_OBSERVABLE, buildRefRelationKey, INPUT_CREATED_BY, INPUT_LABELS, INPUT_MARKINGS } from '../schema/general';
+import { ABSTRACT_STIX_CYBER_OBSERVABLE, buildRefRelationKey, INPUT_CREATED_BY, INPUT_GRANTED_REFS, INPUT_LABELS, INPUT_MARKINGS } from '../schema/general';
 import { RELATION_CONTENT, RELATION_SERVICE_DLL } from '../schema/stixRefRelationship';
 import { RELATION_BASED_ON, RELATION_HAS } from '../schema/stixCoreRelationship';
 import { ENTITY_TYPE_VULNERABILITY } from '../schema/stixDomainObject';
@@ -137,6 +137,7 @@ const createIndicatorFromObservable = async (context, user, input, observable) =
         x_opencti_score: observable.x_opencti_score,
         createdBy: input.createdBy,
         objectMarking: input.objectMarking,
+        objectOrganization: input.objectOrganization,
         objectLabel: input.objectLabel,
         externalReferences: input.externalReferences,
         update: true,
@@ -154,8 +155,9 @@ export const promoteObservableToIndicator = async (context, user, observableId) 
   const observable = await storeLoadByIdWithRefs(context, user, observableId);
   const objectLabel = (observable[INPUT_LABELS] ?? []).map((n) => n.internal_id);
   const objectMarking = (observable[INPUT_MARKINGS] ?? []).map((n) => n.internal_id);
+  const objectOrganization = (observable[INPUT_GRANTED_REFS] ?? []).map((n) => n.internal_id);
   const createdBy = observable[INPUT_CREATED_BY]?.internal_id;
-  await createIndicatorFromObservable(context, user, { objectLabel, objectMarking, createdBy }, observable);
+  await createIndicatorFromObservable(context, user, { objectLabel, objectMarking, objectOrganization, createdBy }, observable);
   return observable;
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -189,8 +189,8 @@ export const createObservablesFromIndicator = async (
         fromId: indicator.id,
         toId: observableToLink,
         relationship_type: RELATION_BASED_ON,
-        objectMarking: indicator.objectMarking,
-        objectOrganization: indicator.objectOrganization,
+        objectMarking: input.objectMarking,
+        objectOrganization: input.objectOrganization,
       };
       return createRelation(context, user, relationInput);
     })

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -14,6 +14,7 @@ import {
   buildRefRelationKey,
   INPUT_CREATED_BY,
   INPUT_EXTERNAL_REFS,
+  INPUT_GRANTED_REFS,
   INPUT_LABELS,
   INPUT_MARKINGS
 } from '../../schema/general';
@@ -154,7 +155,7 @@ export const findIndicatorsForDecay = (context: AuthContext, user: AuthUser, max
 export const createObservablesFromIndicator = async (
   context: AuthContext,
   user: AuthUser,
-  input: { objectLabel?: string[] | null; objectMarking?: string[] | null; createdBy?: string | null; externalReferences?: string[] | null; },
+  input: { objectLabel?: string[] | null; objectMarking?: string[] | null; objectOrganization?: string[] | null; createdBy?: string | null; externalReferences?: string[] | null; },
   indicator: StoreEntityIndicator,
 ) => {
   const { pattern } = indicator;
@@ -170,6 +171,7 @@ export const createObservablesFromIndicator = async (
       x_opencti_score: indicator.x_opencti_score,
       createdBy: input.createdBy,
       objectMarking: input.objectMarking,
+      objectOrganization: input.objectOrganization,
       objectLabel: input.objectLabel,
       externalReferences: input.externalReferences,
       update: true,
@@ -183,7 +185,13 @@ export const createObservablesFromIndicator = async (
   }
   await Promise.all(
     observablesToLink.map((observableToLink) => {
-      const relationInput = { fromId: indicator.id, toId: observableToLink, relationship_type: RELATION_BASED_ON };
+      const relationInput = {
+        fromId: indicator.id,
+        toId: observableToLink,
+        relationship_type: RELATION_BASED_ON,
+        objectMarking: indicator.objectMarking,
+        objectOrganization: indicator.objectOrganization,
+      };
       return createRelation(context, user, relationInput);
     })
   );
@@ -193,9 +201,10 @@ export const promoteIndicatorToObservable = async (context: AuthContext, user: A
   const indicator: StoreEntityIndicator = await storeLoadByIdWithRefs(context, user, indicatorId) as StoreEntityIndicator;
   const objectLabel = (indicator[INPUT_LABELS] ?? []).map((n) => n.internal_id);
   const objectMarking = (indicator[INPUT_MARKINGS] ?? []).map((n) => n.internal_id);
+  const objectOrganization = (indicator[INPUT_GRANTED_REFS] ?? []).map((n) => n.internal_id);
   const externalReferences = (indicator[INPUT_EXTERNAL_REFS] ?? []).map((n) => n.internal_id);
   const createdBy = indicator[INPUT_CREATED_BY]?.internal_id;
-  const input = { objectLabel, objectMarking, createdBy, externalReferences };
+  const input = { objectLabel, objectMarking, objectOrganization, createdBy, externalReferences };
   return createObservablesFromIndicator(context, user, input, indicator);
 };
 
@@ -272,7 +281,13 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   const created = await createEntity(context, user, finalIndicatorToCreate, ENTITY_TYPE_INDICATOR);
   await Promise.all(
     observablesToLink.map((observableToLink) => {
-      const input = { fromId: created.id, toId: observableToLink, relationship_type: RELATION_BASED_ON };
+      const input = {
+        fromId: created.id,
+        toId: observableToLink,
+        relationship_type: RELATION_BASED_ON,
+        objectMarking: indicator.objectMarking,
+        objectOrganization: indicator.objectOrganization,
+      };
       return createRelation(context, user, input);
     })
   );


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* make sure we generate observables / indicators from indicators / observables with the same markings and organization sharing, either from API or in playbooks.

### Related issues

* #6068 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
