### PR TITLE
[backend] Fix observables query for network traffic with dst_port (#6070)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -231,7 +231,7 @@ export const runtimeFieldObservableValueScript = () => {
        } else {
          emit('Unknown')
        }
-     } else if (type == 'process') {
+    } else if (type == 'process') {
        if (have(doc, 'pid')) {
          emit(doc['pid.keyword'].value)
        } else if (have(doc, 'command_line')) {

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -155,144 +155,64 @@ export const observableValue = (stixCyberObservable) => {
 // Be careful to align this script with the previous function
 export const runtimeFieldObservableValueScript = () => {
   return `
-    boolean have(def doc, def key) {
-      doc.containsKey(key) && doc[key + '.keyword'].size()!=0
+    def getFieldValue(def doc, def key) {
+      if (!doc.containsKey(key)) {
+        return 'Unknown';
+      }
+      if (doc.containsKey(key + '.keyword')) {
+        if (doc[key + '.keyword'].size()!=0) {
+          return doc[key + '.keyword'].value;
+        }
+      } else if (doc[key].size()!=0) {
+        return String.valueOf(doc[key].value);
+      }
+      return 'Unknown';
+    }
+    def getFieldsValue(def doc, def fields) {
+      def value = 'Unknown';
+      for (def field : fields) {
+        value = getFieldValue(doc, field);
+        if (value != 'Unknown') {
+          return value;
+        }
+      }
+      return value;
     }
     def type = doc['entity_type.keyword'].value;
     if (type == 'autonomous-system') {
-      if (have(doc, 'name')) {
-        emit(doc['name.keyword'].value)
-      } else if (have(doc, 'number.keyword')) {
-        emit(doc['number.keyword'].value)
-      } else {
-        emit('Unknown')
-      }
+      emit(getFieldsValue(doc, ['name', 'number']))
     } else if (type == 'directory') {
-      if (have(doc, 'path')) {
-        emit(doc['path.keyword'].value)
-      } else {
-        emit('Unknown')
-      }
+      emit(getFieldValue(doc, 'path'))
     } else if (type == 'email-message') {
-      if (have(doc, 'body')) {
-        emit(doc['body.keyword'].value)
-      } else if (have(doc, 'subject')) {
-        emit(doc['subject.keyword'].value)
-      } else {
-        emit('Unknown')
-      }
+      emit(getFieldsValue(doc, ['body', 'subject']))
     } else if (type == 'artifact') {
-       if (have(doc, 'hashes.SHA-512')) {
-         emit(doc['hashes.SHA-512.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-256')) {
-         emit(doc['hashes.SHA-256.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-1')) {
-         emit(doc['hashes.SHA-1.keyword'].value)
-       } else if (have(doc, 'hashes.MD5')) {
-         emit(doc['hashes.MD5.keyword'].value)
-       } else if (have(doc, 'payload_bin')) {
-         emit(doc['payload_bin.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['hashes.SHA-256','hashes.SHA-512', 'hashes.SHA-1', 'hashes.MD5', 'payload_bin']))
     } else if (type == 'stixfile') {
-       if (have(doc, 'hashes.SHA-256')) {
-         emit(doc['hashes.SHA-256.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-512')) {
-         emit(doc['hashes.SHA-512.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-1')) {
-         emit(doc['hashes.SHA-1.keyword'].value)
-       } else if (have(doc, 'hashes.MD5')) {
-         emit(doc['hashes.MD5.keyword'].value)
-       } else if (have(doc, 'name')) {
-        emit(doc['name.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['hashes.SHA-256','hashes.SHA-512', 'hashes.SHA-1', 'hashes.MD5', 'name']))
     } else if (type == 'x509-certificate') {
-       if (have(doc, 'hashes.SHA-256')) {
-         emit(doc['hashes.SHA-256.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-512')) {
-         emit(doc['hashes.SHA-512.keyword'].value)
-       } else if (have(doc, 'hashes.SHA-1')) {
-         emit(doc['hashes.SHA-1.keyword'].value)
-       } else if (have(doc, 'hashes.MD5')) {
-         emit(doc['hashes.MD5.keyword'].value)
-       } else if (have(doc, 'subject')) {
-         emit(doc['subject.keyword'].value)
-       } else if (have(doc, 'issuer')) {
-         emit(doc['issuer.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['hashes.SHA-256','hashes.SHA-512', 'hashes.SHA-1', 'hashes.MD5', 'subject', 'issuer']))
     } else if (type == 'mutex') {
-       if (have(doc, 'name')) {
-         emit(doc['name.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldValue(doc, 'name'))
+    } else if (type == 'network-traffic') {
+      emit(getFieldValue(doc, 'dst_port'))
     } else if (type == 'process') {
-       if (have(doc, 'pid')) {
-         emit(doc['pid.keyword'].value)
-       } else if (have(doc, 'command_line')) {
-         emit(doc['command_line.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['pid', 'command_line']))
     } else if (type == 'software') {
-       if (have(doc, 'name')) {
-         emit(doc['name.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldValue(doc, 'name'))
     } else if (type == 'user-account') {
-       if (have(doc, 'account_login')) {
-         emit(doc['account_login.keyword'].value)
-       } else if (have(doc, 'user_id')) {
-         emit(doc['user_id.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['account_login', 'user_id']))
     } else if (type == 'bank-account') {
-       if (have(doc, 'iban')) {
-         emit(doc['iban.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldValue(doc, 'iban'))
     } else if (type == 'payment-card') {
-       if (have(doc, 'card_number')) {
-         emit(doc['card_number.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldValue(doc, 'card_number'))
     } else if (type == 'media-content') {
-       if (have(doc, 'content')) {
-         emit(doc['content.keyword'].value)
-       } else if (have(doc, 'title')) {
-         emit(doc['title.keyword'].value)
-       } else if (have(doc, 'url')) {
-         emit(doc['url.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldsValue(doc, ['content', 'title', 'url']))
     } else if (type == 'windows-registry-key') {
-       if (have(doc, 'attribute_key')) {
-         emit(doc['attribute_key.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
+      emit(getFieldValue(doc, 'attribute_key'))
     } else if (type == 'windows-registry-value-type') {
-       if (have(doc, 'name')) {
-         emit(doc['name.keyword'].value)
-       } else if (have(doc, 'data')) {
-         emit(doc['data.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
-    } else if (have(doc, 'value')) {
-       emit(doc['value.keyword'].value)
+      emit(getFieldsValue(doc, ['name', 'data']))
     } else {
-      emit('Unknown')
+      emit(getFieldValue(doc, 'value'))
     }
   `;
 };

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -231,13 +231,7 @@ export const runtimeFieldObservableValueScript = () => {
        } else {
          emit('Unknown')
        }
-     } else if (type == 'network-traffic') {
-       if (have(doc, 'dst_port')) {
-         emit(doc['dst_port.keyword'].value)
-       } else {
-         emit('Unknown')
-       }
-    } else if (type == 'process') {
+     } else if (type == 'process') {
        if (have(doc, 'pid')) {
          emit(doc['pid.keyword'].value)
        } else if (have(doc, 'command_line')) {

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -29,7 +29,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(335); // 328 created at init + 2 created in tests + 5 vocabulary organizations types
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(712);
+      expect(createEvents.length).toBe(713);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -78,7 +78,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(91);
+      expect(deleteEvents.length).toBe(92);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 944;
+export const RAW_EVENTS_SIZE = 946;
 export const SYNC_LIVE_EVENTS_SIZE = 594;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* dst_port is an integer, we should not try to query it with ".keyword", it's also the case of other fields like "number", so we have to rewrite completely the script to handle all types of fields.
* Add an integration test create a network traffic with dst_port and to list observables ordered by "observable_value"

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/6070

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
