### PR TITLE
[frontend] fix limit results to display correlation view (#5996)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -1250,7 +1250,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects {
+        objects(first: 500) {
           edges {
             node {
               ... on BasicObject {
@@ -1396,7 +1396,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
                         id
                         definition_type
                         definition


### PR DESCRIPTION
### Proposed changes

- Increase the limit to 500 (default: 20) for results sent by the backend, to display a graph consistent with overview / correlated reports

### Related issues

- #5996 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This will retrieve all the observables linked to the report, up to a limit of 500.
To get around the 500 limit, in the case of a report with more relationships, you would have to completely rethink the method for retrieving this data.

### Test procedure

- Use demo data (yarn insert:dev)
- Create new report
- In Knowledge, add 'send.have8000.com' indicator
- Click on 'correlation view' => The graph display a relation between your NewReport and 'Poison Ivy' report
- Go to 'Poison Ivy' report / overview / Correlated report => Expected : display line with your NewReport
- Go to Knowledge / Correlation view
- => [branch master] Nothing ! Expected : minimum the same relation
- => [branch issue/5996] a beautiful graph with all relations