### PR TITLE
[frontend] fix empty source entity filters list in relationship widget

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetFilters.tsx
@@ -107,6 +107,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
             filters={filtersDynamicFrom}
             helpers={helpersDynamicFrom}
             chipColor={'warning'}
+            entityTypes={['Stix-Core-Object']}
           />
         </>
       )}
@@ -121,6 +122,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
             filters={filtersDynamicTo}
             helpers={helpersDynamicTo}
             chipColor={'success'}
+            entityTypes={['Stix-Core-Object']}
           />
         </>
       )}
@@ -133,6 +135,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
           <FilterIconButton
             filters={filters}
             helpers={helpers}
+            entityTypes={searchContext.entityTypes}
           />
         </>
       ) }


### PR DESCRIPTION
Steps to reproduce the bug: 

Create a widget of type 'relationship'
Select the 'source entity' filter.
The list of available values is empty.