### PR TITLE
[backend] inferred data always have the Rule Manager's confidence (#6093)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2044,9 +2044,6 @@ const createRuleDataPatch = (instance) => {
   if (isBasicRelationship(instance.entity_type)) {
     patch.i_inference_weight = weight;
   }
-  // patch confidence is the Rule Manager's confidence
-  patch.confidence = RULE_MANAGER_USER.effective_confidence_level.max_confidence;
-
   // list supported attributes [{name: string, operation: string}] by entity type
   const supportedAttributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes(instance.entity_type);
   for (let index = 0; index < supportedAttributes.length; index += 1) {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2044,6 +2044,9 @@ const createRuleDataPatch = (instance) => {
   if (isBasicRelationship(instance.entity_type)) {
     patch.i_inference_weight = weight;
   }
+  // patch confidence is the Rule Manager's confidence
+  patch.confidence = RULE_MANAGER_USER.effective_confidence_level.max_confidence;
+
   // list supported attributes [{name: string, operation: string}] by entity type
   const supportedAttributes = RULES_ATTRIBUTES_BEHAVIOR.supportedAttributes(instance.entity_type);
   for (let index = 0; index < supportedAttributes.length; index += 1) {

--- a/opencti-platform/opencti-graphql/src/rules/rules-utils.js
+++ b/opencti-platform/opencti-graphql/src/rules/rules-utils.js
@@ -16,7 +16,6 @@ export const RULES_ATTRIBUTES_BEHAVIOR = {
       return [
         { name: 'first_seen', operation: 'MIN' },
         { name: 'last_seen', operation: 'MAX' },
-        { name: 'confidence', operation: 'AVG' },
         { name: 'attribute_count', operation: 'SUM' },
         { name: 'objectMarking', operation: 'AGG' },
       ];
@@ -25,7 +24,6 @@ export const RULES_ATTRIBUTES_BEHAVIOR = {
       return [
         { name: 'start_time', operation: 'MIN' },
         { name: 'stop_time', operation: 'MAX' },
-        { name: 'confidence', operation: 'AVG' },
         { name: 'objectMarking', operation: 'AGG' },
       ];
     }
@@ -33,7 +31,6 @@ export const RULES_ATTRIBUTES_BEHAVIOR = {
       return [
         { name: 'first_seen', operation: 'MIN' },
         { name: 'last_seen', operation: 'MAX' },
-        { name: 'confidence', operation: 'AVG' },
         { name: 'objectMarking', operation: 'AGG' },
       ];
     }

--- a/opencti-platform/opencti-graphql/tests/05-rules/attribution-merge-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/attribution-merge-test.js
@@ -43,7 +43,7 @@ describe('Attribute use rule when merging', () => {
       const myThreatToParadise = await inferenceLookup(afterActivationRelations, MY_THREAT, PARADISE_RANSOMWARE, RELATION_USES);
       expect(myThreatToParadise).not.toBeNull();
       expect(myThreatToParadise[RULE].length).toBe(1);
-      expect(myThreatToParadise.confidence).toBe(20); // AVG 2 relations (30 + 10) = 20
+      expect(myThreatToParadise.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       // 02. Create a second threat actor
       const secondThreat = await addThreatActorGroup(testContext, SYSTEM_USER, { name: 'MY SECOND TREAT ACTOR', description: 'Threat' });
       // 02. Create require relation

--- a/opencti-platform/opencti-graphql/tests/05-rules/attribution-use-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/attribution-use-test.js
@@ -46,7 +46,7 @@ describe('Attribute use rule', () => {
       const myThreatToParadise = await inferenceLookup(afterActivationRelations, MY_THREAT, PARADISE_RANSOMWARE, RELATION_USES);
       expect(myThreatToParadise).not.toBeNull();
       expect(myThreatToParadise[RULE].length).toBe(1);
-      expect(myThreatToParadise.confidence).toBe(20); // AVG 2 relations (30 + 10) = 20
+      expect(myThreatToParadise.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(myThreatToParadise.start_time).toBe('2020-02-28T23:00:00.000Z');
       expect(myThreatToParadise.stop_time).toBe('2020-02-29T14:00:00.000Z');
       // Create new element to trigger a live event
@@ -68,7 +68,7 @@ describe('Attribute use rule', () => {
       const myThreatToSpelevo = await inferenceLookup(afterLiveRelations, MY_THREAT, SPELEVO, RELATION_USES);
       expect(myThreatToSpelevo).not.toBeNull();
       expect(myThreatToSpelevo[RULE].length).toBe(1);
-      expect(myThreatToSpelevo.confidence).toBe(50); // AVG 2 relations (90 + 10) = 50
+      expect(myThreatToSpelevo.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(myThreatToSpelevo.start_time).toBe('2020-01-20T20:30:00.000Z');
       expect(myThreatToSpelevo.stop_time).toBe('2020-02-28T14:00:00.000Z');
       // Disable the rule

--- a/opencti-platform/opencti-graphql/tests/05-rules/located-at-located-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/located-at-located-test.js
@@ -51,7 +51,7 @@ describe('Located at located rule', () => {
       expect(hietzingToWesternEurope.stop_time).toBe('2020-02-29T23:00:00.000Z');
       const franceToEurope = await inferenceLookup(afterActivationRelations, FRANCE, EUROPE, RELATION_LOCATED_AT);
       expect(franceToEurope).not.toBeNull();
-      expect(franceToEurope.confidence).toBe(1000); // RULE_MANAGER_USER's confidence
+      expect(franceToEurope.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(franceToEurope.start_time).toBe(FROM_START_STR);
       expect(franceToEurope.stop_time).toBe(UNTIL_END_STR);
       const hietzingToEurope = await inferenceLookup(afterActivationRelations, HIETZING, EUROPE, RELATION_LOCATED_AT);

--- a/opencti-platform/opencti-graphql/tests/05-rules/located-at-located-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/located-at-located-test.js
@@ -46,12 +46,12 @@ describe('Located at located rule', () => {
       const afterActivationRelations = await getInferences(RELATION_LOCATED_AT);
       const hietzingToWesternEurope = await inferenceLookup(afterActivationRelations, HIETZING, WESTERN_EUROPE, RELATION_LOCATED_AT);
       expect(hietzingToWesternEurope).not.toBeNull();
-      expect(hietzingToWesternEurope.confidence).toBe(65); // AVG 2 relations (30 + 100)/2 = 65
+      expect(hietzingToWesternEurope.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(hietzingToWesternEurope.start_time).toBe('2020-02-29T23:00:00.000Z');
       expect(hietzingToWesternEurope.stop_time).toBe('2020-02-29T23:00:00.000Z');
       const franceToEurope = await inferenceLookup(afterActivationRelations, FRANCE, EUROPE, RELATION_LOCATED_AT);
       expect(franceToEurope).not.toBeNull();
-      expect(franceToEurope.confidence).toBe(100);
+      expect(franceToEurope.confidence).toBe(1000); // RULE_MANAGER_USER's confidence
       expect(franceToEurope.start_time).toBe(FROM_START_STR);
       expect(franceToEurope.stop_time).toBe(UNTIL_END_STR);
       const hietzingToEurope = await inferenceLookup(afterActivationRelations, HIETZING, EUROPE, RELATION_LOCATED_AT);
@@ -59,7 +59,7 @@ describe('Located at located rule', () => {
       // For confidence we have 2 explanations
       // HIETZING > located-in > WESTERN EUROPE [Confidence: 65] > located-in > EUROPE [Confidence: 100] = (65+100)/2 = 83
       // HIETZING > located-in > FRANCE [Confidence: 30] > located-in > EUROPE  [Confidence: 100] = (30+100)/2 = 65
-      expect(hietzingToEurope.confidence).toBe(74); // AVG 2 relations (83 + 65)/2 = 74
+      expect(hietzingToEurope.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(hietzingToEurope.start_time).toBe('2020-02-29T23:00:00.000Z');
       expect(hietzingToEurope.stop_time).toBe('2020-02-29T23:00:00.000Z');
       expect(hietzingToEurope[RULE].length).toBe(2);
@@ -88,7 +88,7 @@ describe('Located at located rule', () => {
       // Inferences must have been created by the markings combination
       const parisToWesternEurope = await inferenceLookup(afterLiveRelations, PARIS, WESTERN_EUROPE, RELATION_LOCATED_AT);
       expect(parisToWesternEurope).not.toBeNull();
-      expect(parisToWesternEurope.confidence).toBe(75); // AVG 2 relations (100 + 50)/2 = 75
+      expect(parisToWesternEurope.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(parisToWesternEurope.start_time).toBe('2020-01-20T20:30:00.000Z');
       expect(parisToWesternEurope.stop_time).toBe('2020-02-29T10:00:00.000Z');
       const parisToWesternEuropeMarkings = parisToWesternEurope[RELATION_OBJECT_MARKING];
@@ -97,7 +97,7 @@ describe('Located at located rule', () => {
       expect(parisToWesternEuropeMarkings.includes(TLP_TEST_INSTANCE.internal_id)).toBeTruthy();
       const parisToEurope = await inferenceLookup(afterLiveRelations, PARIS, EUROPE, RELATION_LOCATED_AT);
       expect(parisToEurope).not.toBeNull();
-      expect(parisToEurope.confidence).toBe(82); // AVG 2 relations (75 + ((75+100) / 2)) / 2 = 82
+      expect(parisToEurope.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(parisToEurope[RULE].length).toBe(2);
       const parisToEuropeMarkings = parisToEurope[RELATION_OBJECT_MARKING];
       expect(parisToEuropeMarkings.length).toBe(1); // TLP:TEST

--- a/opencti-platform/opencti-graphql/tests/05-rules/observe-sighting-test.js
+++ b/opencti-platform/opencti-graphql/tests/05-rules/observe-sighting-test.js
@@ -64,7 +64,7 @@ describe('Observed sighting rule', () => {
       expect(cbrickToAnssi.first_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToAnssi.last_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToAnssi.attribute_count).toBe(1);
-      expect(cbrickToAnssi.confidence).toBe(100); // RULE_MANAGER_USER has confidence 100
+      expect(cbrickToAnssi.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(cbrickToAnssi.i_inference_weight).toBe(1);
       expect((cbrickToAnssi.object_marking_refs || []).length).toBe(0);
       // Change the organization
@@ -89,7 +89,7 @@ describe('Observed sighting rule', () => {
       expect(cbrickToMitreRescan.first_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToMitreRescan.last_seen).toBe('2020-02-25T09:02:29.040Z');
       expect(cbrickToMitreRescan.attribute_count).toBe(1);
-      expect(cbrickToMitreRescan.confidence).toBe(100);
+      expect(cbrickToMitreRescan.confidence).toBe(100); // RULE_MANAGER_USER's confidence
       expect(cbrickToMitreRescan.i_inference_weight).toBe(1);
       expect((cbrickToMitreRescan.object_marking_refs || []).length).toBe(0);
       // Cleanup


### PR DESCRIPTION
### Proposed changes
* remove `confidence`  from the _rules attribute behavior_ so it does not get averaged
* a patch from a rule always end up with confidence equals to the `RULE_MANAGER_USER`'s max confidence level

### Related issues
 #6093

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
