### PR TITLE
[frontend] fix spacing issue

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -421,7 +421,7 @@ export const defaultValue = (n, fallback = 'Unknown') => {
             20,
           )}`)
       || fallback;
-  return n.x_mitre_id ? `[${n.x_mitre_id}]${mainValue}` : mainValue;
+  return n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue;
 };
 
 export const defaultSecondaryValue = (n) => {


### PR DESCRIPTION
Missing space between mitre id and entity name

Like here:
![image](https://github.com/OpenCTI-Platform/opencti/assets/146674147/5c87f807-d292-49b3-a172-2a758f2091b0)

or in dashboard graphs like relationship distributions.