### PR TITLE
[frontend] fix creator filter in user history redirection

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
@@ -12,6 +12,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import SearchInput from '../../../../components/SearchInput';
 import UserHistoryLines, { userHistoryLinesQuery } from './UserHistoryLines';
+import { generateUUID } from '../../../../../tests_e2e/fixtures/baseFixtures';
 
 const createdByUserRedirectButton = {
   float: 'left',
@@ -65,6 +66,7 @@ const UserHistory: FunctionComponent<UserHistoryProps> = ({
         ],
         operator: 'eq',
         mode: 'or',
+        id: generateUUID(), // because filters in the URL
       },
     ],
   });

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import { useQueryLoader } from 'react-relay';
@@ -12,7 +13,6 @@ import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import SearchInput from '../../../../components/SearchInput';
 import UserHistoryLines, { userHistoryLinesQuery } from './UserHistoryLines';
-import { generateUUID } from '../../../../../tests_e2e/fixtures/baseFixtures';
 
 const createdByUserRedirectButton = {
   float: 'left',
@@ -66,7 +66,7 @@ const UserHistory: FunctionComponent<UserHistoryProps> = ({
         ],
         operator: 'eq',
         mode: 'or',
-        id: generateUUID(), // because filters in the URL
+        id: uuid(), // because filters in the URL
       },
     ],
   });


### PR DESCRIPTION
issue: get all relationships (or entities) created by a user, from the user view, seems to break the filters

Steps to reproduce: 
- go to a user overview
- in the history, click on the 'view all relationships created by the user' button
![image](https://github.com/OpenCTI-Platform/opencti/assets/75783086/9b38609f-0b34-4255-9a32-3aff29ed8275)
- we are redirected to the list of relationships with a filter on the creator
Bug: this filter can't be edited 