### PR TITLE
[frontend] fix display confidence initial value

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -190,6 +190,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     createdBy: convertCreatedBy(organization) as Option,
     objectMarking: convertMarkings(organization),
     references: [],
+    confidence: organization.confidence,
   };
 
   return (


### PR DESCRIPTION
### Proposed changes

- Display initial confidence value in update organization update form

### Related issues

- Display nothing value on confidence field

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Process
- Go to an entities
- Click on Update
- Verify the confidence value into confidence form field is valid
