### PR TITLE
[backend] add missing capa for effective level computation

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1234,7 +1234,7 @@ export const buildCompleteUser = async (context, client) => {
   const default_hidden_types = uniq(defaultHiddenTypesGroups.concat(defaultHiddenTypesOrgs));
 
   // effective confidence level
-  const effective_confidence_level = computeUserEffectiveConfidenceLevel({ ...client, groups });
+  const effective_confidence_level = computeUserEffectiveConfidenceLevel({ ...client, groups, capabilities });
 
   return {
     ...client,


### PR DESCRIPTION
user with bypass were not having the right effective level in the AuthUser passed down to the requests.

to test: 
* have a user with only a group at confidence 20
* user group role must have bypass --> expected effective level is 100
* update a report of a confidence > 20


you should not have errors about insufficient confidence.