### PR TITLE
[backend/frontend] fix creator replaced by user in workbench (#6048)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -332,6 +332,8 @@ export const upload = async (context, user, filePath, fileUpload, opts) => {
     }
   }
 
+  const creatorId = currentFile?.metaData?.creator_id ? currentFile.metaData.creator_id : user.id;
+
   // Upload the data
   const readStream = createReadStream();
   const fileMime = guessMimeType(key) || mimetype;
@@ -344,7 +346,7 @@ export const upload = async (context, user, filePath, fileUpload, opts) => {
     filename: encodeURIComponent(truncatedFileName),
     mimetype: fileMime,
     encoding,
-    creator_id: user.id,
+    creator_id: creatorId,
     entity_id: entity?.internal_id,
   };
   const s3Upload = new Upload({


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  frontend: add state in WorkbenchFileContent to to prevent  useEffect from calling the saveFile() method each time content is loaded.
* backend: replace creator_id by the cerator_id as it is stored in DB instead of user.id

### Related issues

* [issue/6048](https://github.com/OpenCTI-Platform/opencti/issues/6048)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
