### PR TITLE
[backend/frontend] allow sorting groups by confidence level (#5756)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Groups.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Groups.jsx
@@ -102,7 +102,7 @@ class Groups extends Component {
       group_confidence_level: {
         label: 'Max Confidence',
         width: '10%',
-        isSortable: false,
+        isSortable: true,
       },
       created_at: {
         label: 'Platform creation date',

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1243,6 +1243,7 @@ enum GroupsOrdering {
   auto_new_marking
   created_at
   updated_at
+  group_confidence_level
 }
 
 type GroupConnection {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1184,6 +1184,7 @@ enum GroupsOrdering {
   auto_new_marking
   created_at
   updated_at
+  group_confidence_level
 }
 
 type GroupConnection {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7612,6 +7612,7 @@ export enum GroupsOrdering {
   AutoNewMarking = 'auto_new_marking',
   CreatedAt = 'created_at',
   DefaultAssignation = 'default_assignation',
+  GroupConfidenceLevel = 'group_confidence_level',
   Name = 'name',
   UpdatedAt = 'updated_at'
 }

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -240,6 +240,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
       multiple: false,
       upsert: false,
       isFilterable: false,
+      sortBy: { path: 'group_confidence_level.max_confidence', type: 'numeric' },
       mappings: [
         { name: 'max_confidence', label: 'Max Confidence', type: 'numeric', precision: 'integer', editDefault: false, mandatoryType: 'internal', multiple: false, upsert: false, isFilterable: true },
         { name: 'overrides',

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -38,11 +38,17 @@ type BasicDefinition = {
   update?: boolean // If attribute can be updated (null = true)
 };
 
+export type MappingDefinition = AttributeDefinition & {
+  associatedFilterKeys?: { key: string, label: string }[] // filter key and their label, to add if key is different from: 'parentAttributeName.nestedAttributeName'
+};
+
 type BasicObjectDefinition = BasicDefinition & {
-  mappings: (
-    { associatedFilterKeys?: { key: string, label: string }[] } // filter key and their label, to add if key is different from: 'parentAttributeName.nestedAttributeName'
-    & AttributeDefinition
-  )[],
+  mappings: MappingDefinition[],
+  // if the object attribute can be used for sorting, we need to know how
+  sortBy?: {
+    path: string // path leading to the value that serves for sorting
+    type: string // type of this value, copied for convenience from corresponding mapping (checked at registration)
+  }
 };
 export type DateAttribute = { type: 'date' } & BasicDefinition;
 export type BooleanAttribute = { type: 'boolean' } & BasicDefinition;

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -154,7 +154,7 @@ export const files: AttributeDefinition = {
   mappings: [
     id,
     { name: 'name', label: 'Name', type: 'string', format: 'short', editDefault: false, mandatoryType: 'no', multiple: true, upsert: true, isFilterable: true },
-    { name: 'description', label: 'Name', type: 'string', format: 'text', editDefault: false, mandatoryType: 'no', multiple: true, upsert: true, isFilterable: true },
+    { name: 'description', label: 'Description', type: 'string', format: 'text', editDefault: false, mandatoryType: 'no', multiple: true, upsert: true, isFilterable: true },
     { name: 'version', label: 'Version', type: 'date', editDefault: false, mandatoryType: 'no', multiple: true, upsert: true, isFilterable: true },
     { name: 'mime_type', label: 'Mime type', type: 'string', format: 'short', editDefault: false, mandatoryType: 'no', multiple: true, upsert: true, isFilterable: true },
     { name: 'inCarousel', label: 'Include in carousel', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { RULE_PREFIX } from './general';
 import { FunctionalError, UnsupportedError } from '../config/errors';
-import type { AttributeDefinition, AttrType, ComplexAttributeWithMappings } from './attribute-definition';
+import type { AttributeDefinition, AttrType, ComplexAttributeWithMappings, MappingDefinition } from './attribute-definition';
 import { shortStringFormats } from './attribute-definition';
 import { getParentTypes } from './schemaUtils';
 
@@ -16,7 +16,45 @@ export const depsKeysRegister = {
   },
 };
 
+// -- Utilities to manipulate AttributeDefinitions --
+
+const isMandatoryAttributeDefinition = (schemaDef: AttributeDefinition) => schemaDef.mandatoryType === 'external' || schemaDef.mandatoryType === 'internal';
+
+const isNonFlatObjectAttributeDefinition = (schemaDef: AttributeDefinition) : schemaDef is ComplexAttributeWithMappings => { // handy typeguard
+  return schemaDef.type === 'object' && schemaDef.format !== 'flat';
+};
+
+/**
+ * Returns the attribute definition for a given dotted path inside the given AttributeDefinition,
+ * following the mappings recursively.
+ */
+const getAttributeMappingFromPath = (path: string, schemaDef: AttributeDefinition | MappingDefinition): MappingDefinition => {
+  const pathTokens = path.split('.');
+  if (pathTokens.length === 1) {
+    return schemaDef;
+  }
+  if (!isNonFlatObjectAttributeDefinition(schemaDef)) {
+    throw FunctionalError(`Cannot resolve path [${path}], [${schemaDef.name}] is not an object`);
+  }
+  const mapping = schemaDef.mappings.find((m) => m.name === pathTokens[1]);
+  if (!mapping) {
+    throw FunctionalError(`Schema definition named [${schemaDef.name}] is missing mapping for attribute [${pathTokens[1]}]`);
+  }
+
+  if (pathTokens.length > 2) {
+    // remove first and recursively check the rest of the path
+    pathTokens.shift();
+    return getAttributeMappingFromPath(pathTokens.join('.'), mapping);
+  }
+  return mapping;
+};
+
+// Flag to track if the schema was rea; when read for the first time the schema is then read-only and new registration is diallowed
 let usageProtection = false;
+
+/**
+ * Main utility object to write and read the schema in the platform
+ */
 export const schemaAttributesDefinition = {
   allAttributes: new Map<string, AttributeDefinition>(),
   attributes: {} as Record<string, Map<string, AttributeDefinition>>,
@@ -105,6 +143,16 @@ export const schemaAttributesDefinition = {
           entityType
         });
       }
+      // Check sortBy on object
+      if (attribute.type === 'object' && attribute.format !== 'flat' && attribute.sortBy) {
+        const correspondingMapping = getAttributeMappingFromPath(attribute.sortBy.path, attribute);
+        if (correspondingMapping.type !== attribute.sortBy.type) {
+          throw UnsupportedError('You can\'t define a sortBy with path and type that do not match the corresponding mapping', {
+            attributeName: attribute.name,
+            entityType
+          });
+        }
+      }
       // set attribute
       directAttributes.set(attribute.name, attribute);
       // add the attribute name and type in the map of all the attributes
@@ -188,6 +236,15 @@ export const schemaAttributesDefinition = {
     usageProtection = true;
     return attributeType.reduce((r, fn) => this.attributesByTypes[fn].has(attributeName) || r, false);
   },
+
+  getAttributeMappingFromPath(path: string): MappingDefinition {
+    const pathTokens = path.split('.');
+    const schemaDef = this.getAttributeByName(pathTokens[0]);
+    if (!schemaDef) {
+      throw FunctionalError(`Cannot resolve path [${path}], missing schema definition for attribute [${pathTokens[0]}}]`);
+    }
+    return getAttributeMappingFromPath(path, schemaDef);
+  }
 };
 
 // -- TYPE --
@@ -218,15 +275,6 @@ export const isMultipleAttribute = (entityType: string, k: string): boolean => (
   k.startsWith(RULE_PREFIX) || schemaAttributesDefinition.isMultipleAttribute(entityType, k)
 );
 
-// -- utility functions independent of attribute registration --
-// (inner mappings are not registered like first-level attribute)
-
-export const isMandatoryAttributeMapping = (schemaDef: AttributeDefinition) => schemaDef.mandatoryType === 'external' || schemaDef.mandatoryType === 'internal';
-
-export const isNonFlatObjectAttributeMapping = (schemaDef: AttributeDefinition) : schemaDef is ComplexAttributeWithMappings => { // handy typeguard
-  return schemaDef.type === 'object' && schemaDef.format !== 'flat';
-};
-
 /**
  * Validates that the given input conforms to the constraints in the corresponding schema definition.
  * Recursively checks non-flat objects mappings.
@@ -234,12 +282,12 @@ export const isNonFlatObjectAttributeMapping = (schemaDef: AttributeDefinition) 
  * @param schemaDef AttributeDefinition for the given input data
  */
 const validateInputAgainstSchema = (input: any, schemaDef: AttributeDefinition) => {
-  const isMandatory = isMandatoryAttributeMapping(schemaDef);
+  const isMandatory = isMandatoryAttributeDefinition(schemaDef);
   if (isMandatory && R.isNil(input)) {
     throw FunctionalError(`Validation against schema failed on attribute [${schemaDef.name}]: this mandatory field cannot be nil`, { value: input });
   }
 
-  if (isNonFlatObjectAttributeMapping(schemaDef)) {
+  if (isNonFlatObjectAttributeDefinition(schemaDef)) {
     if (!isMandatory && R.isNil(input)) {
       return; // nothing to check (happens on 'remove' operation for instance
     }
@@ -257,7 +305,7 @@ const validateInputAgainstSchema = (input: any, schemaDef: AttributeDefinition) 
       const valueKeys = Object.keys(value);
       schemaDef.mappings.forEach((mapping) => {
         // mandatory fields: the value must have a field with this name
-        if (isMandatoryAttributeMapping(mapping) && !valueKeys.includes(mapping.name)) {
+        if (isMandatoryAttributeDefinition(mapping) && !valueKeys.includes(mapping.name)) {
           throw FunctionalError(`Validation against schema failed on attribute [${schemaDef.name}]: mandatory field [${mapping.name}] is not present`, { value });
         }
         // ...we might add more constraints such as a numeric range.

--- a/opencti-platform/opencti-graphql/src/utils/sorting.ts
+++ b/opencti-platform/opencti-graphql/src/utils/sorting.ts
@@ -1,0 +1,31 @@
+import { isDateNumericOrBooleanAttribute, schemaAttributesDefinition } from '../schema/schema-attributes';
+import { UnsupportedError } from '../config/errors';
+
+export const buildElasticSortingForAttributeCriteria = (orderCriteria: string, orderMode: 'asc' | 'desc') => {
+  const definition = schemaAttributesDefinition.getAttributeByName(orderCriteria);
+
+  // criteria not in schema, attempt keyword sorting as a last resort
+  if (!definition) {
+    return { [`${orderCriteria}.keyword`]: { order: orderMode, missing: '_last' } };
+  }
+
+  if (isDateNumericOrBooleanAttribute(orderCriteria)) {
+    // sorting on null dates results to an error, one way to fix it is to use missing: 0
+    // see https://github.com/elastic/elasticsearch/issues/81960
+    return { [orderCriteria]: { order: orderMode, missing: definition.type === 'date' ? 0 : '_last' } };
+  }
+
+  // for sorting by object attribute, we need the sortBy def to know which internal mapping to use
+  if (definition.type === 'object' && (definition.format === 'standard' || definition.format === 'nested')) {
+    const { sortBy } = definition;
+    if (sortBy) {
+      if (sortBy.type === 'numeric' || sortBy.type === 'boolean' || sortBy.type === 'date') {
+        return { [sortBy.path]: { order: orderMode, missing: sortBy.type === 'date' ? 0 : '_last' } };
+      }
+      return { [`${sortBy.path}.keyword`]: { order: orderMode, missing: '_last' } };
+    }
+    throw UnsupportedError(`Sorting on [${orderCriteria}] is not supported: this criteria does not have a sortByPath definition in schema`);
+  }
+
+  return { [`${orderCriteria}.keyword`]: { order: orderMode, missing: '_last' } };
+};

--- a/opencti-platform/opencti-graphql/src/utils/sorting.ts
+++ b/opencti-platform/opencti-graphql/src/utils/sorting.ts
@@ -24,7 +24,7 @@ export const buildElasticSortingForAttributeCriteria = (orderCriteria: string, o
       }
       return { [`${sortBy.path}.keyword`]: { order: orderMode, missing: '_last' } };
     }
-    throw UnsupportedError(`Sorting on [${orderCriteria}] is not supported: this criteria does not have a sortByPath definition in schema`);
+    throw UnsupportedError(`Sorting on [${orderCriteria}] is not supported: this criteria does not have a sortBy definition in schema`);
   }
 
   return { [`${orderCriteria}.keyword`]: { order: orderMode, missing: '_last' } };

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/schema-attributes-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/schema-attributes-test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { schemaAttributesDefinition } from '../../../src/schema/schema-attributes';
+
+describe('Schema utilities', () => {
+  let mapping;
+  it('getAttributeMappingFromPath gives access to internal attribute definitions', () => {
+    mapping = schemaAttributesDefinition.getAttributeMappingFromPath('name');
+    expect(mapping).toEqual({
+      editDefault: true,
+      format: 'short',
+      isFilterable: true,
+      label: 'Name',
+      mandatoryType: 'external',
+      multiple: false,
+      name: 'name',
+      type: 'string',
+      upsert: false,
+    });
+    mapping = schemaAttributesDefinition.getAttributeMappingFromPath('group_confidence_level.overrides.entity_type');
+    expect(mapping).toEqual({
+      editDefault: false,
+      format: 'short',
+      isFilterable: true,
+      label: 'Entity Type',
+      mandatoryType: 'external',
+      multiple: false,
+      name: 'entity_type',
+      type: 'string',
+      upsert: false,
+    });
+  });
+
+  it('getAttributeMappingFromPath throws errors on schema inconsistencies', () => {
+    mapping = () => schemaAttributesDefinition.getAttributeMappingFromPath('invalid_attribute');
+    expect(mapping).toThrowError('Cannot resolve path [invalid_attribute], missing schema definition');
+    mapping = () => schemaAttributesDefinition.getAttributeMappingFromPath('group_confidence_level.invalid_sub_attribute');
+    expect(mapping).toThrowError('Schema definition named [group_confidence_level] is missing mapping for attribute [invalid_sub_attribute]');
+    mapping = () => schemaAttributesDefinition.getAttributeMappingFromPath('name.fail');
+    expect(mapping).toThrowError('Cannot resolve path [name.fail], [name] is not an object');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/schema-attributes-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/schema-attributes-test.ts
@@ -6,7 +6,7 @@ describe('Schema utilities', () => {
   it('getAttributeMappingFromPath gives access to internal attribute definitions', () => {
     mapping = schemaAttributesDefinition.getAttributeMappingFromPath('name');
     expect(mapping).toEqual({
-      editDefault: true,
+      editDefault: false,
       format: 'short',
       isFilterable: true,
       label: 'Name',

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/sorting-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/sorting-test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildElasticSortingForAttributeCriteria } from '../../../src/utils/sorting';
+
+describe('Sorting utilities', () => {
+  let sorting;
+  it('buildElasticSortingForAttributeCriteria properly construct elastic sorting options', () => {
+    sorting = buildElasticSortingForAttributeCriteria('name', 'asc');
+    expect(sorting).toEqual({
+      'name.keyword': {
+        missing: '_last',
+        order: 'asc',
+      },
+    });
+
+    sorting = buildElasticSortingForAttributeCriteria('confidence', 'desc');
+    expect(sorting).toEqual({
+      confidence: {
+        missing: '_last',
+        order: 'desc',
+      },
+    });
+
+    sorting = buildElasticSortingForAttributeCriteria('created_at', 'desc');
+    expect(sorting).toEqual({
+      created_at: {
+        missing: 0,
+        order: 'desc',
+      },
+    });
+
+    // complex object with sortBy
+    sorting = buildElasticSortingForAttributeCriteria('group_confidence_level', 'asc');
+    expect(sorting).toEqual({
+      'group_confidence_level.max_confidence': {
+        missing: '_last',
+        order: 'asc',
+      },
+    });
+
+    // fallback
+    sorting = buildElasticSortingForAttributeCriteria('some_attribute', 'asc');
+    expect(sorting).toEqual({
+      'some_attribute.keyword': {
+        missing: '_last',
+        order: 'asc',
+      },
+    });
+  });
+
+  it('buildElasticSortingForAttributeCriteria throws on error', () => {
+    sorting = () => buildElasticSortingForAttributeCriteria('context_data', 'asc');
+    expect(sorting).toThrowError('Sorting on [context_data] is not supported: this criteria does not have a sortByPath definition in schema');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/sorting-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/sorting-test.ts
@@ -49,6 +49,6 @@ describe('Sorting utilities', () => {
 
   it('buildElasticSortingForAttributeCriteria throws on error', () => {
     sorting = () => buildElasticSortingForAttributeCriteria('context_data', 'asc');
-    expect(sorting).toThrowError('Sorting on [context_data] is not supported: this criteria does not have a sortByPath definition in schema');
+    expect(sorting).toThrowError('Sorting on [context_data] is not supported: this criteria does not have a sortBy definition in schema');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -613,6 +613,44 @@ describe('Elasticsearch pagination', () => {
     expect(markings[8]).toEqual('PAP:CLEAR');
     expect(markings[9]).toEqual('PAP:AMBER');
   });
+  it('should entity paginate with object ordering (desc)', async () => {
+    const filters = {
+      mode: 'and',
+      filters: [{ key: 'entity_type', operator: 'eq', values: ['Group'] }],
+      filterGroups: [],
+    };
+    const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, {
+      filters,
+      orderBy: 'group_confidence_level',
+      orderMode: 'desc',
+    });
+    expect(data.edges.length).toEqual(5);
+    const groups = R.map((e) => e.node.group_confidence_level.max_confidence, data.edges);
+    expect(groups[0]).toEqual(100);
+    expect(groups[1]).toEqual(100);
+    expect(groups[2]).toEqual(100);
+    expect(groups[3]).toEqual(80);
+    expect(groups[4]).toEqual(50);
+  });
+  it('should entity paginate with object ordering (asc)', async () => {
+    const filters = {
+      mode: 'and',
+      filters: [{ key: 'entity_type', operator: 'eq', values: ['Group'] }],
+      filterGroups: [],
+    };
+    const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, {
+      filters,
+      orderBy: 'group_confidence_level',
+      orderMode: 'asc',
+    });
+    expect(data.edges.length).toEqual(5);
+    const groups = R.map((e) => e.node.group_confidence_level.max_confidence, data.edges);
+    expect(groups[0]).toEqual(50);
+    expect(groups[1]).toEqual(80);
+    expect(groups[2]).toEqual(100);
+    expect(groups[3]).toEqual(100);
+    expect(groups[4]).toEqual(100);
+  });
   it('should relation paginate everything', async () => {
     let data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { includeAuthorities: true });
     expect(data).not.toBeNull();

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -116,7 +116,7 @@ export const GREEN_GROUP: Group = {
   markings: [MARKING_TLP_GREEN],
   roles: [ROLE_PARTICIPATE],
   group_confidence_level: {
-    max_confidence: 100,
+    max_confidence: 50,
     overrides: [],
   }
 };
@@ -126,7 +126,7 @@ export const AMBER_GROUP: Group = {
   markings: [MARKING_TLP_AMBER],
   roles: [ROLE_EDITOR],
   group_confidence_level: {
-    max_confidence: 20,
+    max_confidence: 100,
     overrides: [],
   }
 };
@@ -137,7 +137,7 @@ export const AMBER_STRICT_GROUP: Group = {
   markings: [MARKING_TLP_AMBER_STRICT],
   roles: [ROLE_SECURITY],
   group_confidence_level: {
-    max_confidence: 100,
+    max_confidence: 80,
     overrides: [],
   }
 };
@@ -224,14 +224,8 @@ TESTING_USERS.push(USER_SECURITY);
 
 // region group management
 const GROUP_CREATION_MUTATION = `
-  mutation groupCreation($name: String!) {
-    groupAdd(input: {
-      name: $name
-      group_confidence_level: {
-        max_confidence: 100
-        overrides: []
-      }
-    }) {
+  mutation groupCreation($input: GroupAddInput!) {
+    groupAdd(input: $input) {
       id
     }
   }
@@ -272,8 +266,10 @@ const GROUP_ASSIGN_MUTATION = `
     }
   }
 `;
-const createGroup = async (input: { name: string, markings: string[], roles: Role[] }): Promise<string> => {
-  const { data } = await adminQuery(GROUP_CREATION_MUTATION, { name: input.name });
+const createGroup = async (input: Group): Promise<string> => {
+  const { data } = await adminQuery(GROUP_CREATION_MUTATION, {
+    input: { name: input.name, group_confidence_level: input.group_confidence_level }
+  });
   for (let index = 0; index < input.markings.length; index += 1) {
     const marking = input.markings[index];
     await adminQuery(GROUP_EDITION_MARKINGS_MUTATION, { groupId: data.groupAdd.id, toId: marking });


### PR DESCRIPTION
### Proposed changes

* new enum value for `GroupsOrdering` 
* in the elastic query,handle this complex sorting simply with dot syntax `group_confidence_level.max_confidence: { order: 'asc' }`
* to generalize, add a new field in schema attribute definition for objects: `sortBy`; if defined, it tells how to build the sorting key

### Related issues

Closes #5756 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

