### PR TITLE
[backend] fix filter key 'objects', usable in any sro and sco (#6188)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -224,6 +224,7 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
       position="fixed"
       className={classes.appBar}
       variant="outlined"
+      elevation={0}
     >
       {/* Header and Footer Banners containing classification level of system */}
       <Toolbar

--- a/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
+++ b/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
@@ -27,6 +27,7 @@ import {
   MEMBERS_GROUP_FILTER,
   MEMBERS_ORGANIZATION_FILTER,
   MEMBERS_USER_FILTER,
+  OBJECT_CONTAINS_FILTER,
   TYPE_FILTER,
   WORKFLOW_FILTER
 } from '../utils/filtering/filtering-constants';
@@ -39,7 +40,7 @@ import { isEmptyField } from '../database/utils';
 import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../schema/stixCyberObservable';
 import { ENTITY_TYPE_IDENTITY_INDIVIDUAL, ENTITY_TYPE_IDENTITY_SECTOR, ENTITY_TYPE_IDENTITY_SYSTEM, isStixObjectAliased } from '../schema/stixDomainObject';
 import { ENTITY_TYPE_MALWARE_ANALYSIS } from '../modules/malwareAnalysis/malwareAnalysis-types';
-import { isBasicRelationship } from '../schema/stixRelationship';
+import { isBasicRelationship, isStixRelationship } from '../schema/stixRelationship';
 import { ENTITY_TYPE_LABEL, ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 
@@ -236,6 +237,17 @@ const completeFilterDefinitionMapWithSpecialKeys = (
       subEntityTypes,
       elementsForFilterValuesSearch: ['reliability_ov'],
     });
+    // 'contains' is not only for containers, but might be used in any sro or sco as in "contained inside"
+    if (isStixCoreObject(type) || isStixRelationship(type)) {
+      filterDefinitionsMap.set(OBJECT_CONTAINS_FILTER, {
+        filterKey: OBJECT_CONTAINS_FILTER,
+        type: 'id',
+        label: 'Contains',
+        multiple: true,
+        subEntityTypes,
+        elementsForFilterValuesSearch: [],
+      });
+    }
     // Alias (handle both 'aliases' and 'x_opencti_aliases' attributes
     if (isStixObjectAliased(type)) {
       filterDefinitionsMap.set(ALIAS_FILTER, {


### PR DESCRIPTION
closes #6188 

The filter key 'objects' is not only used as a regular attribute-filter for containers, but also for any SCO/SRO that might be _contained in_ a container.

solution => We declare it in the `filterKeysSchema` for any SRO/SCO