### PR TITLE
[frontend] Fix default pagination that could break screens 

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(() => createStyles({
 
 export const dashboardSettingsDashboardsQuery = graphql`
   query DashboardSettingsDashboardsQuery(
-    $count: Int!
+    $count: Int
     $orderBy: WorkspacesOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferencesLines.jsx
@@ -273,7 +273,7 @@ AddExternalReferencesLinesContainer.propTypes = {
 export const addExternalReferencesLinesQuery = graphql`
   query AddExternalReferencesLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddExternalReferencesLines_data

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencesLines.tsx
@@ -28,7 +28,7 @@ interface ExternalReferencesLinesProps {
 export const externalReferencesLinesQuery = graphql`
   query ExternalReferencesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ExternalReferencesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
@@ -538,7 +538,7 @@ StixCoreObjectExternalReferencesLinesContainerProps
 };
 
 export const stixCoreObjectExternalReferencesLinesQuery = graphql`
-  query StixCoreObjectExternalReferencesLinesQuery($count: Int!, $id: String!) {
+  query StixCoreObjectExternalReferencesLinesQuery($count: Int, $id: String!) {
     ...StixCoreObjectExternalReferencesLines_data
       @arguments(count: $count, id: $id)
   }

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
@@ -450,7 +450,7 @@ StixCoreRelationshipExternalReferencesLinesContainer.propTypes = {
 
 export const stixCoreRelationshipExternalReferencesLinesQuery = graphql`
   query StixCoreRelationshipExternalReferencesLinesQuery(
-    $count: Int!
+    $count: Int
     $id: String!
   ) {
     ...StixCoreRelationshipExternalReferencesLines_data

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -447,7 +447,7 @@ StixSightingRelationshipExternalReferencesLinesContainer.propTypes = {
 
 export const stixSightingRelationshipExternalReferencesLinesQuery = graphql`
   query StixSightingRelationshipExternalReferencesLinesQuery(
-    $count: Int!
+    $count: Int
     $id: String!
   ) {
     ...StixSightingRelationshipExternalReferencesLines_data

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/AddGroupingsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/AddGroupingsLines.jsx
@@ -174,7 +174,7 @@ AddGroupingsLinesContainer.propTypes = {
 };
 
 export const addGroupingsLinesQuery = graphql`
-  query AddGroupingsLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddGroupingsLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddGroupingsLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingsLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const groupingsLinesQuery = graphql`
   query GroupingsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: GroupingsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
@@ -176,7 +176,7 @@ AddNotesLinesContainer.propTypes = {
 };
 
 export const addNotesLinesQuery = graphql`
-  query AddNotesLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddNotesLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddNotesLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NotesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NotesLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const notesLinesQuery = graphql`
   query NotesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: NotesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 export const stixCoreObjectOrStixCoreRelationshipNotesCardsQuery = graphql`
   query StixCoreObjectOrStixCoreRelationshipNotesCardsQuery(
-    $count: Int!
+    $count: Int
     $orderBy: NotesOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/AddOpinionsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/AddOpinionsLines.jsx
@@ -170,7 +170,7 @@ AddOpinionsLinesContainer.propTypes = {
 };
 
 export const addOpinionsLinesQuery = graphql`
-  query AddOpinionsLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddOpinionsLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddOpinionsLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionsLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const opinionsLinesQuery = graphql`
   query OpinionsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: OpinionsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportsLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const reportsLinesQuery = graphql`
   query ReportsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ReportsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelsLines.tsx
@@ -21,7 +21,7 @@ interface ChannelsLinesProps {
 export const channelsLinesQuery = graphql`
   query ChannelsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ChannelsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwaresCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwaresCards.tsx
@@ -16,7 +16,7 @@ const nbOfCardsToLoad = 20;
 export const malwaresCardsQuery = graphql`
   query MalwaresCardsPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: MalwaresOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolsLines.tsx
@@ -21,7 +21,7 @@ interface ToolsLinesProps {
 export const toolsLinesQuery = graphql`
   query ToolsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ToolsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwaresLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwaresLines.jsx
@@ -42,7 +42,7 @@ AddSoftwaresLinesContainer.propTypes = {
 };
 
 export const addSoftwaresLinesQuery = graphql`
-  query AddSoftwaresLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddSoftwaresLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddSoftwaresLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilitiesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilitiesLines.tsx
@@ -21,7 +21,7 @@ interface VulnerabilityLinesProps {
 export const vulnerabilitiesLinesQuery = graphql`
   query VulnerabilitiesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: VulnerabilitiesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -186,9 +186,9 @@ const ContainerAddStixCoreObjects = (props) => {
         defaultCreatedBy={defaultCreatedBy}
         defaultMarkingDefinitions={defaultMarkingDefinitions}
         stixDomainObjectTypes={
-            targetStixCoreObjectTypes && targetStixCoreObjectTypes.length > 0
-              ? targetStixCoreObjectTypes
-              : []
+          targetStixCoreObjectTypes && targetStixCoreObjectTypes.length > 0
+            ? targetStixCoreObjectTypes
+            : []
         }
       />
     );
@@ -212,7 +212,7 @@ const ContainerAddStixCoreObjects = (props) => {
         <SpeedDial
           className={classes.createButton}
           ariaLabel="Create"
-          icon={<SpeedDialIcon/>}
+          icon={<SpeedDialIcon />}
           onClose={() => setOpenSpeedDial(false)}
           onOpen={() => setOpenSpeedDial(true)}
           open={openSpeedDial}
@@ -222,7 +222,7 @@ const ContainerAddStixCoreObjects = (props) => {
         >
           <SpeedDialAction
             title={t_i18n('Create an observable')}
-            icon={<HexagonOutline/>}
+            icon={<HexagonOutline />}
             tooltipTitle={t_i18n('Create an observable')}
             onClick={() => handleOpenCreateObservable()}
             FabProps={{
@@ -231,7 +231,7 @@ const ContainerAddStixCoreObjects = (props) => {
           />
           <SpeedDialAction
             title={t_i18n('Create an entity')}
-            icon={<GlobeModel/>}
+            icon={<GlobeModel />}
             tooltipTitle={t_i18n('Create an entity')}
             onClick={() => handleOpenCreateEntity()}
             FabProps={{
@@ -248,9 +248,9 @@ const ContainerAddStixCoreObjects = (props) => {
           defaultCreatedBy={defaultCreatedBy}
           defaultMarkingDefinitions={defaultMarkingDefinitions}
           stixCoreObjectTypes={
-              targetStixCoreObjectTypes && targetStixCoreObjectTypes.length > 0
-                ? targetStixCoreObjectTypes
-                : []
+            targetStixCoreObjectTypes && targetStixCoreObjectTypes.length > 0
+              ? targetStixCoreObjectTypes
+              : []
           }
           speeddial={true}
           open={openCreateEntity}
@@ -274,22 +274,22 @@ const ContainerAddStixCoreObjects = (props) => {
   const renderEntityCreation = (searchPaginationOptions) => {
     if (
       targetStixCoreObjectTypes
-            && isTypeDomainObject(targetStixCoreObjectTypes)
-            && !isTypeObservable(targetStixCoreObjectTypes)
+      && isTypeDomainObject(targetStixCoreObjectTypes)
+      && !isTypeObservable(targetStixCoreObjectTypes)
     ) {
       return renderDomainObjectCreation(searchPaginationOptions);
     }
     if (
       targetStixCoreObjectTypes
-            && isTypeObservable(targetStixCoreObjectTypes)
-            && !isTypeDomainObject(targetStixCoreObjectTypes)
+      && isTypeObservable(targetStixCoreObjectTypes)
+      && !isTypeDomainObject(targetStixCoreObjectTypes)
     ) {
       return renderObservableCreation(searchPaginationOptions);
     }
     if (
       !targetStixCoreObjectTypes
-            || (isTypeObservable(targetStixCoreObjectTypes)
-                && isTypeDomainObject(targetStixCoreObjectTypes))
+      || (isTypeObservable(targetStixCoreObjectTypes)
+        && isTypeDomainObject(targetStixCoreObjectTypes))
     ) {
       return renderStixCoreObjectCreation(searchPaginationOptions);
     }
@@ -372,11 +372,11 @@ const ContainerAddStixCoreObjects = (props) => {
     );
   };
 
-  const { count: _, ...paginationOptionsNoCount } = addObjectsPaginationOptions;
   const searchPaginationOptions = removeEmptyFields({
-    ...paginationOptionsNoCount,
+    ...addObjectsPaginationOptions,
     search: keyword,
   });
+
   const renderButton = () => {
     if (knowledgeGraph) {
       return (
@@ -387,7 +387,7 @@ const ContainerAddStixCoreObjects = (props) => {
             onClick={() => setOpen(true)}
             size="large"
           >
-            <Add/>
+            <Add />
           </IconButton>
         </Tooltip>
       );
@@ -401,7 +401,7 @@ const ContainerAddStixCoreObjects = (props) => {
           classes={{ root: classes.createButtonSimple }}
           size="large"
         >
-          <Add fontSize="small"/>
+          <Add fontSize="small" />
         </IconButton>
       );
     }
@@ -412,7 +412,7 @@ const ContainerAddStixCoreObjects = (props) => {
         aria-label="Add"
         className={withPadding ? classes.createButtonWithPadding : classes.createButton}
       >
-        <Add/>
+        <Add />
       </Fab>
     );
   };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
@@ -281,7 +281,7 @@ export const containerAddStixCoreObjectsLinesQuery = graphql`
   query ContainerAddStixCoreObjectsLinesQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLines.jsx
@@ -10,7 +10,7 @@ export const containerStixCoreObjectsMappingLinesQuery = graphql`
     query ContainerStixCoreObjectsMappingLinesQuery(
         $id: String!
         $search: String
-        $count: Int!
+        $count: Int
         $cursor: ID
         $orderBy: StixObjectOrStixRelationshipsOrdering
         $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.tsx
@@ -40,7 +40,7 @@ export const containerStixDomainObjectsLinesQuery = graphql`
     $id: String!
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixObjectOrStixRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationshipsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationshipsLines.tsx
@@ -63,7 +63,7 @@ export const ContainerStixObjectsOrStixRelationshipsLinesQuery = graphql`
   query ContainerStixObjectsOrStixRelationshipsLinesQuery(
     $id: String!
     $types: [String]
-    $count: Int!
+    $count: Int
     $orderBy: StixObjectOrStixRelationshipsOrdering
     $orderMode: OrderingMode
   ) {

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersLines.jsx
@@ -62,7 +62,7 @@ StixCoreObjectOrStixCoreRelationshipContainersLines.propTypes = {
 export const stixCoreObjectOrStixCoreRelationshipContainersLinesQuery = graphql`
   query StixCoreObjectOrStixCoreRelationshipContainersLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ContainersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
@@ -74,7 +74,7 @@ const StixCoreObjectsExportsContentComponent = ({
 
 export const stixCoreObjectsExportsContentQuery = graphql`
   query StixCoreObjectsExportsContentRefetchQuery(
-    $count: Int!
+    $count: Int
     $exportContext: ExportContext!
   ) {
     ...StixCoreObjectsExportsContent_data @arguments(count: $count, exportContext: $exportContext)

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesAll.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesAll.jsx
@@ -81,7 +81,7 @@ export const entityStixCoreRelationshipsLinesAllQuery = graphql`
     $elementWithTargetTypes: [String]
     $relationship_type: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesFrom.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesFrom.jsx
@@ -79,7 +79,7 @@ export const entityStixCoreRelationshipsLinesFromQuery = graphql`
     $toTypes: [String]
     $relationship_type: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesTo.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsLinesTo.jsx
@@ -79,7 +79,7 @@ export const entityStixCoreRelationshipsLinesToQuery = graphql`
     $toRole: String
     $relationship_type: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipsLines.jsx
@@ -109,7 +109,7 @@ export const simpleStixObjectOrStixRelationshipStixCoreRelationshipsLinesQuery =
     $confidences: [Int]
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...SimpleStixObjectOrStixRelationshipStixCoreRelationshipsLines_data

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityStixCoreObjectsLines.jsx
@@ -116,7 +116,7 @@ export const stixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery = g
   query StixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
@@ -139,7 +139,7 @@ export const stixCoreRelationshipCreationFromRelationStixCyberObservablesLinesQu
   query StixCoreRelationshipCreationFromRelationStixCyberObservablesLinesQuery(
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
@@ -183,7 +183,7 @@ export const stixCoreRelationshipCreationFromRelationStixDomainObjectsLinesQuery
   query StixCoreRelationshipCreationFromRelationStixDomainObjectsLinesQuery(
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixDomainObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
@@ -153,7 +153,7 @@ export const stixCoreRelationshipStixCoreRelationshipsLinesQuery = graphql`
   query StixCoreRelationshipStixCoreRelationshipsLinesQuery(
     $fromOrToId: [String]
     $relationship_type: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExportsContent.jsx
@@ -129,7 +129,7 @@ class StixCoreRelationshipsExportsContentComponent extends Component {
 
 export const stixCoreRelationshipsExportsContentQuery = graphql`
   query StixCoreRelationshipsExportsContentRefetchQuery(
-    $count: Int!
+    $count: Int
     $exportContext: ExportContext!
   ) {
     ...StixCoreRelationshipsExportsContent_data

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLines.tsx
@@ -57,7 +57,7 @@ export const contextualViewLinesQuery = graphql`
   query EntityStixCoreRelationshipsContextualViewLinesQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $filters: FilterGroup
     $orderBy: StixCoreObjectsOrdering

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLines.tsx
@@ -68,7 +68,7 @@ const entityStixCoreRelationshipsEntitiesFragment = graphql`
 export const entityStixCoreRelationshipsEntitiesQuery = graphql`
   query EntityStixCoreRelationshipsEntitiesViewLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLines.tsx
@@ -54,7 +54,7 @@ const contextualViewLinesFragment = graphql`
 export const contextualViewLinesQuery = graphql`
   query EntityStixCoreRelationshipsIndicatorsContextualViewLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $filters: FilterGroup
     $orderBy: IndicatorsOrdering

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectNestedEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectNestedEntitiesLines.jsx
@@ -169,7 +169,7 @@ export const stixDomainObjectNestedEntitiesLinesQuery = graphql`
   query StixDomainObjectNestedEntitiesLinesQuery(
     $fromOrToId: String
     $search: String
-    $count: Int!
+    $count: Int
     $orderBy: StixRefRelationshipsOrdering
     $orderMode: OrderingMode
   ) {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
@@ -79,7 +79,7 @@ class StixDomainObjectsExportsContentComponent extends Component {
 
 export const stixDomainObjectsExportsContentQuery = graphql`
   query StixDomainObjectsExportsContentRefetchQuery(
-    $count: Int!
+    $count: Int
     $exportContext: ExportContext!
   ) {
     ...StixDomainObjectsExportsContent_data

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
@@ -231,7 +231,7 @@ export const stixDomainObjectsLinesSubTypesQuery = graphql`
 export const stixDomainObjectsLinesQuery = graphql`
   query StixDomainObjectsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixDomainObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLines.jsx
@@ -109,7 +109,7 @@ export const stixNestedRefRelationshipCreationFromEntityLinesQuery = graphql`
   query StixNestedRefRelationshipCreationFromEntityLinesQuery(
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.jsx
@@ -59,7 +59,7 @@ export const stixRelationshipsListSearchQuery = graphql`
     $fromId: [String]
     $toId: [String]
     $relationship_type: [String]
-    $count: Int!
+    $count: Int
     $filters: FilterGroup
     $dynamicFrom: FilterGroup
     $dynamicTo: FilterGroup
@@ -94,7 +94,7 @@ const stixRelationshipsListQuery = graphql`
     $toId: [String]
     $fromTypes: [String]
     $toTypes: [String]
-    $first: Int!
+    $first: Int
     $orderBy: StixRelationshipsOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
@@ -39,7 +39,7 @@ const stixRelationshipsTimelineStixRelationshipQuery = graphql`
     $toId: [String]
     $fromTypes: [String]
     $toTypes: [String]
-    $first: Int!
+    $first: Int
     $orderBy: StixRelationshipsOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup

--- a/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectsLines.tsx
@@ -34,7 +34,7 @@ export const entitiesStixDomainObjectsLinesQuery = graphql`
   query EntitiesStixDomainObjectsLinesPaginationQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixDomainObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLines.jsx
@@ -45,7 +45,7 @@ FeedLines.propTypes = {
 export const FeedLinesQuery = graphql`
   query FeedLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: FeedOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssLines.jsx
@@ -60,7 +60,7 @@ IngestionRssLines.propTypes = {
 export const IngestionRssLinesQuery = graphql`
   query IngestionRssLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IngestionRssOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiLines.jsx
@@ -60,7 +60,7 @@ IngestionTaxiiLines.propTypes = {
 export const IngestionTaxiiLinesQuery = graphql`
   query IngestionTaxiiLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IngestionTaxiiOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybooksLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybooksLines.tsx
@@ -20,7 +20,7 @@ interface PlaybookLinesProps {
 export const playbooksLinesQuery = graphql`
   query PlaybooksLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: PlaybooksOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/relationships/RelationshipsStixCoreRelationshipsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/relationships/RelationshipsStixCoreRelationshipsLines.tsx
@@ -36,7 +36,7 @@ export const relationshipsStixCoreRelationshipsLinesQuery = graphql`
     $toId: [String]
     $fromTypes: [String]
     $toTypes: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamLines.jsx
@@ -45,7 +45,7 @@ StreamLines.propTypes = {
 export const StreamLinesQuery = graphql`
   query StreamLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StreamCollectionOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncLines.jsx
@@ -60,7 +60,7 @@ SyncLines.propTypes = {
 export const SyncLinesQuery = graphql`
   query SyncLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: SynchronizersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLines.jsx
@@ -45,7 +45,7 @@ TaxiiLines.propTypes = {
 export const TaxiiLinesQuery = graphql`
   query TaxiiLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: TaxiiCollectionOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventsLines.tsx
@@ -20,7 +20,7 @@ interface EventsLinesProps {
 export const eventsLinesQuery = graphql`
     query EventsLinesPaginationQuery(
         $search: String
-        $count: Int!
+        $count: Int
         $cursor: ID
         $orderBy: EventsOrdering
         $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualsLines.tsx
@@ -21,7 +21,7 @@ interface IndividualsLinesProps {
 export const individualsLinesQuery = graphql`
   query IndividualsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IndividualsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationsLines.tsx
@@ -24,7 +24,7 @@ interface OrganizationsLinesProps {
 export const organizationsLinesQuery = graphql`
   query OrganizationsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: OrganizationsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSectorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSectorsLines.jsx
@@ -42,7 +42,7 @@ AddSubSectorsLinesContainer.propTypes = {
 };
 
 export const addSubSectorsLinesQuery = graphql`
-  query AddSubSectorsLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddSubSectorsLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddSubSectorsLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorsLines.jsx
@@ -74,7 +74,7 @@ SectorsLinesComponent.propTypes = {
 };
 
 export const sectorsLinesQuery = graphql`
-  query SectorsLinesPaginationQuery($count: Int!, $cursor: ID) {
+  query SectorsLinesPaginationQuery($count: Int, $cursor: ID) {
     ...SectorsLines_data @arguments(count: $count, cursor: $cursor)
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemsLines.tsx
@@ -21,7 +21,7 @@ interface SystemsLinesProps {
 export const systemsLinesQuery = graphql`
   query SystemsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: SystemsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentsLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const incidentsLinesPaginationQuery = graphql`
   query IncidentsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IncidentsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/AddObservedDataLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/AddObservedDataLines.jsx
@@ -173,7 +173,7 @@ AddObservedDataLinesContainer.propTypes = {
 };
 
 export const addObservedDataLinesQuery = graphql`
-  query AddObservedDataLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddObservedDataLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddObservedDataLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDatasLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDatasLines.jsx
@@ -73,7 +73,7 @@ ObservedDatasLines.propTypes = {
 export const observedDatasLinesQuery = graphql`
   query ObservedDatasLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ObservedDatasOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipsLines.tsx
@@ -19,7 +19,7 @@ export const entityStixSightingRelationshipsLinesQuery = graphql`
     $toId: StixRef
     $toTypes: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixSightingRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
@@ -140,7 +140,7 @@ export const stixSightingRelationshipCreationFromEntityStixCyberObservablesLines
   query StixSightingRelationshipCreationFromEntityStixCyberObservablesLinesQuery(
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
@@ -172,7 +172,7 @@ export const stixSightingRelationshipCreationFromEntityStixDomainObjectsLinesQue
   query StixSightingRelationshipCreationFromEntityStixDomainObjectsLinesQuery(
     $search: String
     $types: [String]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixDomainObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipsLines.jsx
@@ -75,7 +75,7 @@ export const stixSightingRelationshipsLinesQuery = graphql`
     $toId: StixRef
     $toTypes: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixSightingRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountriesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountriesLines.tsx
@@ -20,7 +20,7 @@ interface CountriesLinesProps {
 export const countriesLinesQuery = graphql`
   query CountriesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: CountriesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
@@ -45,7 +45,7 @@ export const positionDetailsLocationRelationshipsLinesQuery = graphql`
     $confidences: [Int]
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...PositionDetails_positionRelationships

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionsLines.tsx
@@ -20,7 +20,7 @@ interface PositionsLinesProps {
 export const positionsLinesQuery = graphql`
   query PositionsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: PositionsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionsLines.tsx
@@ -20,7 +20,7 @@ interface RegionsLinesProps {
 export const regionsLinesQuery = graphql`
   query RegionsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: RegionsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactsLines.tsx
@@ -30,7 +30,7 @@ export const artifactsLinesQuery = graphql`
   query ArtifactsLinesPaginationQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservablesLines.jsx
@@ -264,7 +264,7 @@ IndicatorAddObservablesLinesContainer.propTypes = {
 export const indicatorAddObservablesLinesQuery = graphql`
   query IndicatorAddObservablesLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntitiesLines.jsx
@@ -89,7 +89,7 @@ export const indicatorEntitiesLinesQuery = graphql`
     $stopTimeStop: DateTime
     $confidences: [Int]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorsLines.tsx
@@ -14,7 +14,7 @@ const nbOfRowsToLoad = 50;
 export const indicatorsLinesQuery = graphql`
   query IndicatorsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $filters: FilterGroup
     $orderBy: IndicatorsOrdering

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicatorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/StixDomainObjectIndicatorsLines.jsx
@@ -73,7 +73,7 @@ StixDomainObjectIndicatorsLines.propTypes = {
 export const stixDomainObjectIndicatorsLinesQuery = graphql`
   query StixDomainObjectIndicatorsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IndicatorsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructuresLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructuresLines.tsx
@@ -29,7 +29,7 @@ interface InfrastructuresLinesProps {
 export const infrastructuresLinesQuery = graphql`
   query InfrastructuresLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: InfrastructuresOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicatorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicatorsLines.jsx
@@ -31,7 +31,7 @@ StixCyberObservableAddIndicatorsLinesContainer.propTypes = {
 export const stixCyberObservableAddIndicatorsLinesQuery = graphql`
   query StixCyberObservableAddIndicatorsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IndicatorsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -321,7 +321,7 @@ export const stixCyberObservableEntitiesLinesQuery = graphql`
     $stopTimeStop: DateTime
     $confidences: [Int]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreRelationshipsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
@@ -92,7 +92,7 @@ const inlineStyles = {
 const stixCyberObservableIndicatorsPromoteMutation = graphql`
   mutation StixCyberObservableIndicatorsPromoteMutation(
     $id: ID!
-    $first: Int!
+    $first: Int
   ) {
     stixCyberObservableEdit(id: $id) {
       promote {

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
@@ -194,7 +194,7 @@ export const stixCyberObservableNestedEntitiesLinesQuery = graphql`
   query StixCyberObservableNestedEntitiesLinesQuery(
     $fromOrToId: String
     $search: String
-    $count: Int!
+    $count: Int
     $orderBy: StixRefRelationshipsOrdering
     $orderMode: OrderingMode
   ) {

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportsContent.jsx
@@ -119,7 +119,7 @@ class StixCyberObservablesExportsContentComponent extends Component {
 }
 
 export const stixCyberObservablesExportsContentQuery = graphql`
-  query StixCyberObservablesExportsContentRefetchQuery($count: Int!, $exportContext: ExportContext!) {
+  query StixCyberObservablesExportsContentRefetchQuery($count: Int, $exportContext: ExportContext!) {
     ...StixCyberObservablesExportsContent_data @arguments(count: $count, exportContext: $exportContext)
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesLines.jsx
@@ -104,7 +104,7 @@ export const stixCyberObservablesLinesQuery = graphql`
   query StixCyberObservablesLinesPaginationQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesSearchLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesSearchLines.jsx
@@ -160,7 +160,7 @@ StixCyberObservablesContainer.propTypes = {
 export const stixCyberObservablesSearchLinesQuery = graphql`
   query StixCyberObservablesSearchLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCyberObservablesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationsLines.tsx
@@ -29,7 +29,7 @@ interface NotificationLinesProps {
 export const notificationsLinesQuery = graphql`
   query NotificationsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: NotificationsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersLines.tsx
@@ -24,7 +24,7 @@ interface TriggerLinesProps {
 export const triggersLinesQuery = graphql`
   query TriggersLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: TriggersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.tsx
@@ -34,7 +34,7 @@ export const searchStixCoreObjectsLinesQuery = graphql`
   query SearchStixCoreObjectsLinesPaginationQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles<Theme>(() => ({
 export const alertingQuery = graphql`
   query AlertingPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: TriggersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
@@ -49,7 +49,7 @@ export const AuditCSVQuery = graphql`
   query AuditCSVQuery(
     $search: String
     $types: [String!]
-    $first: Int!
+    $first: Int
     $orderBy: LogsOrdering
     $orderMode: OrderingMode
     $filters: FilterGroup

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLines.tsx
@@ -50,7 +50,7 @@ export const AuditLinesQuery = graphql`
   query AuditLinesPaginationQuery(
     $search: String
     $types: [String!]
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: LogsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLines.tsx
@@ -21,7 +21,7 @@ interface CaseTemplatesLinesProps {
 export const caseTemplatesLinesQuery = graphql`
   query CaseTemplateLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: CaseTemplatesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulesLines.tsx
@@ -12,7 +12,7 @@ const nbOfRowsToLoad = 50;
 export const decayRulesLinesQuery = graphql`
   query DecayRulesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: DecayRuleOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupsLines.tsx
@@ -43,7 +43,7 @@ const GroupsLines: React.FC<GroupsLinesProps> = (props) => {
 export const groupsLinesQuery = graphql`
   query GroupsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: GroupsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/kill_chain_phases/KillChainPhasesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/kill_chain_phases/KillChainPhasesLines.jsx
@@ -60,7 +60,7 @@ KillChainPhasesLines.propTypes = {
 export const killChainPhasesLinesQuery = graphql`
   query KillChainPhasesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: KillChainPhasesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/labels/LabelsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/labels/LabelsLines.jsx
@@ -68,7 +68,7 @@ LabelsLines.propTypes = {
 export const labelsLinesQuery = graphql`
   query LabelsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: LabelsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/marking_definitions/MarkingDefinitionsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/marking_definitions/MarkingDefinitionsLines.jsx
@@ -60,7 +60,7 @@ MarkingDefinitionsLines.propTypes = {
 export const markingDefinitionsLinesQuery = graphql`
   query MarkingDefinitionsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: MarkingDefinitionsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifiersLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifiersLines.tsx
@@ -47,7 +47,7 @@ const NotifierLineFragment = graphql`
 export const NotifiersLinesQuery = graphql`
   query NotifiersLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: NotifierOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationsLines.tsx
@@ -18,7 +18,7 @@ export interface SettingsOrganizationsLinesProps {
 export const settingsOrganizationsLinesQuery = graphql`
   query SettingsOrganizationsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: OrganizationsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionLines.jsx
@@ -44,7 +44,7 @@ RetentionLines.propTypes = {
 export const RetentionLinesQuery = graphql`
   query RetentionLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...RetentionLines_data

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RolesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RolesLines.jsx
@@ -40,7 +40,7 @@ RolesLines.propTypes = {
 export const rolesLinesQuery = graphql`
   query RolesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: RolesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplatesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplatesLines.tsx
@@ -20,7 +20,7 @@ interface StatusTemplatesLinesProps {
 export const statusTemplatesLinesQuery = graphql`
   query StatusTemplatesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StatusTemplateOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/users/GroupUsersLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/GroupUsersLines.tsx
@@ -11,7 +11,7 @@ export const groupUsersLinesQuery = graphql`
   query GroupUsersLinesQuery(
     $id: String!
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: UsersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsersLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsersLines.tsx
@@ -11,7 +11,7 @@ export const settingsOrganizationUsersLinesQuery = graphql`
   query SettingsOrganizationUsersLinesQuery(
     $id: String!
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: UsersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UsersLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UsersLines.tsx
@@ -52,7 +52,7 @@ const UsersLines: React.FC<UsersLinesProps> = (props) => {
 export const usersLinesQuery = graphql`
   query UsersLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: UsersOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfActionLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfActionLines.jsx
@@ -44,7 +44,7 @@ AddCoursesOfActionLinesContainer.propTypes = {
 export const addCoursesOfActionLinesQuery = graphql`
   query AddCoursesOfActionLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddCoursesOfActionLines_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponentsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponentsLines.tsx
@@ -23,7 +23,7 @@ export const addDataComponentsMutationRelationDelete = graphql`
 export const addDataComponentsLinesQuery = graphql`
   query AddDataComponentsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddDataComponentsLines_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPatternsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPatternsLines.jsx
@@ -44,7 +44,7 @@ AddSubAttackPatternsLinesContainer.propTypes = {
 export const addSubAttackPatternsLinesQuery = graphql`
   query AddSubAttackPatternsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddSubAttackPatternsLines_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsLines.tsx
@@ -24,7 +24,7 @@ interface AttackPatternsLinesProps {
 export const attackPatternsLinesQuery = graphql`
   query AttackPatternsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: AttackPatternsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
@@ -550,7 +550,7 @@ export const attackPatternsMatrixColumnsQuery = graphql`
   query AttackPatternsMatrixColumnsQuery(
     $orderBy: AttackPatternsOrdering
     $orderMode: OrderingMode
-    $count: Int!
+    $count: Int
     $cursor: ID
     $filters: FilterGroup
   ) {

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatternsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatternsLines.jsx
@@ -43,7 +43,7 @@ AddAttackPatternsLinesContainer.propTypes = {
 export const addAttackPatternsLinesQuery = graphql`
   query AddAttackPatternsLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddAttackPatternsLines_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CoursesOfActionLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CoursesOfActionLines.tsx
@@ -24,7 +24,7 @@ interface CoursesOfActionLinesProps {
 export const coursesOfActionLinesQuery = graphql`
   query CoursesOfActionLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: CoursesOfActionOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatternsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatternsLines.tsx
@@ -23,7 +23,7 @@ export const addAttackPatternsMutationRelationDelete = graphql`
 export const addAttackPatternsLinesQuery = graphql`
   query AddAttackPatternsLinesToDataComponentQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddAttackPatternsLinesToDataComponent_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSourcesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSourcesLines.tsx
@@ -20,7 +20,7 @@ export const addDataSourcesLinesMutationAdd = graphql`
 `;
 
 export const addDataSourcesLinesQuery = graphql`
-  query AddDataSourcesLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddDataSourcesLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddDataSourcesLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentsLines.tsx
@@ -22,7 +22,7 @@ interface DataComponentsLinesProps {
 export const dataComponentsLinesQuery = graphql`
   query DataComponentsLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: DataComponentsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponentsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponentsLines.tsx
@@ -45,7 +45,7 @@ export const addDataComponentsMutationRelationDelete = graphql`
 export const addDataComponentsLinesQuery = graphql`
   query AddDataComponentsLinesToDataSourceQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddDataComponentsLinesToDataSource_data

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourcesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourcesLines.tsx
@@ -21,7 +21,7 @@ interface DataSourceLinesProps {
 export const dataSourcesLinesQuery = graphql`
   query DataSourcesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: DataSourcesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrativesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrativesLines.jsx
@@ -42,7 +42,7 @@ AddSubNarrativesLinesContainer.propTypes = {
 };
 
 export const addSubNarrativesLinesQuery = graphql`
-  query AddSubNarrativesLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddSubNarrativesLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddSubNarrativesLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativesLines.jsx
@@ -77,7 +77,7 @@ NarrativesLinesComponent.propTypes = {
 };
 
 export const narrativesLinesQuery = graphql`
-  query NarrativesLinesPaginationQuery($count: Int!, $cursor: ID) {
+  query NarrativesLinesPaginationQuery($count: Int, $cursor: ID) {
     ...NarrativesLines_data @arguments(count: $count, cursor: $cursor)
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignsCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignsCards.tsx
@@ -16,7 +16,7 @@ const nbOfCardsToLoad = 20;
 export const campaignsCardsQuery = graphql`
   query CampaignsCardsPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: CampaignsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocationsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocationsLines.jsx
@@ -41,7 +41,7 @@ AddLocationsLinesContainer.propTypes = {
 };
 
 export const addLocationsLinesQuery = graphql`
-  query AddLocationsLinesQuery($search: String, $count: Int!, $cursor: ID) {
+  query AddLocationsLinesQuery($search: String, $count: Int, $cursor: ID) {
     ...AddLocationsLines_data
       @arguments(search: $search, count: $count, cursor: $cursor)
   }

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetsCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetsCards.tsx
@@ -16,7 +16,7 @@ const nbOfCardsToLoad = 20;
 export const intrusionSetsCardsQuery = graphql`
   query IntrusionSetsCardsPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: IntrusionSetsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroupLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroupLines.jsx
@@ -43,7 +43,7 @@ AddLocationsThreatActorGroupLinesContainer.propTypes = {
 export const addLocationsThreatActorGroupLinesQuery = graphql`
   query AddLocationsThreatActorGroupLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddLocationsThreatActorGroupLines_data

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorsGroupCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorsGroupCards.tsx
@@ -15,7 +15,7 @@ const nbOfCardsToLoad = 20;
 export const threatActorsGroupCardsQuery = graphql`
   query ThreatActorsGroupCardsPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ThreatActorsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividualLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividualLines.jsx
@@ -43,7 +43,7 @@ AddLocationsThreatActorIndividualLinesContainer.propTypes = {
 export const addLocationsThreatActorIndividualLinesQuery = graphql`
   query AddLocationsThreatActorIndividualLinesQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
   ) {
     ...AddLocationsThreatActorIndividualLines_data

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorsIndividualCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorsIndividualCards.tsx
@@ -16,7 +16,7 @@ const nbOfCardsToLoad = 20;
 export const threatActorsIndividualCardsPaginationQuery = graphql`
   query ThreatActorsIndividualCardsPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ThreatActorsIndividualOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorsIndividualLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorsIndividualLines.tsx
@@ -31,7 +31,7 @@ interface ThreatActorsIndividualLinesProps {
 export const threatActorsIndividualLinesQuery = graphql`
   query ThreatActorsIndividualLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: ThreatActorsIndividualOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacesLines.tsx
@@ -13,7 +13,7 @@ const nbOfRowsToLoad = 50;
 export const workspacesLinesQuery = graphql`
   query WorkspacesLinesPaginationQuery(
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: WorkspacesOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjectsLines.jsx
@@ -197,7 +197,7 @@ export const investigationAddStixCoreObjectsLinesQuery = graphql`
   query InvestigationAddStixCoreObjectsLinesQuery(
     $types: [String]
     $search: String
-    $count: Int!
+    $count: Int
     $cursor: ID
     $orderBy: StixCoreObjectsOrdering
     $orderMode: OrderingMode

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -258,9 +258,8 @@ export const usePaginationLocalStorage = <U>(
   ignoreUri?: boolean,
 ): PaginationLocalStorage<U> => {
   const [viewStorage, setValue] = useLocalStorage(key, initialValue, ignoreUri);
-  const paginationOptions = localStorageToPaginationOptions({ count: 25, ...viewStorage });
+  const paginationOptions = localStorageToPaginationOptions(viewStorage);
   const { filterKeysSchema } = useAuth().schema;
-
   const helpers: UseLocalStorageHelpers = {
     handleSearch: (value: string) => setValue((c) => ({ ...c, searchTerm: value })),
     handleRemoveFilterById: (id: string) => {


### PR DESCRIPTION
Fixes the default count in pagination that could lead to screen failure with Relay.

This must be tested a lot, to ensure screens are not broken.
NO MERGING UNTIL STABLE 6.0.X