### PR TITLE
[frontend] harmonise the size of dashboard icons (#6296)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
@@ -205,7 +205,7 @@ const DashboardSettings = () => {
                                 root: classes.muiSelectIcon,
                               }}
                               >
-                                <ItemIcon type="Dashboard" variant="inline" />
+                                <ItemIcon type="Dashboard" />
                               </ListItemIcon>
                               <ListItemText>{name}</ListItemText>
                             </MenuItem>


### PR DESCRIPTION
### Proposed changes

- harmonise the size of dashboard icons

### Related issues

- #6296 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality