### PR TITLE
[frontend] Fix instance triggers subscription (#6313)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
@@ -35,6 +35,7 @@ import { MESSAGING$ } from '../../../../relay/environment';
 import { convertEventTypes, convertNotifiers, instanceEventTypesOptions } from '../../../../utils/edition';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { deleteNode, insertNode } from '../../../../utils/store';
+import useAuth from '../../../../utils/hooks/useAuth';
 import { TriggerLiveAddInput, TriggerLiveCreationKnowledgeMutation } from '../../profile/triggers/__generated__/TriggerLiveCreationKnowledgeMutation.graphql';
 import { triggerMutationFieldPatch } from '../../profile/triggers/TriggerEditionOverview';
 import { instanceTriggerDescription, triggerLiveKnowledgeCreationMutation } from '../../profile/triggers/TriggerLiveCreation';
@@ -95,6 +96,7 @@ StixCoreObjectQuickSubscriptionContentProps
 > = ({ triggerData, instanceId, paginationOptions, instanceName }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const { me } = useAuth();
   const [open, setOpen] = useState(false);
   const [deleting, setDeleting] = useState<boolean>(false);
   const [expandedLines, setExpandedLines] = useState<boolean>(false);
@@ -102,7 +104,8 @@ StixCoreObjectQuickSubscriptionContentProps
   const [existingInstanceTriggersData, refetch] = useRefetchableFragment<TriggerQuery, FragmentKey>(stixCoreObjectTriggersFragment, triggerData);
 
   const existingInstanceTriggersEdges = existingInstanceTriggersData?.triggersKnowledge?.edges ?? [];
-  const triggerUpdate = existingInstanceTriggersEdges.length > 0;
+  const myInstanceTriggers = existingInstanceTriggersEdges.filter((e) => e.node.recipients?.some((r) => r.id === me.id)) ?? [];
+  const triggerUpdate = myInstanceTriggers.length > 0;
 
   const [commitAddTrigger] = useMutation<TriggerLiveCreationKnowledgeMutation>(
     triggerLiveKnowledgeCreationMutation,
@@ -392,7 +395,7 @@ StixCoreObjectQuickSubscriptionContentProps
   };
 
   const updateInstanceTrigger = () => {
-    const triggerValues = existingInstanceTriggersEdges
+    const triggerValues = myInstanceTriggers
       .filter((l) => l)
       .map((n) => ({
         ...pick(['id', 'name', 'description', 'filters'], n?.node),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Filter instance triggers to handle only triggers of current user
* TODO : add e2e test

### Related issues

The issue happens with admin users (set access capa). Admin users can query all instance triggers (used to display the subscribers details) but they should only update theirs.

* #6313 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
