### PR TITLE
[frontend] increase and sort values in bulk update lists (#6326)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -746,11 +746,14 @@ class ToolBar extends Component {
       .toPromise()
       .then((data) => {
         const elements = data.containers.edges.map((e) => e.node);
-        const containers = elements.map((n) => ({
-          label: n.representative.main,
-          type: n.entity_type,
-          value: n.id,
-        }));
+        const containers = elements
+          .map((n) => ({
+            label: n.representative.main,
+            type: n.entity_type,
+            value: n.id,
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .sort((a, b) => a.type.localeCompare(b.type));
         this.setState({ containers });
       });
   }
@@ -767,14 +770,13 @@ class ToolBar extends Component {
     fetchQuery(objectMarkingFieldAllowedMarkingsQuery)
       .toPromise()
       .then((data) => {
-        const markingDefinitions = R.pipe(
-          R.pathOr([], ['me', 'allowed_marking']),
-          R.map((n) => ({
+        const markingDefinitions = (data?.me?.allowed_marking ?? [])
+          .map((n) => ({
             label: n.definition,
             value: n.id,
             color: n.x_opencti_color,
-          })),
-        )(data);
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label));
         this.setState({ markingDefinitions });
       });
   }
@@ -793,14 +795,13 @@ class ToolBar extends Component {
     })
       .toPromise()
       .then((data) => {
-        const labels = R.pipe(
-          R.pathOr([], ['labels', 'edges']),
-          R.map((n) => ({
+        const labels = (data?.labels?.edges ?? [])
+          .map((n) => ({
             label: n.node.value,
             value: n.node.id,
             color: n.node.color,
-          })),
-        )(data);
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label));
         this.setState({
           labels: R.union(this.state.labels, labels),
         });
@@ -891,15 +892,15 @@ class ToolBar extends Component {
     })
       .toPromise()
       .then((data) => {
-        const statuses = R.pipe(
-          R.pathOr([], ['statuses', 'edges']),
-          R.map((n) => ({
+        const statuses = (data?.statuses?.edges ?? [])
+          .map((n) => ({
             label: n.node.template.name,
             value: n.node.id,
             order: n.node.order,
             color: n.node.template.color,
-          })),
-        )(data);
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .sort((a, b) => a.order - b.order);
         this.setState({ statuses: R.union(this.state.statuses, statuses) });
       });
   }

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -821,17 +821,15 @@ class ToolBar extends Component {
     })
       .toPromise()
       .then((data) => {
-        const externalReferences = R.pipe(
-          R.pathOr([], ['externalReferences', 'edges']),
-          R.sortWith([R.ascend(R.path(['node', 'source_name']))]),
-          R.map((n) => ({
+        const externalReferences = (data?.externalReferences?.edges ?? [])
+          .map((n) => ({
             label: `[${n.node.source_name}] ${truncate(
               n.node.description || n.node.external_id,
               150,
             )} ${n.node.url && `(${n.node.url})`}`,
             value: n.node.id,
-          })),
-        )(data);
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label));
         this.setState({
           externalReferences: R.union(
             this.state.externalReferences,
@@ -853,18 +851,18 @@ class ToolBar extends Component {
     fetchQuery(identitySearchIdentitiesSearchQuery, {
       types: ['Individual', 'Organization', 'System'],
       search: newValue && newValue.length > 0 ? newValue : '',
-      first: 10,
+      first: 100,
     })
       .toPromise()
       .then((data) => {
-        const identities = R.pipe(
-          R.pathOr([], ['identities', 'edges']),
-          R.map((n) => ({
+        const identities = (data?.identities?.edges ?? [])
+          .map((n) => ({
             label: n.node.name,
             value: n.node.id,
             type: n.node.entity_type,
-          })),
-        )(data);
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .sort((a, b) => a.type.localeCompare(b.type));
         this.setState({
           identities: R.union(this.state.identities, identities),
         });
@@ -881,7 +879,7 @@ class ToolBar extends Component {
     );
     this.setState({ actionsInputs });
     fetchQuery(statusFieldStatusesSearchQuery, {
-      first: 10,
+      first: 100,
       filters: {
         mode: 'and',
         filterGroups: [],


### PR DESCRIPTION
Go to the observables list. Select some observables. Click on the edit button in the tool bar.
Choose to replace the authors.
The authors available in the list are not sorted and limited to 10.

PR content:
- increase the number of author displayed in the bulk edition list (https://github.com/OpenCTI-Platform/opencti/issues/6326)
- sort these authors by entity type and name
- also sort some other bulk update values lists (labels, markings etc)