### PR TITLE
[backend] avoid useless operations during batched replace (#6297)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -244,14 +244,26 @@ export const executeReplace = async (context, user, actionContext, element) => {
   if (contextType === ACTION_TYPE_RELATION) {
     // 01 - Delete all relations of the element
     const rels = await listAllRelations(context, user, field, { fromId: element.id });
-    for (let indexRel = 0; indexRel < rels.length; indexRel += 1) {
-      const rel = rels[indexRel];
-      await deleteElementById(context, user, rel.id, rel.entity_type);
-    }
-    // 02 - Create new ones
-    for (let indexCreate = 0; indexCreate < values.length; indexCreate += 1) {
-      const target = values[indexCreate];
-      await createRelation(context, user, { fromId: element.id, toId: target, relationship_type: field });
+    if (rels.length > 0) {
+      for (let index = 0; index < rels.length; index += 1) {
+        if (!values.includes(rels[index].toId)) {
+          for (let indexRel = 0; indexRel < rels.length; indexRel += 1) {
+            const rel = rels[indexRel];
+            await deleteElementById(context, user, rel.id, rel.entity_type);
+          }
+          // 02 - Create new ones
+          for (let indexCreate = 0; indexCreate < values.length; indexCreate += 1) {
+            const target = values[indexCreate];
+            await createRelation(context, user, { fromId: element.id, toId: target, relationship_type: field });
+          }
+        }
+      }
+    } else if (rels.length === 0) {
+      // 02 - Create relations if no relation to replace
+      for (let indexCreate = 0; indexCreate < values.length; indexCreate += 1) {
+        const target = values[indexCreate];
+        await createRelation(context, user, { fromId: element.id, toId: target, relationship_type: field });
+      }
     }
   }
   if (contextType === ACTION_TYPE_ATTRIBUTE) {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -239,7 +239,7 @@ const executeRemove = async (context, user, actionContext, element) => {
     await patchAttribute(context, user, element.id, element.entity_type, patch, { operations });
   }
 };
-const executeReplace = async (context, user, actionContext, element) => {
+export const executeReplace = async (context, user, actionContext, element) => {
   const { field, type: contextType, values } = actionContext;
   if (contextType === ACTION_TYPE_RELATION) {
     // 01 - Delete all relations of the element

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { executeReplace } from '../../../src/manager/taskManager';
+import type { AuthContext } from '../../../src/types/user';
+import { ADMIN_USER } from '../../utils/testQuery';
+import { MARKING_TLP_AMBER, MARKING_TLP_CLEAR } from '../../../src/schema/identifier';
+import { addReport, findById as findReportById } from '../../../src/domain/report';
+import { findById } from '../../../src/domain/markingDefinition';
+import { stixDomainObjectDelete } from '../../../src/domain/stixDomainObject';
+
+describe('REPLACE tests ', () => {
+  const adminContext: AuthContext = { user: ADMIN_USER, tracing: undefined, source: 'decay-integration-test', otp_mandatory: false };
+  const reportsId: string[] = [];
+  afterAll(async () => {
+    for (let index = 0; index < reportsId.length; index += 1) {
+      await stixDomainObjectDelete(adminContext, adminContext.user, reportsId[index]);
+      const report = await findReportById(adminContext, adminContext.user, reportsId[index]);
+      expect(report).toBeUndefined();
+    }
+  });
+  it('REPLACE report marking with different marking', async () => {
+    const reportInput = {
+      name: 'test report marking with different marking',
+      objectMarking: [MARKING_TLP_CLEAR],
+    };
+    const report = await addReport(adminContext, adminContext.user, reportInput);
+    expect(report.id).toBeDefined();
+    reportsId.push(report.id);
+    const reportId = report.id;
+    const actionContext = {
+      field: 'object-marking',
+      type: 'RELATION',
+      values: [MARKING_TLP_AMBER]
+    };
+
+    await executeReplace(adminContext, adminContext.user, actionContext, report);
+    const reportAfterReplace = await findReportById(adminContext, adminContext.user, reportId);
+
+    const markings = reportAfterReplace['object-marking'];
+    expect(markings?.length).toEqual(1);
+    if (markings) {
+      const markingEntity = await findById(adminContext, adminContext.user, markings[0]);
+      expect(markingEntity.standard_id).toEqual(MARKING_TLP_AMBER);
+    }
+  });
+  it('REPLACE report marking with same marking', async () => {
+    const reportInput = {
+      name: 'test report marking with same marking',
+      objectMarking: [MARKING_TLP_CLEAR],
+    };
+    const report = await addReport(adminContext, adminContext.user, reportInput);
+    expect(report.id).toBeDefined();
+    reportsId.push(report.id);
+    const reportId = report.id;
+    const actionContext = {
+      field: 'object-marking',
+      type: 'RELATION',
+      values: [MARKING_TLP_CLEAR]
+    };
+
+    await executeReplace(adminContext, adminContext.user, actionContext, report);
+    const reportAfterReplace = await findReportById(adminContext, adminContext.user, reportId);
+
+    const markings = reportAfterReplace['object-marking'];
+    expect(markings?.length).toEqual(1);
+    if (markings) {
+      const markingEntity = await findById(adminContext, adminContext.user, markings[0]);
+      expect(markingEntity.standard_id).toEqual(MARKING_TLP_CLEAR);
+    }
+  });
+  it('REPLACE report no marking with marking', async () => {
+    const reportInput = {
+      name: 'test report no marking with marking',
+      objectMarking: [],
+    };
+    const report = await addReport(adminContext, adminContext.user, reportInput);
+    expect(report.id).toBeDefined();
+    reportsId.push(report.id);
+    const reportId = report.id;
+    const actionContext = {
+      field: 'object-marking',
+      type: 'RELATION',
+      values: [MARKING_TLP_CLEAR]
+    };
+
+    await executeReplace(adminContext, adminContext.user, actionContext, report);
+    const reportAfterReplace = await findReportById(adminContext, adminContext.user, reportId);
+
+    const markings = reportAfterReplace['object-marking'];
+    expect(markings?.length).toEqual(1);
+    if (markings) {
+      const markingEntity = await findById(adminContext, adminContext.user, markings[0]);
+      expect(markingEntity.standard_id).toEqual(MARKING_TLP_CLEAR);
+    }
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 import { executeReplace } from '../../../src/manager/taskManager';
 import type { AuthContext } from '../../../src/types/user';
 import { ADMIN_USER } from '../../utils/testQuery';
-import { MARKING_TLP_AMBER, MARKING_TLP_CLEAR } from '../../../src/schema/identifier';
+import { MARKING_TLP_CLEAR, MARKING_TLP_AMBER } from '../../../src/schema/identifier';
 import { addReport, findById as findReportById } from '../../../src/domain/report';
 import { findById } from '../../../src/domain/markingDefinition';
 import { stixDomainObjectDelete } from '../../../src/domain/stixDomainObject';
@@ -24,13 +24,16 @@ describe('TaskManager executeReplace tests ', () => {
       objectMarking: [MARKING_TLP_CLEAR],
     };
     const report = await addReport(adminContext, adminContext.user, reportInput);
+
     expect(report.id).toBeDefined();
     reportsId.push(report.id);
     const reportId = report.id;
+    const marking = await findById(adminContext, adminContext.user, MARKING_TLP_AMBER);
+
     const actionContext = {
       field: 'object-marking',
       type: 'RELATION',
-      values: [MARKING_TLP_AMBER]
+      values: [marking.id]
     };
 
     await executeReplace(adminContext, adminContext.user, actionContext, report);
@@ -52,10 +55,13 @@ describe('TaskManager executeReplace tests ', () => {
     expect(report.id).toBeDefined();
     reportsId.push(report.id);
     const reportId = report.id;
+
+    const marking = await findById(adminContext, adminContext.user, MARKING_TLP_CLEAR);
+
     const actionContext = {
       field: 'object-marking',
       type: 'RELATION',
-      values: [MARKING_TLP_CLEAR]
+      values: [marking.id]
     };
 
     await executeReplace(adminContext, adminContext.user, actionContext, report);
@@ -77,10 +83,13 @@ describe('TaskManager executeReplace tests ', () => {
     expect(report.id).toBeDefined();
     reportsId.push(report.id);
     const reportId = report.id;
+
+    const marking = await findById(adminContext, adminContext.user, MARKING_TLP_CLEAR);
+
     const actionContext = {
       field: 'object-marking',
       type: 'RELATION',
-      values: [MARKING_TLP_CLEAR]
+      values: [marking.id]
     };
 
     await executeReplace(adminContext, adminContext.user, actionContext, report);

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/taskManager-test.ts
@@ -7,10 +7,11 @@ import { addReport, findById as findReportById } from '../../../src/domain/repor
 import { findById } from '../../../src/domain/markingDefinition';
 import { stixDomainObjectDelete } from '../../../src/domain/stixDomainObject';
 
-describe('REPLACE tests ', () => {
-  const adminContext: AuthContext = { user: ADMIN_USER, tracing: undefined, source: 'decay-integration-test', otp_mandatory: false };
+describe('TaskManager executeReplace tests ', () => {
+  const adminContext: AuthContext = { user: ADMIN_USER, tracing: undefined, source: 'taskManager-integration-test', otp_mandatory: false };
   const reportsId: string[] = [];
   afterAll(async () => {
+    expect(reportsId.length).toBe(3);
     for (let index = 0; index < reportsId.length; index += 1) {
       await stixDomainObjectDelete(adminContext, adminContext.user, reportsId[index]);
       const report = await findReportById(adminContext, adminContext.user, reportsId[index]);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import * as R from 'ramda';
 import { FIVE_MINUTES, RAW_EVENTS_SIZE } from '../../utils/testQuery';
 import { checkStreamData, checkStreamGenericContent, fetchStreamEvents, } from '../../utils/testStream';
-import { PORT } from '../../../src/config/conf';
+import { logApp, PORT } from '../../../src/config/conf';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE } from '../../../src/database/utils';
 
 describe('Raw streams tests', () => {
@@ -58,9 +58,12 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
+
       updateEventsByTypes['report'].forEach((ev) => {
         console.log(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
+        logApp(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
       });
+      expect(updateEventsByTypes['report']).toEqual([]);
       expect(updateEventsByTypes['report'].length).toBe(7);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(7);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -58,14 +58,14 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
-      expect(updateEventsByTypes['report'].length).toBe(4);
+      expect(updateEventsByTypes['report'].length).toBe(7);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(7);
       expect(updateEventsByTypes['sighting'].length).toBe(4);
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(135);
+      expect(updateEvents.length).toBe(138);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -78,7 +78,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(95);
+      expect(deleteEvents.length).toBe(98);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -25,11 +25,11 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.relationship.length).toBe(126);
       expect(createEventsByTypes.indicator.length).toBe(33);
       expect(createEventsByTypes['attack-pattern'].length).toBe(7);
-      expect(createEventsByTypes.report.length).toBe(19);
+      expect(createEventsByTypes.report.length).toBe(22);
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(335); // 328 created at init + 2 created in tests + 5 vocabulary organizations types
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(720);
+      expect(createEvents.length).toBe(723);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import * as R from 'ramda';
 import { FIVE_MINUTES, RAW_EVENTS_SIZE } from '../../utils/testQuery';
 import { checkStreamData, checkStreamGenericContent, fetchStreamEvents, } from '../../utils/testStream';
-import { logApp, PORT } from '../../../src/config/conf';
+import { PORT } from '../../../src/config/conf';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE } from '../../../src/database/utils';
 
 describe('Raw streams tests', () => {
@@ -58,12 +58,6 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
-
-      updateEventsByTypes['report'].forEach((ev) => {
-        console.log(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
-        logApp.info(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
-      });
-      expect(updateEventsByTypes['report']).toEqual([]);
       expect(updateEventsByTypes['report'].length).toBe(7);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(7);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -61,7 +61,7 @@ describe('Raw streams tests', () => {
 
       updateEventsByTypes['report'].forEach((ev) => {
         console.log(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
-        logApp(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
+        logApp.info(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
       });
       expect(updateEventsByTypes['report']).toEqual([]);
       expect(updateEventsByTypes['report'].length).toBe(7);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -58,6 +58,9 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
+      updateEventsByTypes['report'].forEach((ev) => {
+        console.log(`EVENT UPDATE REPORT ${JSON.stringify(ev, null, '  ')}`);
+      });
       expect(updateEventsByTypes['report'].length).toBe(7);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(7);

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 957;
+export const RAW_EVENTS_SIZE = 964;
 export const SYNC_LIVE_EVENTS_SIZE = 598;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 964;
+export const RAW_EVENTS_SIZE = 966;
 export const SYNC_LIVE_EVENTS_SIZE = 598;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  In the case of a `REPLACE` relationship (with a marking, label, etc.) we check if the` toId` contained in value is not already in the element's relationships.


### Related issues

* [issue/6297](https://github.com/OpenCTI-Platform/opencti/issues/6297)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
