### PR TITLE
[frontend] add entity_type filter in Victimology tab (#6391)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -442,9 +442,7 @@ class ListLines extends Component {
           availableRelationFilterTypes={availableRelationFilterTypes}
           redirection
           entityTypes={entityTypes}
-          restrictedFiltersConfig={{
-            filterRemoving: additionalFilterKeys,
-          }}
+          restrictedFiltersConfig={additionalFilterKeys?.restrictedFiltersConfig ?? undefined}
         />
         <ErrorBoundary key={keyword}>
           {message && (
@@ -634,7 +632,7 @@ class ListLines extends Component {
             });
             availableFilterKeys = uniq(Array.from(filterKeysMap.keys())); // keys of the entity type if availableFilterKeys is not specified
           }
-          if (additionalFilterKeys) availableFilterKeys = availableFilterKeys.concat(additionalFilterKeys);
+          if (additionalFilterKeys) availableFilterKeys = uniq(availableFilterKeys.concat(additionalFilterKeys.filterKeys));
           if (disableExport) {
             return this.renderContent(availableFilterKeys, entityTypes);
           }
@@ -700,7 +698,7 @@ ListLines.propTypes = {
   handleExportCsv: PropTypes.func,
   helpers: PropTypes.object,
   availableFilterKeys: PropTypes.array,
-  additionalFilterKeys: PropTypes.array,
+  additionalFilterKeys: PropTypes.object,
   entityTypes: PropTypes.array,
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.jsx
@@ -63,7 +63,8 @@ const ListFilters = ({
     ? availableFilterKeys
       .map((key) => {
         const subEntityTypes = filterKeysMap.get(key)?.subEntityTypes ?? [];
-        const isFilterKeyForAllTypes = subEntityTypes.some((subType) => entityTypes.includes(subType));
+        const isFilterKeyForAllTypes = (entityTypes.length === 1 && subEntityTypes.some((subType) => entityTypes.includes(subType)))
+          || (entityTypes.length > 1 && entityTypes.every((subType) => subEntityTypes.includes(subType)));
         return {
           value: key,
           label: t_i18n(filterKeysMap.get(key)?.label ?? key),

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -553,7 +553,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                   availableEntityTypes={virtualEntityTypes}
                   handleToggleSelectAll="no"
                   entityTypes={virtualEntityTypes}
-                  additionalFilterKeys={['entity_type']}
+                  additionalFilterKeys={{ filterKeys: ['entity_type'], restrictedFiltersConfig: { filterRemoving: ['entity_type'] } }}
                 >
                   <QueryRenderer
                     query={stixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
@@ -109,7 +109,9 @@ EntityStixCoreRelationshipsEntitiesViewProps
 
   // Filters due to screen context
   const userFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, stixCoreObjectTypes.length > 0 ? stixCoreObjectTypes : ['Stix-Core-Object']);
-  const stixCoreObjectFilter: Filter[] = stixCoreObjectTypes.length > 0 ? [{ key: 'entity_type', operator: 'eq', mode: 'or', values: stixCoreObjectTypes }] : [];
+  const stixCoreObjectFilter: Filter[] = stixCoreObjectTypes.length > 0
+    ? [{ key: 'entity_type', operator: 'eq', mode: 'or', values: stixCoreObjectTypes }]
+    : [];
   const contextFilters: FilterGroup = {
     mode: 'and',
     filters: [
@@ -203,6 +205,7 @@ EntityStixCoreRelationshipsEntitiesViewProps
         enableContextualView={enableContextualView}
         currentView={finalView}
         entityTypes={stixCoreObjectTypes.length > 0 ? stixCoreObjectTypes : ['Stix-Core-Object']}
+        additionalFilterKeys={{ filterKeys: ['entity_type'] }}
       >
         <EntityStixCoreRelationshipsEntitiesViewLines
           paginationOptions={paginationOptions}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
@@ -152,8 +152,8 @@ class StixDomainObjectVictimology extends Component {
           {viewMode === 'nested' && (
           <QueryRenderer
             query={
-                  stixDomainObjectVictimologySectorsStixCoreRelationshipsQuery
-                }
+              stixDomainObjectVictimologySectorsStixCoreRelationshipsQuery
+            }
             variables={{ first: 500, ...paginationOptionsSectors }}
             render={({ props }) => {
               if (props) {

--- a/opencti-platform/opencti-graphql/src/modules/relationsRef/stixDomainObject-registrationRef.ts
+++ b/opencti-platform/opencti-graphql/src/modules/relationsRef/stixDomainObject-registrationRef.ts
@@ -22,6 +22,9 @@ import {
   ENTITY_TYPE_CONTAINER_OPINION,
   ENTITY_TYPE_CONTAINER_REPORT,
   ENTITY_TYPE_COURSE_OF_ACTION,
+  ENTITY_TYPE_IDENTITY_INDIVIDUAL,
+  ENTITY_TYPE_IDENTITY_SECTOR,
+  ENTITY_TYPE_IDENTITY_SYSTEM,
   ENTITY_TYPE_INCIDENT,
   ENTITY_TYPE_INFRASTRUCTURE,
   ENTITY_TYPE_INTRUSION_SET,
@@ -63,6 +66,10 @@ schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_CONTAINER_OPINION,
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_COURSE_OF_ACTION, [{ ...objectOrganization, isFilterable: false }]);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_CONTAINER_GROUPING, [objectOrganization]);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_VULNERABILITY, [objectOrganization]);
+
+schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_IDENTITY_SYSTEM, []);
+schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_IDENTITY_SECTOR, []);
+schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_IDENTITY_INDIVIDUAL, []);
 
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_LOCATION_REGION, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TYPE_LOCATION_CITY, []);


### PR DESCRIPTION
PR content:
- add entity_type filter in Victimology tabs
- fix filters repartition between 'most used filters' and 'all other filters' in filters list in Victimology

issue: https://github.com/OpenCTI-Platform/opencti/issues/6391