### PR TITLE
[backend] Fix Promote observable component crashes (#6399)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -853,7 +853,7 @@ const PLAYBOOK_CREATE_INDICATOR_COMPONENT: PlaybookComponent<CreateIndicatorConf
           type = 'StixFile';
         }
         const pattern = await createStixPattern(context, AUTOMATION_MANAGER_USER, key, value);
-        const { score } = observable.extensions[STIX_EXT_OCTI_SCO];
+        const score = observable.extensions[STIX_EXT_OCTI_SCO]?.score;
         const { granted_refs } = observable.extensions[STIX_EXT_OCTI];
         if (pattern) {
           const indicatorData = {
@@ -881,13 +881,13 @@ const PLAYBOOK_CREATE_INDICATOR_COMPONENT: PlaybookComponent<CreateIndicatorConf
           if (observable.object_marking_refs) {
             indicator.object_marking_refs = observable.object_marking_refs;
           }
-          if (observable.extensions[STIX_EXT_OCTI_SCO].labels) {
+          if (observable.extensions[STIX_EXT_OCTI_SCO]?.labels) {
             indicator.labels = observable.extensions[STIX_EXT_OCTI_SCO].labels;
           }
-          if (observable.extensions[STIX_EXT_OCTI_SCO].created_by_ref) {
+          if (observable.extensions[STIX_EXT_OCTI_SCO]?.created_by_ref) {
             indicator.created_by_ref = observable.extensions[STIX_EXT_OCTI_SCO].created_by_ref;
           }
-          if (observable.extensions[STIX_EXT_OCTI_SCO].external_references) {
+          if (observable.extensions[STIX_EXT_OCTI_SCO]?.external_references) {
             indicator.external_references = observable.extensions[STIX_EXT_OCTI_SCO].external_references;
           }
           if (granted_refs) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* handle case where observable.extensions[STIX_EXT_OCTI_SCO] is undefined

### Related issues

* #6399 

To reproduce the issue, you need to create an observable (reproduced with ipv4) without description nor score. then follow the steps described in the issue.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
