### PR TITLE
[frontend] remove duplicate header (#6401)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
@@ -5,8 +5,6 @@ import { graphql, createFragmentContainer } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import EventPopover from './EventPopover';
-import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 
 class EventKnowledgeComponent extends Component {
@@ -15,11 +13,6 @@ class EventKnowledgeComponent extends Component {
     const link = `/dashboard/entities/events/${event.id}/knowledge`;
     return (
       <>
-        <StixDomainObjectHeader
-          entityType={'Event'}
-          stixDomainObject={event}
-          PopoverComponent={<EventPopover />}
-        />
         <Switch>
           <Route
             exact

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
@@ -3,20 +3,12 @@ import PropTypes from 'prop-types';
 import { Route, Switch, withRouter } from 'react-router-dom';
 import { graphql, createFragmentContainer } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import CourseOfActionPopover from './CourseOfActionPopover';
-import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 
 class CourseOfActionKnowledgeComponent extends Component {
   render() {
     const { courseOfAction } = this.props;
     return (
       <>
-        <StixDomainObjectHeader
-          entityType="Course-Of-Action"
-          stixDomainObject={courseOfAction}
-          PopoverComponent={<CourseOfActionPopover />}
-          isOpenctiAlias={true}
-        />
         <Switch>
           <Route
             exact

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -92,15 +92,7 @@ class RootCourseOfAction extends Component {
               if (props.courseOfAction) {
                 const { courseOfAction } = props;
                 return (
-                  <div
-                    style={{
-                      paddingRight: location.pathname.includes(
-                        `/dashboard/techniques/courses_of_action/${courseOfAction.id}/knowledge`,
-                      )
-                        ? 200
-                        : 0,
-                    }}
-                  >
+                  <div>
                     <Breadcrumbs variant="object" elements={[
                       { label: t('Techniques') },
                       { label: t('Courses of action'), link: '/dashboard/techniques/courses_of_action' },
@@ -126,7 +118,7 @@ class RootCourseOfAction extends Component {
                           location.pathname.includes(
                             `/dashboard/techniques/courses_of_action/${courseOfAction.id}/knowledge`,
                           )
-                            ? `/dashboard/techniques/courses_of_action/${courseOfAction.id}/knowledge`
+                            ? `/dashboard/techniques/courses_of_action/${courseOfAction.id}`
                             : location.pathname
                         }
                       >


### PR DESCRIPTION
### Proposed changes

Entities / Events / Knowledge :
- Remove duplicate header

Techniques / Courses of action / select one / select one relationship :
- Remove duplicate header
- Remove padding right
- Focus Overview tab

### Related issues

- #6401

### Checklist

- [x]  I consider the submitted work as finished
- [x]  I tested the code for its functionality
- [ ]  I wrote test cases for the relevant uses case
- [ ]  I added/update the relevant documentation (either on github or on notion)
- [ ]  Where necessary I refactored code to improve the overall quality

### Further comments

- Please challenge the choice of focus Overview tab
- Demo :
![knowledge](https://github.com/OpenCTI-Platform/opencti/assets/102748848/57fdaa32-7003-4b1f-907a-1320350985c3)
