### PR TITLE
implement route 'infra / knowledge / incident' (#6415)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
@@ -97,7 +97,6 @@ class RootPosition extends Component {
               'countries',
               'areas',
               'cities',
-              'locations',
               'threat_actors',
               'intrusion_sets',
               'campaigns',

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -316,6 +316,22 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           />
         )}
       />
+      <Route
+        exact
+        path="/dashboard/observations/infrastructures/:infrastructureId/knowledge/incidents"
+        render={(routeProps) => (
+          <EntityStixCoreRelationships
+            entityId={infrastructureData.id}
+            relationshipTypes={['uses', 'compromises']}
+            stixCoreObjectTypes={['Incident']}
+            entityLink={link}
+            isRelationReversed={true}
+            defaultStartTime={infrastructureData.first_seen}
+            defaultStopTime={infrastructureData.last_seen}
+            {...routeProps}
+          />
+        )}
+      />
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
@@ -101,7 +101,6 @@ class RootAttackPattern extends Component {
               'tools',
               'vulnerabilities',
               'malwares',
-              'sightings',
               'indicators',
               'observables',
             ]}

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
@@ -109,7 +109,6 @@ class RootIntrusionSet extends Component {
               'observables',
               'infrastructures',
               'sightings',
-              'observed_data',
             ]}
           />
         </Route>


### PR DESCRIPTION
### Proposed changes

- Remove 3 buttons that shouldn't exist
- Create new route to display relashionship between Infrastructures and Incidents (types of relations : 'uses' / 'compromises')

### Related issues

- fix #6415 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

![infra - incident](https://github.com/OpenCTI-Platform/opencti/assets/102748848/4f91b954-f2de-4e39-a590-abc1e985af6a)