### PR TITLE
[frontend] fix widgets number alignment on default dashboard (#6412)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -179,7 +179,6 @@ const DefaultDashboard = ({ timeField }) => {
               <StixCoreObjectsNumber
                 variant="inLine"
                 withoutTitle={true}
-                height={110}
                 dataSelection={[{
                   filters: {
                     mode: 'and',
@@ -211,7 +210,6 @@ const DefaultDashboard = ({ timeField }) => {
               <StixCoreObjectsNumber
                 variant="inLine"
                 withoutTitle={true}
-                height={110}
                 dataSelection={[{
                   filters: {
                     mode: 'and',
@@ -243,7 +241,6 @@ const DefaultDashboard = ({ timeField }) => {
               <StixCoreObjectsNumber
                 variant="inLine"
                 withoutTitle={true}
-                height={110}
                 dataSelection={[{
                   filters: {
                     mode: 'and',
@@ -275,7 +272,6 @@ const DefaultDashboard = ({ timeField }) => {
               <StixCoreObjectsNumber
                 variant="inLine"
                 withoutTitle={true}
-                height={110}
                 dataSelection={[{
                   filters: {
                     mode: 'and',


### PR DESCRIPTION
### Proposed changes

* Remove hard coded height to fit parent content

### Related issues

* #6412 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
