### PR TITLE
[frontend] Fix date attribute for list and timeLine widgets (#6145)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.jsx
@@ -1086,7 +1086,7 @@ const StixRelationshipsTimeline = ({
               return {
                 value: {
                   ...remoteNode,
-                  created: stixRelationship.created,
+                  created: stixRelationship[dateAttribute] ?? stixRelationship.created,
                 },
                 link,
               };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
@@ -424,6 +424,9 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
   const getCurrentIsRelationships = () => {
     return indexedVisualizationTypes[type]?.isRelationships ?? false;
   };
+  const isWidgetListOrTimeline = () => {
+    return indexedVisualizationTypes[type]?.key === 'list' || indexedVisualizationTypes[type]?.key === 'timeline';
+  };
   const getCurrentIsEntities = () => {
     return indexedVisualizationTypes[type]?.isEntities ?? false;
   };
@@ -928,15 +931,8 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
                         labelId="relative"
                         size="small"
                         fullWidth={true}
-                        value={
-                                                        dataSelection[i].date_attribute ?? 'created_at'
-                                                    }
-                        onChange={(event) => handleChangeDataValidationParameter(
-                          i,
-                          'date_attribute',
-                          event.target.value,
-                        )
-                                                    }
+                        value={dataSelection[i].date_attribute ?? 'created_at'}
+                        onChange={(event) => handleChangeDataValidationParameter(i, 'date_attribute', event.target.value)}
                       >
                         <MenuItem value="created_at">
                           created_at ({t_i18n('Technical date')})
@@ -960,12 +956,12 @@ const WidgetConfig = ({ workspace, widget, onComplete, closeMenu }) => {
                           stop_time ({t_i18n('Functional date')})
                         </MenuItem>
                         )}
-                        {getCurrentIsRelationships() && (
+                        {getCurrentIsRelationships() && !isWidgetListOrTimeline() && (
                         <MenuItem value="first_seen">
                           first_seen ({t_i18n('Functional date')})
                         </MenuItem>
                         )}
-                        {getCurrentIsRelationships() && (
+                        {getCurrentIsRelationships() && !isWidgetListOrTimeline() && (
                         <MenuItem value="last_seen">
                           last_seen ({t_i18n('Functional date')})
                         </MenuItem>


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* date display depending on the dateAttribute instead of using `created` all the time
* fix date attribute for list and timeLine widgets => avoids proposing attributes that don't exist in the StixRelationshipsOrdering enum

### Related issues

* [issue/6145](https://github.com/OpenCTI-Platform/opencti/issues/6145)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
