### PR TITLE
[backend] Allow passwords with digits only for initial admin (#6382)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1429,7 +1429,7 @@ export const initAdmin = async (context, email, password, tokenValue) => {
     const patch = {
       account_status: ACCOUNT_STATUS_ACTIVE,
       user_email: email,
-      password: bcrypt.hashSync(password),
+      password: bcrypt.hashSync(password.toString()),
       api_token: tokenValue,
       external: true,
     };
@@ -1445,7 +1445,7 @@ export const initAdmin = async (context, email, password, tokenValue) => {
       lastname: 'OpenCTI',
       description: 'Principal admin account',
       api_token: tokenValue,
-      password,
+      password: password.toString(),
       user_confidence_level: {
         max_confidence: 100,
         overrides: [],

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/providers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/providers-test.ts
@@ -16,15 +16,15 @@ describe('initializeAdminUser configurations verifications', () => {
     initialToken = conf.get('app:admin:token');
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     // reset to value that were set before running this test.
     conf.set('app:admin:email', initialEmail);
     conf.set('app:admin:password', initialPassword);
     conf.set('app:admin:token', initialToken);
-    await initializeAdminUser({});
+    initializeAdminUser({});
   });
 
-  it('should admin be initialized', async () => {
+  it('should well configured admin be initialized', async () => {
     // GIVEN configuration
     conf.set('app:admin:email', 'cecilia.payne@filigran.io');
     conf.set('app:admin:password', 'IDiscoveredUniverseMatter');
@@ -34,74 +34,6 @@ describe('initializeAdminUser configurations verifications', () => {
 
     const existingAdmin = await findById({}, SYSTEM_USER, OPENCTI_ADMIN_UUID);
     expect(existingAdmin.user_email).toBe('cecilia.payne@filigran.io');
-  });
-
-  it('should missing admin email raise exception', async () => {
-    // GIVEN configuration
-    conf.set('app:admin:email', '');
-    conf.set('app:admin:password', initialPassword);
-    conf.set('app:admin:token', initialToken);
-
-    let exceptionNotRaised = false;
-    try {
-      await initializeAdminUser({});
-      exceptionNotRaised = true;
-    } catch (error) {
-      expect(error).toBeDefined();
-    } finally {
-      expect(exceptionNotRaised, 'Having not set an email in env or yml should raise and exception').toBeFalsy();
-    }
-  });
-
-  it('should missing admin password raise exception', async () => {
-    // GIVEN configuration
-    conf.set('app:admin:email', initialEmail);
-    conf.set('app:admin:password', null);
-    conf.set('app:admin:token', initialToken);
-
-    let exceptionNotRaised = false;
-    try {
-      await initializeAdminUser({});
-      exceptionNotRaised = true;
-    } catch (error) {
-      expect(error).toBeDefined();
-    } finally {
-      expect(exceptionNotRaised, 'Having not set a password in env or yml should raise and exception').toBeFalsy();
-    }
-  });
-
-  it('should missing Password raise exception', async () => {
-    // GIVEN configuration
-    conf.set('app:admin:email', initialEmail);
-    conf.set('app:admin:password', initialPassword);
-    conf.set('app:admin:token', null);
-
-    let exceptionNotRaised = false;
-    try {
-      await initializeAdminUser({});
-      exceptionNotRaised = true;
-    } catch (error) {
-      expect(error).toBeDefined();
-    } finally {
-      expect(exceptionNotRaised, 'Having not set a Password in env or yml should raise and exception').toBeFalsy();
-    }
-  });
-
-  it('should missing token raise exception', async () => {
-    // GIVEN configuration
-    conf.set('app:admin:email', initialEmail);
-    conf.set('app:admin:password', initialPassword);
-    conf.set('app:admin:token', null);
-
-    let exceptionNotRaised = false;
-    try {
-      await initializeAdminUser({});
-      exceptionNotRaised = true;
-    } catch (error) {
-      expect(error).toBeDefined();
-    } finally {
-      expect(exceptionNotRaised, 'Having not set a Token in env or yml should raise and exception').toBeFalsy();
-    }
   });
 
   it('should password env with digit only works', async () => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/providers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/providers-test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { initializeAdminUser } from '../../../src/config/providers';
+import conf from '../../../src/config/conf';
+import { SYSTEM_USER } from '../../../src/utils/access';
+import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
+import { findById } from '../../../src/domain/user';
+
+describe('initializeAdminUser configurations verifications', () => {
+  let initialEmail: string;
+  let initialPassword: string;
+  let initialToken: string;
+
+  beforeAll(() => {
+    initialEmail = conf.get('app:admin:email');
+    initialPassword = conf.get('app:admin:password');
+    initialToken = conf.get('app:admin:token');
+  });
+
+  afterAll(async () => {
+    // reset to value that were set before running this test.
+    conf.set('app:admin:email', initialEmail);
+    conf.set('app:admin:password', initialPassword);
+    conf.set('app:admin:token', initialToken);
+    await initializeAdminUser({});
+  });
+
+  it('should admin be initialized', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', 'cecilia.payne@filigran.io');
+    conf.set('app:admin:password', 'IDiscoveredUniverseMatter');
+    conf.set('app:admin:token', 'aaaaaaaa-1111-2222-3333-999999999999');
+
+    await initializeAdminUser({});
+
+    const existingAdmin = await findById({}, SYSTEM_USER, OPENCTI_ADMIN_UUID);
+    expect(existingAdmin.user_email).toBe('cecilia.payne@filigran.io');
+  });
+
+  it('should missing admin email raise exception', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', '');
+    conf.set('app:admin:password', initialPassword);
+    conf.set('app:admin:token', initialToken);
+
+    let exceptionNotRaised = false;
+    try {
+      await initializeAdminUser({});
+      exceptionNotRaised = true;
+    } catch (error) {
+      expect(error).toBeDefined();
+    } finally {
+      expect(exceptionNotRaised, 'Having not set an email in env or yml should raise and exception').toBeFalsy();
+    }
+  });
+
+  it('should missing admin password raise exception', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', initialEmail);
+    conf.set('app:admin:password', null);
+    conf.set('app:admin:token', initialToken);
+
+    let exceptionNotRaised = false;
+    try {
+      await initializeAdminUser({});
+      exceptionNotRaised = true;
+    } catch (error) {
+      expect(error).toBeDefined();
+    } finally {
+      expect(exceptionNotRaised, 'Having not set a password in env or yml should raise and exception').toBeFalsy();
+    }
+  });
+
+  it('should missing Password raise exception', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', initialEmail);
+    conf.set('app:admin:password', initialPassword);
+    conf.set('app:admin:token', null);
+
+    let exceptionNotRaised = false;
+    try {
+      await initializeAdminUser({});
+      exceptionNotRaised = true;
+    } catch (error) {
+      expect(error).toBeDefined();
+    } finally {
+      expect(exceptionNotRaised, 'Having not set a Password in env or yml should raise and exception').toBeFalsy();
+    }
+  });
+
+  it('should missing token raise exception', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', initialEmail);
+    conf.set('app:admin:password', initialPassword);
+    conf.set('app:admin:token', null);
+
+    let exceptionNotRaised = false;
+    try {
+      await initializeAdminUser({});
+      exceptionNotRaised = true;
+    } catch (error) {
+      expect(error).toBeDefined();
+    } finally {
+      expect(exceptionNotRaised, 'Having not set a Token in env or yml should raise and exception').toBeFalsy();
+    }
+  });
+
+  it('should password env with digit only works', async () => {
+    // GIVEN configuration
+    conf.set('app:admin:email', initialEmail);
+    conf.set('app:admin:password', 1111); // ENV var with digit only is interpreted as number by node.
+    conf.set('app:admin:token', initialToken);
+
+    await initializeAdminUser({});
+    // expect no exception, exception are failing tests so nothing to check more.
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* force value to be a String
* add some test coverage on initial admin + coverage on the bug reproduction

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/6382

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
