### PR TITLE
[frontend] create unit tests utils functions and refacto Security tests

### DIFF
--- a/opencti-platform/opencti-front/.eslintrc.js
+++ b/opencti-platform/opencti-front/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
       'error',
       {
         devDependencies: [
+          'src/utils/tests/*.{ts,tsx}',
           '**/*.test.{ts,tsx}',
           'tests_e2e/**/*.{ts,tsx,js}',
         ],

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -91,7 +91,9 @@
   "devDependencies": {
     "@playwright/test": "1.42.1",
     "@rollup/plugin-graphql": "2.0.4",
+    "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "14.2.2",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "20.11.30",
     "@types/qrcode": "1.5.5",
     "@types/ramda": "0.29.11",

--- a/opencti-platform/opencti-front/setup-relay-for-vitest.ts
+++ b/opencti-platform/opencti-front/setup-relay-for-vitest.ts
@@ -1,5 +1,0 @@
-import { vi } from 'vitest';
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-global.jest = vi;

--- a/opencti-platform/opencti-front/setup-vitest.ts
+++ b/opencti-platform/opencti-front/setup-vitest.ts
@@ -1,0 +1,16 @@
+import { cleanup } from '@testing-library/react';
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { expect, afterEach, vi } from 'vitest';
+
+import '@testing-library/jest-dom/vitest';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+global.jest = vi;
+
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});

--- a/opencti-platform/opencti-front/src/utils/Security.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/Security.test.tsx
@@ -1,251 +1,147 @@
 import { describe, it, expect } from 'vitest';
-import { RelayEnvironmentProvider } from 'react-relay/hooks';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
 import React from 'react';
-import { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnvironment';
-import ReactDOM from 'react-dom/client';
-import { createMockEnvironment } from 'relay-test-utils';
 import Alert from '@mui/material/Alert';
-import { act } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import Security from './Security';
-import AppIntlProvider from '../components/AppIntlProvider';
 import { BYPASS, EXPLORE_EXUPDATE, KNOWLEDGE_KNUPDATE } from './hooks/useGranted';
-import { UserContext } from './hooks/useAuth';
+import testRender, { createMockUserContext } from './tests/test-render';
 
-const userAdmin = {
-  name: 'admin',
-  user_email: 'admin@opencti.io',
-  firstname: 'Admin',
-  lastname: 'OpenCTI',
-  language: 'auto',
-  unit_system: 'auto',
-  theme: 'default',
-  external: true,
-  userSubscriptions: {
-    edges: [],
-  },
-  capabilities: [{ name: BYPASS }],
-};
+describe('Component: Security validations', () => {
+  it('admin with BYPASS should be allowed whatever the required permission is.', () => {
+    testRender(
+      <Security
+        needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
+        placeholder={<span>NOT ALLOWED</span>}
+      >
+        <Alert severity="info" variant="outlined">
+          The security allows to see this data.
+        </Alert>
+      </Security>,
+      {
+        userContext: createMockUserContext({
+          me: {
+            name: 'admin',
+            user_email: 'admin@opencti.io',
+            capabilities: [{ name: BYPASS }],
+          },
+        }),
+      },
+    );
 
-const userZeroCapability = {
-  name: 'no capability',
-  user_email: 'nocapa@opencti.io',
-  firstname: 'Zero',
-  lastname: 'Capability',
-  language: 'auto',
-  unit_system: 'auto',
-  theme: 'default',
-  external: true,
-  userSubscriptions: {
-    edges: [],
-  },
-  capabilities: [],
-};
-
-const userOneCapability = {
-  name: 'knowledge',
-  user_email: 'knowledge@opencti.io',
-  firstname: 'Knowledge',
-  lastname: 'Update',
-  language: 'auto',
-  unit_system: 'auto',
-  theme: 'default',
-  external: true,
-  userSubscriptions: {
-    edges: [],
-  },
-  capabilities: [{ name: KNOWLEDGE_KNUPDATE }],
-};
-
-const userTwoCapabilities = {
-  name: 'twocapa',
-  user_email: 'twocapa@opencti.io',
-  firstname: 'Two',
-  lastname: 'Capabilities',
-  language: 'auto',
-  unit_system: 'auto',
-  theme: 'default',
-  external: true,
-  userSubscriptions: {
-    edges: [],
-  },
-  capabilities: [{ name: KNOWLEDGE_KNUPDATE }, { name: EXPLORE_EXUPDATE }],
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const AdminContext: any = { me: userAdmin, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {} };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ZeroCapabilityContext: any = { me: userZeroCapability, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {} };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const OneCapabilityContext: any = { me: userOneCapability, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {} };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const TwoCapabilityContext: any = { me: userTwoCapabilities, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {} };
-
-let container: HTMLDivElement | null;
-describe('Security validations', () => {
-  it('admin with BYPASS should be allowed whatever the required permission is.', async () => {
-    act(() => {
-      const createComponent = (divElement: HTMLDivElement, environment: RelayMockEnvironment) => {
-        ReactDOM.createRoot(divElement).render(
-          <RelayEnvironmentProvider environment={environment}>
-            <AppIntlProvider settings={{ platform_language: 'auto' }}>
-              <ThemeProvider theme={createTheme()}>
-                <UserContext.Provider value={AdminContext}>
-                  <Security needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}>
-                    <Alert
-                      severity="info"
-                      variant="outlined"
-                    >The security allows to see this data.</Alert>
-                  </Security>
-                </UserContext.Provider>
-              </ThemeProvider>
-            </AppIntlProvider>
-          </RelayEnvironmentProvider>,
-        );
-      };
-      container = document.createElement('div');
-      const environment = createMockEnvironment();
-      createComponent(container, environment);
-    });
-
-    const alertContent = container?.querySelectorAll('[role="alert"]')[0];
-    expect(alertContent?.innerHTML).contains('The security allows to see this data');
+    const child = screen.queryByText('The security allows to see this data.');
+    expect(child).toBeInTheDocument();
+    const notAllowed = screen.queryByText('NOT ALLOWED');
+    expect(notAllowed).not.toBeInTheDocument();
   });
 
-  it('user with zero capability should not be allowed whatever the required permission is.', async () => {
-    act(() => {
-      const createComponent = (divElement: HTMLDivElement, environment: RelayMockEnvironment) => {
-        ReactDOM.createRoot(divElement).render(
-          <RelayEnvironmentProvider environment={environment}>
-            <AppIntlProvider settings={{ platform_language: 'auto' }}>
-              <ThemeProvider theme={createTheme()}>
-                <UserContext.Provider value={ZeroCapabilityContext}>
-                  <Security
-                    needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
-                    placeholder={<span>NOT ALLOWED</span>}
-                  >
-                    <Alert
-                      severity="info"
-                      variant="outlined"
-                    >The security allows to see this data.</Alert>
-                  </Security>
-                </UserContext.Provider>
-              </ThemeProvider>
-            </AppIntlProvider>
-          </RelayEnvironmentProvider>,
-        );
-      };
+  it('user with zero capability should not be allowed whatever the required permission is.', () => {
+    testRender(
+      <Security
+        needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
+        placeholder={<span>NOT ALLOWED</span>}
+      >
+        <Alert severity="info" variant="outlined">
+          The security allows to see this data.
+        </Alert>
+      </Security>,
+      {
+        userContext: createMockUserContext({
+          me: {
+            name: 'no capability',
+            user_email: 'nocapa@opencti.io',
+            capabilities: [],
+          },
+        }),
+      },
+    );
 
-      container = document.createElement('div');
-      const environment = createMockEnvironment();
-      createComponent(container, environment);
-    });
-
-    const alertContent = container?.querySelectorAll('[role="alert"]')[0];
-    expect(alertContent).toBeUndefined();
-    expect(container?.innerHTML).contains('NOT ALLOWED');
+    const child = screen.queryByText('The security allows to see this data.');
+    expect(child).not.toBeInTheDocument();
+    const notAllowed = screen.queryByText('NOT ALLOWED');
+    expect(notAllowed).toBeInTheDocument();
   });
 
-  it('user with one capability should not be allowed when all are required.', async () => {
-    act(() => {
-      const createComponent = (divElement: HTMLDivElement, environment: RelayMockEnvironment) => {
-        ReactDOM.createRoot(divElement).render(
-          <RelayEnvironmentProvider environment={environment}>
-            <AppIntlProvider settings={{ platform_language: 'auto' }}>
-              <ThemeProvider theme={createTheme()}>
-                <UserContext.Provider value={OneCapabilityContext}>
-                  <Security
-                    needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
-                    matchAll={true}
-                    placeholder={<span>NOT ALLOWED</span>}
-                  >
-                    <Alert
-                      severity="info"
-                      variant="outlined"
-                    >The security allows to see this data.</Alert>
-                  </Security>
-                </UserContext.Provider>
-              </ThemeProvider>
-            </AppIntlProvider>
-          </RelayEnvironmentProvider>,
-        );
-      };
+  it('user with one capability should not be allowed when all are required.', () => {
+    testRender(
+      <Security
+        needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
+        placeholder={<span>NOT ALLOWED</span>}
+        matchAll={true}
+      >
+        <Alert severity="info" variant="outlined">
+          The security allows to see this data.
+        </Alert>
+      </Security>,
+      {
+        userContext: createMockUserContext({
+          me: {
+            name: 'knowledge',
+            user_email: 'knowledge@opencti.io',
+            capabilities: [{ name: KNOWLEDGE_KNUPDATE }],
+          },
+        }),
+      },
+    );
 
-      container = document.createElement('div');
-      const environment = createMockEnvironment();
-      createComponent(container, environment);
-    });
-
-    const alertContent = container?.querySelectorAll('[role="alert"]')[0];
-    expect(alertContent).toBeUndefined();
-    expect(container?.innerHTML).contains('NOT ALLOWED');
+    const child = screen.queryByText('The security allows to see this data.');
+    expect(child).not.toBeInTheDocument();
+    const notAllowed = screen.queryByText('NOT ALLOWED');
+    expect(notAllowed).toBeInTheDocument();
   });
 
-  it('user with one capability should be allowed when only one is required.', async () => {
-    act(() => {
-      const createComponent = (divElement: HTMLDivElement, environment: RelayMockEnvironment) => {
-        ReactDOM.createRoot(divElement).render(
-          <RelayEnvironmentProvider environment={environment}>
-            <AppIntlProvider settings={{ platform_language: 'auto' }}>
-              <ThemeProvider theme={createTheme()}>
-                <UserContext.Provider value={OneCapabilityContext}>
-                  <Security
-                    needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
-                    matchAll={false}
-                    placeholder={<span>NOT ALLOWED</span>}
-                  >
-                    <Alert
-                      severity="info"
-                      variant="outlined"
-                    >The security allows to see this data.</Alert>
-                  </Security>
-                </UserContext.Provider>
-              </ThemeProvider>
-            </AppIntlProvider>
-          </RelayEnvironmentProvider>,
-        );
-      };
+  it('user with one capability should be allowed when only one is required.', () => {
+    testRender(
+      <Security
+        needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
+        placeholder={<span>NOT ALLOWED</span>}
+        matchAll={false}
+      >
+        <Alert severity="info" variant="outlined">
+          The security allows to see this data.
+        </Alert>
+      </Security>,
+      {
+        userContext: createMockUserContext({
+          me: {
+            name: 'knowledge',
+            user_email: 'knowledge@opencti.io',
+            capabilities: [{ name: KNOWLEDGE_KNUPDATE }],
+          },
+        }),
+      },
+    );
 
-      container = document.createElement('div');
-      const environment = createMockEnvironment();
-      createComponent(container, environment);
-    });
-
-    const alertContent = container?.querySelectorAll('[role="alert"]')[0];
-    expect(alertContent?.innerHTML).contains('The security allows to see this data');
+    const child = screen.queryByText('The security allows to see this data.');
+    expect(child).toBeInTheDocument();
+    const notAllowed = screen.queryByText('NOT ALLOWED');
+    expect(notAllowed).not.toBeInTheDocument();
   });
 
-  it('user with 2 capability should be allowed when 2 are required.', async () => {
-    act(() => {
-      const createComponent = (divElement: HTMLDivElement, environment: RelayMockEnvironment) => {
-        ReactDOM.createRoot(divElement).render(
-          <RelayEnvironmentProvider environment={environment}>
-            <AppIntlProvider settings={{ platform_language: 'auto' }}>
-              <ThemeProvider theme={createTheme()}>
-                <UserContext.Provider value={TwoCapabilityContext}>
-                  <Security
-                    needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
-                    matchAll={true}
-                    placeholder={<span>NOT ALLOWED</span>}
-                  >
-                    <Alert
-                      severity="info"
-                      variant="outlined"
-                    >The security allows to see this data.</Alert>
-                  </Security>
-                </UserContext.Provider>
-              </ThemeProvider>
-            </AppIntlProvider>
-          </RelayEnvironmentProvider>,
-        );
-      };
+  it('user with 2 capability should be allowed when 2 are required.', () => {
+    testRender(
+      <Security
+        needs={[KNOWLEDGE_KNUPDATE, EXPLORE_EXUPDATE]}
+        placeholder={<span>NOT ALLOWED</span>}
+        matchAll={true}
+      >
+        <Alert severity="info" variant="outlined">
+          The security allows to see this data.
+        </Alert>
+      </Security>,
+      {
+        userContext: createMockUserContext({
+          me: {
+            name: 'twocapa',
+            user_email: 'twocapa@opencti.io',
+            capabilities: [{ name: KNOWLEDGE_KNUPDATE }, { name: EXPLORE_EXUPDATE }],
+          },
+        }),
+      },
+    );
 
-      container = document.createElement('div');
-      const environment = createMockEnvironment();
-      createComponent(container, environment);
-    });
-
-    const alertContent = container?.querySelectorAll('[role="alert"]')[0];
-    expect(alertContent?.innerHTML).contains('The security allows to see this data');
+    const child = screen.queryByText('The security allows to see this data.');
+    expect(child).toBeInTheDocument();
+    const notAllowed = screen.queryByText('NOT ALLOWED');
+    expect(notAllowed).not.toBeInTheDocument();
   });
 });

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -40,7 +40,7 @@ export const createMockUserContext = (options?: CreateUserContextOptions): UserC
       user_email: 'admin@opencti.io',
       firstname: 'Admin',
       lastname: 'OpenCTI',
-      language: 'auto',
+      language: 'en-us',
       unit_system: 'auto',
       theme: 'default',
       external: true,
@@ -74,7 +74,7 @@ const ProvidersWrapper = ({ children, relayConfig, userContext }: ProvidersWrapp
             {children}
           </UserContext.Provider>
         </ThemeProvider>
-      </AppIntlProvider>W
+      </AppIntlProvider>
     </RelayEnvironmentProvider>
   );
 };

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -1,0 +1,105 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { RelayEnvironmentProvider } from 'react-relay/hooks';
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { createMockEnvironment } from 'relay-test-utils';
+import { EnvironmentConfig } from 'relay-runtime';
+import { UserContext, UserContextType } from '../hooks/useAuth';
+import AppIntlProvider from '../../components/AppIntlProvider';
+
+// 'unknown' to facilitate mocking partial context without having TS errors
+interface CreateUserContextOptions {
+  me?: unknown,
+  settings?: unknown,
+  bannerSettings?: unknown,
+  entitySettings?: unknown,
+  platformModuleHelpers?: unknown,
+  schema?: unknown,
+}
+
+/**
+ * Create a fake user context to match your needs while testing.
+ * If no special need, you don't have to specify any option.
+ *
+ * @param options (optional) Context values to push into the fake context.
+ * @returns The user context for the tests.
+ */
+export const createMockUserContext = (options?: CreateUserContextOptions): UserContextType => {
+  const {
+    me,
+    settings,
+    bannerSettings,
+    entitySettings,
+    platformModuleHelpers,
+    schema,
+  } = options ?? {};
+
+  return {
+    me: (me ?? {
+      name: 'admin',
+      user_email: 'admin@opencti.io',
+      firstname: 'Admin',
+      lastname: 'OpenCTI',
+      language: 'auto',
+      unit_system: 'auto',
+      theme: 'default',
+      external: true,
+      userSubscriptions: {
+        edges: [],
+      },
+    }) as UserContextType['me'],
+    settings: (settings ?? {}) as UserContextType['settings'],
+    bannerSettings: (bannerSettings ?? {}) as UserContextType['bannerSettings'],
+    entitySettings: (entitySettings ?? {}) as UserContextType['entitySettings'],
+    platformModuleHelpers: (platformModuleHelpers ?? {}) as UserContextType['platformModuleHelpers'],
+    schema: (schema ?? {}) as UserContextType['schema'],
+  };
+};
+
+interface ProvidersWrapperProps {
+  children: ReactNode
+  relayConfig?: Partial<EnvironmentConfig>
+  userContext?: Partial<UserContextType>
+}
+
+const ProvidersWrapper = ({ children, relayConfig, userContext }: ProvidersWrapperProps) => {
+  const relayEnv = createMockEnvironment(relayConfig);
+  const defaultUserContext = userContext ?? createMockUserContext();
+
+  return (
+    <RelayEnvironmentProvider environment={relayEnv}>
+      <AppIntlProvider settings={{ platform_language: 'auto' }}>
+        <ThemeProvider theme={createTheme()}>
+          <UserContext.Provider value={defaultUserContext as UserContextType}>
+            {children}
+          </UserContext.Provider>
+        </ThemeProvider>
+      </AppIntlProvider>W
+    </RelayEnvironmentProvider>
+  );
+};
+
+interface TestRenderOptions {
+  relayConfig?: Partial<EnvironmentConfig>,
+  userContext?: Partial<UserContextType>,
+}
+
+/**
+ * Renders a React component to test it.
+ *
+ * @param ui The React component to test.
+ * @param options (optional) Options to configure mocked providers needed to render the component.
+ * @returns Rendered component we can manipulate and make assertions on.
+ */
+const testRender = (ui: ReactNode, options?: TestRenderOptions) => {
+  const { relayConfig, userContext } = options ?? {};
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <ProvidersWrapper relayConfig={relayConfig} userContext={userContext}>
+        {children}
+      </ProvidersWrapper>
+    ),
+  });
+};
+
+export default testRender;

--- a/opencti-platform/opencti-front/tsconfig.json
+++ b/opencti-platform/opencti-front/tsconfig.json
@@ -22,7 +22,8 @@
     "baseUrl": ".",
     "paths": {
       "@components/*": ["src/private/components/*"]
-    }
+    },
+    "types": ["@testing-library/jest-dom"]
   },
   "include": [
     "src", "index.d.ts", ".eslintrc.js", "tests_e2e"

--- a/opencti-platform/opencti-front/vitest.config.ts
+++ b/opencti-platform/opencti-front/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   plugins: [react(), relay],
   test: {
     environment: 'jsdom',
-    setupFiles: 'setup-relay-for-vitest.ts',
-    include: ['src/**/**/*.test.{ts,tsx}']
+    setupFiles: './setup-vitest.ts',
+    include: ['src/**/**/*.test.{ts,tsx}'],
+    globals: true
   },
 })

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -25,6 +25,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.3.2":
+  version: 4.3.3
+  resolution: "@adobe/css-tools@npm:4.3.3"
+  checksum: 10/0e77057efb4e18182560855503066b75edca98671be327d3f8a7ae89ec3da6821e693114b55225909fca00d7e7ed8422f3d79d71fe95dd4d5df1f2026a9fda02
+  languageName: node
+  linkType: hard
+
 "@alcalzone/ansi-tokenize@npm:^0.1.3":
   version: 0.1.3
   resolution: "@alcalzone/ansi-tokenize@npm:0.1.3"
@@ -1675,7 +1682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.24.1
   resolution: "@babel/runtime@npm:7.24.1"
   dependencies:
@@ -4501,6 +4508,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@testing-library/jest-dom@npm:6.4.2"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.3.2"
+    "@babel/runtime": "npm:^7.9.2"
+    aria-query: "npm:^5.0.0"
+    chalk: "npm:^3.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    lodash: "npm:^4.17.15"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    "@jest/globals": ">= 28"
+    "@types/bun": "*"
+    "@types/jest": ">= 28"
+    jest: ">= 28"
+    vitest: ">= 0.32"
+  peerDependenciesMeta:
+    "@jest/globals":
+      optional: true
+    "@types/bun":
+      optional: true
+    "@types/jest":
+      optional: true
+    jest:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10/7ee1e51caffad032734a4a43a00bf72d49080cf1bbf53021b443e91c7fa3762a66f55ce68f1c6643590fe66fbc4df92142659b8cf17c92166a3fb22691987e0d
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:14.2.2":
   version: 14.2.2
   resolution: "@testing-library/react@npm:14.2.2"
@@ -4512,6 +4552,15 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: 10/3605577fda8d5e27b8919f390f749af91494d03e7ba5ccaf6480ed1184248372c5a4e8fe1c8c3ad4c1a7b3536f37144ba4b4626900ed46dc9811312f280eee31
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.5.2":
+  version: 14.5.2
+  resolution: "@testing-library/user-event@npm:14.5.2"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10/49821459d81c6bc435d97128d6386ca24f1e4b3ba8e46cb5a96fe3643efa6e002d88c1b02b7f2ec58da593e805c59b78d7fdf0db565c1f02ba782f63ee984040
   languageName: node
   linkType: hard
 
@@ -6107,7 +6156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.0":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
   dependencies:
@@ -7923,6 +7972,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10/f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -8715,6 +8771,13 @@ __metadata:
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 10/377b4a7f9eae0a5d72e1068c369c99e0e4ca17fdfd5219f3abd32a73a590749a267475a59d7b03a891f9b673c27429133a818c44b2e47e32fec024b34274e2ca
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10/83d3371f8226487fbad36e160d44f1d9017fb26d46faba6a06fcad15f34633fc827b8c3e99d49f71d5f3253d866e2131826866fd0a3c86626f8eccfc361881ff
   languageName: node
   linkType: hard
 
@@ -14910,7 +14973,9 @@ __metadata:
     "@rjsf/mui": "npm:5.18.1"
     "@rjsf/utils": "npm:5.18.1"
     "@rollup/plugin-graphql": "npm:2.0.4"
+    "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:14.2.2"
+    "@testing-library/user-event": "npm:^14.5.2"
     "@types/node": "npm:20.11.30"
     "@types/qrcode": "npm:1.5.5"
     "@types/ramda": "npm:0.29.11"


### PR DESCRIPTION
### Proposed changes

* Create utils functions to help write unit tests in frontend
* Refacto tests of the component Security to use the new helper functions

### Related issues

*

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

