### PR TITLE
[build] Unpriviledged user in Docker and wx permissions in logs volume

### DIFF
--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -95,7 +95,11 @@ RUN set -ex \
         -S \
         -u "${UID}" \
         "${USERNAME}" \
-    && install -o "${UID}" -g "${GID}" -m 0752 -d '/opt/opencti/logs'
+    && install -o "${UID}" -g "${GID}" -m 0755 -d '/opt/opencti/logs'
+
+RUN mkdir -p /opt/opencti/logs
+
+RUN chmod -R 0733 /opt/opencti/logs
 
 VOLUME ["/opt/opencti/logs"]
 

--- a/opencti-platform/Dockerfile_circleci
+++ b/opencti-platform/Dockerfile_circleci
@@ -67,7 +67,11 @@ RUN set -ex \
         -S \
         -u "${UID}" \
         "${USERNAME}" \
-    && install -o "${UID}" -g "${GID}" -m 0752 -d '/opt/opencti/logs'
+    && install -o "${UID}" -g "${GID}" -m 0755 -d '/opt/opencti/logs'
+
+RUN mkdir -p /opt/opencti/logs
+
+RUN chmod -R 0733 /opt/opencti/logs
 
 VOLUME ["/opt/opencti/logs"]
 

--- a/opencti-platform/Dockerfile_circleci_fips
+++ b/opencti-platform/Dockerfile_circleci_fips
@@ -60,7 +60,11 @@ RUN set -ex \
         -S \
         -u "${UID}" \
         "${USERNAME}" \
-    && install -o "${UID}" -g "${GID}" -m 0752 -d '/opt/opencti/logs'
+    && install -o "${UID}" -g "${GID}" -m 0755 -d '/opt/opencti/logs'
+
+RUN mkdir -p /opt/opencti/logs
+
+RUN chmod -R 0733 /opt/opencti/logs
 
 VOLUME ["/opt/opencti/logs"]
 

--- a/opencti-platform/Dockerfile_fips
+++ b/opencti-platform/Dockerfile_fips
@@ -83,7 +83,11 @@ RUN set -ex \
         -S \
         -u "${UID}" \
         "${USERNAME}" \
-    && install -o "${UID}" -g "${GID}" -m 0752 -d '/opt/opencti/logs'
+    && install -o "${UID}" -g "${GID}" -m 0755 -d '/opt/opencti/logs'
+
+RUN mkdir -p /opt/opencti/logs
+
+RUN chmod -R 0733 /opt/opencti/logs
 
 VOLUME ["/opt/opencti/logs"]
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Set wx permissions to the `/opt/opencti/logs` directory for any user
* Set rx permissions to `/opt/opencti` for any user

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/4885

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

This fix is needed to run OpenCTI as an unprivileged user, where the UID is not configurable but assigned by the cluster. This is a common scenario on some Kubernetes platforms.

I have tested assigning different permissions in Docker-compose [1]. Unfortunately, it seems like the unprivileged user needs `wx` permissions to the logs directory and `rx` permissions everywhere else.

This file grants minimal permissions to the directories involved, to avoid any security risks. It also leaves current permissions for the root user as-is, to avoid any hidden issues. In the future, it would be worth understanding why execute permissions are needed in the logs directory, and why write permissions are needed anywhere else.

[1] https://gist.github.com/leitosama/8581ca2bf7720ea08227338e13200991

#### Errors observed

Without wx permissions on the logs directory:
`opencti-1        | Error: EACCES: permission denied, open 'logs/error.log.2024-04-02'`

Without rx permissions everywhere else:

```
opencti-1        | node:internal/modules/cjs/loader:1147
opencti-1        |   throw err;
opencti-1        |   ^
opencti-1        |
opencti-1        | Error: Cannot find module '/opt/opencti/build/back.js'
opencti-1        |     at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
opencti-1        |     at Module._load (node:internal/modules/cjs/loader:985:27)
opencti-1        |     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
opencti-1        |     at node:internal/main/run_main_module:28:49 {
opencti-1        |   code: 'MODULE_NOT_FOUND',
opencti-1        |   requireStack: []
opencti-1        | }
opencti-1        |
opencti-1        | Node.js v20.11.1
```