### PR TITLE
[backend] Improve connection drop handling for importCSV connector (#6314)

### DIFF
--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
@@ -13,7 +13,7 @@ import { parseCsvMapper } from '../../modules/internal/csvMapper/csvMapper-utils
 import type { ConnectorConfig } from '../connector';
 import { IMPORT_CSV_CONNECTOR } from './importCsv';
 import { internalLoadById } from '../../database/middleware-loader';
-import {DatabaseError, UnknownError} from '../../config/errors';
+import { DatabaseError } from '../../config/errors';
 
 const RETRY_CONNECTION_PERIOD = 10000;
 

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -250,6 +250,11 @@ export const consumeQueue = async (context, connectorId, connectionSetterCallbac
           reject(err);
         } else { // Connection success
           logApp.info('Starting connector queue consuming');
+          conn.on('close', (onConnectError) => {
+            if (onConnectError) {
+              reject(onConnectError);
+            }
+          });
           conn.on('error', (onConnectError) => {
             reject(onConnectError);
           });


### PR DESCRIPTION
### Proposed changes

Some of the connection errors on rabbitMQ are sent to the 'close' event and not in the 'error' event. We added an handler for the 'close' event to be able to reconnect to rabbitMQ when possible

### Related issues

 #6314 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
