### PR TITLE
[frontend] Correct CSS color for various plus icons and one edit pencil

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
@@ -565,7 +565,7 @@ class StixCoreRelationshipCreationFromRelation extends Component {
       <div>
         {variant === 'inLine' ? (
           <IconButton
-            color="secondary"
+            color="primary"
             aria-label="Label"
             onClick={this.handleOpen.bind(this)}
             style={{ float: 'left', margin: '-15px 0 0 -2px' }}
@@ -576,7 +576,7 @@ class StixCoreRelationshipCreationFromRelation extends Component {
         ) : (
           <Fab
             onClick={this.handleOpen.bind(this)}
-            color="secondary"
+            color="primary"
             aria-label="Add"
             className={
               paddingRight

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSector.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSector.jsx
@@ -82,7 +82,7 @@ class AddSubSector extends Component {
     return (
       <div>
         <IconButton
-          color="secondary"
+          color="primary"
           aria-label="Add"
           onClick={this.handleOpen.bind(this)}
           classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
@@ -171,7 +171,7 @@ class StixCyberObservableIndicatorsComponent extends Component {
         </Typography>
         <Security needs={[KNOWLEDGE_KNUPDATE]}>
           <IconButton
-            color="secondary"
+            color="primary"
             aria-label="Label"
             onClick={this.handleOpen.bind(this)}
             style={{ float: 'left', margin: '-15px 0 0 -2px' }}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflowPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflowPopover.tsx
@@ -17,7 +17,7 @@ const SubTypeStatusPopover = ({ subTypeId }: { subTypeId: string }) => {
   return (
     <>
       <IconButton
-        color="secondary"
+        color="primary"
         aria-label="Workflow"
         onClick={handleOpenUpdate}
         aria-haspopup="true"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
@@ -53,7 +53,7 @@ const AddAttackPatterns: FunctionComponent<{
   return (
     <div>
       <IconButton
-        color="secondary"
+        color="primary"
         aria-label="Add"
         onClick={handleOpen}
         classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
@@ -51,7 +51,7 @@ const AddDataSources: FunctionComponent<{ dataComponentId: string }> = ({
   return (
     <div>
       <IconButton
-        color="secondary"
+        color="primary"
         aria-label="Add"
         onClick={handleOpen}
         classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
@@ -51,7 +51,7 @@ const AddDataComponents: FunctionComponent<{
   return (
     <div>
       <IconButton
-        color="secondary"
+        color="primary"
         aria-label="Add"
         onClick={handleOpen}
         classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
@@ -48,7 +48,7 @@ class AddSubNarrative extends Component {
     return (
       <div>
         <IconButton
-          color="secondary"
+          color="primary"
           aria-label="Add"
           onClick={this.handleOpen.bind(this)}
           classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
@@ -55,7 +55,7 @@ class AddLocations extends Component {
     return (
       <>
         <IconButton
-          color="secondary"
+          color="primary"
           aria-label="Add"
           onClick={this.handleOpen.bind(this)}
           classes={{ root: classes.createButton }}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividual.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividual.jsx
@@ -60,7 +60,7 @@ class AddLocationsThreatActorIndividual extends Component {
     return (
       <>
         <IconButton
-          color="secondary"
+          color="primary"
           aria-label="Add"
           onClick={this.handleOpen.bind(this)}
           classes={{ root: classes.createButton }}


### PR DESCRIPTION
### Proposed changes

* CSS Color corrects (9) '+' icons that are using the "secondary" CSS versus "primary" CSS resulting in conflicting coloring on the form/report
* CSS Color corrects (1) '+'  FAB that is using the "secondary" CSS versus "primary" CSS resulting in conflicting coloring on the form/report
* CSS Color corrects (1) '+'  edit pencil that is using the "secondary" CSS versus "primary" CSS resulting in conflicting coloring on the form/report

### Related issues

* N/A

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

N/A
