### PR TITLE
[frontend] fix bulk search not returning HashedObservable (#6522)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -333,7 +333,8 @@ const SearchBulk = () => {
                         || o.observable_value?.toLowerCase()
                           === value.toLowerCase()
                         || o.subject?.toLowerCase() === value.toLowerCase()
-                        || o.abstract?.toLowerCase() === value.toLowerCase(),
+                        || o.abstract?.toLowerCase() === value.toLowerCase()
+                        || o.hashes?.map((hash) => hash.hash.toLowerCase() === value.toLowerCase()),
                     );
                     if (resolvedStixCoreObjects.length > 0) {
                       return resolvedStixCoreObjects.map(

--- a/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectsLines.tsx
@@ -218,6 +218,12 @@ export const searchStixCoreObjectsLinesSearchQuery = graphql`
           ... on StixFile {
             x_opencti_additional_names
           }
+          ... on HashedObservable {
+            hashes {
+              algorithm
+              hash
+            }
+          }
           ... on IPv4Addr {
             countries {
               edges {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add HashedObservable in searchStixCoreObjectsLinesSearchQuery
*

### Related issues

* [issue/6522](https://github.com/OpenCTI-Platform/opencti/issues/6522)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
