### PR TITLE
[frontend] replace primary color by marking color (#6542)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
@@ -7,7 +7,6 @@ import ListItemText from '@mui/material/ListItemText';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import Alert from '@mui/lab/Alert';
-import { CenterFocusStrongOutlined } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Field, Form, Formik } from 'formik';
 import Typography from '@mui/material/Typography';
@@ -201,7 +200,10 @@ const GroupEditionMarkingsComponent = ({
                     return (
                       <ListItem key={markingDefinition.id} divider={true}>
                         <ListItemIcon color="primary">
-                          <CenterFocusStrongOutlined />
+                          <ItemIcon
+                            type="Marking-Definition"
+                            color={markingDefinition.x_opencti_color ?? undefined}
+                          />
                         </ListItemIcon>
                         <ListItemText primary={markingDefinition.definition} />
                         <ListItemSecondaryAction>

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
@@ -199,7 +199,7 @@ const GroupEditionMarkingsComponent = ({
                     );
                     return (
                       <ListItem key={markingDefinition.id} divider={true}>
-                        <ListItemIcon color="primary">
+                        <ListItemIcon>
                           <ItemIcon
                             type="Marking-Definition"
                             color={markingDefinition.x_opencti_color ?? undefined}


### PR DESCRIPTION
### Proposed changes

- replace MUI icon by custom component ItemIcon
- use marking color

![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/f4ba41e4-fc1d-4ff6-bab0-8cfcb90aef2e)

### Related issues

- close #6542 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- Need to define a way to improve visibility of TLP icon with white color in light mode (FFFFFF icon on FFFFFF background)

![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/9f30eb8d-9c22-4a1e-9c5d-503f49b9ad8f)