### PR TITLE
[backend] Fix No error when merging two entities with a higher confidence level (#6502)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1333,7 +1333,7 @@ export const mergeEntities = async (context, user, targetEntityId, sourceEntityI
   if (mergedIds.length !== mergedInstances.length) {
     throw FunctionalError('Cannot access all entities for merging');
   }
-
+  mergedInstances.forEach((instance) => controlUserConfidenceAgainstElement(user, instance));
   if (mergedInstances.some(({ entity_type, builtIn }) => entity_type === ENTITY_TYPE_VOCABULARY && Boolean(builtIn))) {
     throw FunctionalError('Cannot merge builtin vocabularies');
   }

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -13,7 +13,6 @@ import { ENTITY_TYPE_VOCABULARY } from '../modules/vocabulary/vocabulary-types';
 import { ENTITY_TYPE_NOTIFICATION } from '../modules/notification/notification-types';
 import { ENTITY_TYPE_CASE_TEMPLATE } from '../modules/case/case-template/case-template-types';
 import { ENTITY_TYPE_LABEL } from '../schema/stixMetaObject';
-import { adaptFiltersWithUserConfidence } from '../utils/confidence-level';
 
 export const DEFAULT_ALLOWED_TASK_ENTITY_TYPES = [
   ABSTRACT_STIX_CORE_OBJECT,
@@ -45,9 +44,8 @@ export const findAll = (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_BACKGROUND_TASK], args);
 };
 
-const buildQueryFilters = async (user, filters, search, taskPosition) => {
+const buildQueryFilters = async (filters, search, taskPosition) => {
   const inputFilters = filters ? JSON.parse(filters) : undefined;
-  const finalFilters = adaptFiltersWithUserConfidence(user, inputFilters);
   // Construct filters
   return {
     types: DEFAULT_ALLOWED_TASK_ENTITY_TYPES,
@@ -55,7 +53,7 @@ const buildQueryFilters = async (user, filters, search, taskPosition) => {
     orderMode: 'asc',
     orderBy: 'created_at',
     after: taskPosition,
-    filters: finalFilters,
+    filters: inputFilters,
     search: search && search.length > 0 ? search : null,
   };
 };

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -58,7 +58,7 @@ const buildQueryFilters = async (filters, search, taskPosition) => {
   };
 };
 export const executeTaskQuery = async (context, user, filters, search, start = null) => {
-  const options = await buildQueryFilters(user, filters, search, start);
+  const options = await buildQueryFilters(filters, search, start);
   return elPaginate(context, user, READ_DATA_INDICES_WITHOUT_INFERRED, options);
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -57,7 +57,6 @@ import { promoteIndicatorToObservable } from '../modules/indicator/indicator-dom
 import { askElementEnrichmentForConnector } from '../domain/stixCoreObject';
 import { RELATION_GRANTED_TO, RELATION_OBJECT } from '../schema/stixRefRelationship';
 import { ACTION_TYPE_DELETE, ACTION_TYPE_SHARE, ACTION_TYPE_UNSHARE, TASK_TYPE_LIST, TASK_TYPE_QUERY, TASK_TYPE_RULE } from '../domain/backgroundTask-common';
-import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { validateUpdatableAttribute } from '../schema/schema-validator';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 
@@ -163,11 +162,7 @@ const computeListTaskElements = async (context, user, task) => {
     const elementToResolve = ids[indexId];
     const element = await internalLoadById(context, user, elementToResolve, { type: DEFAULT_ALLOWED_TASK_ENTITY_TYPES });
     if (element) {
-      // only process elements allowed by confidence control (no throw)
-      const isConfidenceMatch = controlUserConfidenceAgainstElement(user, element, true);
-      if (isConfidenceMatch) {
-        processingElements.push({ element, next: element.id });
-      }
+      processingElements.push({ element, next: element.id });
     }
   }
   return { actions, elements: processingElements };

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -4,8 +4,6 @@ import { isEmptyField } from '../database/utils';
 import { FunctionalError, LockTimeoutError } from '../config/errors';
 import { logApp } from '../config/conf';
 import { schemaAttributesDefinition } from '../schema/schema-attributes';
-import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../generated/graphql';
-import { isFilterGroupNotEmpty } from './filtering/filtering-utils';
 import { isBypassUser } from './access';
 
 type ObjectWithConfidence = {
@@ -193,49 +191,4 @@ export const adaptUpdateInputsConfidence = <T extends ObjectWithConfidence>(user
   }
 
   return newInputs;
-};
-
-/**
- * Narrow the input filter with a AND on the user's max confidence.
- * Result filter will filter out any element without the required confidence (+ input filter).
- */
-export const adaptFiltersWithUserConfidence = (user: AuthUser, filters: FilterGroup): FilterGroup => {
-  if (isEmptyField(user.effective_confidence_level?.max_confidence)) {
-    throw LockTimeoutError({ user_id: user.id }, 'User has no effective max confidence level and cannot run this filter');
-  }
-  const userMaxConfidenceLevel = user.effective_confidence_level?.max_confidence as number;
-
-  // we will filter to get only elements that have...
-  // ... no confidence attribute (no control to do)
-  const entitiesWithoutConfidence: Filter = {
-    key: [
-      'entity_type'
-    ],
-    operator: FilterOperator.NotEq,
-    values: ['Stix-Domain-Object', 'Stix-Relationship'] // only types with confidence judging from schema
-  };
-  // ... a confidence level lower or equal to the user's level
-  const userConfidenceFilter: Filter = {
-    key: ['confidence'],
-    operator: FilterOperator.Lte,
-    values: [userMaxConfidenceLevel]
-  };
-  // ... or no confidence level at all (might happen when inserting data with the API with version <6.0, we consider zero)
-  const nilConfidenceFilter: Filter = {
-    key: ['confidence'],
-    operator: FilterOperator.Nil,
-    values: [],
-  };
-  const orFilterGroup: FilterGroup = {
-    mode: FilterMode.Or,
-    filters: [entitiesWithoutConfidence, userConfidenceFilter, nilConfidenceFilter,],
-    filterGroups: [],
-  };
-
-  // nest: this filter AND the input filters
-  return {
-    mode: FilterMode.And,
-    filters: [],
-    filterGroups: isFilterGroupNotEmpty(filters) ? [orFilterGroup, filters] : [orFilterGroup],
-  };
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/confidence-level-test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  adaptFiltersWithUserConfidence,
   adaptUpdateInputsConfidence,
   computeUserEffectiveConfidenceLevel,
   controlCreateInputWithUserConfidence,
@@ -8,7 +7,6 @@ import {
   controlUserConfidenceAgainstElement
 } from '../../../src/utils/confidence-level';
 import type { AuthUser } from '../../../src/types/user';
-import { type FilterGroup, FilterMode, FilterOperator } from '../../../src/generated/graphql';
 import { BYPASS } from '../../../src/utils/access';
 
 const makeUser = (confidence: number | null) => ({
@@ -252,55 +250,5 @@ describe('Confidence level utilities', () => {
       .toEqual([otherInput, { key: 'confidence', value: ['10'] }]); // inject user's confidence
     expect(adaptUpdateInputsConfidence(makeUser(10), makeConfidenceInput(30), makeElement(null)))
       .toEqual([{ key: 'confidence', value: ['10'] }]); // capped / no need to inject user's confidence
-  });
-
-  it('getConfidenceFilterForUser shall produce correct filters', () => {
-    const emptyFilterGroup: FilterGroup = {
-      mode: FilterMode.And,
-      filterGroups: [],
-      filters: [],
-    };
-    const exampleFilterGroup: FilterGroup = {
-      mode: FilterMode.Or,
-      filterGroups: [],
-      filters: [
-        { key: ['name'], operator: FilterOperator.Contains, mode: FilterMode.Or, values: ['aa', 'bb', 'cc'] },
-        { key: ['score'], operator: FilterOperator.Gte, mode: FilterMode.And, values: [70] }
-      ],
-    };
-    const injectedFilters: FilterGroup = {
-      mode: FilterMode.Or,
-      filterGroups: [],
-      filters: [
-        {
-          key: ['entity_type'],
-          operator: FilterOperator.NotEq,
-          values: ['Stix-Domain-Object', 'Stix-Relationship'],
-        },
-        {
-          key: ['confidence'],
-          operator: FilterOperator.Lte,
-          values: [50],
-        },
-        {
-          key: ['confidence'],
-          operator: FilterOperator.Nil,
-          values: [],
-        },
-      ],
-    };
-
-    expect(adaptFiltersWithUserConfidence(makeUser(50), emptyFilterGroup))
-      .toEqual({
-        mode: FilterMode.And,
-        filters: [],
-        filterGroups: [injectedFilters]
-      });
-    expect(adaptFiltersWithUserConfidence(makeUser(50), exampleFilterGroup))
-      .toEqual({
-        mode: FilterMode.And,
-        filters: [],
-        filterGroups: [injectedFilters, exampleFilterGroup]
-      });
   });
 });


### PR DESCRIPTION
### Proposed changes

* Remove the filter that was implemented before in the background task to avoid error. We want to display an error now
* Move the check of confidence low level in middleware (mergeEntities) instead of the function that compute the list task

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/6502
* https://github.com/OpenCTI-Platform/opencti/issues/6501