### PR TITLE
[frontend] Fix "Select all" not available for relationship creation (#6407)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -37,7 +37,7 @@ import StixCoreRelationshipCreationFromEntityStixCoreObjectsLines, {
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 import type { Theme } from '../../../../components/Theme';
 import { ModuleHelper } from '../../../../utils/platformModulesHelper';
-import { StixCoreRelationshipCreationFromEntityStixCoreObjectsLine_node$data } from './__generated__/StixCoreRelationshipCreationFromEntityStixCoreObjectsLine_node.graphql';
+import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
@@ -311,7 +311,6 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
   const [targetEntities, setTargetEntities] = useState(
     targetEntitiesProps,
   );
-  const [selectedElements, setSelectedElements] = useState<Record<string, StixCoreRelationshipCreationFromEntityStixCoreObjectsLine_node$data>>({});
   useEffect(() => {
     if (!R.equals(targetEntitiesProps, targetEntities) && targetEntitiesProps.length > targetEntities.length) {
       setTargetEntities(targetEntitiesProps);
@@ -461,10 +460,16 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
     setStep(1);
   };
 
-  const onToggleEntity = (entity: TargetEntity) => {
+  const {
+    onToggleEntity,
+    selectedElements,
+    deSelectedElements,
+  } = useEntityToggle(`${entityId}_stixCoreRelationshipCreationFromEntity`);
+
+  const onInstanceToggleEntity = (entity: TargetEntity) => {
+    onToggleEntity(entity);
     if (entity.id in (selectedElements || {})) {
       const newSelectedElements = R.omit([entity.id], selectedElements);
-      setSelectedElements(newSelectedElements);
       setTargetEntities(R.values(newSelectedElements));
     } else {
       const newSelectedElements = R.assoc(
@@ -472,7 +477,6 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
         entity,
         selectedElements || {},
       );
-      setSelectedElements(newSelectedElements);
       setTargetEntities(R.values(newSelectedElements));
     }
   };
@@ -567,9 +571,9 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                         setNumberOfElements={setNumberOfElements}
                         containerRef={containerRef}
                         selectedElements={selectedElements}
-                        deSelectedElements={{}}
+                        deSelectedElements={deSelectedElements}
                         selectAll={false}
-                        onToggleEntity={onToggleEntity}
+                        onToggleEntity={onInstanceToggleEntity}
                       />
                     )}
                   />
@@ -695,9 +699,9 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
         {({ schema }) => {
           const relationshipTypes = R.uniq(R.filter(
             (n) => R.isNil(allowedRelationshipTypes)
-                            || allowedRelationshipTypes.length === 0
-                            || allowedRelationshipTypes.includes('stix-core-relationship')
-                            || allowedRelationshipTypes.includes(n),
+            || allowedRelationshipTypes.length === 0
+            || allowedRelationshipTypes.includes('stix-core-relationship')
+            || allowedRelationshipTypes.includes(n),
             resolveRelationsTypes(
               fromEntities[0].entity_type,
               toEntities[0].entity_type,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -35,6 +35,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ListLines from '../../../../components/list_lines/ListLines';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 import { emptyFilterGroup, removeIdFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
@@ -333,7 +334,6 @@ const StixNestedRefRelationshipCreationFromEntity = ({
   const [openCreateObservable, setOpenCreateObservable] = useState(false);
   const [step, setStep] = useState(0);
   const [targetEntity, setTargetEntity] = useState([]);
-  const [selectedElements, setSelectedElements] = useState({});
   const [sortBy, setSortBy] = useState('_score');
   const [orderAsc, setOrderAsc] = useState(false);
   const [numberOfElements, setNumberOfElements] = useState({
@@ -466,10 +466,16 @@ const StixNestedRefRelationshipCreationFromEntity = ({
     setTargetEntity(stixDomainObject);
   };
 
-  const onToggleEntity = (entity) => {
+  const {
+    onToggleEntity,
+    selectedElements,
+    deSelectedElements,
+  } = useEntityToggle(`${entityId}_stixNestedRefRelationshipCreationFromEntity`);
+
+  const onInstanceToggleEntity = (entity) => {
+    onToggleEntity(entity);
     if (entity.id in (selectedElements || {})) {
       const newSelectedElements = R.omit([entity.id], selectedElements);
-      setSelectedElements(newSelectedElements);
       setTargetEntity(R.values(newSelectedElements));
     } else {
       const newSelectedElements = R.assoc(
@@ -477,7 +483,6 @@ const StixNestedRefRelationshipCreationFromEntity = ({
         entity,
         selectedElements || {},
       );
-      setSelectedElements(newSelectedElements);
       setTargetEntity(R.values(newSelectedElements));
     }
   };
@@ -576,10 +581,10 @@ const StixNestedRefRelationshipCreationFromEntity = ({
                         dataColumns={dataColumns}
                         initialLoading={false}
                         setNumberOfElements={setNumberOfElements}
-                        onToggleEntity={onToggleEntity}
+                        onToggleEntity={onInstanceToggleEntity}
                         containerRef={containerRef}
                         selectedElements={selectedElements}
-                        deSelectedElements={{}}
+                        deSelectedElements={deSelectedElements}
                         selectAll={false}
                       />
                     );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLines.jsx
@@ -153,6 +153,7 @@ const StixNestedRefRelationshipCreationFromEntityLines = createPaginationContain
           ) @connection(key: "Pagination_stixCoreObjects") {
             edges {
               node {
+                id
                 ...StixNestedRefRelationshipCreationFromEntityLine_node
               }
             }


### PR DESCRIPTION
### Proposed changes

* As said in the issue the disabled "select all" was there on purpose. To avoid the pain of entities by entities selection, we just add the possiblity to MAJ+select to perform bulk selection for both StixCoreRelationships & StixNestedRef. By selecting the correct filters, users will still be able to perform a mutli select more quickly and painlessly.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/6407
