### PR TITLE
[frontend] fix call to stixCoreRelationshipsDistribution

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -97,8 +97,18 @@ const dashboardStixCoreRelationshipsDistributionQuery = graphql`
         ... on BasicRelationship {
           entity_type
         }
+        ... on StixObject {
+          representative {
+            main
+          }
+        }
+        ... on StixRelationship {
+          representative {
+            main
+          }
+        }
         ... on Country {
-          name
+          # nullable fields, so it will work even if the Country is Restricted
           x_opencti_aliases
           latitude
           longitude


### PR DESCRIPTION
If a country has a marking unavailable for a user, the dashboard query `stixCoreRelationshipsDistribution` crashes because said country is Restricted.

This is due to PR #6323.

Now the `relationshipDistributions` data are checked and returned with "Restricted" representative if the user cannot access one this side of the relationship. Before they were filtered out, leading to inconsistencies (see #6319).

The bug happens because we do a `...on Country { name }` and name is non-nullable, but will be null because it's restricted.
