### PR TITLE
[frontend] change message if no vocabulary when creating opinion (#6578)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -143,7 +143,6 @@
   "Update a opinions": "Aktualisieren einer Meinung",
   "Do you want to delete this opinions?": "Möchten Sie diese Meinung löschen?",
   "Distribution of opinions": "Verteilung der Meinungen",
-  "There are no opinions. You should create some before.": "Es gibt keine Meinungen. Sie sollten vorher welche erstellen.",
   "Report types": "Berichtstypen",
   "Reliability": "Verlässlichkeit",
   "Create a report": "Einen Bericht erstellen",
@@ -2683,5 +2682,6 @@
   "Most used filters": "Meist genutzte Filter",
   "All other filters": "Alle anderen Filter",
   "Testing csv mapper": "Testen des csv-Mappers",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Diese Operationen gelten nur für Labels oder Markierungen, die im Kontext dieses Playbooks hinzugefügt werden, wie z. B. Anreicherung oder andere Wissensmanipulationen, nicht aber, wenn die Labels oder Markierungen bereits in der Plattform geschrieben sind."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Diese Operationen gelten nur für Labels oder Markierungen, die im Kontext dieses Playbooks hinzugefügt werden, wie z. B. Anreicherung oder andere Wissensmanipulationen, nicht aber, wenn die Labels oder Markierungen bereits in der Plattform geschrieben sind.",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Die Meinungen haben keinen in Ihrem Wortschatz definierten Wert. Bitte fügen Sie sie erst hinzu, um Meinungen hinzufügen zu können."
 }

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -143,7 +143,6 @@
   "Update a opinions": "Update a opinions",
   "Do you want to delete this opinions?": "Do you want to delete this opinions?",
   "Distribution of opinions": "Distribution of opinions",
-  "There are no opinions. You should create some before.": "There are no opinions. You should create some before.",
   "Report types": "Report types",
   "Reliability": "Reliability",
   "Create a report": "Create a report",
@@ -2683,5 +2682,6 @@
   "Most used filters": "Most used filters",
   "All other filters": "All other filters",
   "Testing csv mapper": "Testing csv mapper",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2426,7 +2426,6 @@
   "Do you want to unlink this task ?": "¿Desea desvincular esta tarea?",
   "CREATE": "CREAR",
   "entity_Analyses": "entity_Analyses",
-  "There are no opinions. You should create some before.": "No hay opiniones. Deberías crear algunas antes.",
   "workflow_id": "Estado",
   "Do you want to delete this CSV ingester?": "¿Quieres eliminar este importador CSV?",
   "Do you want to start this CSV ingester?": "¿Quieres iniciar este importador CSV?",
@@ -2683,5 +2682,6 @@
   "Most used filters": "Filtros más utilizados",
   "All other filters": "Todos los demás filtros",
   "Testing csv mapper": "Probando el mapeador csv",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Estas operaciones sólo se aplicarán a las etiquetas o marcas añadidas en el contexto de este libro de jugadas, como el enriquecimiento u otras manipulaciones del conocimiento, pero no si las etiquetas o marcas ya están escritas en la plataforma."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Estas operaciones sólo se aplicarán a las etiquetas o marcas añadidas en el contexto de este libro de jugadas, como el enriquecimiento u otras manipulaciones del conocimiento, pero no si las etiquetas o marcas ya están escritas en la plataforma.",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Las opiniones no tienen ningún valor definido en su vocabulario. Por favor, añádelas primero para poder añadir opiniones."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2426,7 +2426,6 @@
   "malware-author": "malware-author",
   "sponsor": "sponsor",
   "valid": "valide",
-  "There are no opinions. You should create some before.": "Il n'y a pas d'd’opinions. Vous devriez en créer avant.",
   "workflow_id": "Statut",
   "Do you want to delete this CSV ingester?": "Voulez-vous supprimer cet ingéreur CSV ?",
   "Do you want to start this CSV ingester?": "Voulez-vous démarrer cet ingéreur CSV ?",
@@ -2683,5 +2682,6 @@
   "Most used filters": "Filtres les plus utilisés",
   "All other filters": "Tous les autres filtres",
   "Testing csv mapper": "Test du mappeur csv",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Ces opérations ne s'appliqueront qu'aux étiquettes ou marquages ajoutés dans le contexte de ce playbook, comme l'enrichissement ou d'autres manipulations de connaissances, mais pas si les étiquettes ou marquages sont déjà écrits dans la plateforme."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Ces opérations ne s'appliqueront qu'aux étiquettes ou marquages ajoutés dans le contexte de ce playbook, comme l'enrichissement ou d'autres manipulations de connaissances, mais pas si les étiquettes ou marquages sont déjà écrits dans la plateforme.",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Les opinions n'ont pas de valeur définie dans votre vocabulaire. Veuillez d'abord les ajouter pour pouvoir ajouter des opinions."
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2426,7 +2426,6 @@
   "Task": "タスク",
   "CREATE": "作成",
   "entity_Analyses": "エンティティ_分析",
-  "There are no opinions. You should create some before.": "意見がない。事前にいくつか作っておくべきだ。",
   "workflow_id": "ステータス",
   "Do you want to delete this CSV ingester?": "このCSVインガスターを削除しますか？",
   "Do you want to start this CSV ingester?": "このCSVインガスターを開始しますか？",
@@ -2683,5 +2682,6 @@
   "Most used filters": "最も使用されるフィルター",
   "All other filters": "その他のフィルター",
   "Testing csv mapper": "csvマッパーのテスト",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "この操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたラベルやマーキングに対してのみ適用されます。"
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "この操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたラベルやマーキングに対してのみ適用されます。",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意見には、あなたの語彙で定義された価値はありません。意見を追加できるようにするには、まずそれらを追加してください。"
 }

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2426,7 +2426,6 @@
   "Task": "任务",
   "CREATE": "创建",
   "entity_Analyses": "实体_分析",
-  "There are no opinions. You should create some before.": "没有意见。你应该先提出一些意见。",
   "workflow_id": "状态",
   "Do you want to delete this CSV ingester?": "您要删除此CSV导入程序吗？",
   "Do you want to start this CSV ingester?": "您要启动此CSV导入程序吗？",
@@ -2683,5 +2682,6 @@
   "Most used filters": "最常用的过滤器",
   "All other filters": "所有其他筛选器",
   "Testing csv mapper": "测试 csv 映射器",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "此操作仅适用于在此播放列表中添加的标签或标记，如充实或其他知识操作，但不适用于平台中已写入的标签或标记。"
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "此操作仅适用于在此播放列表中添加的标签或标记，如充实或其他知识操作，但不适用于平台中已写入的标签或标记。",
+  "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意见在您的词汇中没有定义值。请先添加意见，才能添加观点。"
 }

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadarDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadarDialog.tsx
@@ -88,7 +88,7 @@ StixCoreObjectOpinionsRadarDialogProps
     } else {
       MESSAGING$.notifyError(
         <span>
-          {t_i18n('There are no opinions. You should create some before.')}
+          {t_i18n('The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.')}
         </span>,
       );
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  change message if no vocabulary when creating opinion


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [issue/6578](https://github.com/OpenCTI-Platform/opencti/issues/6578)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
