### PR TITLE
[graphql] Replace redlock@5.0.0-beta.2 w/ @sesamecare-oss/redlock@1.2.1

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -145,7 +145,6 @@
     "python-shell": "5.0.0",
     "ramda": "0.30.1",
     "rate-limiter-flexible": "4.0.1",
-    "redlock": "5.0.0-beta.2",
     "sanitize-filename": "1.6.3",
     "semver": "7.6.3",
     "set-interval-async": "3.0.3",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -73,7 +73,7 @@
     "@opentelemetry/sdk-trace-base": "1.25.1",
     "@opentelemetry/sdk-trace-node": "1.25.1",
     "@opentelemetry/semantic-conventions": "1.25.1",
-    "@sesamecare-oss/redlock": "1.2.1",
+    "@sesamecare-oss/redlock": "1.3.1",
     "ajv": "8.17.1",
     "amqplib": "0.10.4",
     "antlr4": "4.13.2",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -73,6 +73,7 @@
     "@opentelemetry/sdk-trace-base": "1.25.1",
     "@opentelemetry/sdk-trace-node": "1.25.1",
     "@opentelemetry/semantic-conventions": "1.25.1",
+    "@sesamecare-oss/redlock": "1.2.1",
     "ajv": "8.17.1",
     "amqplib": "0.10.4",
     "antlr4": "4.13.2",

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -1,6 +1,6 @@
 import { SEMATTRS_DB_NAME } from '@opentelemetry/semantic-conventions';
 import Redis, { Cluster, type RedisOptions, type SentinelAddress } from 'ioredis';
-import Redlock from 'redlock';
+import { Redlock } from '@sesamecare-oss/redlock';
 import * as jsonpatch from 'fast-json-patch';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import * as R from 'ramda';

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -3850,12 +3850,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sesamecare-oss/redlock@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@sesamecare-oss/redlock@npm:1.2.1"
+"@sesamecare-oss/redlock@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@sesamecare-oss/redlock@npm:1.3.1"
   peerDependencies:
     ioredis: ">=5"
-  checksum: 10/b4dc20c4ac1ade779e84fdd429617986fea84199be98948f27b2b2cecdc3033e7397e077b59ee78958f0dc16340e51af913a25e41d0bfcb89be6911d721ee365
+  checksum: 10/db6f0a2a6b571687229fc0261459f74529de412b3b14d80c048df7323e20da94885680b0678a5e819a7750de3d9e63e9863874a2b54e3ec4c6f8c5d71dcf8651
   languageName: node
   linkType: hard
 

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -3850,6 +3850,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sesamecare-oss/redlock@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@sesamecare-oss/redlock@npm:1.2.1"
+  peerDependencies:
+    ioredis: ">=5"
+  checksum: 10/b4dc20c4ac1ade779e84fdd429617986fea84199be98948f27b2b2cecdc3033e7397e077b59ee78958f0dc16340e51af913a25e41d0bfcb89be6911d721ee365
+  languageName: node
+  linkType: hard
+
 "@smithy/abort-controller@npm:^3.1.5, @smithy/abort-controller@npm:^3.1.6":
   version: 3.1.6
   resolution: "@smithy/abort-controller@npm:3.1.6"
@@ -11066,7 +11075,6 @@ __metadata:
     python-shell: "npm:5.0.0"
     ramda: "npm:0.30.1"
     rate-limiter-flexible: "npm:4.0.1"
-    redlock: "npm:5.0.0-beta.2"
     sanitize-filename: "npm:1.6.3"
     semver: "npm:7.6.3"
     set-interval-async: "npm:3.0.3"
@@ -11881,15 +11889,6 @@ __metadata:
   dependencies:
     redis-errors: "npm:^1.0.0"
   checksum: 10/b10846844b4267f19ce1a6529465819c3d78c3e89db7eb0c3bb4eb19f83784797ec411274d15a77dbe08038b48f95f76014b83ca366dc955a016a3a0a0234650
-  languageName: node
-  linkType: hard
-
-"redlock@npm:5.0.0-beta.2":
-  version: 5.0.0-beta.2
-  resolution: "redlock@npm:5.0.0-beta.2"
-  dependencies:
-    node-abort-controller: "npm:^3.0.1"
-  checksum: 10/c1df94fb229182ccf59b744f600b45f2cda1d9c7e5b87b9bbf5c3ef92eb47339af7b33b80dc71e97c08c1f476443be68987dad6c49cfc1a89e9a647127884963
   languageName: node
   linkType: hard
 

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -10581,7 +10581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abort-controller@npm:^3.0.1, node-abort-controller@npm:^3.1.1":
+"node-abort-controller@npm:^3.1.1":
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
   checksum: 10/0a2cdb7ec0aeaf3cb31e1ca0e192f5add48f1c5c9c9ed822129f9dddbd9432f69b7425982f94ce803c56a2104884530aa67cd57696e5774b2e5b8ec2f58de042
@@ -10972,6 +10972,7 @@ __metadata:
     "@opentelemetry/sdk-trace-node": "npm:1.25.1"
     "@opentelemetry/semantic-conventions": "npm:1.25.1"
     "@rollup/plugin-graphql": "npm:2.0.4"
+    "@sesamecare-oss/redlock": "npm:1.3.1"
     "@types/archiver": "npm:6.0.2"
     "@types/bcryptjs": "npm:2.4.6"
     "@types/bluebird": "npm:3.5.42"


### PR DESCRIPTION
### Proposed changes
Replace `redlock` TS module with `@sesamecare-oss/redlock` which is a rewrite of the algorithm. The older `redlock` project hasn't released a new release since a 5.0.0 beta in March of 2023.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
This was discussed in #6285 - it is not yet determined if this will address the reported problems. I am currently doing some testing, but wanted to open the PR as a preliminary reference for tracking the code changes that need to occur

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
