### PR TITLE
[frontend] disable nested relation creation in Knowledge graph if relation doesn't exist (#3389)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -15,7 +15,6 @@ import {
   FilterListOutlined,
   GestureOutlined,
   LinkOutlined,
-  ReadMoreOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -42,6 +41,7 @@ import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import ContainerAddStixCoreObjects from '../../common/containers/ContainerAddStixCoreObjects';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
@@ -53,13 +53,12 @@ import { parseDomain } from '../../../../utils/Graph';
 import StixSightingRelationshipCreation from '../../events/stix_sighting_relationships/StixSightingRelationshipCreation';
 import StixSightingRelationshipEdition from '../../events/stix_sighting_relationships/StixSightingRelationshipEdition';
 import SearchInput from '../../../../components/SearchInput';
-import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -978,35 +977,15 @@ class GroupingKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                    <Tooltip title={t('Create a nested relationship')}>
-                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
-                        && (<QueryRenderer
-                          query={stixNestedRefRelationshipCreationResolveQuery}
-                          variables={{
-                            id: relationFromObjects[0].id,
-                            toType: relationToObjects[0].entity_type,
-                          }}
-                          render={({ props }) => {
-                            if (props && props.stixSchemaRefRelationships) {
-                              const { from, to } = props.stixSchemaRefRelationships;
-                              if (from.length > 0 || to.length > 0) {
-                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
-                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
-                            }
-                          }}
-                            />)
-                      }
-                      <span>
-                        <IconButton
-                          color="primary"
-                          onClick={this.handleOpenCreateNested.bind(this)}
-                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
-                          size="large"
-                        >
-                          <ReadMoreOutlined />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
+                      <StixNestedRefRelationshipCreationFromKnowledgeGraph
+                        nestedRelationExist={this.state.nestedRelationExist}
+                        openCreateNested={this.state.openCreateNested}
+                        nestedEnabled={nestedEnabled}
+                        relationFromObjects={relationFromObjects}
+                        relationToObjects={relationToObjects}
+                        handleSetNestedRelationExist={this.handleSetNestedRelationExist.bind(this)}
+                        handleOpenCreateNested={this.handleOpenCreateNested.bind(this)}
+                      />
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -53,12 +53,13 @@ import { parseDomain } from '../../../../utils/Graph';
 import StixSightingRelationshipCreation from '../../events/stix_sighting_relationships/StixSightingRelationshipCreation';
 import StixSightingRelationshipEdition from '../../events/stix_sighting_relationships/StixSightingRelationshipEdition';
 import SearchInput from '../../../../components/SearchInput';
-import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
+import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -97,6 +98,7 @@ class GroupingKnowledgeGraphBar extends Component {
       relationReversed: false,
       sightingReversed: false,
       nestedReversed: false,
+      nestedRelationExist: false,
       openEditRelation: false,
       openEditSighting: false,
       openEditNested: false,
@@ -210,6 +212,10 @@ class GroupingKnowledgeGraphBar extends Component {
 
   handleReverseNested() {
     this.setState({ nestedReversed: !this.state.nestedReversed });
+  }
+
+  handleSetNestedRelationExist(val) {
+    this.setState({ nestedRelationExist: val });
   }
 
   handleOpenEditItem() {
@@ -972,18 +978,35 @@ class GroupingKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                      <Tooltip title={t('Create a nested relationship')}>
-                        <span>
-                          <IconButton
-                            color="primary"
-                            onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled}
-                            size="large"
-                          >
-                            <ReadMoreOutlined />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                    <Tooltip title={t('Create a nested relationship')}>
+                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
+                        && (<QueryRenderer
+                          query={stixNestedRefRelationshipCreationResolveQuery}
+                          variables={{
+                            id: relationFromObjects[0].id,
+                            toType: relationToObjects[0].entity_type,
+                          }}
+                          render={({ props }) => {
+                            if (props && props.stixSchemaRefRelationships) {
+                              const { from, to } = props.stixSchemaRefRelationships;
+                              if (from.length > 0 || to.length > 0) {
+                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
+                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
+                            }
+                          }}
+                            />)
+                      }
+                      <span>
+                        <IconButton
+                          color="primary"
+                          onClick={this.handleOpenCreateNested.bind(this)}
+                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
+                          size="large"
+                        >
+                          <ReadMoreOutlined />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -15,7 +15,6 @@ import {
   FilterListOutlined,
   GestureOutlined,
   LinkOutlined,
-  ReadMoreOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -42,6 +41,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
+import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import ContainerAddStixCoreObjects from '../../common/containers/ContainerAddStixCoreObjects';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
@@ -53,13 +53,12 @@ import { parseDomain } from '../../../../utils/Graph';
 import StixSightingRelationshipCreation from '../../events/stix_sighting_relationships/StixSightingRelationshipCreation';
 import StixSightingRelationshipEdition from '../../events/stix_sighting_relationships/StixSightingRelationshipEdition';
 import SearchInput from '../../../../components/SearchInput';
-import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -981,35 +980,15 @@ class ReportKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                      <Tooltip title={t('Create a nested relationship')}>
-                        {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
-                          && (<QueryRenderer
-                            query={stixNestedRefRelationshipCreationResolveQuery}
-                            variables={{
-                              id: relationFromObjects[0].id,
-                              toType: relationToObjects[0].entity_type,
-                            }}
-                            render={({ props }) => {
-                              if (props && props.stixSchemaRefRelationships) {
-                                const { from, to } = props.stixSchemaRefRelationships;
-                                if (from.length > 0 || to.length > 0) {
-                                  if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
-                                } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
-                              }
-                            }}
-                              />)
-                        }
-                        <span>
-                          <IconButton
-                            color="primary"
-                            onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled || !this.state.nestedRelationExist}
-                            size="large"
-                          >
-                            <ReadMoreOutlined />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                      <StixNestedRefRelationshipCreationFromKnowledgeGraph
+                        nestedRelationExist={this.state.nestedRelationExist}
+                        openCreateNested={this.state.openCreateNested}
+                        nestedEnabled={nestedEnabled}
+                        relationFromObjects={relationFromObjects}
+                        relationToObjects={relationToObjects}
+                        handleSetNestedRelationExist={this.handleSetNestedRelationExist.bind(this)}
+                        handleOpenCreateNested={this.handleOpenCreateNested.bind(this)}
+                      />
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -15,7 +15,6 @@ import {
   FilterListOutlined,
   GestureOutlined,
   LinkOutlined,
-  ReadMoreOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -42,6 +41,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
+import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import ContainerAddStixCoreObjects from '../../common/containers/ContainerAddStixCoreObjects';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
@@ -53,13 +53,12 @@ import { parseDomain } from '../../../../utils/Graph';
 import StixSightingRelationshipCreation from '../../events/stix_sighting_relationships/StixSightingRelationshipCreation';
 import StixSightingRelationshipEdition from '../../events/stix_sighting_relationships/StixSightingRelationshipEdition';
 import SearchInput from '../../../../components/SearchInput';
-import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -984,35 +983,15 @@ class IncidentKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                      <Tooltip title={t('Create a nested relationship')}>
-                        {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
-                          && (<QueryRenderer
-                            query={stixNestedRefRelationshipCreationResolveQuery}
-                            variables={{
-                              id: relationFromObjects[0].id,
-                              toType: relationToObjects[0].entity_type,
-                            }}
-                            render={({ props }) => {
-                              if (props && props.stixSchemaRefRelationships) {
-                                const { from, to } = props.stixSchemaRefRelationships;
-                                if (from.length > 0 || to.length > 0) {
-                                  if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
-                                } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
-                              }
-                            }}
-                              />)
-                        }
-                        <span>
-                          <IconButton
-                            color="primary"
-                            onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled || !this.state.nestedRelationExist}
-                            size="large"
-                          >
-                            <ReadMoreOutlined />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                      <StixNestedRefRelationshipCreationFromKnowledgeGraph
+                        nestedRelationExist={this.state.nestedRelationExist}
+                        openCreateNested={this.state.openCreateNested}
+                        nestedEnabled={nestedEnabled}
+                        relationFromObjects={relationFromObjects}
+                        relationToObjects={relationToObjects}
+                        handleSetNestedRelationExist={this.handleSetNestedRelationExist.bind(this)}
+                        handleOpenCreateNested={this.handleOpenCreateNested.bind(this)}
+                      />
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -53,12 +53,13 @@ import { parseDomain } from '../../../../utils/Graph';
 import StixSightingRelationshipCreation from '../../events/stix_sighting_relationships/StixSightingRelationshipCreation';
 import StixSightingRelationshipEdition from '../../events/stix_sighting_relationships/StixSightingRelationshipEdition';
 import SearchInput from '../../../../components/SearchInput';
-import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import { isStixNestedRefRelationship } from '../../../../utils/Relation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
+import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -97,6 +98,7 @@ class IncidentKnowledgeGraphBar extends Component {
       relationReversed: false,
       sightingReversed: false,
       nestedReversed: false,
+      nestedRelationExist: false,
       openEditRelation: false,
       openEditSighting: false,
       openEditNested: false,
@@ -210,6 +212,10 @@ class IncidentKnowledgeGraphBar extends Component {
 
   handleReverseNested() {
     this.setState({ nestedReversed: !this.state.nestedReversed });
+  }
+
+  handleSetNestedRelationExist(val) {
+    this.setState({ nestedRelationExist: val });
   }
 
   handleOpenEditItem() {
@@ -979,11 +985,28 @@ class IncidentKnowledgeGraphBar extends Component {
                     )}
                     {onAddRelation && (
                       <Tooltip title={t('Create a nested relationship')}>
+                        {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
+                          && (<QueryRenderer
+                            query={stixNestedRefRelationshipCreationResolveQuery}
+                            variables={{
+                              id: relationFromObjects[0].id,
+                              toType: relationToObjects[0].entity_type,
+                            }}
+                            render={({ props }) => {
+                              if (props && props.stixSchemaRefRelationships) {
+                                const { from, to } = props.stixSchemaRefRelationships;
+                                if (from.length > 0 || to.length > 0) {
+                                  if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
+                                } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
+                              }
+                            }}
+                              />)
+                        }
                         <span>
                           <IconButton
                             color="primary"
                             onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled}
+                            disabled={!nestedEnabled || !this.state.nestedRelationExist}
                             size="large"
                           >
                             <ReadMoreOutlined />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -55,9 +55,10 @@ import StixSightingRelationshipEdition from '../../events/stix_sighting_relation
 import SearchInput from '../../../../components/SearchInput';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
-import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
+import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -96,6 +97,7 @@ class CaseRfiKnowledgeGraphBar extends Component {
       relationReversed: false,
       sightingReversed: false,
       nestedReversed: false,
+      nestedRelationExist: false,
       openEditRelation: false,
       openEditSighting: false,
       openEditNested: false,
@@ -209,6 +211,10 @@ class CaseRfiKnowledgeGraphBar extends Component {
 
   handleReverseNested() {
     this.setState({ nestedReversed: !this.state.nestedReversed });
+  }
+
+  handleSetNestedRelationExist(val) {
+    this.setState({ nestedRelationExist: val });
   }
 
   handleOpenEditItem() {
@@ -975,18 +981,35 @@ class CaseRfiKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                      <Tooltip title={t('Create a nested relationship')}>
-                        <span>
-                          <IconButton
-                            color="primary"
-                            onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled}
-                            size="large"
-                          >
-                            <ReadMoreOutlined />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                    <Tooltip title={t('Create a nested relationship')}>
+                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
+                        && (<QueryRenderer
+                          query={stixNestedRefRelationshipCreationResolveQuery}
+                          variables={{
+                            id: relationFromObjects[0].id,
+                            toType: relationToObjects[0].entity_type,
+                          }}
+                          render={({ props }) => {
+                            if (props && props.stixSchemaRefRelationships) {
+                              const { from, to } = props.stixSchemaRefRelationships;
+                              if (from.length > 0 || to.length > 0) {
+                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
+                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
+                            }
+                          }}
+                            />)
+                          }
+                      <span>
+                        <IconButton
+                          color="primary"
+                          onClick={this.handleOpenCreateNested.bind(this)}
+                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
+                          size="large"
+                        >
+                          <ReadMoreOutlined />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -15,7 +15,6 @@ import {
   FilterListOutlined,
   GestureOutlined,
   LinkOutlined,
-  ReadMoreOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -42,6 +41,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
+import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import ContainerAddStixCoreObjects from '../../common/containers/ContainerAddStixCoreObjects';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
@@ -55,10 +55,9 @@ import StixSightingRelationshipEdition from '../../events/stix_sighting_relation
 import SearchInput from '../../../../components/SearchInput';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
-import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -981,35 +980,15 @@ class CaseRfiKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                    <Tooltip title={t('Create a nested relationship')}>
-                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
-                        && (<QueryRenderer
-                          query={stixNestedRefRelationshipCreationResolveQuery}
-                          variables={{
-                            id: relationFromObjects[0].id,
-                            toType: relationToObjects[0].entity_type,
-                          }}
-                          render={({ props }) => {
-                            if (props && props.stixSchemaRefRelationships) {
-                              const { from, to } = props.stixSchemaRefRelationships;
-                              if (from.length > 0 || to.length > 0) {
-                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
-                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
-                            }
-                          }}
-                            />)
-                          }
-                      <span>
-                        <IconButton
-                          color="primary"
-                          onClick={this.handleOpenCreateNested.bind(this)}
-                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
-                          size="large"
-                        >
-                          <ReadMoreOutlined />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
+                      <StixNestedRefRelationshipCreationFromKnowledgeGraph
+                        nestedRelationExist={this.state.nestedRelationExist}
+                        openCreateNested={this.state.openCreateNested}
+                        nestedEnabled={nestedEnabled}
+                        relationFromObjects={relationFromObjects}
+                        relationToObjects={relationToObjects}
+                        handleSetNestedRelationExist={this.handleSetNestedRelationExist.bind(this)}
+                        handleOpenCreateNested={this.handleOpenCreateNested.bind(this)}
+                      />
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -15,7 +15,6 @@ import {
   FilterListOutlined,
   GestureOutlined,
   LinkOutlined,
-  ReadMoreOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -42,6 +41,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
+import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import ContainerAddStixCoreObjects from '../../common/containers/ContainerAddStixCoreObjects';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
@@ -55,10 +55,9 @@ import StixSightingRelationshipEdition from '../../events/stix_sighting_relation
 import SearchInput from '../../../../components/SearchInput';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
-import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -981,35 +980,15 @@ class CaseRftKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                    <Tooltip title={t('Create a nested relationship')}>
-                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
-                        && (<QueryRenderer
-                          query={stixNestedRefRelationshipCreationResolveQuery}
-                          variables={{
-                            id: relationFromObjects[0].id,
-                            toType: relationToObjects[0].entity_type,
-                          }}
-                          render={({ props }) => {
-                            if (props && props.stixSchemaRefRelationships) {
-                              const { from, to } = props.stixSchemaRefRelationships;
-                              if (from.length > 0 || to.length > 0) {
-                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
-                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
-                            }
-                          }}
-                            />)
-                          }
-                      <span>
-                        <IconButton
-                          color="primary"
-                          onClick={this.handleOpenCreateNested.bind(this)}
-                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
-                          size="large"
-                        >
-                          <ReadMoreOutlined />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
+                      <StixNestedRefRelationshipCreationFromKnowledgeGraph
+                        nestedRelationExist={this.state.nestedRelationExist}
+                        openCreateNested={this.state.openCreateNested}
+                        nestedEnabled={nestedEnabled}
+                        relationFromObjects={relationFromObjects}
+                        relationToObjects={relationToObjects}
+                        handleSetNestedRelationExist={this.handleSetNestedRelationExist.bind(this)}
+                        handleOpenCreateNested={this.handleOpenCreateNested.bind(this)}
+                      />
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -55,9 +55,10 @@ import StixSightingRelationshipEdition from '../../events/stix_sighting_relation
 import SearchInput from '../../../../components/SearchInput';
 import StixCyberObservableEdition from '../../observations/stix_cyber_observables/StixCyberObservableEdition';
 import StixNestedRefRelationshipEdition from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipEdition';
-import StixNestedRefRelationshipCreation from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import StixNestedRefRelationshipCreation, { stixNestedRefRelationshipCreationResolveQuery } from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
 import { convertCreatedBy, convertMarkings } from '../../../../utils/edition';
 import { UserContext } from '../../../../utils/hooks/useAuth';
+import { QueryRenderer } from '../../../../relay/environment';
 
 const styles = () => ({
   bottomNav: {
@@ -96,6 +97,7 @@ class CaseRftKnowledgeGraphBar extends Component {
       relationReversed: false,
       sightingReversed: false,
       nestedReversed: false,
+      nestedRelationExist: false,
       openEditRelation: false,
       openEditSighting: false,
       openEditNested: false,
@@ -209,6 +211,10 @@ class CaseRftKnowledgeGraphBar extends Component {
 
   handleReverseNested() {
     this.setState({ nestedReversed: !this.state.nestedReversed });
+  }
+
+  handleSetNestedRelationExist(val) {
+    this.setState({ nestedRelationExist: val });
   }
 
   handleOpenEditItem() {
@@ -975,18 +981,35 @@ class CaseRftKnowledgeGraphBar extends Component {
                       />
                     )}
                     {onAddRelation && (
-                      <Tooltip title={t('Create a nested relationship')}>
-                        <span>
-                          <IconButton
-                            color="primary"
-                            onClick={this.handleOpenCreateNested.bind(this)}
-                            disabled={!nestedEnabled}
-                            size="large"
-                          >
-                            <ReadMoreOutlined />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                    <Tooltip title={t('Create a nested relationship')}>
+                      {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !this.state.openCreatedNested)
+                        && (<QueryRenderer
+                          query={stixNestedRefRelationshipCreationResolveQuery}
+                          variables={{
+                            id: relationFromObjects[0].id,
+                            toType: relationToObjects[0].entity_type,
+                          }}
+                          render={({ props }) => {
+                            if (props && props.stixSchemaRefRelationships) {
+                              const { from, to } = props.stixSchemaRefRelationships;
+                              if (from.length > 0 || to.length > 0) {
+                                if (this.state.nestedRelationExist === false) this.handleSetNestedRelationExist(true);
+                              } else if (this.state.nestedRelationExist) this.handleSetNestedRelationExist(false);
+                            }
+                          }}
+                            />)
+                          }
+                      <span>
+                        <IconButton
+                          color="primary"
+                          onClick={this.handleOpenCreateNested.bind(this)}
+                          disabled={!nestedEnabled || !this.state.nestedRelationExist}
+                          size="large"
+                        >
+                          <ReadMoreOutlined />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                     )}
                     {onAddRelation && (
                       <StixNestedRefRelationshipCreation

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -859,6 +859,10 @@ class StixNestedRefRelationshipCreation extends Component {
           }}
           render={({ props }) => {
             if (props && props.stixSchemaRefRelationships) {
+              if (props.stixSchemaRefRelationships.from.length === 0 && props.stixSchemaRefRelationships.to.length > 0) {
+                this.handleReverseRelation();
+                return this.renderLoader();
+              }
               return (
                 <div>
                   {this.renderForm(props.stixSchemaRefRelationships)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -370,7 +370,7 @@ class StixNestedRefRelationshipCreation extends Component {
     this.props.handleClose();
   }
 
-  renderForm(resolveEntityRef) {
+  renderForm(resolveEntityRef, canReverseRelation) {
     const {
       t,
       classes,
@@ -472,14 +472,14 @@ class StixNestedRefRelationshipCreation extends Component {
                 <div className={classes.middle} style={{ paddingTop: 25 }}>
                   <ArrowRightAlt fontSize="large" />
                   <br />
-                  <Button
+                  {canReverseRelation && <Button
                     variant="outlined"
                     onClick={this.handleReverseRelation.bind(this)}
                     color="secondary"
                     size="small"
-                  >
+                                         >
                     {t('Reverse')}
-                  </Button>
+                  </Button>}
                 </div>
                 <div
                   className={classes.item}
@@ -865,7 +865,7 @@ class StixNestedRefRelationshipCreation extends Component {
               }
               return (
                 <div>
-                  {this.renderForm(props.stixSchemaRefRelationships)}
+                  {this.renderForm(props.stixSchemaRefRelationships, props.stixSchemaRefRelationships.to.length > 0)}
                 </div>
               );
             }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -133,7 +133,7 @@ const styles = (theme) => ({
   },
 });
 
-const stixNestedRefRelationshipCreationResolveQuery = graphql`
+export const stixNestedRefRelationshipCreationResolveQuery = graphql`
   query StixNestedRefRelationshipCreationResolveQuery($id: String!, $toType: String!) {
     stixSchemaRefRelationships(id: $id, toType: $toType) {
       from

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph.tsx
@@ -1,0 +1,68 @@
+import { stixNestedRefRelationshipCreationResolveQuery } from '@components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import IconButton from '@mui/material/IconButton';
+import { ReadMoreOutlined } from '@mui/icons-material';
+import Tooltip from '@mui/material/Tooltip';
+import React, { FunctionComponent } from 'react';
+import {
+  StixNestedRefRelationshipCreationResolveQuery$data,
+} from '@components/common/stix_nested_ref_relationships/__generated__/StixNestedRefRelationshipCreationResolveQuery.graphql';
+import { NodeObject } from 'react-force-graph-2d';
+import { QueryRenderer } from '../../../../relay/environment';
+import { useFormatter } from '../../../../components/i18n';
+
+interface StixNestedRefRelationshipCreationFromKnowledgeGraphProps {
+  nestedRelationExist: boolean,
+  openCreateNested: boolean,
+  nestedEnabled: boolean,
+  relationFromObjects: NodeObject[],
+  relationToObjects: NodeObject[],
+  handleSetNestedRelationExist: (val: boolean) => void,
+  handleOpenCreateNested: () => void,
+}
+const StixNestedRefRelationshipCreationFromKnowledgeGraph: FunctionComponent<StixNestedRefRelationshipCreationFromKnowledgeGraphProps> = ({
+  nestedRelationExist,
+  openCreateNested,
+  nestedEnabled,
+  relationFromObjects,
+  relationToObjects,
+  handleSetNestedRelationExist,
+  handleOpenCreateNested,
+}) => {
+  const { t_i18n } = useFormatter();
+  console.log('relation from', relationFromObjects);
+  return (
+    <Tooltip title={t_i18n('Create a nested relationship')}>
+      <>
+        {(nestedEnabled && relationFromObjects[0] && relationToObjects[0] && !openCreateNested) && (
+        <QueryRenderer
+          query={stixNestedRefRelationshipCreationResolveQuery}
+          variables={{
+            id: relationFromObjects[0].id,
+            toType: relationToObjects[0].entity_type,
+          }}
+          render={({ props }: { props: StixNestedRefRelationshipCreationResolveQuery$data }) => {
+            if (props && props.stixSchemaRefRelationships) {
+              const { from, to } = props.stixSchemaRefRelationships;
+              if ((from && from.length > 0) || (to && to.length > 0)) {
+                if (nestedRelationExist === false) handleSetNestedRelationExist(true);
+              } else if (nestedRelationExist) handleSetNestedRelationExist(false);
+            }
+          }}
+        />)
+                }
+        <span>
+          <IconButton
+            color="primary"
+            onClick={() => handleOpenCreateNested()}
+            disabled={!nestedEnabled || !nestedRelationExist}
+            size="large"
+          >
+            <ReadMoreOutlined />
+          </IconButton>
+        </span>
+      </>
+    </Tooltip>
+  );
+};
+
+export default StixNestedRefRelationshipCreationFromKnowledgeGraph;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraphContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraphContent.tsx
@@ -1,0 +1,44 @@
+import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
+import { stixNestedRefRelationshipCreationResolveQuery } from '@components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation';
+import {
+  StixNestedRefRelationshipCreationResolveQuery,
+} from '@components/common/stix_nested_ref_relationships/__generated__/StixNestedRefRelationshipCreationResolveQuery.graphql';
+import React, { FunctionComponent } from 'react';
+import IconButton from '@mui/material/IconButton';
+import { ReadMoreOutlined } from '@mui/icons-material';
+
+interface StixNestedRefRelationshipCreationFromKnowledgeGraphContentProps {
+  queryRef: PreloadedQuery<StixNestedRefRelationshipCreationResolveQuery>,
+  nestedRelationExist: boolean,
+  handleSetNestedRelationExist: (val: boolean) => void,
+  handleOpenCreateNested: () => void,
+}
+
+const StixNestedRefRelationshipCreationFromKnowledgeGraphContent: FunctionComponent<StixNestedRefRelationshipCreationFromKnowledgeGraphContentProps> = ({
+  queryRef,
+  nestedRelationExist,
+  handleSetNestedRelationExist,
+  handleOpenCreateNested,
+}) => {
+  const { stixSchemaRefRelationships } = usePreloadedQuery<StixNestedRefRelationshipCreationResolveQuery>(stixNestedRefRelationshipCreationResolveQuery, queryRef);
+  if (stixSchemaRefRelationships) {
+    const { from, to } = stixSchemaRefRelationships;
+    if ((from && from.length > 0) || (to && to.length > 0)) {
+      if (nestedRelationExist === false) handleSetNestedRelationExist(true);
+    } else if (nestedRelationExist) handleSetNestedRelationExist(false);
+  }
+  return (
+    <span>
+      <IconButton
+        color="primary"
+        onClick={() => handleOpenCreateNested()}
+        disabled={!nestedRelationExist}
+        size="large"
+      >
+        <ReadMoreOutlined />
+      </IconButton>
+    </span>
+  );
+};
+
+export default StixNestedRefRelationshipCreationFromKnowledgeGraphContent;


### PR DESCRIPTION
PR content : 
 In graphs, grey out nested relationship button if no relationship available 

(this PR is the front part of issue: https://github.com/OpenCTI-Platform/opencti/issues/3389 )