### PR TITLE
Fix the redirection to "files" when exporting in observed data and notes

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -106,6 +106,7 @@ class RootNote extends Component {
                       <ContainerHeader
                         container={props.note}
                         PopoverComponent={<NotePopover note={note} />}
+                        redirectToContent={false}
                       />
                     </CollaborativeSecurity>
                     <Box

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -118,11 +118,7 @@ class RootNote extends Component {
                     >
                       <Tabs
                         value={
-                          location.pathname.includes(
-                            `/dashboard/analyses/notes/${note.id}/knowledge`,
-                          )
-                            ? `/dashboard/analyses/notes/${note.id}/knowledge`
-                            : location.pathname
+                          location.pathname
                         }
                       >
                         <Tab

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -898,7 +898,7 @@ const ContainerHeader = (props) => {
               <StixCoreObjectFileExport
                 id={container.id}
                 type={container.entity_type}
-                redirectToContent={true}
+                redirectToContent={!!redirectToContent}
               />
             )}
             {enableSuggestions && (

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -458,6 +458,7 @@ const ContainerHeader = (props) => {
     enableManageAuthorizedMembers,
     authorizedMembersMutation,
     enableAskAi,
+    redirectToContent,
   } = props;
   const classes = useStyles();
   const { t_i18n, fd } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -113,6 +113,7 @@ class RootObservedData extends Component {
                   <ContainerHeader
                     container={observedData}
                     PopoverComponent={<ObservedDataPopover />}
+                    redirectToContent = {false}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -124,11 +124,7 @@ class RootObservedData extends Component {
                   >
                     <Tabs
                       value={
-                        location.pathname.includes(
-                          `/dashboard/events/observed_data/${observedData.id}/knowledge`,
-                        )
-                          ? `/dashboard/events/observed_data/${observedData.id}/knowledge`
-                          : location.pathname
+                        location.pathname
                       }
                     >
                       <Tab


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the 'redirectToContent' props to the roots of notes and observed data

## Reproducible Steps

In Events/observed data and Events/Notes:
1. Click on the quick button export, at the top right
2. Verify that the page displays correctly with 'files?' in the URL and not 'content?'

## Actual Output
![button export with content in path](https://github.com/OpenCTI-Platform/opencti/assets/87119259/aedf5969-a6c0-4d69-8420-ac2b39ffbdf0)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
