### PR TITLE
[frontend] relationship page - remove padding right

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -203,7 +203,6 @@ class RootObservedData extends Component {
                       element={
                         <StixCoreRelationship
                           entityId={observedData.id}
-                          paddingRight={true}
                         />
                       }
                     />

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
@@ -15,7 +15,6 @@ const StixCyberObservableKnowledgeComponent = (props) => {
           element={
             <StixCoreRelationship
               entityId={stixCyberObservable.id}
-              paddingRight={true}
             />
           }
         />


### PR DESCRIPTION
### Proposed changes

- Remove padding right when dont have right bar

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- Before : update button -> padding right without right bar
![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/12ee39b6-2292-4fcf-a256-d2276844f966)

- Now : No padding
![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/6a33a80c-33bc-4886-9e6e-9a4b903320fc)
