### PR TITLE
[frontend] replace icon anchor on minimap (#6599)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMap.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMap.jsx
@@ -29,16 +29,16 @@ const styles = () => ({
 const cityIcon = (dark = true) => new L.Icon({
   iconUrl: dark ? fileUri(CityDark) : fileUri(CityLight),
   iconRetinaUrl: dark ? fileUri(CityDark) : fileUri(CityLight),
-  iconAnchor: [5, 55],
-  popupAnchor: [10, -44],
+  iconAnchor: [12, 12],
+  popupAnchor: [0, -12],
   iconSize: [25, 25],
 });
 
 const positionIcon = (dark = true) => new L.Icon({
   iconUrl: dark ? fileUri(MarkerDark) : fileUri(MarkerLight),
   iconRetinaUrl: dark ? fileUri(MarkerDark) : fileUri(MarkerLight),
-  iconAnchor: [5, 55],
-  popupAnchor: [10, -44],
+  iconAnchor: [12, 12],
+  popupAnchor: [0, -12],
   iconSize: [25, 25],
 });
 


### PR DESCRIPTION
### Proposed changes

- Replace icon anchor on minimap

### Related issues
- #6599 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- I use `12` because it's approximatly 25 (icon size) / 2, to replace anchor on icon center
- I replace too popup anchor, even if not used
