### PR TITLE
[frontend] fix content listing in grouping page (#6379)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -33,6 +33,7 @@ const subscription = graphql`
         ...Grouping_grouping
         ...GroupingKnowledgeGraph_grouping
         ...GroupingEditionContainer_grouping
+        ...StixDomainObjectContent_stixDomainObject
       }
       ...FileImportViewer_entity
       ...FileExportViewer_entity
@@ -55,6 +56,7 @@ const groupingQuery = graphql`
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
+      ...StixDomainObjectContent_stixDomainObject
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContent.jsx
@@ -279,7 +279,7 @@ class StixDomainObjectContentComponent extends Component {
       next: () => this.setState({ navOpen: localStorage.getItem('navOpen') === 'true' }),
     });
     this.subscription = interval$.subscribe(() => {
-      this.props.relay.refetch();
+      this.props.relay.refetch({ id: this.props.stixDomainObject.id });
     });
 
     const { stixDomainObject } = this.props;
@@ -804,7 +804,7 @@ const StixDomainObjectContent = createRefetchContainer(
             focusOn
           }
         }
-        importFiles(first: 500) {
+        importFiles(first: 500) @connection(key: "Pagination_importFiles") {
           edges {
             node {
               id


### PR DESCRIPTION
### Proposed changes

* fix missing id in refetch query variable
* fix missing fragment in query to be able to use the listed content data

### Related issues
* Closes #6379 
* Closes #6360

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
