### PR TITLE
[frontend] add deprecated message on makeStyles calls

### DIFF
--- a/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
+++ b/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
@@ -16,6 +16,8 @@ interface BreadcrumbsProps {
   elements: element[],
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   breadcrumbsList: {
     marginTop: -5,

--- a/opencti-platform/opencti-front/src/components/ColumnsLinesTitles.tsx
+++ b/opencti-platform/opencti-front/src/components/ColumnsLinesTitles.tsx
@@ -9,6 +9,8 @@ import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import { useFormatter } from './i18n';
 import { DataColumns } from './list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -19,6 +19,8 @@ import FilterIconButtonGlobalMode from './FilterIconButtonGlobalMode';
 import { filterValuesContentQuery } from './FilterValuesContent';
 import { FilterRepresentative } from './filters/FiltersModel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   filter3: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ImageCarousel.tsx
+++ b/opencti-platform/opencti-front/src/components/ImageCarousel.tsx
@@ -11,6 +11,8 @@ import { convertImagesToCarousel } from '../utils/edition';
 import type { Theme } from './Theme';
 import { isNotEmptyField } from '../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme: Theme) => ({
   carousel: {
     textAlign: 'center',

--- a/opencti-platform/opencti-front/src/components/ItemAccountStatus.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemAccountStatus.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ItemConfidence.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemConfidence.tsx
@@ -5,6 +5,8 @@ import Tooltip from '@mui/material/Tooltip';
 import { useLevel } from '../utils/hooks/useScale';
 import { hexToRGB } from '../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ItemCopy.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCopy.tsx
@@ -6,6 +6,8 @@ import { copyToClipboard } from '../utils/utils';
 import type { Theme } from './Theme';
 import { truncate } from '../utils/String';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   containerInline: {
     position: 'relative',

--- a/opencti-platform/opencti-front/src/components/ItemCreators.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemCreators.jsx
@@ -13,6 +13,8 @@ const systemUsers = [
   '31afac4e-6b99-44a0-b91b-e04738d31461', // REDACTED USER
 ];
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   button: {
     margin: '0 7px 7px 0',

--- a/opencti-platform/opencti-front/src/components/ItemDueDate.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemDueDate.tsx
@@ -3,6 +3,8 @@ import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from './i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     borderRadius: 4,

--- a/opencti-platform/opencti-front/src/components/ItemEntityType.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemEntityType.tsx
@@ -4,6 +4,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import { hexToRGB, itemColor } from '../utils/Colors';
 import { useFormatter } from './i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 13,

--- a/opencti-platform/opencti-front/src/components/ItemMarkings.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemMarkings.jsx
@@ -9,6 +9,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import EnrichedTooltip from './EnrichedTooltip';
 import { useFormatter } from './i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ItemOpenVocab.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOpenVocab.tsx
@@ -13,6 +13,8 @@ import useQueryLoading from '../utils/hooks/useQueryLoading';
 import ItemSeverity from './ItemSeverity';
 import ItemPriority from './ItemPriority';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/components/ItemPatternType.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemPatternType.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 15,

--- a/opencti-platform/opencti-front/src/components/ItemPriority.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemPriority.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ItemSeverity.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemSeverity.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/ItemStatusTemplate.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemStatusTemplate.tsx
@@ -6,6 +6,8 @@ import { useFormatter } from './i18n';
 import { hexToRGB } from '../utils/Colors';
 import { SubType_subType$data } from '../private/components/settings/sub_types/__generated__/SubType_subType.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/Loader.tsx
+++ b/opencti-platform/opencti-front/src/components/Loader.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     width: '100vh',

--- a/opencti-platform/opencti-front/src/components/RichTextField.jsx
+++ b/opencti-platform/opencti-front/src/components/RichTextField.jsx
@@ -16,6 +16,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import TextFieldAskAI from '../private/components/common/form/TextFieldAskAI';
 import { useFormatter } from './i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/components/SearchInput.jsx
+++ b/opencti-platform/opencti-front/src/components/SearchInput.jsx
@@ -8,6 +8,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import Tooltip from '@mui/material/Tooltip';
 import { useFormatter } from './i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   searchRoot: {
     borderRadius: 4,

--- a/opencti-platform/opencti-front/src/components/TaskFilterValue.tsx
+++ b/opencti-platform/opencti-front/src/components/TaskFilterValue.tsx
@@ -12,6 +12,8 @@ import { truncate } from '../utils/String';
 import type { Theme } from './Theme';
 import DisplayFilterGroup from './filters/DisplayFilterGroup';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   filter: {
     margin: '5px 10px 5px 0',

--- a/opencti-platform/opencti-front/src/components/TaskScope.tsx
+++ b/opencti-platform/opencti-front/src/components/TaskScope.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
@@ -3,6 +3,8 @@ import Paper from '@mui/material/Paper';
 import React, { CSSProperties, ReactNode } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   paper: {
     minHeight: 110,

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -13,6 +13,8 @@ import { truncate } from '../../utils/String';
 import FilterValuesContent from '../FilterValuesContent';
 import { FilterRepresentative } from './FiltersModel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   inlineOperator: {
     display: 'inline-block',

--- a/opencti-platform/opencti-front/src/front.tsx
+++ b/opencti-platform/opencti-front/src/front.tsx
@@ -16,6 +16,8 @@ import { environment } from './relay/environment';
 import Loader from './components/Loader';
 import { THEME_DARK_DEFAULT_BACKGROUND } from './components/ThemeDark';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   loading: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/Index.tsx
+++ b/opencti-platform/opencti-front/src/private/Index.tsx
@@ -35,6 +35,8 @@ const RootWorkspaces = lazy(() => import('./components/workspaces/Root'));
 const RootSettings = lazy(() => import('./components/settings/Root'));
 const RootAudit = lazy(() => import('./components/settings/activity/audit/Root'));
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme: Theme) => ({
   toolbar: theme.mixins.toolbar,
 }));

--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -29,6 +29,8 @@ import DashboardView from './workspaces/dashboards/Dashboard';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 
 // region styles
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,

--- a/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/DashboardSettings.jsx
@@ -24,6 +24,8 @@ import Security from '../../utils/Security';
 import ItemIcon from '../../components/ItemIcon';
 import Transition from '../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => createStyles({
   muiSelect: {
     display: 'flex',

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -33,6 +33,8 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 
 const SEARCH$ = new Subject().pipe(debounce(() => timer(500)));
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   container: {
     transition: theme.transitions.create('padding', {

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
@@ -12,6 +12,8 @@ import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddExternalReferencesLines, { addExternalReferencesLinesQuery } from './AddExternalReferencesLines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
@@ -13,6 +13,8 @@ import ExternalReferenceStixCoreObjects from './ExternalReferenceStixCoreObjects
 import { ExternalReference_externalReference$data } from './__generated__/ExternalReference_externalReference.graphql';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
@@ -24,6 +24,8 @@ import type { Theme } from '../../../../components/Theme';
 import { ExternalReferenceAddInput, ExternalReferenceCreationMutation$data } from './__generated__/ExternalReferenceCreationMutation.graphql';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDetails.tsx
@@ -17,6 +17,8 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemCreators from '../../../../components/ItemCreators';
 import Transition from '../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
@@ -31,6 +31,8 @@ import { scopesConn } from '../../common/stix_core_objects/StixCoreObjectFilesAn
 
 const interval$ = interval(TEN_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceHeader.tsx
@@ -7,6 +7,8 @@ import Security from '../../../../utils/Security';
 import { ExternalReferenceHeader_externalReference$data } from './__generated__/ExternalReferenceHeader_externalReference.graphql';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceLine.tsx
@@ -15,6 +15,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { ExternalReferenceLine_node$data } from './__generated__/ExternalReferenceLine_node.graphql';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceOverview.tsx
@@ -9,6 +9,8 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { truncate } from '../../../../utils/String';
 import { ExternalReferenceOverview_externalReference$data } from './__generated__/ExternalReferenceOverview_externalReference.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
@@ -14,6 +14,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import { computeLink } from '../../../../utils/Entity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
@@ -45,6 +45,8 @@ import { StixCoreObjectExternalReferencesLines_data$data } from './__generated__
 import { isNotEmptyField } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Grouping.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Grouping.jsx
@@ -11,6 +11,8 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import StixCoreObjectOrStixCoreRelationshipNotes from '../notes/StixCoreObjectOrStixCoreRelationshipNotes';
 import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCoreObjectLatestHistory';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -29,6 +29,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import RichTextField from '../../../../components/RichTextField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysis.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysis.tsx
@@ -14,6 +14,8 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import MalwareAnalysisEdition from './MalwareAnalysisEdition';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
@@ -30,6 +30,8 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
@@ -17,6 +17,8 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import { emptyFilled } from '../../../../utils/String';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisLine.tsx
@@ -16,6 +16,8 @@ import { MalwareAnalysisLine_node$data, MalwareAnalysisLine_node$key } from './_
 import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectLabels';
 import ItemMarkings from '../../../../components/ItemMarkings';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
@@ -34,6 +34,8 @@ import { NoteCreationMutation$variables } from './__generated__/NoteCreationMuta
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButtonContextual: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteLine.tsx
@@ -20,6 +20,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -33,6 +33,8 @@ import ItemLikelihood from '../../../../components/ItemLikelihood';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   card: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -38,6 +38,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { convertMarking } from '../../../../utils/edition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   heading: {
     display: 'flex',

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/Opinion.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/Opinion.jsx
@@ -13,6 +13,8 @@ import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCore
 import OpinionPopover from './OpinionPopover';
 import ContainerStixObjectsOrStixRelationships from '../../common/containers/ContainerStixObjectsOrStixRelationships';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionCreation.tsx
@@ -23,6 +23,8 @@ import { OpinionCreationMutation$variables } from './__generated__/OpinionCreati
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -32,6 +32,8 @@ import RichTextField from '../../../../components/RichTextField';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeTimeLine.jsx
@@ -40,6 +40,8 @@ export const reportKnowledgeTimeLineQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportLine.tsx
@@ -21,6 +21,8 @@ import { ReportLine_node$data } from './__generated__/ReportLine_node.graphql';
 import { emptyFilled } from '../../../../utils/String';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
@@ -27,6 +27,8 @@ import { ChannelsLinesPaginationQuery$variables } from './__generated__/Channels
 import type { Theme } from '../../../../components/Theme';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelLine.tsx
@@ -15,6 +15,8 @@ import type { Theme } from '../../../../components/Theme';
 import { ChannelLine_node$key } from './__generated__/ChannelLine_node.graphql';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Malware.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Malware.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import { Malware_malware$key } from './__generated__/Malware_malware.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
@@ -29,6 +29,8 @@ import { MalwaresCardsPaginationQuery$variables } from './__generated__/Malwares
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Tool.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Tool.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import { Tool_tool$key } from './__generated__/Tool_tool.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
@@ -28,6 +28,8 @@ import { ToolCreationMutation, ToolCreationMutation$variables } from './__genera
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolLine.tsx
@@ -14,6 +14,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
 import { ToolLine_node$key } from './__generated__/ToolLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
@@ -28,6 +28,8 @@ import { VulnerabilityCreationMutation$variables } from './__generated__/Vulnera
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDetails.jsx
@@ -11,6 +11,8 @@ import VulnerabilitySoftwares from './VulnerabilitySoftwares';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { emptyFilled } from '../../../../utils/String';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityLine.tsx
@@ -14,6 +14,8 @@ import { VulnerabilityLine_node$key } from './__generated__/VulnerabilityLine_no
 import { DataColumns } from '../../../../components/list_lines';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
@@ -26,6 +26,8 @@ import ListLines from '../../../../components/list_lines/ListLines';
 import { CaseTasksLineDummy } from '../tasks/CaseTasksLine';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -32,6 +32,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -21,6 +21,8 @@ import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseIncidentDetails_case$key } from './__generated__/CaseIncidentDetails_case.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentLine.tsx
@@ -20,6 +20,8 @@ import { CaseIncidentLineCase_node$data, CaseIncidentLineCase_node$key } from '.
 import ItemSeverity from '../../../../components/ItemSeverity';
 import ItemPriority from '../../../../components/ItemPriority';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeTimeLine.jsx
@@ -40,6 +40,8 @@ export const incidentKnowledgeTimeLineQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
@@ -26,6 +26,8 @@ import { tasksDataColumns } from '../tasks/TasksLine';
 import { CaseTasksLineDummy } from '../tasks/CaseTasksLine';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -32,6 +32,8 @@ import RichTextField from '../../../../components/RichTextField';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -21,6 +21,8 @@ import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseRfiDetails_case$key } from './__generated__/CaseRfiDetails_case.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeTimeLine.jsx
@@ -40,6 +40,8 @@ export const caseRfiKnowledgeTimeLineQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiLine.tsx
@@ -20,6 +20,8 @@ import { CaseRfiLineCase_node$data, CaseRfiLineCase_node$key } from './__generat
 import ItemPriority from '../../../../components/ItemPriority';
 import ItemSeverity from '../../../../components/ItemSeverity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiPopover.tsx
@@ -22,6 +22,8 @@ import useDeletion from '../../../../utils/hooks/useDeletion';
 import CaseRfiEditionContainer, { caseRfiEditionQuery } from './CaseRfiEditionContainer';
 import { CaseRfiEditionContainerCaseQuery } from './__generated__/CaseRfiEditionContainerCaseQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRft.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRft.tsx
@@ -26,6 +26,8 @@ import { tasksDataColumns } from '../tasks/TasksLine';
 import { CaseTasksLineDummy } from '../tasks/CaseTasksLine';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -32,6 +32,8 @@ import RichTextField from '../../../../components/RichTextField';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -21,6 +21,8 @@ import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseRftDetails_case$key } from './__generated__/CaseRftDetails_case.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeTimeLine.jsx
@@ -40,6 +40,8 @@ export const caseRftKnowledgeTimeLineQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftLine.tsx
@@ -20,6 +20,8 @@ import { CaseRftLineCase_node$data, CaseRftLineCase_node$key } from './__generat
 import ItemPriority from '../../../../components/ItemPriority';
 import ItemSeverity from '../../../../components/ItemSeverity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftPopover.tsx
@@ -22,6 +22,8 @@ import useDeletion from '../../../../utils/hooks/useDeletion';
 import CaseRftEditionContainer, { caseRftEditionQuery } from './CaseRftEditionContainer';
 import { CaseRftEditionContainerCaseQuery } from './__generated__/CaseRftEditionContainerCaseQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
@@ -12,6 +12,8 @@ import StixCoreObjectExternalReferences from '../../analyses/external_references
 import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCoreObjectLatestHistory';
 import { Feedback_case$key } from './__generated__/Feedback_case.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackCreation.tsx
@@ -23,6 +23,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import SimpleMarkdownField from '../../../../components/SimpleMarkdownField';
 import Drawer from '../../common/drawer/Drawer';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDetails.tsx
@@ -9,6 +9,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { FeedbackDetails_case$data, FeedbackDetails_case$key } from './__generated__/FeedbackDetails_case.graphql';
 import RatingField from '../../../../components/RatingField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackLine.tsx
@@ -19,6 +19,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import RatingField from '../../../../components/RatingField';
 import { FeedbackLine_node$data, FeedbackLine_node$key } from './__generated__/FeedbackLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackPopover.tsx
@@ -22,6 +22,8 @@ import useDeletion from '../../../../utils/hooks/useDeletion';
 import FeedbackEditionContainer, { feedbackEditionQuery } from './FeedbackEditionContainer';
 import { FeedbackEditionContainerQuery } from './__generated__/FeedbackEditionContainerQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
@@ -22,6 +22,8 @@ import { Option } from '../../common/form/ReferenceField';
 import { CaseTasksLinesQuery$variables } from './__generated__/CaseTasksLinesQuery.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLine.tsx
@@ -20,6 +20,8 @@ import { CaseTasksLine_data$key } from './__generated__/CaseTasksLine_data.graph
 import TaskPopover from './TaskPopover';
 import { CaseTasksLinesQuery$variables } from './__generated__/CaseTasksLinesQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 15,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLines.tsx
@@ -28,6 +28,8 @@ import { tasksDataColumns } from './TasksLine';
 import { CaseTasksLines_data$key } from './__generated__/CaseTasksLines_data.graphql';
 import { CaseTasksLinesQuery, CaseTasksLinesQuery$variables } from './__generated__/CaseTasksLinesQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Task.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Task.tsx
@@ -12,6 +12,8 @@ import Security from '../../../../utils/Security';
 import TaskEdition from './TaskEdition';
 import ContainerStixObjectsOrStixRelationships from '../../common/containers/ContainerStixObjectsOrStixRelationships';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
@@ -23,6 +23,8 @@ import { TaskCreationMutation, TaskCreationMutation$variables } from './__genera
 import { TasksLinesPaginationQuery$variables } from './__generated__/TasksLinesPaginationQuery.graphql';
 import { insertNode } from '../../../../utils/store';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskDetails.tsx
@@ -9,6 +9,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { TaskDetails_task$data, TaskDetails_task$key } from './__generated__/TaskDetails_task.graphql';
 import ItemDueDate from '../../../../components/ItemDueDate';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
@@ -25,6 +25,8 @@ import { TasksEditionContainerQuery } from './__generated__/TasksEditionContaine
 import { deleteNode } from '../../../../utils/store';
 import { CaseTasksLinesQuery$variables } from './__generated__/CaseTasksLinesQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
@@ -18,6 +18,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemStatus from '../../../../components/ItemStatus';
 import ItemDueDate from '../../../../components/ItemDueDate';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/LineDummy.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/LineDummy.tsx
@@ -9,6 +9,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import { DataColumns } from '../../../components/list_lines';
 import type { Theme } from '../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.jsx
@@ -30,6 +30,8 @@ import useGranted, { SETTINGS } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import useDistributionGraphData from '../../../../utils/hooks/useDistributionGraphData';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.jsx
@@ -35,6 +35,8 @@ import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetLoader from '../../../../components/dashboard/WidgetLoader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/cards/GenericAttackCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/cards/GenericAttackCard.tsx
@@ -19,6 +19,8 @@ import { addBookmark, deleteBookMark } from '../stix_domain_objects/StixDomainOb
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   card: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/charts/Chart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/charts/Chart.tsx
@@ -10,6 +10,8 @@ import MenuItem from '@mui/material/MenuItem';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -21,6 +21,8 @@ import useAttributes from '../../../../utils/hooks/useAttributes';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { removeEmptyFields } from '../../../../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -15,6 +15,8 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerContent.jsx
@@ -53,6 +53,8 @@ export const contentMutationFieldPatch = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -45,6 +45,8 @@ import Transition from '../../../../components/Transition';
 import { authorizedMembersToOptions } from '../../../../utils/authorizedMembers';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   containerDefault: {
     marginTop: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMapping.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMapping.jsx
@@ -9,6 +9,8 @@ import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStora
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
@@ -21,6 +21,8 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import ContainerStixCoreObjectPopover from './ContainerStixCoreObjectPopover';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
@@ -22,6 +22,8 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -23,6 +23,8 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
@@ -20,6 +20,8 @@ import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 15,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectsOrStixRelationships.tsx
@@ -15,6 +15,8 @@ import useAuth, { UserContext } from '../../../../utils/hooks/useAuth';
 import useGranted, { KNOWLEDGE_KNPARTICIPATE, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { ContainerStixObjectOrStixRelationshipLineDummy } from './ContainerStixObjectOrStixRelationshipLine';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
@@ -13,6 +13,8 @@ import FilterIconButton from '../../../../components/FilterIconButton';
 import useAuth, { FilterDefinition, UserContext } from '../../../../utils/hooks/useAuth';
 import { Filter, FilterGroup } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   bottomNav: {
     zIndex: 1000,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
@@ -20,6 +20,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import { StixCoreObjectOrStixCoreRelationshipContainerLine_node$data } from './__generated__/StixCoreObjectOrStixCoreRelationshipContainerLine_node.graphql';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
@@ -24,6 +24,8 @@ import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStora
 import { emptyFilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     paddingBottom: 70,

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -20,6 +20,8 @@ export enum DrawerVariant {
   updateWithPanel = 'updateWithPanel',
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme, { bannerHeightNumber: number }>((theme) => createStyles({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
@@ -8,6 +8,8 @@ import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import useGranted, { SETTINGS } from '../../../../utils/hooks/useGranted';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     fontSize: 'xx-small',

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEField.tsx
@@ -3,6 +3,8 @@ import React, { FunctionComponent } from 'react';
 import EEChip from '@components/common/entreprise_edition/EEChip';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   labelRoot: {
     '& .MuiFormLabel-root': {

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEdition.tsx
@@ -21,6 +21,8 @@ import EnterpriseEditionButton from '@components/common/entreprise_edition/Enter
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
@@ -9,6 +9,8 @@ import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS } from '../../../../utils/hooks/useGranted';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   button: {
     marginLeft: 20,

--- a/opencti-platform/opencti-front/src/private/components/common/files/CustomFileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/CustomFileUploader.tsx
@@ -24,6 +24,8 @@ interface CustomFileUploadProps {
   sizeLimit?: number; // in bytes
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   box: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileExportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileExportViewer.tsx
@@ -16,6 +16,8 @@ import { FileExportViewer_entity$data } from './__generated__/FileExportViewer_e
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileImportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileImportViewer.tsx
@@ -16,6 +16,8 @@ import { FileLine_file$data } from './__generated__/FileLine_file.graphql';
 
 const interval$ = interval(TEN_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -36,6 +36,8 @@ const Transition = React.forwardRef(({ children, ...otherProps }: SlideProps, re
 ));
 Transition.displayName = 'TransitionSlide';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     height: 50,

--- a/opencti-platform/opencti-front/src/private/components/common/files/PictureLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/PictureLine.tsx
@@ -16,6 +16,8 @@ import { PictureManagementUtils_node$key } from './__generated__/PictureManageme
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementEdition.tsx
@@ -16,6 +16,8 @@ import { PictureManagementUtils_node$data } from './__generated__/PictureManagem
 import { PictureManagementUtilsMutation, StixDomainObjectFileEditInput } from './__generated__/PictureManagementUtilsMutation.graphql';
 import SwitchField from '../../../../components/SwitchField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementViewer.tsx
@@ -10,6 +10,8 @@ import PictureLine from './PictureLine';
 import { PictureManagementViewer_entity$data, PictureManagementViewer_entity$key } from './__generated__/PictureManagementViewer_entity.graphql';
 import ColumnsLinesTitles from '../../../../components/ColumnsLinesTitles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -62,6 +62,8 @@ import RichTextField from '../../../../../components/RichTextField';
 import Drawer from '../../drawer/Drawer';
 import Transition from '../../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -21,6 +21,8 @@ import { WorkbenchFileViewer_entity$data } from './__generated__/WorkbenchFileVi
 import { WorkbenchFileCreatorMutation } from './__generated__/WorkbenchFileCreatorMutation.graphql';
 import { fetchQuery } from '../../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateField.tsx
@@ -10,6 +10,8 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { CaseTemplateFieldQuery } from './__generated__/CaseTemplateFieldQuery.graphql';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
@@ -20,6 +20,8 @@ import { CaseTemplateTasksSearchQuery$data } from './__generated__/CaseTemplateT
 import { Option } from './ReferenceField';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/CommitMessage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CommitMessage.tsx
@@ -14,6 +14,8 @@ import { BYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -7,6 +7,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { GenericContext } from '../model/GenericContextModel';
 import useConfidenceLevel from '../../../../utils/hooks/useConfidenceLevel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/form/CountryField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CountryField.tsx
@@ -9,6 +9,8 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
@@ -9,6 +9,8 @@ import { CreatorFieldSearchQuery$data } from './__generated__/CreatorFieldSearch
 import ItemIcon from '../../../../components/ItemIcon';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/CsvMapperField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CsvMapperField.tsx
@@ -9,6 +9,8 @@ import AutocompleteField from '../../../../components/AutocompleteField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/DashboardField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/DashboardField.tsx
@@ -13,6 +13,8 @@ import { Option } from './ReferenceField';
 import ItemIcon from '../../../../components/ItemIcon';
 import { GenericContext } from '../model/GenericContextModel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ExternalReferencesField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ExternalReferencesField.tsx
@@ -19,6 +19,8 @@ import ExternalReferenceCreation from '../../analyses/external_references/Extern
 import { externalReferencesQueriesSearchQuery } from '../../analyses/external_references/ExternalReferencesQueries';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/FilesNativeField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/FilesNativeField.tsx
@@ -18,6 +18,8 @@ interface FilesFieldProps {
   helperText?: string;
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/GroupField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/GroupField.tsx
@@ -8,6 +8,8 @@ import AutocompleteField from '../../../../components/AutocompleteField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/NotifierConnectorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/NotifierConnectorField.tsx
@@ -8,6 +8,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { NotifierConnectorFieldSearchQuery$data } from './__generated__/NotifierConnectorFieldSearchQuery.graphql';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/NotifierField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/NotifierField.tsx
@@ -10,6 +10,8 @@ import { NotifierFieldSearchQuery$data } from './__generated__/NotifierFieldSear
 import { Option } from './ReferenceField';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectLabelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectLabelField.tsx
@@ -12,6 +12,8 @@ import { labelsSearchQuery } from '../../settings/LabelsQuery';
 import { Option } from './ReferenceField';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
@@ -16,6 +16,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { convertMarking } from '../../../../utils/edition';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
@@ -10,6 +10,8 @@ import AutocompleteField from '../../../../components/AutocompleteField';
 import ItemIcon from '../../../../components/ItemIcon';
 import { Option } from './ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectOrganizationField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectOrganizationField.jsx
@@ -9,6 +9,8 @@ import AutocompleteField from '../../../../components/AutocompleteField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
@@ -38,6 +38,8 @@ export const objectParticipantFieldParticipantsSearchQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObservableTypesField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObservableTypesField.tsx
@@ -8,6 +8,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import type { Theme } from '../../../../components/Theme';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/PasswordPolicies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/PasswordPolicies.tsx
@@ -7,6 +7,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { PasswordPolicies$key } from './__generated__/PasswordPolicies.graphql';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/form/ReferenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ReferenceField.tsx
@@ -6,6 +6,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/StatusTemplateField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StatusTemplateField.tsx
@@ -11,6 +11,8 @@ import { StatusTemplateFieldSearchQuery$data } from './__generated__/StatusTempl
 import { Option } from './ReferenceField';
 import { StatusTemplateCreationContextualMutation$data } from '../../settings/status_templates/__generated__/StatusTemplateCreationContextualMutation.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectsField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectsField.jsx
@@ -191,6 +191,8 @@ export const stixCoreObjectsFieldSearchQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -10,6 +10,8 @@ import SearchScopeElement from './SearchScopeElement';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 import { Option } from '../form/ReferenceField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FiltersElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FiltersElement.tsx
@@ -9,6 +9,8 @@ import FilterAutocomplete from './FilterAutocomplete';
 import type { Theme } from '../../../../components/Theme';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   helpertext: {
     display: 'inline-block',

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.jsx
@@ -11,6 +11,8 @@ import MUIAutocomplete from '@mui/material/Autocomplete';
 import { useFormatter } from '../../../../components/i18n';
 import { useBuildFilterKeysMapFromEntityType, getDefaultFilterObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     width: 600,

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.jsx
@@ -8,6 +8,8 @@ import React from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   filters: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.jsx
@@ -12,6 +12,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../../components/i18n';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container2: {
     width: 300,

--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
@@ -26,6 +26,8 @@ import MarkdownField from '../../../../components/MarkdownField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -11,6 +11,8 @@ import type { Theme } from '../../../../components/Theme';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawer: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.jsx
@@ -22,6 +22,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import Transition from '../../../../components/Transition';
 import { commitMutation, fetchQuery, MESSAGING$ } from '../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKillChainPhasesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKillChainPhasesView.tsx
@@ -8,6 +8,8 @@ import { makeStyles } from '@mui/styles';
 import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   killChainPhaseItem: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -14,6 +14,8 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawer: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
@@ -53,6 +53,8 @@ interface InstanceTriggerEditionFormValues {
   filters: string | null;
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     textAlign: 'right',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
@@ -37,6 +37,8 @@ interface OrganizationForm {
 
 // endregion
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   organizationInHeader: {
     margin: '4px 7px 0 0',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSubscribers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSubscribers.tsx
@@ -27,6 +27,8 @@ interface ContainerHeaderSharedProps {
 }
 // endregion
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -20,6 +20,8 @@ import SelectField from '../../../../components/SelectField';
 import Loader from '../../../../components/Loader';
 import { ExportContext } from '../../../../utils/ExportContextProvider';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.jsx
@@ -15,6 +15,8 @@ import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/d
 import { itemColor } from '../../../../utils/Colors';
 import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.js
@@ -27,6 +27,8 @@ import useGranted, { KNOWLEDGE_KNUPDATE, SETTINGS_SETLABELS } from '../../../../
 import CommitMessage from '../form/CommitMessage';
 import Transition from '../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   label: {
     margin: '0 7px 7px 0',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
@@ -7,6 +7,8 @@ import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStora
 import { PaginationOptions } from '../../../../components/list_lines';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: 15,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars.jsx
@@ -14,6 +14,8 @@ import { horizontalBarsChartOptions } from '../../../../utils/Charts';
 import { simpleNumberFormat } from '../../../../utils/Number';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.js
@@ -23,6 +23,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   containerRelation: {
     padding: '10px 20px 20px 20px',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -39,6 +39,8 @@ import type { Theme } from '../../../../components/Theme';
 import { ModuleHelper } from '../../../../utils/platformModulesHelper';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList.js
@@ -17,6 +17,8 @@ import StixCoreRelationshipCreationForm, { stixCoreRelationshipBasicShape } from
 import { formatDate } from '../../../../utils/Time';
 import { APP_BASE_PATH } from '../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   icon: {
     color: theme.palette.primary.main,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityStixCoreObjectsLine.jsx
@@ -17,6 +17,8 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import { APP_BASE_PATH } from '../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEdition.jsx
@@ -6,6 +6,8 @@ import StixCoreRelationshipEditionOverview, { stixCoreRelationshipEditionOvervie
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
@@ -34,6 +34,8 @@ import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipSharing.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipSharing.tsx
@@ -37,6 +37,8 @@ interface OrganizationForm {
 
 // endregion
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   organization: {
     margin: '0 7px 0 0',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
@@ -29,6 +29,8 @@ import type { Theme } from '../../../../../components/Theme';
 import { resolveLink } from '../../../../../utils/Entity';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   chipInList: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
@@ -17,6 +17,8 @@ import {
   EntityStixCoreRelationshipsContextualViewLine_node$key,
 } from './__generated__/EntityStixCoreRelationshipsContextualViewLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLineDummy.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLineDummy.tsx
@@ -9,6 +9,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import type { Theme } from '../../../../../components/Theme';
 import { DataColumns } from '../../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: theme.spacing(1.5),

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
@@ -25,6 +25,8 @@ import {
   EntityStixCoreRelationshipsEntitiesViewLine_node$key,
 } from './__generated__/EntityStixCoreRelationshipsEntitiesViewLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators.tsx
@@ -8,6 +8,8 @@ import { PaginationOptions } from '../../../../../../components/list_lines';
 import EntityStixCoreRelationshipsIndicatorsContextualView from './EntityStixCoreRelationshipsIndicatorsContextualView';
 import { emptyFilterGroup } from '../../../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: 15,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
@@ -32,6 +32,8 @@ import { resolveLink } from '../../../../../../utils/Entity';
 import type { Theme } from '../../../../../../components/Theme';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   chip: {
     fontSize: 13,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLine.tsx
@@ -17,6 +17,8 @@ import {
   EntityStixCoreRelationshipsIndicatorsContextualViewLine_node$key,
 } from './__generated__/EntityStixCoreRelationshipsIndicatorsContextualViewLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/stix_cyber_observable/EntityStixCoreRelationshipsStixCyberObservable.tsx
@@ -8,6 +8,8 @@ import EntityStixCoreRelationshipsRelationshipsView from '../EntityStixCoreRelat
 import ExportContextProvider from '../../../../../../utils/ExportContextProvider';
 import { emptyFilterGroup } from '../../../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: 15,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatterns.jsx
@@ -6,6 +6,8 @@ import StixDomainObjectAttackPatternsKillChain, { stixDomainObjectAttackPatterns
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { emptyFilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContentBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectContentBar.tsx
@@ -11,6 +11,8 @@ import { createStyles } from '@mui/styles';
 import type { Theme } from '../../../../components/Theme';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme, { bannerHeightNumber: number }>(() => createStyles({
   bottomNav: {
     zIndex: 1000,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -90,6 +90,8 @@ const THREAT_ACTOR_ENTITIES = [
   'Threat-Actor',
 ];
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
@@ -22,6 +22,8 @@ import ConfidenceField from '../form/ConfidenceField';
 import { convertMarkings } from '../../../../utils/edition';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -43,6 +43,8 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import Transition from '../../../../components/Transition';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectThreatKnowledge.tsx
@@ -52,6 +52,8 @@ import {
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: 300,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsRightBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsRightBar.jsx
@@ -17,6 +17,8 @@ import { stixDomainObjectsLinesSubTypesQuery } from './StixDomainObjectsLines';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -37,6 +37,8 @@ import useFiltersState from '../../../../utils/filters/useFiltersState';
 import { emptyFilterGroup, removeIdFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLine.tsx
@@ -23,6 +23,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
@@ -17,6 +17,8 @@ import { useFormatter } from '../../../components/i18n';
 
 const LOCAL_STORAGE_KEY_CSV_MAPPERS = 'csvMappers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     paddingRight: '200px',

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -18,6 +18,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'ingestionCsvs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionRss.jsx
@@ -14,6 +14,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'ingestionRss';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.jsx
@@ -14,6 +14,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'ingestionTaxii';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
@@ -33,6 +33,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 export const LOCAL_STORAGE_KEY_PLAYBOOKS = 'playbooks';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/ProcessingMenu.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ProcessingMenu.jsx
@@ -11,6 +11,8 @@ import useAuth from '../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
 import useGranted, { KNOWLEDGE_KNUPDATE, SETTINGS_SETACCESSES, TAXIIAPI_SETCSVMAPPERS } from '../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawer: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/data/SharingMenu.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/SharingMenu.jsx
@@ -9,6 +9,8 @@ import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawer: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.jsx
@@ -15,6 +15,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'sync';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Tasks.jsx
@@ -11,6 +11,8 @@ import { TASK_MANAGER } from '../../../utils/platformModulesHelper';
 import ProcessingMenu from './ProcessingMenu';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
@@ -31,6 +31,8 @@ import Security from '../../../../utils/Security';
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -30,6 +30,8 @@ import SortConnectorsHeader from './SortConnectorsHeader';
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   linesContainer: {
     marginTop: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -22,6 +22,8 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import { representationInitialization } from './representations/RepresentationUtils';
 import CsvMapperTestDialog from './CsvMapperTestDialog';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperLine.tsx
@@ -13,6 +13,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperRepresentationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperRepresentationForm.tsx
@@ -22,6 +22,8 @@ import type { Theme } from '../../../../../components/Theme';
 import useDeletion from '../../../../../utils/hooks/useDeletion';
 import DeleteDialog from '../../../../../components/DeleteDialog';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeForm.tsx
@@ -13,6 +13,8 @@ import { SchemaAttribute } from '@components/data/csvMapper/representations/attr
 import { useFormatter } from '../../../../../../components/i18n';
 import { isEmptyField } from '../../../../../../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeRefForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeRefForm.tsx
@@ -18,6 +18,8 @@ import useAuth from '../../../../../../utils/hooks/useAuth';
 import { resolveTypesForRelationship, resolveTypesForRelationshipRef } from '../../../../../../utils/Relation';
 import { useFormatter } from '../../../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
@@ -18,6 +18,8 @@ import { resolveLink } from '../../../../utils/Entity';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/PublicFeedLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/PublicFeedLines.tsx
@@ -20,6 +20,8 @@ import type { Theme } from '../../../../components/Theme';
 import { copyToClipboard } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   bodyItem: {
     height: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -26,6 +26,8 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
@@ -28,6 +28,8 @@ import type { Theme } from '../../../../components/Theme';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvLine.tsx
@@ -16,6 +16,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/Playbook.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/Playbook.jsx
@@ -26,6 +26,8 @@ import edgeTypes from './types/edges';
 import { addPlaceholders, computeNodes, computeEdges } from './utils/playbook';
 import useManipulateComponents from './hooks/useManipulateComponents';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -37,6 +37,8 @@ import AutocompleteField from '../../../../components/AutocompleteField';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   lines: {
     padding: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookCreation.jsx
@@ -25,6 +25,8 @@ import TextField from '../../../../components/TextField';
 import { insertNode } from '../../../../utils/store';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookHeader.tsx
@@ -41,6 +41,8 @@ import Transition from '../../../../components/Transition';
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookLine.tsx
@@ -14,6 +14,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookPopover.jsx
@@ -32,6 +32,8 @@ import { deleteNode } from '../../../../utils/store';
 import { useFormatter } from '../../../../components/i18n';
 import Transition from '../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/PlaceholderEdge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/PlaceholderEdge.tsx
@@ -3,6 +3,8 @@ import { getBezierPath, EdgeProps, EdgeLabelRenderer } from 'reactflow';
 import { makeStyles } from '@mui/styles';
 import type { Theme } from '../../../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   placeholderPath: {
     strokeWidth: 0.5,

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/WorkflowEdge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/WorkflowEdge.tsx
@@ -3,6 +3,8 @@ import { EdgeLabelRenderer, EdgeProps, getBezierPath, useReactFlow } from 'react
 import { makeStyles } from '@mui/styles';
 import type { Theme } from '../../../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   edgeButton: {
     cursor: 'pointer',

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodePlaceholder.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodePlaceholder.tsx
@@ -3,6 +3,8 @@ import { Handle, Position, NodeProps, useReactFlow } from 'reactflow';
 import makeStyles from '@mui/styles/makeStyles';
 import type { Theme } from '../../../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   node: {
     border:

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
@@ -14,6 +14,8 @@ type node = {
   id: string;
 };
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   node: {
     position: 'relative',

--- a/opencti-platform/opencti-front/src/private/components/data/relationships/RelationshipsStixCoreRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/relationships/RelationshipsStixCoreRelationshipLine.jsx
@@ -20,6 +20,8 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import { computeLink } from '../../../../utils/Entity';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/stream/PublicStreamLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/PublicStreamLines.tsx
@@ -19,6 +19,8 @@ import { PublicStreamLines_node$key } from './__generated__/PublicStreamLines_no
 import { copyToClipboard } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   bodyItem: {
     height: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.tsx
@@ -35,6 +35,8 @@ interface StreamCollectionCreationForm {
   name: string
   description: string
 }
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
@@ -22,6 +22,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { convertAuthorizedMembers } from '../../../../utils/edition';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncCreation.jsx
@@ -29,6 +29,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
@@ -24,6 +24,8 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx
@@ -32,6 +32,8 @@ import TaskScope from '../../../../components/TaskScope';
 import { deserializeFilterGroupForFrontend, isFilterFormatCorrect, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 import { convertFiltersFromOldFormat } from '../../../../utils/filters/filtersFromOldFormat';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/PublicTaxiiLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/PublicTaxiiLines.tsx
@@ -20,6 +20,8 @@ import type { Theme } from '../../../../components/Theme';
 import { copyToClipboard } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   bodyItem: {
     height: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionCreation.tsx
@@ -36,6 +36,8 @@ interface TaxiiCollectionCreationForm {
   description: string
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.tsx
@@ -22,6 +22,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { convertAuthorizedMembers } from '../../../../utils/edition';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -29,6 +29,8 @@ import { EventsLinesPaginationQuery$variables } from './__generated__/EventsLine
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
@@ -13,6 +13,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -27,6 +27,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualLine.tsx
@@ -14,6 +14,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -27,6 +27,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -12,6 +12,8 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -25,6 +25,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   formContainer: {
     margin: '20px 0 20px 0',

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
@@ -14,6 +14,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -26,6 +26,8 @@ import { SectorsLinesPaginationQuery$variables } from './__generated__/SectorsLi
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -27,6 +27,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemLine.tsx
@@ -14,6 +14,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Incident.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Incident.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import { Incident_incident$key } from './__generated__/Incident_incident.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
@@ -30,6 +30,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
@@ -12,6 +12,8 @@ import { IncidentDetails_incident$data, IncidentDetails_incident$key } from './_
 import StixCoreObjectsDonut from '../../common/stix_core_objects/StixCoreObjectsDonut';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentLine.tsx
@@ -19,6 +19,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import { IncidentLine_node$data, IncidentLine_node$key } from './__generated__/IncidentLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataCreation.tsx
@@ -28,6 +28,8 @@ import { ObservedDatasLinesPaginationQuery$variables } from './__generated__/Obs
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
@@ -24,6 +24,8 @@ import { resolveLink } from '../../../../utils/Entity';
 import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
@@ -16,6 +16,8 @@ import { FilterGroup, emptyFilterGroup, useRemoveIdAndIncorrectKeysFromFilterGro
 
 export const LOCAL_STORAGE_KEY = 'sightings';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: 15,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
@@ -7,6 +7,8 @@ import Loader from '../../../../components/Loader';
 import { StixSightingRelationshipQuery$data } from './__generated__/StixSightingRelationshipQuery.graphql';
 import { QueryRenderer } from '../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginTop: 10,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.js
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.js
@@ -20,6 +20,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   containerRelation: {
     padding: '10px 20px 20px 20px',

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
@@ -29,6 +29,8 @@ import StixSightingRelationshipCreationForm from './StixSightingRelationshipCrea
 import { useFormatter } from '../../../../components/i18n';
 import { insertNode } from '../../../../utils/store';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEdition.jsx
@@ -6,6 +6,8 @@ import StixSightingRelationshipEditionOverview, { stixSightingRelationshipEditio
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -35,6 +35,8 @@ import type { Theme } from '../../../../components/Theme';
 import { StixSightingRelationshipEditionOverviewQuery } from './__generated__/StixSightingRelationshipEditionOverviewQuery.graphql';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipSharing.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipSharing.tsx
@@ -38,6 +38,8 @@ interface OrganizationForm {
 
 // endregion
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   organization: {
     margin: '0 7px 0 0',

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeArea.tsx
@@ -14,6 +14,8 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { AdministrativeArea_administrativeArea$key } from './__generated__/AdministrativeArea_administrativeArea.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
@@ -25,6 +25,8 @@ import { Option } from '../../common/form/ReferenceField';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaLine.tsx
@@ -13,6 +13,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import { AdministrativeAreaLine_node$key } from './__generated__/AdministrativeAreaLine_node.graphql';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/City.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/City.tsx
@@ -14,6 +14,8 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { City_city$key } from './__generated__/City_city.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
@@ -25,6 +25,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityLine.tsx
@@ -13,6 +13,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import { CityLine_node$key } from './__generated__/CityLine_node.graphql';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityPopover.tsx
@@ -21,6 +21,8 @@ import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted'
 import { CityEditionContainerQuery } from './__generated__/CityEditionContainerQuery.graphql';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Country.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Country.tsx
@@ -14,6 +14,8 @@ import LocationMiniMap from '../../common/location/LocationMiniMap';
 import { Country_country$key } from './__generated__/Country_country.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
@@ -25,6 +25,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import { CountryCreationMutation, CountryCreationMutation$variables } from './__generated__/CountryCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryLine.tsx
@@ -15,6 +15,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import { APP_BASE_PATH } from '../../../../relay/environment';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryOverview.tsx
@@ -12,6 +12,8 @@ import ItemAuthor from '../../../../components/ItemAuthor';
 import { CountryOverview_country$key } from './__generated__/CountryOverview_country.graphql';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Position.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Position.tsx
@@ -18,6 +18,8 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { PositionDetailsLocationRelationshipsLinesQueryLinesPaginationQuery } from './__generated__/PositionDetailsLocationRelationshipsLinesQueryLinesPaginationQuery.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
@@ -26,6 +26,8 @@ import { PositionsLinesPaginationQuery$variables } from './__generated__/Positio
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
@@ -14,6 +14,8 @@ import usePreloadedFragment from '../../../../utils/hooks/usePreloadedFragment';
 import { PositionDetails_positionRelationships$key } from './__generated__/PositionDetails_positionRelationships.graphql';
 import { isNotEmptyField } from '../../../../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionLine.tsx
@@ -13,6 +13,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import { CountryLine_node$key } from '../countries/__generated__/CountryLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Region.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Region.tsx
@@ -14,6 +14,8 @@ import LocationMiniMap from '../../common/location/LocationMiniMap';
 import { Region_region$key } from './__generated__/Region_region.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
@@ -25,6 +25,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import { RegionCreationMutation$variables } from './__generated__/RegionCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionLine.tsx
@@ -13,6 +13,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionOverview.tsx
@@ -12,6 +12,8 @@ import { RegionOverview_region$key } from './__generated__/RegionOverview_region
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionPopover.tsx
@@ -19,6 +19,8 @@ import { RegionEditionContainerQuery } from './__generated__/RegionEditionContai
 import Transition from '../../../../components/Transition';
 import RegionEditionContainer, { regionEditionQuery } from './RegionEditionContainer';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -100,6 +100,8 @@ import logoFiligranTextLight from '../../../static/images/logo_filigran_text_lig
 import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 import useDimensions from '../../../utils/hooks/useDimensions';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => createStyles({
   drawerPaper: {
     width: 55,

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -38,6 +38,8 @@ import omtdDark from '../../../static/images/xtm/omtd_dark.png';
 import omtdLight from '../../../static/images/xtm/omtd_light.png';
 import { isNotEmptyField } from '../../../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   appBar: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -20,6 +20,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { insertNode } from '../../../../utils/store';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactLine.tsx
@@ -16,6 +16,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservablesLines.jsx
@@ -20,6 +20,8 @@ import { deleteNodeFromEdge } from '../../../../utils/store';
 import { useIsEnforceReference, useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import { parse } from '../../../../utils/Time';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   container: {
     padding: '20px 0 20px 0',

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -37,6 +37,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButtonContextual: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -30,6 +30,8 @@ import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import Transition from '../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorLine.jsx
@@ -14,6 +14,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Infrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Infrastructure.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import { Infrastructure_infrastructure$key } from './__generated__/Infrastructure_infrastructure.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
@@ -30,6 +30,8 @@ import { InfrastructuresLinesPaginationQuery$variables } from './__generated__/I
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDetails.tsx
@@ -13,6 +13,8 @@ import StixCoreObjectKillChainPhasesView from '../../common/stix_core_objects/St
 import type { Theme } from '../../../../components/Theme';
 import { InfrastructureDetails_infrastructure$data, InfrastructureDetails_infrastructure$key } from './__generated__/InfrastructureDetails_infrastructure.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureLine.tsx
@@ -18,6 +18,8 @@ import { InfrastructureLine_node$data, InfrastructureLine_node$key } from './__g
 import type { Theme } from '../../../../components/Theme';
 import { emptyFilled } from '../../../../utils/String';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -37,6 +37,8 @@ import { convertMarking } from '../../../../utils/edition';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
@@ -20,6 +20,8 @@ import useVocabularyCategory from '../../../../utils/hooks/useVocabularyCategory
 import StixCyberObservableMalwareAnalyses from './StixCyberObservableMalwareAnalyses';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
@@ -9,6 +9,8 @@ import { SubscriptionAvatars } from '../../../../components/Subscription';
 import StixCyberObservableEditionOverview from './StixCyberObservableEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -9,6 +9,8 @@ import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObj
 import StixCoreObjectSharing from '../../common/stix_core_objects/StixCoreObjectSharing';
 import useGranted, { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableLine.jsx
@@ -16,6 +16,8 @@ import { renderObservableValue } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalyses.tsx
@@ -19,6 +19,8 @@ import { MalwareAnalysesOrdering } from '../../analyses/malware_analyses/__gener
 import { StixCyberObservableMalwareAnalyses_data$key } from './__generated__/StixCyberObservableMalwareAnalyses_data.graphql';
 import StixCyberObservableMalwareAnalysesDummyList from './StixCyberObservableMalwareAnalysesDummyList';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   goIcon: {
     position: 'absolute',

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalysesDummyList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalysesDummyList.tsx
@@ -6,6 +6,8 @@ import ListItemText from '@mui/material/ListItemText';
 import makeStyles from '@mui/styles/makeStyles';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   itemIcon: {
     marginRight: 0,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesRightBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesRightBar.jsx
@@ -17,6 +17,8 @@ import { stixCyberObservablesLinesSubTypesQuery } from './StixCyberObservablesLi
 import useAuth from '../../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/profile/Profile.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Profile.tsx
@@ -6,6 +6,8 @@ import Loader, { LoaderVariant } from '../../../components/Loader';
 import type { ProfileQuery } from './__generated__/ProfileQuery.graphql';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationLine.tsx
@@ -33,6 +33,8 @@ import { NotificationsLinesPaginationQuery$variables } from './__generated__/Not
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { isNotEmptyField } from '../../../../utils/utils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationsToolBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationsToolBar.tsx
@@ -32,6 +32,8 @@ import { UserContext } from '../../../../utils/hooks/useAuth';
 import { FilterGroup, serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import TasksFilterValueContainer from '../../../../components/TasksFilterValueContainer';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   bottomNav: {
     padding: 0,

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerCreation.tsx
@@ -12,6 +12,8 @@ import TriggerDigestCreation from './TriggerDigestCreation';
 import TriggerLiveCreation from './TriggerLiveCreation';
 import { TriggerLiveCreationKnowledgeMutation$data } from './__generated__/TriggerLiveCreationKnowledgeMutation.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerDigestCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerDigestCreation.tsx
@@ -29,6 +29,8 @@ import { Option } from '../../common/form/ReferenceField';
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
 import TriggersField from './TriggersField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -18,6 +18,8 @@ import { dayStartDate, formatTimeForToday } from '../../../../utils/Time';
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
 import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
@@ -33,6 +33,8 @@ import { TriggerEventType, TriggerLiveCreationKnowledgeMutation, TriggerLiveCrea
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   dialogActions: {
     padding: '0 17px 20px 0',

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersField.tsx
@@ -13,6 +13,8 @@ import { TriggerEventType, TriggerLiveCreationKnowledgeMutation$data } from './_
 import { TriggerType } from './__generated__/TriggerLine_node.graphql';
 import { TriggersQueriesSearchKnowledgeQuery$data } from './__generated__/TriggersQueriesSearchKnowledgeQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/search/SearchIndexedFileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchIndexedFileLine.tsx
@@ -34,6 +34,8 @@ import { getFileUri } from '../../../utils/utils';
 import { resolveLink } from '../../../utils/Entity';
 import useGranted, { KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPLOAD } from '../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchStixCoreObjectLine.jsx
@@ -18,6 +18,8 @@ import { resolveLink } from '../../../utils/Entity';
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import ItemEntityType from '../../../components/ItemEntityType';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/Notifiers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Notifiers.tsx
@@ -17,6 +17,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'notifiers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
@@ -31,6 +31,8 @@ import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 import ItemBoolean from '../../../components/ItemBoolean';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Retention.jsx
@@ -14,6 +14,8 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'retention';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/Rules.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Rules.jsx
@@ -20,6 +20,8 @@ const Transition = React.forwardRef((props, ref) => (
 ));
 Transition.displayName = 'TransitionSlide';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/RulesList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/RulesList.jsx
@@ -32,6 +32,8 @@ import ItemNumberDifference from '../../../components/ItemNumberDifference';
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   card: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.jsx
@@ -31,6 +31,8 @@ import ItemBoolean from '../../../components/ItemBoolean';
 import { availableLanguage } from '../../../components/AppIntlProvider';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: '0 0 60px 0',

--- a/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
@@ -15,6 +15,8 @@ import { SettingsOrganizationLine_node$data as Organization } from './organizati
 import useAuth from '../../../utils/hooks/useAuth';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/Users.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Users.jsx
@@ -14,6 +14,8 @@ import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 import { useFormatter } from '../../../components/i18n';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -19,6 +19,8 @@ import useVocabularyCategory from '../../../utils/hooks/useVocabularyCategory';
 import { emptyFilterGroup } from '../../../utils/filters/filtersUtils';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
@@ -9,6 +9,8 @@ import ListLinesContent from '../../../components/list_lines/ListLinesContent';
 import { VocabularyCategoryLine, VocabularyCategoryLineDummy } from './attributes/VocabularyCategoryLine';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertCreation.tsx
@@ -12,6 +12,8 @@ import { AlertingPaginationQuery$variables } from './__generated__/AlertingPagin
 import { AlertLiveCreationActivityMutation$data } from './__generated__/AlertLiveCreationActivityMutation.graphql';
 import AlertDigestCreation from './AlertDigestCreation';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestCreation.tsx
@@ -29,6 +29,8 @@ import AlertsField from './AlertsField';
 import { AlertingPaginationQuery$variables } from './__generated__/AlertingPaginationQuery.graphql';
 import ObjectMembersField from '../../../common/form/ObjectMembersField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestEdition.tsx
@@ -76,6 +76,8 @@ const alertDigestEditionFieldPatch = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveCreation.tsx
@@ -11,7 +11,7 @@ import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
 import { Field, Form, Formik } from 'formik';
 import { FormikConfig, FormikHelpers } from 'formik/dist/types';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { graphql, useMutation } from 'react-relay';
 import * as Yup from 'yup';
 import Box from '@mui/material/Box';
@@ -32,6 +32,8 @@ import { TriggersLinesPaginationQuery$variables } from '../../../profile/trigger
 import { AlertLiveCreationActivityMutation, AlertLiveCreationActivityMutation$data } from './__generated__/AlertLiveCreationActivityMutation.graphql';
 import useFiltersState from '../../../../../utils/filters/useFiltersState';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveEdition.tsx
@@ -67,6 +67,8 @@ const alertLiveEditionFieldPatch = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   header: {
     backgroundColor: theme.palette.background.nav,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/Alerting.tsx
@@ -20,6 +20,8 @@ import { useFormatter } from '../../../../../components/i18n';
 export const LOCAL_STORAGE_KEY_DATA_SOURCES = 'alerting';
 const nbOfRowsToLoad = 50;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertingLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertingLine.tsx
@@ -19,6 +19,8 @@ import { AlertingPaginationQuery$variables } from './__generated__/AlertingPagin
 import AlertingPopover from './AlertingPopover';
 import { deserializeFilterGroupForFrontend } from '../../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertingPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertingPopover.tsx
@@ -23,6 +23,8 @@ import { AlertEditionQuery } from './__generated__/AlertEditionQuery.graphql';
 import { alertEditionQuery } from './AlertEditionQuery';
 import AlertDigestEdition from './AlertDigestEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertsField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertsField.tsx
@@ -14,6 +14,8 @@ import AlertLiveCreation from './AlertLiveCreation';
 import { AlertLiveCreationActivityMutation$data } from './__generated__/AlertLiveCreationActivityMutation.graphql';
 import { AlertingPaginationQuery$variables } from './__generated__/AlertingPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
@@ -36,6 +36,8 @@ import { emptyFilterGroup } from '../../../../../utils/filters/filtersUtils';
 import { fetchQuery } from '../../../../../relay/environment';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLine.tsx
@@ -17,6 +17,8 @@ import ItemIcon from '../../../../../components/ItemIcon';
 import { isNotEmptyField } from '../../../../../utils/utils';
 import MarkdownDisplay from '../../../../../components/MarkdownDisplay';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/configuration/Configuration.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/configuration/Configuration.tsx
@@ -44,6 +44,8 @@ import { isEmptyField } from '../../../../../utils/utils';
 import EnterpriseEdition from '../../../common/entreprise_edition/EnterpriseEdition';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyCategoryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyCategoryLine.tsx
@@ -10,6 +10,8 @@ import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 import { VocabularyDefinition } from '../../../../utils/hooks/useVocabularyCategory';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyCreation.tsx
@@ -20,6 +20,8 @@ interface VocabularyCreationProps {
   category: VocabularyCategory;
 }
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyEdition.tsx
@@ -16,6 +16,8 @@ import AutocompleteFreeSoloField from '../../../../components/AutocompleteFreeSo
 import { Option } from '../../common/form/ReferenceField';
 import { RelayError } from '../../../../relay/relayTypes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyLine.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../../../utils/hooks/__generated__/useVocabularyCategory_Vocabularynode.graphql';
 import { LocalStorage } from '../../../../utils/hooks/useLocalStorageModel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/attributes/VocabularyPopover.tsx
@@ -20,6 +20,8 @@ import useDeletion from '../../../../utils/hooks/useDeletion';
 import { deleteNode } from '../../../../utils/store';
 import { LocalStorage } from '../../../../utils/hooks/useLocalStorageModel';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateCreation.tsx
@@ -16,6 +16,8 @@ import CaseTemplateTasks from '../../common/form/CaseTemplateTasks';
 import { CaseTemplateAddInput } from './__generated__/CaseTemplateCreationMutation.graphql';
 import { CaseTemplateLinesPaginationQuery$variables } from './__generated__/CaseTemplateLinesPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLine.tsx
@@ -11,6 +11,8 @@ import { CaseTemplateLine_node$key } from './__generated__/CaseTemplateLine_node
 import { DataColumns } from '../../../../components/list_lines';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLineDummy.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLineDummy.tsx
@@ -9,6 +9,8 @@ import React, { FunctionComponent } from 'react';
 import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
@@ -31,6 +31,8 @@ import { CaseTemplateLine_node$key } from './__generated__/CaseTemplateLine_node
 import { CaseTemplateLineFragment } from './CaseTemplateLine';
 import { FilterGroup, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksLine.tsx
@@ -14,6 +14,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { CaseTemplateTasksLinesPaginationQuery$data } from './__generated__/CaseTemplateTasksLinesPaginationQuery.graphql';
 import CaseTemplateTasksPopover from './CaseTemplateTasksPopover';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksPopover.tsx
@@ -23,6 +23,8 @@ import { CaseTemplateTasksLine_node$data } from './__generated__/CaseTemplateTas
 import { CaseTemplateTasksLinesPaginationQuery$data } from './__generated__/CaseTemplateTasksLinesPaginationQuery.graphql';
 import CaseTemplateTasksEdition from './CaseTemplateTasksEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplates.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplates.tsx
@@ -12,6 +12,8 @@ import CaseTemplateLines, { caseTemplatesLinesQuery } from './CaseTemplateLines'
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/common/Triggers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/common/Triggers.tsx
@@ -19,6 +19,8 @@ import { LOCAL_STORAGE_KEY_TRIGGERS } from '../../profile/Triggers';
 import { TriggerLineDummy } from '../../profile/triggers/TriggerLine';
 import { GqlFilterGroup, emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
@@ -21,6 +21,8 @@ import { DecayRule_decayRule$key } from './__generated__/DecayRule_decayRule.gra
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreation.tsx
@@ -24,6 +24,8 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import decayRuleValidator from './DecayRuleValidator';
 import { DecayRulesLinesPaginationQuery$variables } from './__generated__/DecayRulesLinesPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulePopover.tsx
@@ -17,6 +17,8 @@ import Transition from '../../../../components/Transition';
 import { useFormatter } from '../../../../components/i18n';
 import { handleError } from '../../../../relay/environment';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRules.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRules.tsx
@@ -20,6 +20,8 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 
 const LOCAL_STORAGE_KEY = 'view-decay-rules';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRulesLine.tsx
@@ -13,6 +13,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 import { DecayRulesLine_node$key } from './__generated__/DecayRulesLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingConfiguration.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingConfiguration.tsx
@@ -36,6 +36,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import TextField from '../../../../components/TextField';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
@@ -41,6 +41,8 @@ import { TEN_SECONDS } from '../../../../utils/Time';
 
 const interval$ = interval(TEN_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   chip: {
     fontSize: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -29,6 +29,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import GroupHiddenTypesChipList from './GroupHiddenTypesChipList';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
@@ -14,6 +14,8 @@ import MarkdownField from '../../../../components/MarkdownField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
@@ -21,6 +21,8 @@ import { Option } from '../../common/form/ReferenceField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { convertMarking } from '../../../../utils/edition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   icon: {
     paddingTop: 4,

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupLine.tsx
@@ -16,6 +16,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupPopover.tsx
@@ -15,6 +15,8 @@ import { useNavigate } from 'react-router-dom';
 import { useFormatter } from '../../../../components/i18n';
 import GroupEdition from './GroupEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/hidden_types/HiddenTypesChipList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/hidden_types/HiddenTypesChipList.tsx
@@ -7,6 +7,8 @@ import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/settings/hidden_types/HiddenTypesIndicator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/hidden_types/HiddenTypesIndicator.tsx
@@ -30,6 +30,8 @@ const hiddenTypesIndicatorQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   indication: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/settings/labels/LabelLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/labels/LabelLine.jsx
@@ -13,6 +13,8 @@ import { useFormatter } from '../../../../components/i18n';
 import LabelPopover from './LabelPopover';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierCreation.tsx
@@ -24,6 +24,8 @@ import NotifierTestDialog, { notifierTestQuery } from './NotifierTestDialog';
 import { NotifierTestDialogQuery } from './__generated__/NotifierTestDialogQuery.graphql';
 import notifierValidator from './NotifierValidator';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierEdition.tsx
@@ -24,6 +24,8 @@ import notifierValidator from './NotifierValidator';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { convertAuthorizedMembers } from '../../../../utils/edition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierLine.tsx
@@ -13,6 +13,8 @@ import { NotifierLine_node$key, NotifierLine_node$data } from './__generated__/N
 import { NotifiersLinesPaginationQuery$variables } from './__generated__/NotifiersLinesPaginationQuery.graphql';
 import NotifierPopover from './NotifierPopover';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/notifiers/NotifierTestDialog.tsx
@@ -14,6 +14,8 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import type { Theme } from '../../../../components/Theme';
 import { NotifierTestDialogQuery } from './__generated__/NotifierTestDialogQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: 400,

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
@@ -30,6 +30,8 @@ import useGranted, { BYPASS, SETTINGS, SETTINGS_SETACCESSES } from '../../../../
 import Security from '../../../../utils/Security';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
@@ -10,6 +10,8 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { SettingsOrganization_organization$data } from './__generated__/SettingsOrganization_organization.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationLine.tsx
@@ -15,6 +15,8 @@ import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 import { SettingsOrganizationLine_node$key } from './__generated__/SettingsOrganizationLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/Role.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/Role.tsx
@@ -25,6 +25,8 @@ import { GroupsSearchQuery } from '../__generated__/GroupsSearchQuery.graphql';
 import ItemIcon from '../../../../components/ItemIcon';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
@@ -14,6 +14,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessageForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessageForm.tsx
@@ -16,6 +16,8 @@ import SwitchField from '../../../../components/SwitchField';
 import { SettingsMessagesLine_settingsMessage$data } from './__generated__/SettingsMessagesLine_settingsMessage.graphql';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: theme.spacing(2),

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
@@ -17,6 +17,8 @@ import SettingsMessagesLines from './SettingsMessagesLines';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import ColumnsLinesTitles from '../../../../components/ColumnsLinesTitles';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.tsx
@@ -43,6 +43,8 @@ const settingsSubscription = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesLine.tsx
@@ -14,6 +14,8 @@ import type { Theme } from '../../../../components/Theme';
 import { SettingsMessagesLine_settingsMessage$key } from './__generated__/SettingsMessagesLine_settingsMessage.graphql';
 import SettingsMessagesPopover from './SettingsMessagesPopover';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: theme.spacing(1),

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateCreation.tsx
@@ -20,6 +20,8 @@ import type { Theme } from '../../../../components/Theme';
 import { StatusTemplateCreationContextualMutation$data } from './__generated__/StatusTemplateCreationContextualMutation.graphql';
 import { StatusTemplatesLinesPaginationQuery$variables } from './__generated__/StatusTemplatesLinesPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateLine.tsx
@@ -9,6 +9,8 @@ import { graphql, useFragment } from 'react-relay';
 import StatusTemplatePopover from './StatusTemplatePopover';
 import { StatusTemplateLine_node$key } from './__generated__/StatusTemplateLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateLineDummy.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplateLineDummy.tsx
@@ -10,6 +10,8 @@ import IconButton from '@mui/material/IconButton';
 import type { Theme } from '../../../../components/Theme';
 import { DataColumnsType } from './StatusTemplateLine';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplatePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplatePopover.tsx
@@ -21,6 +21,8 @@ import { deleteNode } from '../../../../utils/store';
 import Transition from '../../../../components/Transition';
 import { StatusTemplatePopoverEditionQuery$data } from './__generated__/StatusTemplatePopoverEditionQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplates.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplates.tsx
@@ -11,6 +11,8 @@ import LabelsVocabulariesMenu from '../LabelsVocabulariesMenu';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
@@ -14,6 +14,8 @@ import SearchInput from '../../../../components/SearchInput';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { DataSourcesLinesPaginationQuery$variables } from '../../techniques/data_sources/__generated__/DataSourcesLinesPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
@@ -17,6 +17,8 @@ import { SubTypeWorkflow_subType$data } from './__generated__/SubTypeWorkflow_su
 import ItemCopy from '../../../../components/ItemCopy';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   bodyItem: {
     height: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflowStatusAdd.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflowStatusAdd.tsx
@@ -15,6 +15,8 @@ import TextField from '../../../../components/TextField';
 import StatusTemplateField from '../../common/form/StatusTemplateField';
 import { StatusForm, statusValidation } from './statusFormUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypes.tsx
@@ -14,6 +14,8 @@ import { useFormatter } from '../../../../components/i18n';
 
 const LOCAL_STORAGE_KEY_SUB_TYPES = 'sub-types';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
@@ -15,6 +15,8 @@ import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import { SubTypesLine_node$key } from './__generated__/SubTypesLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/ToolBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/ToolBar.tsx
@@ -25,6 +25,8 @@ import type { EntitySetting } from '../../../../utils/hooks/useEntitySettings';
 import { MESSAGING$ } from '../../../../relay/environment';
 import useAuth from '../../../../utils/hooks/useAuth';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   bottomNav: {
     zIndex: 1040,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
@@ -23,6 +23,8 @@ import { fetchQuery, handleErrorInForm } from '../../../../../relay/environment'
 import { AccessRight, INPUT_AUTHORIZED_MEMBERS } from '../../../../../utils/authorizedMembers';
 import { defaultValuesToStringArray } from '../../../../../utils/defaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeLine.tsx
@@ -17,6 +17,8 @@ import { EntitySettingAttributes_entitySetting$data } from './__generated__/Enti
 import { INPUT_AUTHORIZED_MEMBERS } from '../../../../../utils/authorizedMembers';
 import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleBar.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import type { Theme } from '../../../../../components/Theme';
 import type { ScaleConfig } from './scale';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   railSpan: {
     height: '5px',

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleConfiguration.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleConfiguration.tsx
@@ -12,6 +12,8 @@ import type { ScaleConfig, Tick, UndefinedTick } from './scale';
 import ScaleConfigurationLine from './ScaleConfigurationLine';
 import ScaleBar from './ScaleBar';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   container: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleConfigurationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/scale_configuration/ScaleConfigurationLine.tsx
@@ -10,6 +10,8 @@ import ColorPickerField from '../../../../../components/ColorPickerField';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Tick, UndefinedTick } from './scale';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   button: {
     display: 'flex',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/GroupUsers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/GroupUsers.tsx
@@ -14,6 +14,8 @@ import { GroupUsersLinesQuery, GroupUsersLinesQuery$variables } from './__genera
 import ColumnsLinesTitles from '../../../../components/ColumnsLinesTitles';
 import { UserLineDummy } from './UserLine';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
@@ -19,6 +19,8 @@ import { useFormatter } from '../../../../components/i18n';
 import useAuth from '../../../../utils/hooks/useAuth';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserCreation.jsx
@@ -25,6 +25,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { insertNode } from '../../../../utils/store';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserLine.tsx
@@ -14,6 +14,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsers.tsx
@@ -17,6 +17,8 @@ import { UserLineDummy } from './UserLine';
 import ListLines from '../../../../components/list_lines/ListLines';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -52,6 +52,8 @@ import type { Theme } from '../../../../components/Theme';
 const startDate = yearsAgo(1);
 const endDate = now();
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   floatingButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserAnalytics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserAnalytics.tsx
@@ -28,6 +28,8 @@ import AuditsList from '@components/common/audits/AuditsList';
 import { useFormatter } from '../../../../components/i18n';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevelField.tsx
@@ -12,6 +12,8 @@ import UserConfidenceLevel from './UserConfidenceLevel';
 import type { Theme } from '../../../../components/Theme';
 import SwitchField from '../../../../components/SwitchField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme: Theme) => ({
   alert: {
     width: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserCreation.jsx
@@ -22,6 +22,8 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import { insertNode } from '../../../../utils/store';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
@@ -18,6 +18,8 @@ import { useFormatter } from '../../../../components/i18n';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     marginBottom: 5,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
@@ -13,6 +13,8 @@ import type { Theme } from '../../../../components/Theme';
 
 const interval$ = interval(FIVE_SECONDS);
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
@@ -13,6 +13,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddDataComponents.tsx
@@ -12,6 +12,8 @@ import { AddDataComponentsLinesQuery, AddDataComponentsLinesQuery$variables } fr
 import { AttackPatternDataComponents_attackPattern$data } from './__generated__/AttackPatternDataComponents_attackPattern.graphql';
 import DataComponentCreation from '../data_components/DataComponentCreation';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
@@ -27,6 +27,8 @@ import { AttackPatternsLinesPaginationQuery$variables } from './__generated__/At
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternLine.tsx
@@ -15,6 +15,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { emptyFilled } from '../../../../utils/String';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
@@ -31,6 +31,8 @@ import { CourseOfActionCreationMutation, CourseOfActionCreationMutation$variable
 import { CoursesOfActionLinesPaginationQuery$variables } from './__generated__/CoursesOfActionLinesPaginationQuery.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionLine.tsx
@@ -14,6 +14,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddAttackPatterns.tsx
@@ -14,6 +14,8 @@ import {
 } from './__generated__/AddAttackPatternsLinesToDataComponentQuery.graphql';
 import AddAttackPatternsLines, { addAttackPatternsLinesQuery } from './AddAttackPatternsLines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/AddDataSources.tsx
@@ -12,6 +12,8 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { DataSourcesLinesPaginationQuery$variables } from '../data_sources/__generated__/DataSourcesLinesPaginationQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponent.tsx
@@ -14,6 +14,8 @@ import StixCoreObjectOrStixCoreRelationshipNotes from '../../analyses/notes/Stix
 import { DataComponent_dataComponent$key } from './__generated__/DataComponent_dataComponent.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
@@ -30,6 +30,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { DataComponentCreationMutation$variables } from './__generated__/DataComponentCreationMutation.graphql';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDetails.tsx
@@ -10,6 +10,8 @@ import { DataComponentDetails_dataComponent$data, DataComponentDetails_dataCompo
 import DataComponentDataSource from './DataComponentDataSource';
 import DataComponentAttackPatterns from './DataComponentAttackPatterns';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentLine.tsx
@@ -13,6 +13,8 @@ import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectL
 import { DataColumns } from '../../../../components/list_lines';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentLineDummy.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentLineDummy.tsx
@@ -8,6 +8,8 @@ import Skeleton from '@mui/material/Skeleton';
 import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponents.tsx
@@ -13,6 +13,8 @@ import { DataSourceDataComponents_dataSource$data } from './__generated__/DataSo
 import { AddDataComponentsLinesToDataSourceQuery } from './__generated__/AddDataComponentsLinesToDataSourceQuery.graphql';
 import DataComponentCreation from '../data_components/DataComponentCreation';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   createButton: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponentsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/AddDataComponentsLines.tsx
@@ -14,6 +14,8 @@ import { DataSourceDataComponents_dataSource$data } from './__generated__/DataSo
 import { AddDataComponentsLinesToDataSourceQuery } from './__generated__/AddDataComponentsLinesToDataSourceQuery.graphql';
 import { AddDataComponentsLinesToDataSource_data$key } from './__generated__/AddDataComponentsLinesToDataSource_data.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     color: theme.palette.primary.main,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSource.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSource.tsx
@@ -14,6 +14,8 @@ import DataSourceEdition from './DataSourceEdition';
 import DataSourceDetailsComponent from './DataSourceDetails';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -32,6 +32,8 @@ import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySe
 import { DataSourceCreationMutation$variables } from './__generated__/DataSourceCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
@@ -10,6 +10,8 @@ import { DataSourceDetails_dataSource$data, DataSourceDetails_dataSource$key } f
 import DataSourceDataComponents from './DataSourceDataComponents';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceLine.tsx
@@ -14,6 +14,8 @@ import { DataSourceLine_node$key } from './__generated__/DataSourceLine_node.gra
 import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectLabels';
 import ItemIcon from '../../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -31,6 +31,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Campaign.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Campaign.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import { Campaign_campaign$key } from './__generated__/Campaign_campaign.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
@@ -26,6 +26,8 @@ import { CampaignCreationMutation, CampaignCreationMutation$variables } from './
 import { CampaignsCardsPaginationQuery$variables } from './__generated__/CampaignsCardsPaginationQuery.graphql';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSet.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSet.tsx
@@ -14,6 +14,8 @@ import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../commo
 import { IntrusionSet_intrusionSet$key } from './__generated__/IntrusionSet_intrusionSet.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
@@ -26,6 +26,8 @@ import { IntrusionSetsCardsPaginationQuery$variables } from './__generated__/Int
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
@@ -27,6 +27,8 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { ThreatActorGroupCreationMutation, ThreatActorGroupCreationMutation$variables } from './__generated__/ThreatActorGroupCreationMutation.graphql';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividual.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividual.tsx
@@ -19,6 +19,8 @@ import {
   ThreatActorIndividual_ThreatActorIndividual$key,
 } from './__generated__/ThreatActorIndividual_ThreatActorIndividual.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   gridContainer: {
     marginBottom: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualBiographics.tsx
@@ -11,6 +11,8 @@ import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import { isEmptyField } from '../../../../utils/utils';
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -41,6 +41,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDemographics.tsx
@@ -5,6 +5,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { ThreatActorIndividual_ThreatActorIndividual$data } from './__generated__/ThreatActorIndividual_ThreatActorIndividual.graphql';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetails.tsx
@@ -22,6 +22,8 @@ import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import ImageCarousel, { ImagesData } from '../../../../components/ImageCarousel';
 import ThreatActorIndividualLocation from './ThreatActorIndividualLocation';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLine.tsx
@@ -14,6 +14,8 @@ import { DataColumns } from '../../../../components/list_lines';
 import ItemIcon from '../../../../components/ItemIcon';
 import { ThreatActorIndividualLine_node$data, ThreatActorIndividualLine_node$key } from './__generated__/ThreatActorIndividualLine_node.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -18,6 +18,8 @@ import MarkdownField from '../../../components/MarkdownField';
 import { resolveLink } from '../../../utils/Entity';
 import { insertNode } from '../../../utils/store';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
@@ -44,6 +44,8 @@ import WorkspaceManageAccessDialog from './WorkspaceManageAccessDialog';
 import Transition from '../../../components/Transition';
 import useHelper from '../../../utils/hooks/useHelper';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   title: {
     float: 'left',

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
@@ -14,6 +14,8 @@ import { useFormatter } from '../../../components/i18n';
 import WorkspacePopover from './WorkspacePopover';
 import ItemIcon from '../../../components/ItemIcon';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
@@ -22,6 +22,8 @@ import { deleteNode, insertNode } from '../../../utils/store';
 import handleExportJson from './workspaceExportHandler';
 import WorkspaceDuplicationDialog from './WorkspaceDuplicationDialog';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
@@ -22,6 +22,8 @@ import { handleError } from '../../../relay/environment';
 import type { Theme } from '../../../components/Theme';
 import useSearchEntities, { EntityValue } from '../../../utils/filters/useSearchEntities';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   icon: {
     display: 'inline-block',

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
@@ -63,6 +63,8 @@ import {
   serializeDashboardManifestForBackend,
 } from '../../../../utils/filters/filtersUtils';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   container: {
     margin: '0 -20px 0 -20px',

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetConfig.jsx
@@ -62,6 +62,8 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   createButton: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WidgetPopover.jsx
@@ -16,6 +16,8 @@ import { EXPLORE_EXUPDATE } from '../../../../utils/hooks/useGranted';
 import WidgetConfig from './WidgetConfig';
 import Transition from '../../../../components/Transition';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     margin: 0,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjectsLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationAddStixCoreObjectsLine.tsx
@@ -17,6 +17,8 @@ import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import type { Theme } from '../../../../components/Theme';
 import { DataColumns } from '../../../../components/list_lines';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   item: {
     paddingLeft: 10,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
@@ -69,6 +69,8 @@ const investigationExpandFormRelDistributionQuery = graphql`
   }
 `;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   checkboxesContainer: {
     display: 'flex',

--- a/opencti-platform/opencti-front/src/public/components/Login.tsx
+++ b/opencti-platform/opencti-front/src/public/components/Login.tsx
@@ -26,6 +26,8 @@ import { isNotEmptyField } from '../../utils/utils';
 import useDimensions from '../../utils/hooks/useDimensions';
 import SystemBanners from './SystemBanners';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     textAlign: 'center',

--- a/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
@@ -11,6 +11,8 @@ import { FormikConfig } from 'formik/dist/types';
 import { RelayResponsePayload } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { useFormatter } from '../../components/i18n';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   login: {
     padding: 15,

--- a/opencti-platform/opencti-front/src/public/components/OTPForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/OTPForm.tsx
@@ -7,6 +7,8 @@ import { useFormatter } from '../../components/i18n';
 import type { Theme } from '../../components/Theme';
 import OtpInputField, { OTP_CODE_SIZE } from './OtpInputField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   otp: {
     textAlign: 'center',

--- a/opencti-platform/opencti-front/src/public/components/OtpActivation.tsx
+++ b/opencti-platform/opencti-front/src/public/components/OtpActivation.tsx
@@ -11,6 +11,8 @@ import { OtpActivationQuery$data } from './__generated__/OtpActivationQuery.grap
 import type { Theme } from '../../components/Theme';
 import OtpInputField, { OTP_CODE_SIZE } from './OtpInputField';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   input: {
     display: 'flex',

--- a/opencti-platform/opencti-front/src/public/components/OtpInputField.tsx
+++ b/opencti-platform/opencti-front/src/public/components/OtpInputField.tsx
@@ -5,6 +5,8 @@ import type { Theme } from '../../components/Theme';
 
 export const OTP_CODE_SIZE = 6;
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   inputStyle: {
     outline: 'none',

--- a/opencti-platform/opencti-front/src/public/components/PublicDataSharing.tsx
+++ b/opencti-platform/opencti-front/src/public/components/PublicDataSharing.tsx
@@ -13,6 +13,8 @@ import { rootPublicQuery } from '../LoginRoot';
 import logoLight from '../../static/images/logo_light.png';
 import logoDark from '../../static/images/logo_dark.png';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   container: {
     textAlign: 'center',

--- a/opencti-platform/opencti-front/src/public/components/SystemBanners.js
+++ b/opencti-platform/opencti-front/src/public/components/SystemBanners.js
@@ -10,6 +10,8 @@ const BANNER_Z_INDEX = 2000;
 /* Styled class is not used in component  custom-rules/classes-rule */
 /* for the banner classes below which are derived in bannerColorClassName() component */
 /* eslint-disable */
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   banner: {
     textAlign: 'center',

--- a/opencti-platform/opencti-front/src/utils/graph/BasicRelationshipDetails.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/BasicRelationshipDetails.tsx
@@ -8,6 +8,8 @@ import ItemMarkings from '../../components/ItemMarkings';
 import { useFormatter } from '../../components/i18n';
 import type { SelectedEntity } from './EntitiesDetailsRightBar';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   label: {
     marginTop: 20,

--- a/opencti-platform/opencti-front/src/utils/graph/EntitiesDetailsRightBar.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/EntitiesDetailsRightBar.tsx
@@ -18,6 +18,8 @@ import { isStixNestedRefRelationship } from '../Relation';
 import StixMetaObjectDetails from './StixMetaObjectDetails';
 import BasicRelationshipDetails from './BasicRelationshipDetails';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>(() => ({
   drawerPaper: {
     position: 'fixed',

--- a/opencti-platform/opencti-front/src/utils/graph/EntityDetails.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/EntityDetails.tsx
@@ -29,6 +29,8 @@ import { EntityDetailsQuery } from './__generated__/EntityDetailsQuery.graphql';
 import ItemConfidence from '../../components/ItemConfidence';
 import FieldOrEmpty from '../../components/FieldOrEmpty';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   label: {
     marginTop: '20px',

--- a/opencti-platform/opencti-front/src/utils/graph/LassoSelection.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/LassoSelection.tsx
@@ -6,6 +6,8 @@ import { ForceGraphMethods } from 'react-force-graph-2d';
 import type { Theme } from '../../components/Theme';
 import { pointInPolygon } from '../Graph';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   canvas: {
     position: 'absolute',

--- a/opencti-platform/opencti-front/src/utils/graph/RelationSelection.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/RelationSelection.tsx
@@ -5,6 +5,8 @@ import React, { FunctionComponent, MutableRefObject, useCallback, useEffect, use
 import { ForceGraphMethods } from 'react-force-graph-2d';
 import type { Theme } from '../../components/Theme';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles({
   canvas: {
     position: 'absolute',

--- a/opencti-platform/opencti-front/src/utils/graph/RelationShipFromAndTo.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/RelationShipFromAndTo.tsx
@@ -9,6 +9,8 @@ import { RelationShipFromAndToQuery } from './__generated__/RelationShipFromAndT
 import { truncate } from '../String';
 import { getMainRepresentative } from '../defaultRepresentatives';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   label: {
     marginTop: '20px',

--- a/opencti-platform/opencti-front/src/utils/graph/RelationshipDetails.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/RelationshipDetails.tsx
@@ -27,6 +27,8 @@ import { hexToRGB, itemColor } from '../Colors';
 import ItemCreators from '../../components/ItemCreators';
 import { RelationshipDetailsQuery } from './__generated__/RelationshipDetailsQuery.graphql';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
   label: {
     marginTop: '20px',

--- a/opencti-platform/opencti-front/src/utils/graph/StixMetaObjectDetails.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/StixMetaObjectDetails.tsx
@@ -16,6 +16,8 @@ import ItemCreators from '../../components/ItemCreators';
 import { StixMetaObjectDetailsQuery } from './__generated__/StixMetaObjectDetailsQuery.graphql';
 import ItemMarkings from '../../components/ItemMarkings';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
 const useStyles = makeStyles(() => ({
   label: {
     marginTop: '20px',


### PR DESCRIPTION
### Proposed changes

* Add a comment deprecated on all calls to makeStyles in frontend to avoid people copy paste it in new code

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
