### PR TITLE
[backend] use reverse relation on countries located at regions (#6528)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/region.js
+++ b/opencti-platform/opencti-graphql/src/domain/region.js
@@ -24,7 +24,7 @@ export const childRegionsPaginated = async (context, user, regionId, args) => {
 };
 
 export const countriesPaginated = async (context, user, elementId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, true, args);
 };
 
 export const addRegion = async (context, user, region) => {


### PR DESCRIPTION
### Proposed changes

- Update boolean `reverse_relation` to true, to find countries located at regions

### Related issues

- #6528 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- Before : the countries query for a region returns an empty table, even if countries have a located at relationship with this region.
- The highlithings was working before, but wasn't displaying anything because it wasn't receiving any data.
- Now : the countries query return countries list.
- The highlithings is dependent on country aliases ISO3. With local data, you can try displaying Europe, but first you need to add the FRA alias to France and the ESP alias to Spain
![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/9e4a7ad0-e41c-469d-833a-d6aa82f4cfbc)

- Exemple of simple query after change :
![image](https://github.com/OpenCTI-Platform/opencti/assets/102748848/90746963-fa01-432c-bf78-29f260fb520d)
