### PR TITLE
[frontend] Add property 'name' on ObservedData queries (#6687)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
@@ -201,6 +201,7 @@ const StixCoreObjectOrStixCoreRelationshipContainerLineFragment = createFragment
             created
           }
           ... on ObservedData {
+              name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
@@ -201,7 +201,7 @@ const StixCoreObjectOrStixCoreRelationshipContainerLineFragment = createFragment
             created
           }
           ... on ObservedData {
-              name
+            name
             first_observed
             last_observed
           }
@@ -240,6 +240,7 @@ const StixCoreObjectOrStixCoreRelationshipContainerLineFragment = createFragment
             color
           }
           ... on ObservedData {
+            name
             objects(first: 1) {
               edges {
                 node {
@@ -278,6 +279,7 @@ const StixCoreObjectOrStixCoreRelationshipContainerLineFragment = createFragment
                     attribute_abstract
                   }
                   ... on ObservedData {
+                    name
                     first_observed
                     last_observed
                   }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
@@ -101,7 +101,7 @@ const stixCoreObjectOrStixRelationshipLastContainersQuery = graphql`
             created
           }
           ... on ObservedData {
-              name
+            name
             first_observed
             last_observed
           }
@@ -139,6 +139,7 @@ const stixCoreObjectOrStixRelationshipLastContainersQuery = graphql`
             color
           }
           ... on ObservedData {
+            name
             objects(first: 1) {
               edges {
                 node {
@@ -177,6 +178,7 @@ const stixCoreObjectOrStixRelationshipLastContainersQuery = graphql`
                     attribute_abstract
                   }
                   ... on ObservedData {
+                    name
                     first_observed
                     last_observed
                   }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
@@ -101,6 +101,7 @@ const stixCoreObjectOrStixRelationshipLastContainersQuery = graphql`
             created
           }
           ... on ObservedData {
+              name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
@@ -44,6 +44,7 @@ const stixCoreObjectsListQuery = graphql`
             attribute_abstract
           }
           ... on ObservedData {
+            name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmarksList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmarksList.jsx
@@ -30,6 +30,7 @@ const stixDomainObjectBookmarksListQuery = graphql`
             attribute_abstract
           }
           ... on ObservedData {
+            name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
@@ -43,6 +43,7 @@ const publicStixCoreObjectsListQuery = graphql`
             attribute_abstract
           }
           ... on ObservedData {
+            name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_domain_objects/PublicStixDomainObjectBookmarksList.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_domain_objects/PublicStixDomainObjectBookmarksList.tsx
@@ -37,6 +37,7 @@ const publicStixDomainObjectBookmarksListQuery = graphql`
             attribute_abstract
           }
           ... on ObservedData {
+            name
             first_observed
             last_observed
           }

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -65,6 +65,7 @@ const filtersStixCoreObjectsSearchQuery = graphql`
             content
           }
           ... on ObservedData {
+            name
             first_observed
             last_observed
           }


### PR DESCRIPTION
### Proposed changes

- Add property 'name' on ObservedData query

### Related issues

- close #6687 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- Previously, the name of the observed data was not requested, and what is displayed is nothing, or a cached value that was potentially the wrong one.
- For the bug, only the `StixCoreObjectOrStixRelationshipLastContainers.jsx` file is concerned.
- In Observations/Observables/Select one/Analyses, the file concerned is `StixCoreObjectOrStixCoreRelationshipContainerLine.tsx`
- I have extended this to all observedData queries, to prevent bugs on other pages.
- To reproduce, follow process decribed in bug page