### PR TITLE
[frontend] sort status by type in playbook (#6585)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StatusField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StatusField.jsx
@@ -123,6 +123,9 @@ class StatusField extends Component {
             type: n.node.type,
           })),
         )(data);
+        statuses.sort((a, b) => {
+          return a.type < b.type ? -1 : 1;
+        });
         this.setState({ statuses: R.union(this.state.statuses, statuses) });
       });
   }


### PR DESCRIPTION
### Proposed changes

- Sort array of statuses by type before displaying in field

### Related issues

- close #6585 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- The statuses are sorted with graphQL by 'order'. After the query, but before display, I sort the table to group the statuses by type
- By default, there are 4 statuses associated with the 'report' type. You can add statuses to the 'organisation' type in Settings / Customization / Organization / Workflow / click update / click add / create 2 statuses with 'order' 1 and 2.
Then, go to Data / Processing, create a new playbook, add a 'listen knowledge', then a 'Manipulate knowledge' with:
  - Action type : Replace
  - Field : Status
  - And when you click on 'Status', you should see the list sorted by type and order.
![bug](https://github.com/OpenCTI-Platform/opencti/assets/102748848/09e32eed-1247-4801-93f1-3acfa978918d)