### PR TITLE
[backend] improve users loading using cache (#6702)

### DIFF
--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
@@ -2,13 +2,13 @@ import { Readable } from 'stream';
 import type { SdkStream } from '@smithy/types/dist-types/serde';
 import conf, { logApp } from '../../config/conf';
 import { executionContext } from '../../utils/access';
-import type { AuthContext } from '../../types/user';
+import type { AuthContext, AuthUser } from '../../types/user';
 import { consumeQueue, pushToSync, registerConnectorQueues } from '../../database/rabbitmq';
 import { downloadFile, upload } from '../../database/file-storage';
 import { reportExpectation, updateExpectationsNumber, updateProcessedTime, updateReceivedTime } from '../../domain/work';
 import { bundleProcess } from '../../parser/csv-bundler';
 import { OPENCTI_SYSTEM_UUID } from '../../schema/general';
-import { resolveUserById } from '../../domain/user';
+import { resolveUserByIdFromCache } from '../../domain/user';
 import { parseCsvMapper } from '../../modules/internal/csvMapper/csvMapper-utils';
 import type { ConnectorConfig } from '../connector';
 import { IMPORT_CSV_CONNECTOR } from './importCsv';
@@ -40,7 +40,7 @@ const initImportCsvConnector = () => {
     const workId = messageParsed.internal.work_id;
     const applicantId = messageParsed.internal.applicant_id;
     const fileId = messageParsed.event.file_id;
-    const applicantUser = await resolveUserById(context, applicantId);
+    const applicantUser = await resolveUserByIdFromCache(context, applicantId) as AuthUser;
     const entityId = messageParsed.event.entity_id;
     const entity = entityId ? await internalLoadById(context, applicantUser, entityId) : undefined;
 

--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -1,5 +1,6 @@
 import { SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION } from '@opentelemetry/semantic-conventions';
 import type { BasicStoreIdentifier, StoreEntity, StoreRelation } from '../types/store';
+import { logApp } from '../config/conf';
 import { UnsupportedError } from '../config/errors';
 import { telemetry } from '../config/tracing';
 import type { AuthContext, AuthUser } from '../types/user';
@@ -57,6 +58,7 @@ export const resetCacheForEntity = (entityType: string) => {
   const types = [entityType, ...(STORE_ENTITIES_LINKS[entityType] ?? [])];
   types.forEach((type) => {
     if (cache[type]) {
+      logApp.debug('Reset cache for entity', { type, entityType });
       cache[type].values = undefined;
     } else {
       // This entity type is not part of the caching system

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -32,7 +32,7 @@ import {
 } from '../database/middleware-loader';
 import { delEditContext, delUserContext, notify, setEditContext } from '../database/redis';
 import { findSessionsForUsers, killUserSessions, markSessionForRefresh } from '../database/session';
-import { buildPagination, isEmptyField, isNotEmptyField, READ_INDEX_INTERNAL_OBJECTS } from '../database/utils';
+import { buildPagination, isEmptyField, isNotEmptyField, READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { extractEntityRepresentativeName } from '../database/entity-representative';
 import { publishUserAction } from '../listener/UserActionListener';
 import { ABSTRACT_INTERNAL_RELATIONSHIP, ABSTRACT_STIX_DOMAIN_OBJECT, OPENCTI_ADMIN_UUID } from '../schema/general';
@@ -1212,8 +1212,9 @@ export const buildCompleteUser = async (context, client) => {
     filters: [{ key: 'contact_information', values: [client.user_email] }],
     filterGroups: [],
   };
-  const args = { filters: contactInformationFilter, connectionFormat: false, noFiltersChecking: true };
-  const individualsPromise = listEntities(context, SYSTEM_USER, [ENTITY_TYPE_IDENTITY_INDIVIDUAL], args);
+  // find user corresponding individual (we need only to get the first one)
+  const individualArgs = { first: 1, indices: [READ_INDEX_STIX_DOMAIN_OBJECTS], filters: contactInformationFilter, connectionFormat: false, noFiltersChecking: true };
+  const individualsPromise = listEntities(context, SYSTEM_USER, [ENTITY_TYPE_IDENTITY_INDIVIDUAL], individualArgs);
   const organizationsPromise = listAllToEntitiesThroughRelations(
     context,
     SYSTEM_USER,
@@ -1261,6 +1262,12 @@ export const buildCompleteUser = async (context, client) => {
     default_marking: marking.default,
     effective_confidence_level,
   };
+};
+
+export const resolveUserByIdFromCache = async (context, id) => {
+  if (INTERNAL_USERS[id]) return INTERNAL_USERS[id];
+  const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  return platformUsers.get(id);
 };
 
 export const resolveUserById = async (context, id) => {
@@ -1311,7 +1318,7 @@ export const internalAuthenticateUser = async (context, req, user, provider, { t
   const applicantId = req.headers['opencti-applicant-id'];
   if (isNotEmptyField(applicantId) && logged.id !== applicantId) {
     if (isBypassUser(logged)) {
-      const applicantUser = await resolveUserById(context, applicantId);
+      const applicantUser = await resolveUserByIdFromCache(context, applicantId);
       if (isEmptyField(applicantUser)) {
         logApp.warn('User cant be impersonate (not exists)', { applicantId });
       } else {
@@ -1477,19 +1484,20 @@ export const findDefaultDashboards = async (context, user, currentUser) => {
 // region context
 export const userCleanContext = async (context, user, userId) => {
   await delEditContext(user, userId);
-  return storeLoadById(context, user, userId, ENTITY_TYPE_USER).then((userToReturn) => notify(BUS_TOPICS[ENTITY_TYPE_USER].EDIT_TOPIC, userToReturn, user));
+  return storeLoadById(context, user, userId, ENTITY_TYPE_USER);
 };
 
 export const userEditContext = async (context, user, userId, input) => {
   await setEditContext(user, userId, input);
-  return storeLoadById(context, user, userId, ENTITY_TYPE_USER).then((userToReturn) => notify(BUS_TOPICS[ENTITY_TYPE_USER].EDIT_TOPIC, userToReturn, user));
+  return storeLoadById(context, user, userId, ENTITY_TYPE_USER);
 };
 // endregion
 
-export const getUserEffectiveConfidenceLevel = async (userId, context) => {
-  const user = await findById(context, context.user, userId); // this returns a complete user, with groups
-  if (!user) {
-    throw FunctionalError('User not found', { user_id: userId });
+export const getUserEffectiveConfidenceLevel = async (user, context) => {
+  let completeUser = user;
+  if (!user.groups) { // if we don't have groups, try to load the user from cache to have the complete user
+    const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+    completeUser = platformUsers.get(user.id) || user;
   }
-  return computeUserEffectiveConfidenceLevel(user);
+  return computeUserEffectiveConfidenceLevel(completeUser);
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1494,10 +1494,8 @@ export const userEditContext = async (context, user, userId, input) => {
 // endregion
 
 export const getUserEffectiveConfidenceLevel = async (user, context) => {
-  let completeUser = user;
-  if (!user.groups) { // if we don't have groups, try to load the user from cache to have the complete user
-    const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-    completeUser = platformUsers.get(user.id) || user;
-  }
+  // we load the user from cache to have the complete user with groupos
+  const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const completeUser = platformUsers.get(user.id) || user;
   return computeUserEffectiveConfidenceLevel(completeUser);
 };

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -20,7 +20,7 @@ import {
   updateTask
 } from '../domain/backgroundTask';
 import conf, { booleanConf, logApp } from '../config/conf';
-import { resolveUserById } from '../domain/user';
+import { resolveUserByIdFromCache } from '../domain/user';
 import {
   createRelation,
   deleteElementById,
@@ -460,7 +460,7 @@ const taskHandler = async () => {
     const startPatch = { last_execution_date: now() };
     await updateTask(context, task.id, startPatch);
     // Fetch the user responsible for the task
-    const rawUser = await resolveUserById(context, task.initiator_id);
+    const rawUser = await resolveUserByIdFromCache(context, task.initiator_id);
     const user = { ...rawUser, origin: { user_id: rawUser.id, referer: 'background_task' } };
     let jobToExecute;
     if (isQueryTask) {

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -84,7 +84,7 @@ const userResolvers = {
     objectOrganization: (current, args, context) => userOrganizationsPaginated(context, context.user, current.id, args),
     editContext: (current) => fetchEditContext(current.id),
     sessions: (current) => findUserSessions(current.id),
-    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current.id, context),
+    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current, context),
   },
   Member: {
     name: (current, _, context) => {
@@ -103,7 +103,7 @@ const userResolvers = {
     objectOrganization: (current, args, context) => userOrganizationsPaginated(context, context.user, current.id, args),
     default_dashboards: (current, _, context) => findDefaultDashboards(context, context.user, current),
     default_dashboard: (current, _, context) => findWorskpaceById(context, context.user, current.default_dashboard),
-    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current.id, context),
+    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current, context),
   },
   UserSession: {
     user: (session, _, context) => creatorLoader.load(session.user_id, context, context.user),

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
@@ -1,6 +1,6 @@
 import { expect, it, describe, beforeAll, afterAll } from 'vitest';
 import gql from 'graphql-tag';
-import { adminQuery, queryAsAdmin } from '../../utils/testQuery';
+import { internalAdminQuery, queryAsAdmin } from '../../utils/testQuery';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP } from '../../../src/schema/general';
 
 const MAPPER_INPUT = {
@@ -244,11 +244,11 @@ describe('CSV Mapper Resolver', () => {
   let addedMapper;
 
   beforeAll(async () => {
-    const { data } = await adminQuery(ENTITY_SETTINGS_GET);
+    const { data } = await internalAdminQuery(ENTITY_SETTINGS_GET);
     const entitySettings = data.entitySettings.edges.map((e) => e.node);
     entitySettingStixCoreRel = entitySettings.find((setting) => setting.target_type === ABSTRACT_STIX_CORE_RELATIONSHIP);
 
-    await adminQuery(
+    await internalAdminQuery(
       ENTITY_SETTINGS_UPDATE,
       {
         ids: [entitySettingStixCoreRel.id],
@@ -263,7 +263,7 @@ describe('CSV Mapper Resolver', () => {
   });
 
   afterAll(async () => {
-    await adminQuery(
+    await internalAdminQuery(
       ENTITY_SETTINGS_UPDATE,
       {
         ids: [entitySettingStixCoreRel.id],

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCyberObservable-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCyberObservable-test.js
@@ -1,6 +1,6 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
-import { adminQuery, queryAsAdmin } from '../../utils/testQuery';
+import { internalAdminQuery, queryAsAdmin } from '../../utils/testQuery';
 
 const LIST_QUERY = `
     query stixCyberObservables(
@@ -112,7 +112,7 @@ describe('StixCyberObservable resolver standard behavior', () => {
     expect(queryResult.data.stixCyberObservables.edges.length).toEqual(6);
   });
   it('should list stixCyberObservables orderBy observable_value', async () => {
-    const queryResult = await adminQuery(LIST_QUERY, { first: 10, orderBy: 'observable_value', orderMode: 'desc' });
+    const queryResult = await internalAdminQuery(LIST_QUERY, { first: 10, orderBy: 'observable_value', orderMode: 'desc' });
     expect(queryResult.data.stixCyberObservables).not.toBeNull();
     expect(queryResult.data.stixCyberObservables.edges.length).toEqual(6);
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { elLoadById } from '../../../src/database/engine';
 import { generateStandardId } from '../../../src/schema/identifier';
 import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
-import { ADMIN_USER, editorQuery, queryAsAdmin, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, adminQuery, editorQuery, queryAsAdmin, testContext } from '../../utils/testQuery';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../src/modules/organization/organization-types';
 
 const LIST_QUERY = gql`
@@ -183,7 +183,7 @@ describe('User resolver standard behavior', () => {
         lastname: 'OpenCTI',
       },
     };
-    const user = await queryAsAdmin({
+    const user = await adminQuery({
       query: CREATE_QUERY,
       variables: USER_TO_CREATE,
     });
@@ -210,7 +210,7 @@ describe('User resolver standard behavior', () => {
         }
       },
     };
-    const user2 = await queryAsAdmin({
+    const user2 = await adminQuery({
       query: CREATE_QUERY,
       variables: USER_TO_CREATE_WITH_CONFIDENCE,
     });
@@ -293,7 +293,7 @@ describe('User resolver standard behavior', () => {
         }
       }
     `;
-    const queryResult = await queryAsAdmin({
+    const queryResult = await adminQuery({
       query: UPDATE_QUERY,
       variables: {
         id: userInternalId,
@@ -348,7 +348,7 @@ describe('User resolver standard behavior', () => {
         }
       },
     };
-    const group = await queryAsAdmin({
+    const group = await adminQuery({
       query: GROUP_ADD_QUERY,
       variables: GROUP_TO_CREATE,
     });
@@ -377,7 +377,7 @@ describe('User resolver standard behavior', () => {
         }
       }
     `;
-    const queryResult = await queryAsAdmin({
+    const queryResult = await adminQuery({
       query: RELATION_ADD_QUERY,
       variables: {
         id: groupInternalId,
@@ -390,13 +390,13 @@ describe('User resolver standard behavior', () => {
     expect(queryResult.data.groupEdit.relationAdd.to.members.edges.length).toEqual(1);
   });
   it('should user groups to be accurate', async () => {
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: userInternalId } });
+    const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: userInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.user).not.toBeNull();
     expect(queryResult.data.user.groups.edges.length).toEqual(2); // the 2 groups are: 'Group of user' and 'Default'
   });
   it('should user confidence level be unchanged', async () => {
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: userInternalId } });
+    const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: userInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.user).not.toBeNull();
     expect(queryResult.data.user.user_confidence_level.max_confidence).toEqual(33);
@@ -426,7 +426,7 @@ describe('User resolver standard behavior', () => {
         }
       }
     `;
-    const queryResult = await queryAsAdmin({
+    const queryResult = await adminQuery({
       query: UPDATE_QUERY,
       variables: {
         id: userInternalId,
@@ -573,7 +573,7 @@ describe('User resolver standard behavior', () => {
     expect(queryResult.data.userEdit.relationDelete.groups.edges.length).toEqual(1);
     expect(queryResult.data.userEdit.relationDelete.groups.edges[0].node.name).toEqual('Default');
     // Delete the group
-    await queryAsAdmin({
+    await adminQuery({
       query: DELETE_GROUP_QUERY,
       variables: { id: groupInternalId },
     });
@@ -582,12 +582,12 @@ describe('User resolver standard behavior', () => {
     // Delete the users
     for (let i = 0; i < userToDeleteIds.length; i += 1) {
       const userId = userToDeleteIds[i];
-      await queryAsAdmin({
+      await adminQuery({
         query: DELETE_QUERY,
         variables: { id: userId },
       });
       // Verify is no longer found
-      const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: userId } });
+      const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: userId } });
       expect(queryResult).not.toBeNull();
       expect(queryResult.data.user).toBeNull();
     }

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
@@ -189,15 +189,16 @@ describe('User resolver standard behavior', () => {
     });
     expect(user).not.toBeNull();
     expect(user.data.userAdd).not.toBeNull();
+    userInternalId = user.data.userAdd.id;
+    userStandardId = user.data.userAdd.standard_id;
+    userToDeleteIds.push(userInternalId);
+
     expect(user.data.userAdd.name).toEqual('User');
     expect(user.data.userAdd.user_confidence_level).toBeNull();
     // user created with default group, so effective confidence level shall be set
     expect(user.data.userAdd.effective_confidence_level.max_confidence).toEqual(100);
     expect(user.data.userAdd.effective_confidence_level.source.type).toEqual('Group');
     expect(user.data.userAdd.effective_confidence_level.source.object).toBeDefined();
-    userInternalId = user.data.userAdd.id;
-    userStandardId = user.data.userAdd.standard_id;
-    userToDeleteIds.push(userInternalId);
 
     const USER_TO_CREATE_WITH_CONFIDENCE = {
       input: {
@@ -434,7 +435,7 @@ describe('User resolver standard behavior', () => {
       },
     });
     const { userEdit } = queryResult.data;
-    expect(userEdit.fieldPatch.user_confidence_level).toBeNull;
+    expect(userEdit.fieldPatch.user_confidence_level).toBeNull();
     // now effective level is the highest values among the 2 groups (default: 100)
     expect(userEdit.fieldPatch.effective_confidence_level.max_confidence).toEqual(100);
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-mapper-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/05-parser/csv-mapper-test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
-import { ADMIN_USER, adminQuery, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, internalAdminQuery, testContext } from '../../utils/testQuery';
 import { csvMapperAreaMalware, csvMapperAreaMalwareDefault } from './default-values/mapper-area-malware';
 import { parsingProcess } from '../../../src/parser/csv-parser';
 import { mappingProcess } from '../../../src/parser/csv-mapper';
@@ -75,14 +75,14 @@ describe('CSV-MAPPER', () => {
   let markings;
 
   afterAll(async () => {
-    await adminQuery(ENTITY_SETTINGS_UPDATE, {
+    await internalAdminQuery(ENTITY_SETTINGS_UPDATE, {
       ids: [entitySettingArea.id],
       input: {
         key: 'attributes_configuration',
         value: entitySettingArea.attributes_configuration
       }
     });
-    await adminQuery(ENTITY_SETTINGS_UPDATE, {
+    await internalAdminQuery(ENTITY_SETTINGS_UPDATE, {
       ids: [entitySettingMalware.id],
       input: {
         key: 'attributes_configuration',
@@ -92,7 +92,7 @@ describe('CSV-MAPPER', () => {
   });
 
   beforeAll(async () => {
-    const { data } = await adminQuery(GET_QUERY);
+    const { data } = await internalAdminQuery(GET_QUERY);
     [individual,] = data.individuals.edges.map((e) => e.node);
     const entitySettings = data.entitySettings.edges.map((e) => e.node);
     entitySettingArea = entitySettings.find((setting) => setting.target_type === ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA);
@@ -106,7 +106,7 @@ describe('CSV-MAPPER', () => {
       { name: 'longitude', default_values: ['2.22'], mandatory: false },
       { name: 'description', default_values: ['hello'], mandatory: false }
     ];
-    await adminQuery(
+    await internalAdminQuery(
       ENTITY_SETTINGS_UPDATE,
       {
         ids: [entitySettingArea.id],
@@ -124,7 +124,7 @@ describe('CSV-MAPPER', () => {
       { name: 'architecture_execution_envs', default_values: ['powerpc', 'x86'], mandatory: false },
       { name: 'description', default_values: ['hello'], mandatory: false }
     ];
-    await adminQuery(ENTITY_SETTINGS_UPDATE, {
+    await internalAdminQuery(ENTITY_SETTINGS_UPDATE, {
       ids: [entitySettingMalware.id],
       input: {
         key: 'attributes_configuration',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use cache to load users (for connectors, task manager)
* use cache to load user to get effective confidence level
* add debug log for cache reset

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6702 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
