### PR TITLE
[backend] handle string fields trimming in create/update operations (#6708)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -933,7 +933,12 @@ const rebuildAndMergeInputFromExistingData = (rawInput, instance) => {
     }
     finalVal = [patchedInstance[key]];
   } else {
-    const evaluateValue = value ? R.head(value) : null;
+    // now we  check if the new value would actually result in no change in database
+    let evaluateValue = value ? R.head(value) : null;
+    // string values will be trimmed before indexing ; we should not update attribute if the value once trimmed is identical.
+    if (typeof evaluateValue === 'string') {
+      evaluateValue = evaluateValue.trim();
+    }
     if (isDateAttribute(key)) {
       if (isEmptyField(evaluateValue)) {
         if (instance[key] === FROM_START_STR || instance[key] === UNTIL_END_STR) {

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -328,11 +328,11 @@ const filteredIdContributions = (contrib, way, data) => {
     }
     const destKey = dest || src;
     const resolver = contrib.resolvers[src];
-    const resolvedValue = (resolver && value) ? resolver(value) : value;
-    if (isEmptyField(resolvedValue)) {
-      return {}; // missing contribution
+    if (resolver) {
+      objectData[destKey] = value ? resolver(value) : value;
+    } else {
+      objectData[destKey] = value;
     }
-    objectData[destKey] = resolvedValue;
   }
   return R.filter((keyValue) => !R.isEmpty(keyValue) && !R.isNil(keyValue), objectData);
 };

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -328,11 +328,11 @@ const filteredIdContributions = (contrib, way, data) => {
     }
     const destKey = dest || src;
     const resolver = contrib.resolvers[src];
-    if (resolver) {
-      objectData[destKey] = value ? resolver(value) : value;
-    } else {
-      objectData[destKey] = value;
+    const resolvedValue = (resolver && value) ? resolver(value) : value;
+    if (isEmptyField(resolvedValue)) {
+      return {}; // missing contribution
     }
+    objectData[destKey] = resolvedValue;
   }
   return R.filter((keyValue) => !R.isEmpty(keyValue) && !R.isNil(keyValue), objectData);
 };


### PR DESCRIPTION
When receiving an update payload, we check if such patch would result in real change compared to database, and prevent these blank change to happen.

With a string value having heading or trailing whitespaces, the patched value is different from the database value, as the database value is always trimmed before indexing. Thus the change is authorized whereas there is no change.

In context described in #6708, this leads to an infinite syncing loop.

### Proposed changes

* compare database value with trimmed input value during said check.

### Related issues
* #6708 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
