### PR TITLE
[frontend] Yup trim before validation for required string (#6698)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -95,9 +95,9 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
-    context: Yup.string().required(t_i18n('This field is required')),
+    context: Yup.string().trim().required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -85,9 +85,9 @@ const GroupingEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
-    context: Yup.string().required(t_i18n('This field is required')),
+    context: Yup.string().trim().required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
@@ -128,7 +128,7 @@ export const NoteCreationForm: FunctionComponent<NoteFormProps> = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .required(t_i18n('This field is required')),
     attribute_abstract: Yup.string().nullable(),
-    content: Yup.string().min(2).required(t_i18n('This field is required')),
+    content: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
     note_types: Yup.array().nullable(),
     likelihood: Yup.number().min(0).max(100),

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
@@ -90,7 +90,7 @@ NoteEditionOverviewProps
 
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const basicShape = {
-    content: Yup.string().min(2).required(t_i18n('This field is required')),
+    content: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     created: Yup.date()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .required(t_i18n('This field is required')),

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -165,7 +165,7 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
   const { t_i18n } = useFormatter();
   const classes = useStyles();
   const basicShape = {
-    content: Yup.string().min(2).required(t_i18n('This field is required')),
+    content: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     attribute_abstract: Yup.string().nullable(),
     confidence: Yup.number(),
     note_types: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -104,7 +104,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const basicShape = {
-    name: Yup.string().min(2, t_i18n('Name must be at least 2 characters')).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')).required(t_i18n('This field is required')),
     published: Yup.date()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .required(t_i18n('This field is required')),

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -89,7 +89,7 @@ const ReportEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     published: Yup.date()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .required(t_i18n('This field is required')),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
@@ -89,7 +89,7 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     channel_types: Yup.array().nullable(),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -81,7 +81,7 @@ const ChannelEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     channel_types: Yup.array().nullable(),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
@@ -97,6 +97,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
   const { t_i18n } = useFormatter();
   const basicShape = {
     name: Yup.string()
+      .trim()
       .min(2)
       .required(t_i18n('This field is required')),
     is_family: Yup.boolean()

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -86,7 +86,7 @@ const MalwareEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     is_family: Yup.boolean().required(t_i18n('This field is required')),
     malware_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
@@ -91,7 +91,7 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     tool_types: Yup.array().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
@@ -85,7 +85,7 @@ const ToolEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     tool_types: Yup.array().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -86,7 +86,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -104,7 +104,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -172,7 +172,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
   const caseData = useFragment(caseIncidentEditionOverviewFragment, caseRef);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     severity: Yup.string().nullable(),
     priority: Yup.string().nullable(),
     response_types: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -103,7 +103,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
   };
   const caseRfiValidator = useSchemaCreationValidation(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -171,7 +171,7 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
   const caseData = useFragment(caseRfiEditionOverviewFragment, caseRef);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     information_types: Yup.array().nullable(),
     severity: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -103,7 +103,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -171,7 +171,7 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
   const caseData = useFragment(caseRftEditionOverviewFragment, caseRef);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     takedown_types: Yup.array().nullable(),
     severity: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -151,7 +151,7 @@ FeedbackEditionOverviewProps
   const feedbackData = useFragment(feedbackEditionOverviewFragment, feedbackRef);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     x_opencti_workflow_id: Yup.object(),
     rating: Yup.number(),

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
@@ -69,7 +69,7 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
   const classes = useStyles();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     due_date: Yup.date().nullable(),
     objectLabel: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
@@ -79,7 +79,7 @@ const TaskCreationForm: FunctionComponent<TaskCreationProps> = ({
   const classes = useStyles();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     due_date: Yup.date().nullable(),
     objectLabel: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionOverview.tsx
@@ -156,7 +156,7 @@ const TasksEditionOverview: FunctionComponent<TasksEditionOverviewProps> = ({
   const taskData = useFragment(tasksEditionOverviewFragment, taskRef);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     x_opencti_workflow_id: Yup.object().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
@@ -111,18 +111,18 @@ export const scopesConn = (exportConnectors) => {
 };
 
 const exportValidation = (t) => Yup.object().shape({
-  format: Yup.string().required(t('This field is required')),
-  type: Yup.string().required(t('This field is required')),
+  format: Yup.string().trim().required(t('This field is required')),
+  type: Yup.string().trim().required(t('This field is required')),
 });
 
 const importValidation = (t, configurations) => {
   const shape = {
-    connector_id: Yup.string().required(t('This field is required')),
+    connector_id: Yup.string().trim().required(t('This field is required')),
   };
   if (configurations) {
     return Yup.object().shape({
       ...shape,
-      configuration: Yup.string().required(t('This field is required')),
+      configuration: Yup.string().trim().required(t('This field is required')),
     });
   }
   return Yup.object().shape(shape);

--- a/opencti-platform/opencti-front/src/private/components/common/files/FreeTextUploader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FreeTextUploader.jsx
@@ -44,7 +44,7 @@ const freeTextUploaderEntityMutation = graphql`
 `;
 
 const freeTextValidation = (t) => Yup.object().shape({
-  content: Yup.string().required(t('This field is required')),
+  content: Yup.string().trim().required(t('This field is required')),
 });
 
 class FreeTextUploader extends Component {

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -240,7 +240,7 @@ const workbenchFileContentMutation = graphql`
 `;
 
 const importValidation = (t) => Yup.object().shape({
-  connector_id: Yup.string().required(t('This field is required')),
+  connector_id: Yup.string().trim().required(t('This field is required')),
 });
 
 const WorkbenchFileContentComponent = ({

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -58,7 +58,7 @@ const workbenchFileCreatorMutation = graphql`
 `;
 
 const fileValidation = (t: (value: string) => string) => Yup.object().shape({
-  name: Yup.string().required(t('This field is required')),
+  name: Yup.string().trim().required(t('This field is required')),
 });
 
 interface WorkbenchFileCreatorFormValues {

--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -57,12 +57,12 @@ const formikSchema = Yup.object().shape({
   applyAccesses: Yup.boolean(),
   newAccessMember: Yup.object()
     .shape({
-      value: Yup.string().required(),
-      label: Yup.string().required(),
-      type: Yup.string().required(),
+      value: Yup.string().trim().required(),
+      label: Yup.string().trim().required(),
+      type: Yup.string().trim().required(),
     })
     .required(''),
-  newAccessRight: Yup.string().required(''),
+  newAccessRight: Yup.string().trim().required(''),
 });
 
 const AuthorizedMembersField = ({

--- a/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
@@ -78,8 +78,8 @@ const identityMutation = graphql`
 `;
 
 const identityValidation = (t) => Yup.object().shape({
-  name: Yup.string().required(t('This field is required')),
-  type: Yup.string().required(t('This field is required')),
+  name: Yup.string().trim().required(t('This field is required')),
+  type: Yup.string().trim().required(t('This field is required')),
 });
 
 class IdentityCreation extends Component {

--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
@@ -87,9 +87,9 @@ const locations = [
 ];
 
 const locationValidation = (t: (name: string | object) => string) => Yup.object().shape({
-  name: Yup.string().required(t('This field is required')),
+  name: Yup.string().trim().required(t('This field is required')),
   description: Yup.string().nullable(),
-  type: Yup.string().required(t('This field is required')),
+  type: Yup.string().trim().required(t('This field is required')),
 });
 
 const LocationCreationForm: FunctionComponent<LocationCreationFormProps> = ({

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
@@ -42,7 +42,7 @@ const stixCoreObjectFileExportQuery = graphql`
 `;
 
 const exportValidation = (t: (arg: string) => string) => Yup.object().shape({
-  format: Yup.string().required(t('This field is required')),
+  format: Yup.string().trim().required(t('This field is required')),
 });
 interface StixCoreObjectFileExportComponentProps {
   queryRef: PreloadedQuery<StixCoreObjectFileExportQuery>;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -114,18 +114,18 @@ export const scopesConn = (exportConnectors) => {
 };
 
 const exportValidation = (t) => Yup.object().shape({
-  format: Yup.string().required(t('This field is required')),
-  type: Yup.string().required(t('This field is required')),
+  format: Yup.string().trim().required(t('This field is required')),
+  type: Yup.string().trim().required(t('This field is required')),
 });
 
 const importValidation = (t, configurations) => {
   const shape = {
-    connector_id: Yup.string().required(t('This field is required')),
+    connector_id: Yup.string().trim().required(t('This field is required')),
   };
   if (configurations) {
     return Yup.object().shape({
       ...shape,
-      configuration: Yup.string().required(t('This field is required')),
+      configuration: Yup.string().trim().required(t('This field is required')),
     });
   }
   return Yup.object().shape(shape);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
@@ -128,7 +128,7 @@ StixCoreObjectQuickSubscriptionContentProps
   };
 
   const liveTriggerValidation = () => Yup.object().shape({
-    name: Yup.string().required(t_i18n('This field is required')),
+    name: Yup.string().trim().required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     event_types: Yup.array()
       .min(1, t_i18n('Minimum one event type'))

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -60,7 +60,7 @@ export const StixCoreObjectsExportCreationMutation = graphql`
 `;
 
 const exportValidation = (t) => Yup.object().shape({
-  format: Yup.string().required(t('This field is required')),
+  format: Yup.string().trim().required(t('This field is required')),
 });
 
 export const scopesConn = (exportConnectors) => {

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -49,9 +49,9 @@ const useStyles = makeStyles<Theme>((theme) => ({
 }));
 
 const csvMapperValidation = (t_i18n: (s: string) => string) => Yup.object().shape({
-  name: Yup.string().required(t_i18n('This field is required')),
+  name: Yup.string().trim().required(t_i18n('This field is required')),
   has_header: Yup.boolean().required(t_i18n('This field is required')),
-  separator: Yup.string().required(t_i18n('This field is required')),
+  separator: Yup.string().trim().required(t_i18n('This field is required')),
   skipLineChar: Yup.string().max(1),
 });
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -83,7 +83,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const addComponentValidation = (t) => Yup.object().shape({
-  name: Yup.string().required(t('This field is required')),
+  name: Yup.string().trim().required(t('This field is required')),
 });
 
 const PlaybookAddComponentsContent = ({

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
@@ -55,10 +55,10 @@ const syncMutationFieldPatch = graphql`
 `;
 
 const syncValidation = (t) => Yup.object().shape({
-  name: Yup.string().required(t('This field is required')),
-  uri: Yup.string().required(t('This field is required')),
+  name: Yup.string().trim().required(t('This field is required')),
+  uri: Yup.string().trim().required(t('This field is required')),
   token: Yup.string(),
-  stream_id: Yup.string().required(t('This field is required')),
+  stream_id: Yup.string().trim().required(t('This field is required')),
   current_state_date: Yup.date()
     .nullable()
     .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -92,7 +92,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -79,7 +79,7 @@ const EventEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -87,7 +87,7 @@ const IndividualEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -115,7 +115,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -83,7 +83,7 @@ const SectorEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -84,7 +84,7 @@ const SystemEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
@@ -97,7 +97,7 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
   const { t_i18n } = useFormatter();
   const [commit] = useMutation(IncidentMutation);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
     incident_type: Yup.string().nullable(),
     severity: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -157,7 +157,7 @@ IncidentEditionOverviewProps
   const { t_i18n } = useFormatter();
   const incident = useFragment(incidentEditionOverviewFragment, incidentRef);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     incident_type: Yup.string().nullable(),
     severity: Yup.string().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
@@ -89,7 +89,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -146,7 +146,7 @@ AdministrativeAreaEditionOverviewProps
     administrativeAreaRef,
   );
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
@@ -86,7 +86,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -139,7 +139,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
   const { t_i18n } = useFormatter();
   const city = useFragment(cityEditionOverviewFragment, cityRef);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
@@ -84,7 +84,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -137,7 +137,7 @@ CountryEditionOverviewProps
   const { t_i18n } = useFormatter();
   const country = useFragment(countryEditionOverviewFragment, countryRef);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
@@ -89,7 +89,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -85,7 +85,7 @@ const PositionEditionOverviewComponent = (props) => {
   const { position, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
@@ -85,7 +85,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -137,7 +137,7 @@ RegionEdititionOverviewProps
   const { t_i18n } = useFormatter();
   const region = useFragment(regionEditionOverviewFragment, regionRef);
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -117,12 +117,12 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     indicator_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
-    pattern: Yup.string().required(t_i18n('This field is required')),
-    pattern_type: Yup.string().required(t_i18n('This field is required')),
-    x_opencti_main_observable_type: Yup.string().required(
+    pattern: Yup.string().trim().required(t_i18n('This field is required')),
+    pattern_type: Yup.string().trim().required(t_i18n('This field is required')),
+    x_opencti_main_observable_type: Yup.string().trim().required(
       t_i18n('This field is required'),
     ),
     valid_from: Yup.date()

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -84,10 +84,10 @@ const IndicatorEditionOverviewComponent = ({
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     indicator_types: Yup.array(),
     confidence: Yup.number(),
-    pattern: Yup.string().required(t_i18n('This field is required')),
+    pattern: Yup.string().trim().required(t_i18n('This field is required')),
     valid_from: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
@@ -94,7 +94,7 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     infrastructure_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -159,7 +159,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
   const infrastructure = useFragment(infrastructureEditionOverviewFragment, infrastructureData);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     infrastructure_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksEdition.tsx
@@ -22,7 +22,7 @@ const CaseTemplateTasksEdition = ({ task }: { task: CaseTemplateTasksLine_node$d
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
   };
   const taskValidator = useSchemaEditionValidation('Task', basicShape);

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleValidator.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleValidator.ts
@@ -1,7 +1,7 @@
 import * as Yup from 'yup';
 
 const decayRuleValidator = (t: (value: string) => string) => Yup.object().shape({
-  name: Yup.string().min(2).required(t('This field is required')),
+  name: Yup.string().trim().min(2).required(t('This field is required')),
   description: Yup.string().nullable(),
   active: Yup.boolean(),
   order: Yup.number()

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
@@ -108,7 +108,7 @@ const SettingsOrganizationEdition = ({
   const isEnterpriseEdition = useEnterpriseEdition();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_organization_type: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
@@ -111,7 +111,7 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     x_mitre_id: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -87,7 +87,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     x_mitre_id: Yup.string().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -86,7 +86,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_threat_hunting: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -143,7 +143,7 @@ DataComponentEditionOverviewComponentProps
   const dataComponent = useFragment(DataComponentEditionOverviewFragment, data);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -113,7 +113,7 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -149,7 +149,7 @@ DataSourceEditionOverviewProps
   const dataSource = useFragment(dataSourceEditionOverviewFragment, data);
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     x_mitre_platforms: Yup.array().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -127,7 +127,7 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
   };
   const narrativeValidator = useSchemaCreationValidation(

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -83,7 +83,7 @@ const NarrativeEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     references: Yup.array(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
@@ -87,7 +87,7 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -86,7 +86,7 @@ const CampaignEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
@@ -88,7 +88,7 @@ IntrusionSetFormProps
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number(),
     description: Yup.string().nullable(),
   };

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -86,7 +86,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
 
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -86,7 +86,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
   const { threatActorGroup, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -142,7 +142,7 @@ ThreatActorIndividualEditionOverviewProps
     threatActorIndividualRef,
   );
   const basicShape = {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),


### PR DESCRIPTION
## Proposed changes

* front: for all required strings in forms, trim in validation to avoid empty strings

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6698

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I will add a test directly in the other branch I am working on that regroups all tests for reports
