### PR TITLE
[backend] update GQL API: names cannot be blank (#6742)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
@@ -305,7 +305,7 @@ const ExternalReferenceCreation: FunctionComponent<ExternalReferenceCreationProp
             enableReinitialize={true}
             onSubmit={!handleCloseContextual ? onSubmit : onSubmitContextual}
             initialValues={{
-              source_name: inputValue,
+              source_name: inputValue || '',
               external_id: '',
               url: '',
               description: '',

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -752,10 +752,10 @@ type SynchronizerConnection {
 }
 
 input SynchronizerAddInput {
-  name: name_String_NotNull_minLength_2!
-  uri: uri_String_NotNull_minLength_2!
+  name: String!
+  uri: String!
   token: String
-  stream_id: stream_id_String_NotNull_minLength_2!
+  stream_id: String!
   user_id: String
   recover: DateTime
   current_state_date: DateTime
@@ -764,12 +764,6 @@ input SynchronizerAddInput {
   ssl_verify: Boolean
   synchronized: Boolean
 }
-
-scalar name_String_NotNull_minLength_2
-
-scalar uri_String_NotNull_minLength_2
-
-scalar stream_id_String_NotNull_minLength_2
 
 input SynchronizerFetchInput {
   uri: String!
@@ -1066,10 +1060,8 @@ input QueryTaskAddInput {
 input RetentionRuleAddInput {
   name: String!
   filters: String!
-  max_retention: max_retention_Int_NotNull_min_1!
+  max_retention: Int!
 }
-
-scalar max_retention_Int_NotNull_min_1
 
 type RetentionRule {
   id: ID!
@@ -1524,8 +1516,8 @@ type UserSession {
 }
 
 input UserAddInput {
-  user_email: user_email_String_NotNull_minLength_5_format_email!
-  name: name_String_NotNull_minLength_2!
+  user_email: String!
+  name: String!
   password: String!
   firstname: String
   lastname: String
@@ -1541,8 +1533,6 @@ input UserAddInput {
   groups: [ID!]
   user_confidence_level: ConfidenceLevelInput
 }
-
-scalar user_email_String_NotNull_minLength_5_format_email
 
 input ConfidenceLevelInput {
   max_confidence: Int
@@ -2024,7 +2014,7 @@ type ExternalReference implements BasicObject & StixObject & StixMetaObject {
 input ExternalReferenceAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  source_name: source_name_String_NotNull_minLength_2!
+  source_name: String!
   description: String
   url: String
   hash: String
@@ -2035,8 +2025,6 @@ input ExternalReferenceAddInput {
   clientMutationId: String
   update: Boolean
 }
-
-scalar source_name_String_NotNull_minLength_2
 
 enum KillChainPhasesOrdering {
   x_opencti_order
@@ -2276,7 +2264,7 @@ interface StixDomainObject {
 input StixDomainObjectAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   confidence: Int
   pattern_type: String
@@ -2382,7 +2370,7 @@ type AttackPattern implements BasicObject & StixObject & StixCoreObject & StixDo
 input AttackPatternAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   revoked: Boolean
@@ -2487,7 +2475,7 @@ type Campaign implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input CampaignAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   revoked: Boolean
@@ -2661,7 +2649,7 @@ input NoteAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
   attribute_abstract: String
-  content: content_String_NotNull_minLength_2!
+  content: String!
   authors: [String]
   note_types: [String]
   likelihood: Int
@@ -2682,13 +2670,11 @@ input NoteAddInput {
   file: Upload
 }
 
-scalar content_String_NotNull_minLength_2
-
 input NoteUserAddInput {
   stix_id: String
   x_opencti_stix_ids: [String]
   attribute_abstract: String
-  content: content_String_NotNull_minLength_2!
+  content: String!
   note_types: [String]
   likelihood: Int
   revoked: Boolean
@@ -3014,7 +3000,7 @@ type Report implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input ReportAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   content: String
   content_mapping: String
@@ -3120,7 +3106,7 @@ type CourseOfAction implements BasicObject & StixObject & StixCoreObject & StixD
 input CourseOfActionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   x_opencti_aliases: [String]
   x_mitre_id: String
@@ -3328,7 +3314,7 @@ type Individual implements BasicObject & StixObject & StixCoreObject & StixDomai
 input IndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   contact_information: String
   roles: [String]
@@ -3436,7 +3422,7 @@ type Sector implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input SectorAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   contact_information: String
   roles: [String]
@@ -3538,7 +3524,7 @@ type System implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input SystemAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   contact_information: String
   roles: [String]
@@ -3646,7 +3632,7 @@ type Infrastructure implements BasicObject & StixObject & StixCoreObject & StixD
 input InfrastructureAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   infrastructure_types: [String]
@@ -3751,7 +3737,7 @@ type IntrusionSet implements BasicObject & StixObject & StixCoreObject & StixDom
 input IntrusionSetAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   first_seen: DateTime
@@ -3959,7 +3945,7 @@ type Position implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input PositionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   latitude: Float
   longitude: Float
@@ -4065,7 +4051,7 @@ type City implements BasicObject & StixObject & StixCoreObject & StixDomainObjec
 input CityAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   latitude: Float
   longitude: Float
@@ -4165,7 +4151,7 @@ type Country implements BasicObject & StixObject & StixCoreObject & StixDomainOb
 input CountryAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   latitude: Float
   longitude: Float
@@ -4267,7 +4253,7 @@ type Region implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input RegionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   latitude: Float
   longitude: Float
@@ -4377,7 +4363,7 @@ type Malware implements BasicObject & StixObject & StixCoreObject & StixDomainOb
 input MalwareAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   malware_types: [String]
   aliases: [String]
@@ -4567,7 +4553,7 @@ type ThreatActorGroup implements BasicObject & StixObject & StixCoreObject & Sti
 input ThreatActorGroupAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   threat_actor_types: [String]
@@ -4675,7 +4661,7 @@ type Tool implements BasicObject & StixObject & StixCoreObject & StixDomainObjec
 input ToolAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   tool_types: [String]
@@ -4783,7 +4769,7 @@ type Vulnerability implements BasicObject & StixObject & StixCoreObject & StixDo
 input VulnerabilityAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   x_opencti_aliases: [String]
   x_opencti_cvss_base_score: Float
@@ -4898,7 +4884,7 @@ type Incident implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input IncidentAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   confidence: Int
   revoked: Boolean
@@ -5312,13 +5298,9 @@ input EmailMimePartTypeAddInput {
 }
 
 input HashInput {
-  algorithm: algorithm_String_NotNull_minLength_3!
-  hash: hash_String_NotNull_minLength_5!
+  algorithm: String!
+  hash: String!
 }
-
-scalar algorithm_String_NotNull_minLength_3
-
-scalar hash_String_NotNull_minLength_5
 
 type Hash {
   algorithm: String!
@@ -8430,7 +8412,7 @@ type ChannelEdge {
 input ChannelAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   channel_types: [String]
   aliases: [String]
@@ -8525,7 +8507,7 @@ type LanguageEdge {
 input LanguageAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   confidence: Int
@@ -8624,7 +8606,7 @@ type EventEdge {
 input EventAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   event_types: [String!]
   start_time: DateTime
@@ -8728,11 +8710,11 @@ type GroupingEdge {
 input GroupingAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   content: String
   content_mapping: String
-  context: context_String_NotNull_minLength_2!
+  context: String!
   x_opencti_aliases: [String]
   revoked: Boolean
   lang: String
@@ -8750,8 +8732,6 @@ input GroupingAddInput {
   update: Boolean
   file: Upload
 }
-
-scalar context_String_NotNull_minLength_2
 
 type Narrative implements BasicObject & StixCoreObject & StixDomainObject & StixObject {
   id: ID!
@@ -8834,7 +8814,7 @@ type NarrativeEdge {
 input NarrativeAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   narrative_types: [String!]
   aliases: [String]
@@ -8886,7 +8866,7 @@ enum TriggerEventType {
 }
 
 input TriggerLiveAddInput {
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   event_types: [TriggerEventType!]!
   notifiers: [StixRef!]
@@ -8895,10 +8875,8 @@ input TriggerLiveAddInput {
   recipients: [String!]
 }
 
-scalar name_String_NotNull_minLength_1
-
 input TriggerDigestAddInput {
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   trigger_ids: [String!]!
   period: DigestPeriod!
@@ -8951,7 +8929,7 @@ enum TriggerActivityEventType {
 }
 
 input TriggerActivityLiveAddInput {
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   notifiers: [StixRef!]
   filters: String
@@ -8959,7 +8937,7 @@ input TriggerActivityLiveAddInput {
 }
 
 input TriggerActivityDigestAddInput {
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   trigger_ids: [String!]!
   period: DigestPeriod!
@@ -9103,7 +9081,7 @@ input DataComponentAddInput {
   modified: DateTime
   clientMutationId: String
   update: Boolean
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   dataSource: String
@@ -9200,7 +9178,7 @@ input DataSourceAddInput {
   modified: DateTime
   clientMutationId: String
   update: Boolean
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   x_mitre_platforms: [String!]
@@ -9313,7 +9291,7 @@ type VocabularyEdge {
 input VocabularyAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   category: VocabularyCategory!
   order: Int
@@ -9403,7 +9381,7 @@ type AdministrativeAreaEdge {
 input AdministrativeAreaAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   latitude: Float
   longitude: Float
@@ -9506,7 +9484,7 @@ type TaskConnection {
 }
 
 input TaskAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   created: DateTime
   due_date: DateTime
@@ -9553,7 +9531,7 @@ type TaskTemplateEdge {
 }
 
 input TaskTemplateAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
 }
 
@@ -9667,7 +9645,7 @@ type CaseTemplateEdge {
 }
 
 input CaseTemplateAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   created: DateTime
   tasks: [StixRef!]!
@@ -9764,7 +9742,7 @@ type CaseIncidentEdge {
 input CaseIncidentAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   severity: String
   priority: String
   description: String
@@ -9880,7 +9858,7 @@ type CaseRfiEdge {
 input CaseRfiAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   content: String
   content_mapping: String
@@ -9997,7 +9975,7 @@ type CaseRftEdge {
 input CaseRftAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   content: String
   content_mapping: String
@@ -10112,7 +10090,7 @@ type FeedbackEdge {
 input FeedbackAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   content: String
   content_mapping: String
@@ -10453,7 +10431,7 @@ input NotifierTestInput {
 }
 
 input NotifierAddInput {
-  name: name_String_NotNull_minLength_1!
+  name: String!
   description: String
   notifier_connector_id: String!
   notifier_configuration: String!
@@ -10568,7 +10546,7 @@ type ThreatActorIndividualEdge {
 input ThreatActorIndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   aliases: [String]
   threat_actor_types: [String]
@@ -10675,7 +10653,7 @@ type PlaybookEdge {
 }
 
 input PlaybookAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
 }
 
@@ -10733,9 +10711,9 @@ type IngestionRssEdge {
 }
 
 input IngestionRssAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
-  uri: uri_String_NotNull_minLength_5!
+  uri: String!
   current_state_date: DateTime
   ingestion_running: Boolean
   user_id: String
@@ -10743,8 +10721,6 @@ input IngestionRssAddInput {
   object_marking_refs: [String!]
   report_types: [String!]
 }
-
-scalar uri_String_NotNull_minLength_5
 
 enum TaxiiVersion {
   v1
@@ -10799,19 +10775,17 @@ type IngestionTaxiiEdge {
 }
 
 input IngestionTaxiiAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   version: TaxiiVersion!
   authentication_type: TaxiiAuthType!
   authentication_value: String
-  uri: uri_String_NotNull_minLength_5!
-  collection: collection_String_NotNull_minLength_5!
+  uri: String!
+  collection: String!
   added_after_start: DateTime
   ingestion_running: Boolean
   user_id: String
 }
-
-scalar collection_String_NotNull_minLength_5
 
 enum CsvAuthType {
   none
@@ -10859,12 +10833,12 @@ type IngestionCsvEdge {
 }
 
 input IngestionCsvAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   authentication_type: CsvAuthType!
   authentication_value: String
   current_state_date: DateTime
-  uri: uri_String_NotNull_minLength_5!
+  uri: String!
   csv_mapper_id: String!
   ingestion_running: Boolean
   user_id: String!
@@ -10998,7 +10972,7 @@ input IndicatorAddInput {
   pattern_type: String!
   pattern_version: String
   pattern: String!
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   indicator_types: [String!]
   valid_from: DateTime
@@ -11067,7 +11041,7 @@ type DecayRuleEdge {
 }
 
 input DecayRuleAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   order: Int!
   active: Boolean!
@@ -11167,7 +11141,7 @@ type OrganizationEdge {
 input OrganizationAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: name_String_NotNull_minLength_2!
+  name: String!
   description: String
   contact_information: String
   roles: [String]
@@ -11362,7 +11336,7 @@ input CsvMapperRepresentationInput {
 }
 
 input CsvMapperAddInput {
-  name: name_String_NotNull_minLength_2!
+  name: String!
   has_header: Boolean!
   separator: String!
   representations: String!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -498,7 +498,7 @@ type TaxiiCollectionEdge {
   node: TaxiiCollection!
 }
 input TaxiiCollectionAddInput {
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   filters: String
   taxii_public: Boolean
@@ -547,7 +547,7 @@ input FeedAttributeMappingInput {
 }
 
 input FeedAddInput {
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   filters: String
   separator: String!
@@ -601,7 +601,7 @@ type StreamCollectionEdge {
   node: StreamCollection!
 }
 input StreamCollectionAddInput {
-  name: String!
+  name: String! @constraint(minLength:2, format: "not-blank")
   description: String
   filters: String
   stream_live: Boolean
@@ -680,7 +680,7 @@ input StatusAddInput {
   order: Int!
 }
 input StatusTemplateAddInput {
-  name: String!
+  name: String! @constraint(minLength:2, format: "not-blank")
   color: String!
 }
 
@@ -720,7 +720,7 @@ type SynchronizerConnection {
 }
 
 input SynchronizerAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   uri: String! @constraint(minLength: 2)
   token: String
   stream_id: String! @constraint(minLength: 2)
@@ -1012,7 +1012,7 @@ input QueryTaskAddInput {
 }
 
 input RetentionRuleAddInput {
-  name: String!
+  name: String! @constraint(minLength:2, format: "not-blank")
   filters: String!
   max_retention: Int! @constraint(min: 1)
 }
@@ -1234,7 +1234,7 @@ type Group implements InternalObject & BasicObject {
   editContext: [EditUserContext!]
 }
 input GroupAddInput {
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   default_assignation: Boolean
   auto_new_marking: Boolean
@@ -1455,7 +1455,7 @@ type UserSession {
 }
 input UserAddInput {
   user_email: String! @constraint(minLength: 5, format: "email")
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   password: String!
   firstname: String
   lastname: String
@@ -1524,7 +1524,7 @@ type Role implements BasicObject & InternalObject {
   editContext: [EditUserContext!]
 }
 input RoleAddInput {
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   clientMutationId: String
 }
@@ -1619,7 +1619,7 @@ input StixCyberObservablesExportAskInput {
 
 input RegisterConnectorInput {
   id: ID!
-  name: String!
+  name: String! @constraint(minLength:2, format: "not-blank")
   type: ConnectorType!
   scope: [String!]
   auto: Boolean
@@ -1958,7 +1958,7 @@ type ExternalReference implements BasicObject & StixObject & StixMetaObject {
 input ExternalReferenceAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  source_name: String! @constraint(minLength: 2)
+  source_name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   url: String
   hash: String
@@ -2321,7 +2321,7 @@ interface StixDomainObject {
 input StixDomainObjectAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   confidence: Int
   pattern_type: String
@@ -2484,7 +2484,7 @@ type AttackPattern implements BasicObject & StixObject & StixCoreObject & StixDo
 input AttackPatternAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   revoked: Boolean
@@ -2646,7 +2646,7 @@ type Campaign implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input CampaignAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   revoked: Boolean
@@ -3548,7 +3548,7 @@ type Report implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input ReportAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   content: String
   content_mapping: String
@@ -3711,7 +3711,7 @@ type CourseOfAction implements BasicObject & StixObject & StixCoreObject & StixD
 input CourseOfActionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   x_opencti_aliases: [String]
   x_mitre_id: String
@@ -3872,7 +3872,7 @@ input IdentityAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
   type: IdentityType!
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]
@@ -4032,7 +4032,7 @@ type Individual implements BasicObject & StixObject & StixCoreObject & StixDomai
 input IndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]
@@ -4198,7 +4198,7 @@ type Sector implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input SectorAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]
@@ -4358,7 +4358,7 @@ type System implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input SystemAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]
@@ -4523,7 +4523,7 @@ type Infrastructure implements BasicObject & StixObject & StixCoreObject & StixD
 input InfrastructureAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   infrastructure_types: [String]
@@ -4685,7 +4685,7 @@ type IntrusionSet implements BasicObject & StixObject & StixCoreObject & StixDom
 input IntrusionSetAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   first_seen: DateTime
@@ -5007,7 +5007,7 @@ type Position implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input PositionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   latitude: Float
   longitude: Float
@@ -5171,7 +5171,7 @@ type City implements BasicObject & StixObject & StixCoreObject & StixDomainObjec
 input CityAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   latitude: Float
   longitude: Float
@@ -5328,7 +5328,7 @@ type Country implements BasicObject & StixObject & StixCoreObject & StixDomainOb
 input CountryAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   latitude: Float
   longitude: Float
@@ -5488,7 +5488,7 @@ type Region implements BasicObject & StixObject & StixCoreObject & StixDomainObj
 input RegionAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   latitude: Float
   longitude: Float
@@ -5655,7 +5655,7 @@ type Malware implements BasicObject & StixObject & StixCoreObject & StixDomainOb
 input MalwareAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   malware_types: [String]
   aliases: [String]
@@ -5965,7 +5965,7 @@ type ThreatActorGroup implements BasicObject & StixObject & StixCoreObject & Sti
 input ThreatActorGroupAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   threat_actor_types: [String]
@@ -6130,7 +6130,7 @@ type Tool implements BasicObject & StixObject & StixCoreObject & StixDomainObjec
 input ToolAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   tool_types: [String]
@@ -6295,7 +6295,7 @@ type Vulnerability implements BasicObject & StixObject & StixCoreObject & StixDo
 input VulnerabilityAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   x_opencti_aliases: [String]
   x_opencti_cvss_base_score: Float
@@ -6467,7 +6467,7 @@ type Incident implements BasicObject & StixObject & StixCoreObject & StixDomainO
 input IncidentAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   confidence: Int
   revoked: Boolean

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -4847,7 +4847,7 @@ input LocationAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
   type: String!
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   latitude: Float
   longitude: Float

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -95,7 +95,7 @@
     "file-type": "19.0.0",
     "github-api": "3.4.0",
     "graphql": "16.8.1",
-    "graphql-constraint-directive": "5.4.2",
+    "graphql-constraint-directive": "5.4.3",
     "graphql-import": "1.0.2",
     "graphql-redis-subscriptions": "2.6.0",
     "graphql-relay": "0.10.0",

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -17,8 +17,7 @@ import { executionContext } from '../utils/access';
 
 const createApolloServer = () => {
   let schema = createSchema();
-
-  // constraint-directive plugin configuration
+  // graphql-constraint-directive plugin configuration
   const formats = {
     'not-blank': (value) => {
       if (value.length > 0 && value.trim() === '') {
@@ -32,6 +31,8 @@ const createApolloServer = () => {
 
   const apolloPlugins = [loggerPlugin, httpResponsePlugin, constraintPlugin];
   const apolloValidationRules = [];
+
+  // optional graphql-armor plugin configuration
   if (GRAPHQL_ARMOR_ENABLED) {
     const armor = new ApolloArmor({
       costLimit: { // Blocking too expensive requests (DoS attack attempts).

--- a/opencti-platform/opencti-graphql/src/graphql/schema.js
+++ b/opencti-platform/opencti-graphql/src/graphql/schema.js
@@ -1,7 +1,7 @@
 import { GraphQLDateTime } from 'graphql-scalars';
 import { mergeResolvers } from 'merge-graphql-schemas';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { constraintDirective } from 'graphql-constraint-directive';
+import { constraintDirectiveTypeDefs, constraintDirectiveDocumentation } from 'graphql-constraint-directive';
 // eslint-disable-next-line import/extensions
 import { GraphQLScalarType, GraphQLError, Kind } from 'graphql/index.js';
 import { validate as uuidValidate } from 'uuid';
@@ -172,6 +172,8 @@ const globalResolvers = {
   }),
 };
 const schemaResolvers = [
+  // EXTERNAL
+  constraintDirectiveTypeDefs,
   // INTERNAL
   globalResolvers,
   taxiiResolvers,
@@ -268,7 +270,6 @@ const createSchema = () => {
     resolvers,
     inheritResolversFromInterfaces: true,
   });
-  schema = constraintDirective()(schema);
   schema = authDirectiveTransformer(schema);
   return schema;
 };

--- a/opencti-platform/opencti-graphql/src/graphql/schema.js
+++ b/opencti-platform/opencti-graphql/src/graphql/schema.js
@@ -1,7 +1,7 @@
 import { GraphQLDateTime } from 'graphql-scalars';
 import { mergeResolvers } from 'merge-graphql-schemas';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { constraintDirectiveTypeDefs, constraintDirectiveDocumentation } from 'graphql-constraint-directive';
+import { constraintDirectiveTypeDefs } from 'graphql-constraint-directive';
 // eslint-disable-next-line import/extensions
 import { GraphQLScalarType, GraphQLError, Kind } from 'graphql/index.js';
 import { validate as uuidValidate } from 'uuid';

--- a/opencti-platform/opencti-graphql/src/modules/administrativeArea/administrativeArea.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/administrativeArea/administrativeArea.graphql
@@ -154,7 +154,7 @@ type Query {
 input AdministrativeAreaAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     latitude: Float
     longitude: Float

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
@@ -186,7 +186,7 @@ type Query {
 input CaseIncidentAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   severity: String
   priority: String
   description: String

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
@@ -185,7 +185,7 @@ type Query {
 input CaseRfiAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   content: String
   content_mapping: String

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
@@ -186,7 +186,7 @@ type Query {
 input CaseRftAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   content: String
   content_mapping: String

--- a/opencti-platform/opencti-graphql/src/modules/case/case-template/case-template.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-template/case-template.graphql
@@ -40,7 +40,7 @@ type Query {
 
 # Mutations
 input CaseTemplateAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   created: DateTime
   tasks: [StixRef!]!

--- a/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.graphql
@@ -184,7 +184,7 @@ type Query {
 input FeedbackAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   content: String
   content_mapping: String

--- a/opencti-platform/opencti-graphql/src/modules/channel/channel.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/channel/channel.graphql
@@ -152,7 +152,7 @@ type Query {
 input ChannelAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     channel_types: [String]
     aliases: [String]

--- a/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
@@ -164,7 +164,7 @@ input DataComponentAddInput {
     modified: DateTime
     clientMutationId: String
     update: Boolean
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     aliases: [String]
     dataSource: String

--- a/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
@@ -164,7 +164,7 @@ input DataSourceAddInput {
     modified: DateTime
     clientMutationId: String
     update: Boolean
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     aliases: [String]
     x_mitre_platforms: [String!]

--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.graphql
@@ -55,7 +55,7 @@ type Query {
 }
 
 input DecayRuleAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   order: Int!
   active: Boolean!

--- a/opencti-platform/opencti-graphql/src/modules/event/event.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/event/event.graphql
@@ -156,7 +156,7 @@ type Query {
 input EventAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     event_types: [String!]
     start_time: DateTime

--- a/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
@@ -210,7 +210,7 @@ type Query {
 input GroupingAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     content: String
     content_mapping: String

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
@@ -186,7 +186,7 @@ input IndicatorAddInput {
   pattern_type: String!
   pattern_version: String
   pattern: String!
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   indicator_types: [String!]
   valid_from: DateTime

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -59,7 +59,7 @@ type Query {
 
 # Mutations
 input IngestionCsvAddInput {
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     authentication_type: CsvAuthType!
     authentication_value: String

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-rss.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-rss.graphql
@@ -46,7 +46,7 @@ type Query {
 
 # Mutations
 input IngestionRssAddInput {
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     uri: String! @constraint(minLength: 5)
     current_state_date: DateTime

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii.graphql
@@ -63,7 +63,7 @@ type Query {
 
 # Mutations
 input IngestionTaxiiAddInput {
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     version: TaxiiVersion!
     authentication_type: TaxiiAuthType!

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.graphql
@@ -166,7 +166,7 @@ input CsvMapperRepresentationInput {
   to: String
 }
 input CsvMapperAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   has_header: Boolean!
   separator: String!
   representations: String!

--- a/opencti-platform/opencti-graphql/src/modules/language/language.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/language/language.graphql
@@ -147,7 +147,7 @@ type Query {
 input LanguageAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     aliases: [String]
     confidence: Int

--- a/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
@@ -154,7 +154,7 @@ type Query {
 input NarrativeAddInput {
     stix_id: StixId
     x_opencti_stix_ids: [StixId]
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     narrative_types: [String!]
     aliases: [String]

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
@@ -30,7 +30,7 @@ enum TriggerEventType {
     delete
 }
 input TriggerLiveAddInput {
-    name: String! @constraint(minLength: 1)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     event_types: [TriggerEventType!]!
     notifiers: [StixRef!]
@@ -39,7 +39,7 @@ input TriggerLiveAddInput {
     recipients: [String!]
 }
 input TriggerDigestAddInput {
-    name: String! @constraint(minLength: 1)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     trigger_ids: [String!]! # Triggers that composed the digest
     period: DigestPeriod!
@@ -90,7 +90,7 @@ enum TriggerActivityEventType {
     command
 }
 input TriggerActivityLiveAddInput {
-    name: String! @constraint(minLength: 1)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     notifiers: [StixRef!]
     filters: String
@@ -98,7 +98,7 @@ input TriggerActivityLiveAddInput {
 }
 
 input TriggerActivityDigestAddInput {
-    name: String! @constraint(minLength: 1)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     trigger_ids: [String!]! # Triggers that composed the digest
     period: DigestPeriod!

--- a/opencti-platform/opencti-graphql/src/modules/notifier/notifier.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/notifier/notifier.graphql
@@ -65,7 +65,7 @@ type Query {
 
 # Mutations
 input NotifierAddInput {
-    name: String! @constraint(minLength: 1)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     notifier_connector_id: String!
     notifier_configuration: String!

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
@@ -171,7 +171,7 @@ type Query {
 input OrganizationAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -79,7 +79,7 @@ type Query {
 }
 
 input PlaybookAddInput {
-    name: String! @constraint(minLength: 2)
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
 }
 
@@ -89,7 +89,7 @@ input PositionInput {
 }
 
 input PlaybookAddNodeInput {
-    name: String!
+    name: String! @constraint(minLength: 2, format: "not-blank")
     component_id: String!
     position: PositionInput!
     configuration: String

--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard.graphql
@@ -114,7 +114,7 @@ type PublicDashboardEdge {
 
 # Mutation
 input PublicDashboardAddInput {
-  name: String!
+  name: String! @constraint(minLength: 2, format: "not-blank")
   uri_key: String!
   description: String
   dashboard_id: String!

--- a/opencti-platform/opencti-graphql/src/modules/task/task-template/task-template.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/task/task-template/task-template.graphql
@@ -45,7 +45,7 @@ type Query {
 
 # Mutations
 input TaskTemplateAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/task/task.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/task/task.graphql
@@ -175,7 +175,7 @@ type Query {
 
 # Mutations
 input TaskAddInput {
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   created: DateTime
   due_date: DateTime

--- a/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.graphql
@@ -163,7 +163,7 @@ type ThreatActorIndividualEdge {
 input ThreatActorIndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   aliases: [String]
   threat_actor_types: [String]

--- a/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
@@ -123,7 +123,7 @@ type Query {
 input VocabularyAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 1)
+  name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   category: VocabularyCategory!
   order: Int

--- a/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
@@ -123,7 +123,7 @@ type Query {
 input VocabularyAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2, format: "not-blank")
+  name: String! @constraint(format: "not-blank")
   description: String
   category: VocabularyCategory!
   order: Int

--- a/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
@@ -123,7 +123,7 @@ type Query {
 input VocabularyAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(format: "not-blank")
+  name: String! @constraint(minLength: 1, format: "not-blank")
   description: String
   category: VocabularyCategory!
   order: Int

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace.graphql
@@ -68,7 +68,7 @@ type WorkspaceEdge {
 # Mutations
 input WorkspaceAddInput {
     type: String!
-    name: String!
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     tags: [String]
     authorized_members: [MemberAccessInput!]
@@ -77,7 +77,7 @@ input WorkspaceAddInput {
 
 input WorkspaceDuplicateInput {
     type: String!
-    name: String!
+    name: String! @constraint(minLength: 2, format: "not-blank")
     description: String
     manifest: String
     tags: [String]

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -287,7 +287,7 @@ const assignGroupToUser = async (group: Group, user: User) => {
 
 // region organization management
 const ORGANIZATION_CREATION_MUTATION = `
-  mutation organizationCreation($name: name_String_NotNull_minLength_2!) {
+  mutation organizationCreation($name: String!) {
      organizationAdd(input: {
       name: $name
     }) {
@@ -371,7 +371,7 @@ const createRole = async (input: { name: string, description: string, capabiliti
 
 // region user management
 const USER_CREATION_MUTATION = `
-  mutation userCreation($email: user_email_String_NotNull_minLength_5_format_email!, $name: name_String_NotNull_minLength_2!, $password: String!) {
+  mutation userCreation($email: String!, $name: String!, $password: String!) {
     userAdd(input: {
       user_email: $email
       name: $name

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -8660,16 +8660,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-constraint-directive@npm:5.4.2":
-  version: 5.4.2
-  resolution: "graphql-constraint-directive@npm:5.4.2"
+"graphql-constraint-directive@npm:5.4.3":
+  version: 5.4.3
+  resolution: "graphql-constraint-directive@npm:5.4.3"
   dependencies:
     "@graphql-tools/schema": "npm:^9.0.0"
     "@graphql-tools/utils": "npm:^9.0.0"
     validator: "npm:^13.6.0"
   peerDependencies:
     graphql: ">=14.0.0"
-  checksum: 10/e539080ea8ddb192d8728872fcff4ee28eb7c62dda59c7725915654b12283167b7fd7e5ef71c1cc850b990b52d3411da1397dd450eff6132908532035f652309
+  checksum: 10/1be31b75f981db291cfa7a0f6e1b70b734a2142d2b88d51b7a0e64284f0faefe4fb80be54fe9b3b5c52c8e49abbff623e4e0f1b1c685fe3b8a8a1670bff389cf
   languageName: node
   linkType: hard
 
@@ -11116,7 +11116,7 @@ __metadata:
     file-type: "npm:19.0.0"
     github-api: "npm:3.4.0"
     graphql: "npm:16.8.1"
-    graphql-constraint-directive: "npm:5.4.2"
+    graphql-constraint-directive: "npm:5.4.3"
     graphql-import: "npm:1.0.2"
     graphql-redis-subscriptions: "npm:2.6.0"
     graphql-relay: "npm:0.10.0"


### PR DESCRIPTION
Some schema constraints are in place in our GQL schema, but this is not consistent across the API.

With this PR we targets the mandatory `name` string fields, that should all given 2 constraints: minimum length 2 (this is already the case for some but not all object types), and the impossibility to be only made of whitespaces

### Proposed changes

* introduce new `format` constraint named `not-blank` registered in `graphql-constraints-directive` plugin to check if a value is only made of whitespaces
* pass on all the Input types in the API to consistently add constraints `name: String! @constraint(minLength: 2, format: "not-blank")`

### Related issues
* closes #6742 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

