### PR TITLE
Control Redis memory usage: limit stix_ids array length in redis stream entries to 1000 ids

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -441,6 +441,12 @@ const buildMergeEvent = async (user: AuthUser, previous: StoreObject, instance: 
   const message = generateMergeMessage(instance, sourceEntities);
   const previousStix = convertStoreToStix(previous) as StixCoreObject;
   const currentStix = convertStoreToStix(instance) as StixCoreObject;
+  if ('extensions' in currentStix
+      && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in currentStix.extensions
+      && 'stix_ids' in currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
+      && currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
+    currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
+  }
   return {
     version: EVENT_CURRENT_VERSION,
     type: EVENT_TYPE_MERGE,
@@ -476,11 +482,18 @@ export const buildStixUpdateEvent = (user: AuthUser, previousStix: StixCoreObjec
   // Build and send the event
   const patch = jsonpatch.compare(previousStix, stix);
   const previousPatch = jsonpatch.compare(stix, previousStix);
+  const stixCopy = stix;
   if (patch.length === 0 || previousPatch.length === 0) {
     throw UnsupportedError('Update event must contains a valid previous patch');
   }
   if (patch.length === 1 && patch[0].path === '/modified') {
     throw UnsupportedError('Update event must contains more operation than just modified/updated_at value');
+  }
+  if ('extensions' in stixCopy
+      && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in stixCopy.extensions
+      && 'stix_ids' in stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
+      && stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
+    stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
   }
   return {
     version: EVENT_CURRENT_VERSION,
@@ -488,7 +501,7 @@ export const buildStixUpdateEvent = (user: AuthUser, previousStix: StixCoreObjec
     scope: 'external',
     message,
     origin: user.origin,
-    data: stix,
+    data: stixCopy,
     commit: opts.commit,
     context: {
       patch,
@@ -520,6 +533,12 @@ export const storeUpdateEvent = async (context: AuthContext, user: AuthUser, pre
 // Create
 export const buildCreateEvent = (user: AuthUser, instance: StoreObject, message: string): StreamDataEvent => {
   const stix = convertStoreToStix(instance) as StixCoreObject;
+  if ('extensions' in stix
+      && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in stix.extensions
+      && 'stix_ids' in stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
+      && stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
+    stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
+  }
   return {
     version: EVENT_CURRENT_VERSION,
     type: EVENT_TYPE_CREATE,

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -445,7 +445,7 @@ const buildMergeEvent = async (user: AuthUser, previous: StoreObject, instance: 
       && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in currentStix.extensions
       && 'stix_ids' in currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
       && currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
-    currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
+    currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = currentStix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000);
   }
   return {
     version: EVENT_CURRENT_VERSION,
@@ -493,7 +493,7 @@ export const buildStixUpdateEvent = (user: AuthUser, previousStix: StixCoreObjec
       && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in stixCopy.extensions
       && 'stix_ids' in stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
       && stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
-    stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
+    stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stixCopy.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000);
   }
   return {
     version: EVENT_CURRENT_VERSION,
@@ -537,7 +537,7 @@ export const buildCreateEvent = (user: AuthUser, instance: StoreObject, message:
       && 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba' in stix.extensions
       && 'stix_ids' in stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba']
       && stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.length > 1000) {
-    stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000, 0);
+    stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids = stix.extensions['extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba'].stix_ids.slice(-1000);
   }
   return {
     version: EVENT_CURRENT_VERSION,


### PR DESCRIPTION
### Proposed changes
When redis `stream.opencti` entries have a `extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba` modification which changes the `stix_ids` field, this appears to sometimes grow extremely large during ingestion for common entity types which don't have a deterministic formula for producing a STIX id.

This seems to be able to result in a long sequence of entries in redis, during re-ingestion of the same entity (such as a `malware` STIX type) with new randomly-assigned STIX ids. My observation is that these get added to the stream once for each new STIX id encountered for the same item, and the list of `stix_ids` in the added/updated entity can grow infinitely. This is the source of one of the reasons why `redis` memory consumption can grow so high, under some circumstances, despite implementing a low TRIMMING size (such as `100000`).

This change proposes to identify when this list exceeds an upper limit (set to `1000` in this case) and will cut the list down such that it only contains the trailing `1000` items from the provided list, **in redis stream inserts only**. This appears to fix the Out-Of-Memory conditions I was experiencing while ingesting from the ESET connector (issue linked below), and also seems to continue to work elsewhere that I have tested, from what I can tell. Additionally, with TRIMMING set to `100000`, this change appears to keep the `redis` memory usage around 200-500MB, where I have tested, rather than it consuming multiple GB.

Definitely recognize that this might not be an ideal solution, due to the potential for data loss in the `stix_ids`, so proposing this change for some broader testing & feedback, particularly from people who leverage the streams features, as well as those who better understand how the local system uses its own stream.

The problem we are running into, and this tries to address, is that redis memory consumption can easily grow to 10-20GB, even with a very low TRIMMING value, due to the way `stix_ids` is reported in the data stream, per the situation above. This creates an unpredictable availability bug in the system, as well as putting extremely high RAM resource pressure on the system (that can be expensive to run) for lots of highly-duplicative information that is going into the stream.

If the community/maintainers don't agree with this change, we would appreciate some alternative recommendations to address this. Allocating more RAM for `redis` is not a viable mitigation in this case.

### Related issues
* https://github.com/OpenCTI-Platform/connectors/issues/1834

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality