### PR TITLE
[backend] restrict knowledge widgets to core relationships, sightings and 'contains' (#6777)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -30,7 +30,10 @@ export const stixCoreRelationshipsDistribution = async (context, user, args) => 
   return stixRelationshipsDistribution(context, user, { ...args, relationship_type });
 };
 export const stixCoreRelationshipsNumber = async (context, user, args) => {
-  const { relationship_type = [ABSTRACT_STIX_CORE_RELATIONSHIP], authorId } = args;
+  const {
+    relationship_type = isStixCoreRelationship(args.relationship_type) ? args.relationship_type : [ABSTRACT_STIX_CORE_RELATIONSHIP],
+    authorId
+  } = args;
   const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
   if (isEmptyDynamic) {
     return { count: 0, total: 0 };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -23,18 +23,21 @@ export const findById = (context, user, stixCoreRelationshipId) => {
   return storeLoadById(context, user, stixCoreRelationshipId, ABSTRACT_STIX_CORE_RELATIONSHIP);
 };
 
+const buildStixCoreRelationshipTypes = (relationshipTypes) => {
+  const isValidRelationshipTypes = relationshipTypes && relationshipTypes.length > 0 && relationshipTypes.every((type) => isStixCoreRelationship(type));
+  return isValidRelationshipTypes ? relationshipTypes : [ABSTRACT_STIX_CORE_RELATIONSHIP];
+};
+
 // region stats
 // TODO future refacto : use the more generic functions of domain/stixRelationship.js
 export const stixCoreRelationshipsDistribution = async (context, user, args) => {
-  const relationship_type = isStixCoreRelationship(args.relationship_type) ? args.relationship_type : [ABSTRACT_STIX_CORE_RELATIONSHIP];
+  const relationship_type = buildStixCoreRelationshipTypes(args.relationship_type);
   return stixRelationshipsDistribution(context, user, { ...args, relationship_type });
 };
 export const stixCoreRelationshipsNumber = async (context, user, args) => {
-  const {
-    relationship_type = isStixCoreRelationship(args.relationship_type) ? args.relationship_type : [ABSTRACT_STIX_CORE_RELATIONSHIP],
-    authorId
-  } = args;
-  const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
+  const { authorId } = args;
+  const relationship_type = buildStixCoreRelationshipTypes(args.relationship_type);
+  const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, { ...args, relationship_type });
   if (isEmptyDynamic) {
     return { count: 0, total: 0 };
   }

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { delEditContext, notify, setEditContext } from '../database/redis';
-import { createRelation, deleteElementById, deleteRelationsByFromAndTo, distributionRelations, timeSeriesRelations, updateAttribute } from '../database/middleware';
+import { createRelation, deleteElementById, deleteRelationsByFromAndTo, timeSeriesRelations, updateAttribute } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
 import { FunctionalError } from '../config/errors';
 import { elCount } from '../database/engine';
@@ -13,7 +13,7 @@ import { askListExport, exportTransformFilters } from './stix';
 import { workToExportFile } from './work';
 import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefRelations, stixObjectOrRelationshipDeleteRefRelation } from './stixObjectOrStixRelationship';
 import { addFilter } from '../utils/filtering/filtering-utils';
-import { buildArgsFromDynamicFilters } from './stixRelationship';
+import { buildArgsFromDynamicFilters, stixRelationshipsDistribution } from './stixRelationship';
 
 export const findAll = async (context, user, args) => {
   return listRelations(context, user, R.propOr(ABSTRACT_STIX_CORE_RELATIONSHIP, 'relationship_type', args), args);
@@ -26,13 +26,8 @@ export const findById = (context, user, stixCoreRelationshipId) => {
 // region stats
 // TODO future refacto : use the more generic functions of domain/stixRelationship.js
 export const stixCoreRelationshipsDistribution = async (context, user, args) => {
-  // it's not possible to have a dynamicFrom and dynamicTo in args here for the moment
-  // consider adding these fields in opencti.graphql if you want to use them
-  const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
-  if (isEmptyDynamic) {
-    return [];
-  }
-  return distributionRelations(context, user, dynamicArgs);
+  const relationship_type = isStixCoreRelationship(args.relationship_type) ? args.relationship_type : [ABSTRACT_STIX_CORE_RELATIONSHIP];
+  return stixRelationshipsDistribution(context, user, { ...args, relationship_type });
 };
 export const stixCoreRelationshipsNumber = async (context, user, args) => {
   const { relationship_type = [ABSTRACT_STIX_CORE_RELATIONSHIP], authorId } = args;

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -65,16 +65,17 @@ export const stixRelationshipDelete = async (context, user, stixRelationshipId) 
   return stixRelationshipId;
 };
 
-const buildValidWidgetRelationshipType = (relationship_type) => {
-  const isValidRelationshipType = isStixCoreRelationship(relationship_type)
-    || isStixSightingRelationship(relationship_type)
-    || relationship_type === RELATION_CONTAINS;
-  return isValidRelationshipType ? relationship_type : widgetsRelationshipTypes;
+const buildValidWidgetRelationshipTypes = (relationshipTypes) => {
+  const isValidRelationshipTypes = relationshipTypes && relationshipTypes.length > 0 && (relationshipTypes.every((type) => (
+    isStixCoreRelationship(type)
+    || isStixSightingRelationship(type)
+    || type === RELATION_CONTAINS)));
+  return isValidRelationshipTypes ? relationshipTypes : widgetsRelationshipTypes;
 };
 
 // region stats
 export const stixRelationshipsDistribution = async (context, user, args) => {
-  const relationship_type = buildValidWidgetRelationshipType(args.relationship_type);
+  const relationship_type = buildValidWidgetRelationshipTypes(args.relationship_type);
   const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, { ...args, relationship_type });
   if (isEmptyDynamic) {
     return [];
@@ -82,7 +83,7 @@ export const stixRelationshipsDistribution = async (context, user, args) => {
   return distributionRelations(context, context.user, dynamicArgs);
 };
 export const stixRelationshipsNumber = async (context, user, args) => {
-  const relationship_type = buildValidWidgetRelationshipType(args.relationship_type);
+  const relationship_type = buildValidWidgetRelationshipTypes(args.relationship_type);
   const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
   if (isEmptyDynamic) {
     return { count: 0, total: 0 };

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -11,6 +11,8 @@ import { isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import { STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { RELATION_OBJECT } from '../schema/stixRefRelationship';
 
+const widgetsRelationshipTypes = [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP, RELATION_OBJECT];
+
 export const buildArgsFromDynamicFilters = async (context, user, args) => {
   const { dynamicFrom, dynamicTo } = args;
   const listEntitiesWithFilters = async (filters) => listEntities(context, user, [ABSTRACT_STIX_OBJECT], {
@@ -64,7 +66,7 @@ export const stixRelationshipDelete = async (context, user, stixRelationshipId) 
 
 // region stats
 export const stixRelationshipsDistribution = async (context, user, args) => {
-  const relationship_type = args.relationship_type ?? [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP, RELATION_OBJECT];
+  const relationship_type = args.relationship_type ?? widgetsRelationshipTypes;
   const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, { ...args, relationship_type });
   if (isEmptyDynamic) {
     return [];
@@ -72,7 +74,7 @@ export const stixRelationshipsDistribution = async (context, user, args) => {
   return distributionRelations(context, context.user, dynamicArgs);
 };
 export const stixRelationshipsNumber = async (context, user, args) => {
-  const relationship_type = args.relationship_type ?? [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP, RELATION_OBJECT];
+  const relationship_type = args.relationship_type ?? widgetsRelationshipTypes;
   const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
   if (isEmptyDynamic) {
     return { count: 0, total: 0 };

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -64,7 +64,8 @@ export const stixRelationshipDelete = async (context, user, stixRelationshipId) 
 
 // region stats
 export const stixRelationshipsDistribution = async (context, user, args) => {
-  const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, args);
+  const relationship_type = args.relationship_type ?? [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP, RELATION_OBJECT];
+  const { dynamicArgs, isEmptyDynamic } = await buildArgsFromDynamicFilters(context, user, { ...args, relationship_type });
   if (isEmptyDynamic) {
     return [];
   }


### PR DESCRIPTION
issue: https://github.com/OpenCTI-Platform/opencti/issues/6777#issuecomment-2082086679