### PR TITLE
[backend] missing opts definition file_marking for file upload(#5548)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -14,6 +14,7 @@ interface FileUploadOpts {
   meta? : any,
   noTriggerImport?: boolean,
   errorOnExisting?: boolean,
+  file_markings?: [],
 }
 
 interface FileUploadData {

--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -14,7 +14,7 @@ interface FileUploadOpts {
   meta? : any,
   noTriggerImport?: boolean,
   errorOnExisting?: boolean,
-  file_markings?: [],
+  file_markings?: string[],
 }
 
 interface FileUploadData {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-helper-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-helper-test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { fileToReadStream, SUPPORT_STORAGE_PATH, uploadToStorage } from '../../../src/database/file-storage-helper';
+import type { AuthContext } from '../../../src/types/user';
+import { ADMIN_USER } from '../../utils/testQuery';
+import { MARKING_TLP_CLEAR } from '../../../src/schema/identifier';
+import { findById as findDocumentById } from '../../../src/modules/internal/document/document-domain';
+
+const adminContext: AuthContext = { user: ADMIN_USER, tracing: undefined, source: 'file-storage-helper-test', otp_mandatory: false };
+
+describe('File storage upload with marking', () => {
+  it('should file upload succeed to S3 and data in elastic have marking stored.', async () => {
+    const file = fileToReadStream('./tests/data/', 'file-storage-helper-test.txt', 'file-storage-test.txt', 'text/plain');
+    const uploadedFileWithMarking = await uploadToStorage(adminContext, ADMIN_USER, SUPPORT_STORAGE_PATH, file, { file_markings: [MARKING_TLP_CLEAR] });
+    expect(uploadedFileWithMarking.upload.id).toBeDefined();
+    // and expect no exception.
+
+    const document = await findDocumentById(adminContext, ADMIN_USER, uploadedFileWithMarking.upload.id);
+    expect(document.metaData.file_markings).toBeDefined();
+    expect(document.metaData.file_markings?.length, 'One marking MARKING_TLP_CLEAR is expected on this document.').toBe(1);
+    if (document.metaData.file_markings) {
+      expect(document.metaData.file_markings[0]).toBe(MARKING_TLP_CLEAR);
+    }
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/data/file-storage-helper-test.txt
+++ b/opencti-platform/opencti-graphql/tests/data/file-storage-helper-test.txt
@@ -1,0 +1,1 @@
+The content is anything.


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Missing a opts definition in file-storage-helper.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
Small left over between 2 PRs:
* https://github.com/OpenCTI-Platform/opencti/pull/6735
* https://github.com/OpenCTI-Platform/opencti/pull/6510

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
