### PR TITLE
[backend] fix relationship_type check in distributions queries (#6777)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -4,7 +4,7 @@ import { createRelation, deleteElementById, deleteRelationsByFromAndTo, timeSeri
 import { BUS_TOPICS } from '../config/conf';
 import { FunctionalError } from '../config/errors';
 import { elCount } from '../database/engine';
-import { fillTimeSeries, isNotEmptyField, READ_INDEX_INFERRED_RELATIONSHIPS, READ_INDEX_STIX_CORE_RELATIONSHIPS } from '../database/utils';
+import { fillTimeSeries, isEmptyField, isNotEmptyField, READ_INDEX_INFERRED_RELATIONSHIPS, READ_INDEX_STIX_CORE_RELATIONSHIPS } from '../database/utils';
 import { isStixCoreRelationship, stixCoreRelationshipOptions } from '../schema/stixCoreRelationship';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
 import { RELATION_CREATED_BY, } from '../schema/stixRefRelationship';
@@ -24,8 +24,16 @@ export const findById = (context, user, stixCoreRelationshipId) => {
 };
 
 const buildStixCoreRelationshipTypes = (relationshipTypes) => {
-  const isValidRelationshipTypes = relationshipTypes && relationshipTypes.length > 0 && relationshipTypes.every((type) => isStixCoreRelationship(type));
-  return isValidRelationshipTypes ? relationshipTypes : [ABSTRACT_STIX_CORE_RELATIONSHIP];
+  if (isEmptyField(relationshipTypes)) {
+    return [ABSTRACT_STIX_CORE_RELATIONSHIP];
+  }
+  const isValidRelationshipTypes = relationshipTypes.every((type) => isStixCoreRelationship(type));
+  if (!isValidRelationshipTypes) {
+    // TODO: we disable this error because query stixCoreRelationshipsDistribution is used
+    // in widgets that should call stixRelationshipsDistribution instead
+    // throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship');
+  }
+  return relationshipTypes;
 };
 
 // region stats

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -10,7 +10,7 @@ import { UnsupportedError } from '../config/errors';
 import { schemaTypesDefinition } from '../schema/schema-types';
 import { isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import { isStixSightingRelationship, STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
-import { RELATION_CONTAINS, RELATION_OBJECT } from '../schema/stixRefRelationship';
+import { RELATION_OBJECT } from '../schema/stixRefRelationship';
 import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 
 const defaultRelationshipTypesForWidgets = [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP, RELATION_OBJECT];


### PR DESCRIPTION
A regression was introduced in PR https://github.com/OpenCTI-Platform/opencti/pull/6831

We now properly throw errors on incorrect `relationship_type` input for distribution queries.

The error throws for `stixCoreRelationshipDistribution` query is currently commented as the frontend currently uses it incorrectly with non-SCR relationships like `object`.

Fixing the frontend will require a lot more work and can be pushed to next milestone IMO.

issue: #6777