### PR TITLE
[backend/frontend] Add restore message in history event (#1536)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2341,7 +2341,7 @@
   "The following groups require your attention:": "Les groupes suivants requièrent votre attention :",
   "The importation of the file has been started": "L'importation du fichier a été lancée",
   "The main object and the ... relationships/references linked to it will be deleted permanently.": "L'objet principal ainsi que les {count} relations/références qui lui sont liées seront définitivement supprimés.",
-  "The main object and the ... relationships/references linked to it will be restored.": "L'objet principal et les relations/références {count} qui lui sont liées seront restaurés.",
+  "The main object and the ... relationships/references linked to it will be restored.": "L'objet principal ainsi que les {count} relations/références qui lui sont liées seront restaurés.",
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "Le niveau de confiance maximal est actuellement défini au niveau de l'utilisateur. Il remplace le niveau de confiance maximal des groupes d'utilisateurs.",
   "The Max Confidence Level is currently inherited from...": "Le niveau de confiance maximum est actuellement hérité du groupe {link}.",
   "The min value cannot be greater than max value": "La valeur min ne peut pas être supérieure à la valeur max",

--- a/opencti-platform/opencti-graphql/src/database/generate-message.js
+++ b/opencti-platform/opencti-graphql/src/database/generate-message.js
@@ -50,6 +50,10 @@ export const generateCreateMessage = (instance) => {
 export const generateDeleteMessage = (instance) => {
   return generateCreateDeleteMessage(EVENT_TYPE_DELETE, instance);
 };
+export const generateRestoreMessage = (instance) => {
+  // this method is used only to generate a history message, there is no event restore in stream.
+  return generateCreateDeleteMessage('restore', instance);
+};
 
 export const generateUpdateMessage = async (context, entityType, inputs) => {
   const inputsByOperations = R.groupBy((m) => m.operation ?? UPDATE_OPERATION_REPLACE, inputs);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -188,7 +188,7 @@ import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { validateInputCreation, validateInputUpdate } from '../schema/schema-validator';
 import { telemetry } from '../config/tracing';
 import { cleanMarkings, handleMarkingOperations } from '../utils/markingDefinition-utils';
-import { generateCreateMessage, generateUpdateMessage } from './generate-message';
+import { generateCreateMessage, generateRestoreMessage, generateUpdateMessage } from './generate-message';
 import { confidence, creators, xOpenctiStixIds } from '../schema/attribute-definition';
 import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { FilterMode, FilterOperator } from '../generated/graphql';
@@ -2914,7 +2914,11 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
         }
       }
       dataEntity.element = { ...dataEntity.element, ...additionalInputs };
-      dataMessage = generateCreateMessage(dataEntity.element);
+      if (opts.restore === true) {
+        dataMessage = generateRestoreMessage(dataEntity.element);
+      } else {
+        dataMessage = generateCreateMessage(dataEntity.element);
+      }
     }
     // Index the created element
     lock.signal.throwIfAborted();

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -22,7 +22,7 @@ import { filterEmpty } from '../types/type-utils';
 import type { ClusterConfig } from '../manager/clusterManager';
 import type { ActivityStreamEvent } from '../manager/activityListener';
 import type { ExecutionEnvelop } from '../manager/playbookManager';
-import { generateCreateMessage, generateDeleteMessage, generateMergeMessage } from './generate-message';
+import { generateCreateMessage, generateDeleteMessage, generateMergeMessage, generateRestoreMessage } from './generate-message';
 import { INPUT_OBJECTS } from '../schema/general';
 
 export const REDIS_PREFIX = conf.get('redis:namespace') ? `${conf.get('redis:namespace')}:` : '';
@@ -534,8 +534,11 @@ export const buildCreateEvent = (user: AuthUser, instance: StoreObject, message:
 export const storeCreateRelationEvent = async (context: AuthContext, user: AuthUser, instance: StoreRelation, opts: CreateEventOpts = {}) => {
   try {
     if (isStixExportableData(instance)) {
-      const { withoutMessage = false } = opts;
-      const message = withoutMessage ? '-' : generateCreateMessage(instance);
+      const { withoutMessage = false, restore = false } = opts;
+      let message = '-';
+      if (!withoutMessage) {
+        message = restore ? generateRestoreMessage(instance) : generateCreateMessage(instance);
+      }
       const event = buildCreateEvent(user, instance, message);
       await pushToStream(context, user, getClientBase(), event, opts);
       return event;

--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
@@ -293,9 +293,9 @@ export const restoreDelete = async (context: AuthContext, user: AuthUser, id: st
     // restore main element
     let result: any;
     if (isStixObject(mainElementToRestore.entity_type)) {
-      result = await createEntity(context, user, mainElementToRestoreInput, main_entity_type);
+      result = await createEntity(context, user, mainElementToRestoreInput, main_entity_type, { restore: true });
     } else if (isStixRelationship(mainElementToRestore.entity_type)) {
-      result = await createRelation(context, user, mainElementToRestoreInput, main_entity_type);
+      result = await createRelation(context, user, mainElementToRestoreInput, { restore: true });
     }
 
     const mainEntityRestoredId = result.id;

--- a/opencti-platform/opencti-graphql/src/types/event.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/event.d.ts
@@ -14,6 +14,7 @@ interface EventOpts {
 
 interface CreateEventOpts extends EventOpts {
   withoutMessage?: boolean;
+  restore?: boolean;
 }
 
 interface UpdateEventOpts extends EventOpts {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* set "restore" in history message instead of create when restoring entities and relationships
* history has still a create event, we didn't change that because it's linked to the stream event (which still is create)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #1536 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

![Capture d'écran 2024-05-03 104056](https://github.com/OpenCTI-Platform/opencti/assets/668192/cd74ac33-15fa-4367-8af5-3deebfa87b75)

![Capture d'écran 2024-05-03 104135](https://github.com/OpenCTI-Platform/opencti/assets/668192/7f533900-0c8f-44e0-b305-80b43750af05)
