### PR TITLE
Bulk add hashes

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "Meist genutzte Filter",
   "All other filters": "Alle anderen Filter",
   "Testing csv mapper": "Testen des csv-Mappers",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Diese Operationen gelten nur für Labels oder Markierungen, die im Kontext dieses Playbooks hinzugefügt werden, wie z. B. Anreicherung oder andere Wissensmanipulationen, nicht aber, wenn die Labels oder Markierungen bereits in der Plattform geschrieben sind."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Diese Operationen gelten nur für Labels oder Markierungen, die im Kontext dieses Playbooks hinzugefügt werden, wie z. B. Anreicherung oder andere Wissensmanipulationen, nicht aber, wenn die Labels oder Markierungen bereits in der Plattform geschrieben sind.",
+  "Multiple values entered. Edit with the TT button": "Mehrere Werte eingegeben. Bearbeiten Sie mit der TT-Taste",
+  "Bulk Observable Creation": "Massenbeobachtbare Erstellung",
+  "Observables listed must be of the same type.": "Die aufgeführten Observablen müssen vom gleichen Typ sein.",
+  "One Observable per line.": "Ein Observable pro Zeile.",
+  "Bulk Content": "Masseninhalte",
+  "Observable successfully added": "Observable erfolgreich hinzugefügt",
+  "were added successfully.": "wurden erfolgreich hinzugefügt.",
+  "observables contained errors and were not added.": "Observablen enthielten Fehler und wurden nicht hinzugefügt."
 }

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "Most used filters",
   "All other filters": "All other filters",
   "Testing csv mapper": "Testing csv mapper",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.",
+  "Multiple values entered. Edit with the TT button": "Multiple values entered. Edit with the TT button",
+  "Bulk Observable Creation": "Bulk Observable Creation",
+  "Observables listed must be of the same type.": "Observables listed must be of the same type.",
+  "One Observable per line.": "One Observable per line.",
+  "Bulk Content": "Bulk Content",
+  "Observable successfully added": "Observable successfully added",
+  "were added successfully.": "were added successfully.",
+  "observables contained errors and were not added.": "observables contained errors and were not added."
 }

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "Filtros más utilizados",
   "All other filters": "Todos los demás filtros",
   "Testing csv mapper": "Probando el mapeador csv",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Estas operaciones sólo se aplicarán a las etiquetas o marcas añadidas en el contexto de este libro de jugadas, como el enriquecimiento u otras manipulaciones del conocimiento, pero no si las etiquetas o marcas ya están escritas en la plataforma."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Estas operaciones sólo se aplicarán a las etiquetas o marcas añadidas en el contexto de este libro de jugadas, como el enriquecimiento u otras manipulaciones del conocimiento, pero no si las etiquetas o marcas ya están escritas en la plataforma.",
+  "Multiple values entered. Edit with the TT button": "Se ingresaron varios valores. Editar con el botón TT",
+  "Bulk Observable Creation": "Creación observable masiva",
+  "Observables listed must be of the same type.": "Los observables enumerados deben ser del mismo tipo.",
+  "One Observable per line.": "Un Observable por línea.",
+  "Bulk Content": "Contenido masivo",
+  "Observable successfully added": "Observable agregado con éxito",
+  "were added successfully.": "fueron agregados exitosamente.",
+  "observables contained errors and were not added.": "Los observables contenían errores y no se agregaron."
 }

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "Filtres les plus utilisés",
   "All other filters": "Tous les autres filtres",
   "Testing csv mapper": "Test du mappeur csv",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Ces opérations ne s'appliqueront qu'aux étiquettes ou marquages ajoutés dans le contexte de ce playbook, comme l'enrichissement ou d'autres manipulations de connaissances, mais pas si les étiquettes ou marquages sont déjà écrits dans la plateforme."
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Ces opérations ne s'appliqueront qu'aux étiquettes ou marquages ajoutés dans le contexte de ce playbook, comme l'enrichissement ou d'autres manipulations de connaissances, mais pas si les étiquettes ou marquages sont déjà écrits dans la plateforme.",
+  "Multiple values entered. Edit with the TT button": "Plusieurs valeurs saisies. Modifier avec le bouton TT",
+  "Bulk Observable Creation": "Création observable en masse",
+  "Observables listed must be of the same type.": "Les observables répertoriés doivent être du même type.",
+  "One Observable per line.": "Un observable par ligne.",
+  "Bulk Content": "Contenu en vrac",
+  "Observable successfully added": "Observable ajouté avec succès",
+  "were added successfully.": "ont été ajoutés avec succès.",
+  "observables contained errors and were not added.": "les observables contenaient des erreurs et n’étaient pas ajoutés."
 }

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "最も使用されるフィルター",
   "All other filters": "その他のフィルター",
   "Testing csv mapper": "csvマッパーのテスト",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "この操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたラベルやマーキングに対してのみ適用されます。"
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "この操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたラベルやマーキングに対してのみ適用されます。",
+  "Multiple values entered. Edit with the TT button": "複数の値が入力されました。 TTボタンで編集",
+  "Bulk Observable Creation": "監視可能な一括作成",
+  "Observables listed must be of the same type.": "リストされる Observable は同じタイプである必要があります。",
+  "One Observable per line.": "1 行に 1 つの Observable。",
+  "Bulk Content": "バルクコンテンツ",
+  "Observable successfully added": "オブザーバブルが正常に追加されました",
+  "were added successfully.": "は正常に追加されました。",
+  "observables contained errors and were not added.": "オブザーバブルにはエラーが含まれていたため、追加されませんでした。"
 }

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2683,5 +2683,13 @@
   "Most used filters": "最常用的过滤器",
   "All other filters": "所有其他筛选器",
   "Testing csv mapper": "测试 csv 映射器",
-  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "此操作仅适用于在此播放列表中添加的标签或标记，如充实或其他知识操作，但不适用于平台中已写入的标签或标记。"
+  "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "此操作仅适用于在此播放列表中添加的标签或标记，如充实或其他知识操作，但不适用于平台中已写入的标签或标记。",
+  "Multiple values entered. Edit with the TT button": "输入多个值。使用 TT 按钮进行编辑",
+  "Bulk Observable Creation": "批量可观察创建",
+  "Observables listed must be of the same type.": "列出的可观察量必须属于同一类型。",
+  "One Observable per line.": "每行一个 Observable。",
+  "Bulk Content": "批量内容",
+  "Observable successfully added": "可观察对象添加成功",
+  "were added successfully.": "已添加成功。",
+  "observables contained errors and were not added.": "observables 包含错误并且未添加。"
 }

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -235,20 +235,24 @@ const StixCyberObservableCreation = ({
   const localHandleClose = () => setStatus({ open: false, type: type ?? null });
   const selectType = (selected) => setStatus({ open: status.open, type: selected });
   const [genericValueFieldDisabled, setGenericValueFieldDisabled] = useState(false);
-  // const [md5FieldDisabled, setMD5FieldDisabled] = useState(false);
-  // const [sha1FieldDisabled, setSHA1FieldDisabled] = useState(false);
-  // const [sha256FieldDisabled, setSHA256FieldDisabled] = useState(false);
-  // const [sha512FieldDisabled, setSHA512FieldDisabled] = useState(false);
   const [keyFieldDisabled, setKeyFieldDisabled] = useState(false);
   const bulkAddMsg = t_i18n('Multiple values entered. Edit with the TT button');
+  const hashes_MD5_field = document.getElementById('hashes_MD5');
+  const hashes_SHA1_field = document.getElementById('hashes_SHA-1');
+  const hashes_SHA256_field = document.getElementById('hashes_SHA-256');
+  const hashes_SHA512_field = document.getElementById('hashes_SHA-512');
+  const divRowStyle = { display: 'flex', flexWrap: 'wrap' };
+  const [myValue, setMyValue] = useState("");
 
   const onSubmit = (values, { setSubmitting, setErrors, resetForm }) => {
+    console.log('onSubmit was called');
     let adaptedValues = values;
     if (adaptedValues) { // Verify not null for DeepScan compliance
       // Bulk Add Modal was used
+      console.log("adaptedValues " + adaptedValues.value);
+      console.log("adaptedValues.bulk_value_field " + adaptedValues.bulk_value_field);
       if (adaptedValues.value && adaptedValues.bulk_value_field && adaptedValues.value === bulkAddMsg) {
-        console.log("adaptedValues " + adaptedValues);
-        console.log("inside bulk add, " + bulkAddMsg)
+        console.log("inside bulk add, " + bulkAddMsg);
         const array_of_bulk_values = adaptedValues.bulk_value_field.split(/\r?\n/);
         // Trim them just to remove any extra spacing on front or rear of string
         const trimmed_bulk_values = array_of_bulk_values.map((s) => s.trim());
@@ -258,6 +262,7 @@ const StixCyberObservableCreation = ({
         adaptedValues.value = [...new Set(cleaned_bulk_values)].join('\n');
       }
 
+      console.log("adaptedValues.hashes_SHA-256 " + adaptedValues['hashes_SHA-256']);
       // Potential dicts
       if (
         adaptedValues.hashes_MD5
@@ -265,6 +270,7 @@ const StixCyberObservableCreation = ({
         || adaptedValues['hashes_SHA-256']
         || adaptedValues['hashes_SHA-512']
       ) {
+        console.log('inside potential dicts');
         adaptedValues.hashes = [];
         if (adaptedValues.hashes_MD5.length > 0) {
           adaptedValues.hashes.push({
@@ -483,10 +489,6 @@ const StixCyberObservableCreation = ({
     // console.log('inside BulkAddDialog function');
     const [openBulkAddDialog, setOpenBulkAddDialog] = React.useState(false);
     const handleOpenBulkAddDialog = () => {
-      const hashes_MD5_field = document.getElementById('hashes_MD5');
-      const hashes_SHA1_field = document.getElementById('hashes_SHA-1');
-      const hashes_SHA256_field = document.getElementById('hashes_SHA-256');
-      const hashes_SHA512_field = document.getElementById('hashes_SHA-512');
       if (hashes_MD5_field != null && hashes_MD5_field.value != null
         && hashes_MD5_field.value.length > 0 && hashes_MD5_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
@@ -517,10 +519,10 @@ const StixCyberObservableCreation = ({
       setOpenBulkAddDialog(false);
       const bulk_value_field = document.getElementById('bulk_value_field');
       if (bulk_value_field != null && bulk_value_field.value != null && bulk_value_field.value.length > 0) {
-        props.setValue('value', bulkAddMsg);
+        props.setValue('hashes', bulkAddMsg);
         setKeyFieldDisabled(true);
       } else {
-        props.setValue('value', '');
+        props.setValue('hashes', '');
         setKeyFieldDisabled(false);
       }
     };
@@ -534,7 +536,7 @@ const StixCyberObservableCreation = ({
         <IconButton
           onClick={handleOpenBulkAddDialog}
           size="large"
-          color="primary" style={{ float: 'right', marginRight: 25 }}
+          color="primary" style={{ float: 'left', marginRight: 25 }}
         >
           <TextFieldsOutlined />
         </IconButton>
@@ -547,16 +549,17 @@ const StixCyberObservableCreation = ({
           <DialogContent style={{ marginTop: 0, paddingTop: 10 }}>
             <form name="formSelectAttributes" id="formSelectAttributes" style={{ border: '2px solid #FFA500', paddingLeft: 10 }} action="/action_page.php">
               {t_i18n('Create Entities from multiple')}:
-              <select name="attributes" id="attributes" onSelect={getOption}>
+              <select name="attributes" id="attributes" onSelect={getOption} onChange={(e) => setMyValue(e.target.value)}>
                 <option selected disabled>Select attribute</option>
-                <option value="MD5">md5</option>
                 <option value="NAME">name</option>
+                <option value="MD5">md5</option>
                 <option value="SHA1">sha1</option>
                 <option value="SHA256">sha256</option>
                 <option value="SHA512">sha512</option>
               </select>
             </form>
             <Typography style={{ float: 'left', marginTop: 10 }}>
+              <span>{myValue}</span>
               <span className="output"></span>
             </Typography>
             <Field
@@ -590,7 +593,7 @@ const StixCyberObservableCreation = ({
     const handleOpenBulkModal = () => {
       const generic_value_field = document.getElementById('generic_value_field');
       if (generic_value_field != null && generic_value_field.value != null
-          && generic_value_field.value.length > 0 && generic_value_field.value !== bulkAddMsg) {
+        && generic_value_field.value.length > 0 && generic_value_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
         props.setValue('bulk_value_field', generic_value_field.value.trim());
       }
@@ -638,7 +641,7 @@ const StixCyberObservableCreation = ({
             <Typography id="add-bulk-observable-instructions" variant="subtitle1" component="subtitle1" style={{ whiteSpace: 'pre-line' }}>
               <div style={{ border: '2px solid #FFA500', paddingLeft: 10 }}>
                 {t_i18n('Observables listed must be of the same type.')}
-                <br/>
+                <br />
                 {t_i18n('One Observable per line.')}
               </div>
             </Typography>
@@ -674,8 +677,7 @@ const StixCyberObservableCreation = ({
   };
 
   const renderForm = () => {
-    // console.log("renderForm");
-    // console.log("renderForm; status.type " + status.type);
+    console.log("renderForm; status.type " + status.type);
     return (
       <QueryRenderer
         query={stixCyberObservablesLinesAttributesQuery}
@@ -742,6 +744,14 @@ const StixCyberObservableCreation = ({
                       margin: contextual ? '10px 0 0 0' : '20px 0 20px 0',
                     }}
                   >
+                    <div style={(divRowStyle)}>
+                      <p>{t_i18n('Create a single observable or multiple with ')}</p>
+                      <Tooltip title="Copy/paste text content">
+                        <BulkAddDialog
+                          setValue={(field_name, new_value) => setFieldValue(field_name, new_value)}
+                        />
+                      </Tooltip>
+                    </div>
                     <div>
                       <Field
                         component={TextField}
@@ -761,10 +771,9 @@ const StixCyberObservableCreation = ({
                         style={{ marginTop: 20 }}
                       />
                       {attributes.map((attribute) => {
-                        if (attribute.value === 'hashes') {
+                        if (attribute.value === 'hashes' && status.type === 'StixFile') {
                           return (
                             <div key={attribute.value}>
-                              {/* TODO: Disable these fields */}
                               <Field
                                 id="hashes_MD5"
                                 disabled={keyFieldDisabled}
@@ -877,22 +886,6 @@ const StixCyberObservableCreation = ({
                             />
                           );
                         }
-                        if (status.type === 'StixFile') {
-                          // console.log('inside StixFile; attribute.value ' + attribute.value);
-                          return (
-                            <div key={attribute.value}>
-                              <Typography className={keyFieldDisabled ? classes.disabled : classes.active_typography} style={{ float: 'left', marginTop: 20 }}>
-                                {attribute.value}
-                              </Typography>
-                              <Tooltip title="Copy/paste text content">
-                                <BulkAddDialog
-                                  setValue={(field_name, new_value) => setFieldValue(field_name, new_value)}
-                                />
-                              </Tooltip>
-                            </div>
-                          );
-                        }
-                        // console.log('attribute.value ' + attribute.value);
                         if (attribute.value === 'value') {
                           return (
                             <div key={attribute.value}>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -246,6 +246,7 @@ const StixCyberObservableCreation = ({
   const hashes_SHA512_field = document.getElementById('hashes_SHA-512');
   const divRowStyle = { display: 'flex', flexWrap: 'wrap' };
   let hashesList = [];
+  const algorithm = selectedAttribute.toLowerCase();
   const onSubmit = (values, { setSubmitting, setErrors, resetForm }) => {
     let adaptedValues = values;
 
@@ -275,6 +276,7 @@ const StixCyberObservableCreation = ({
         delete adaptedValues['hashes_SHA-256'];
         delete adaptedValues['hashes_SHA-512'];
         delete adaptedValues.name;
+        delete adaptedValues.bulk_hashes_field;
       }
       // Potential dicts
       if (
@@ -321,6 +323,7 @@ const StixCyberObservableCreation = ({
         dissoc('hashes_SHA-1'),
         dissoc('hashes_SHA-256'),
         dissoc('hashes_SHA-512'),
+        dissoc('bulk_hashes_field'),
         toPairs,
         map((n) => (includes(n[0], dateAttributes)
           ? [n[0], n[1] ? parse(n[1]).format() : null]
@@ -359,7 +362,6 @@ const StixCyberObservableCreation = ({
       let validObservables = 0;
       const commit = async () => {
         const valueList = values?.value !== '' ? values?.value?.split('\n') || values?.value : undefined; // List of the inputs
-        const algorithm = selectedAttribute.toLowerCase();
         if (hashesList && selectedAttribute === 'NAME') {
           const promises = hashesList.map((hash) => commitMutationWithPromise({
             mutation: stixCyberObservableMutation,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -773,6 +773,7 @@ const StixCyberObservableCreation = ({
                                 variant="standard"
                                 key={attribute.value}
                                 name={attribute.value}
+                                label="generic_value_field"
                                 fullWidth={true}
                                 multiline={true}
                                 rows="1"

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -473,7 +473,86 @@ const StixCyberObservableCreation = ({
     );
   };
 
+  function BulkAddDialog(props) {
+    console.log('inside BulkAddDialog function');
+    const [openBulkAddDialog, setOpenBulkAddDialog] = React.useState(false);
+    const handleOpenBulkAddDialog = () => {
+      const generic_value_field = document.getElementById('generic_value_field');
+      if (generic_value_field != null && generic_value_field.value != null
+        && generic_value_field.value.length > 0 && generic_value_field.value !== bulkAddMsg) {
+        props.setValue('bulk_value_field', generic_value_field.value.trim());
+      }
+      setOpenBulkAddDialog(true);
+    };
+    const handleCloseBulkAddDialog = () => {
+      setOpenBulkAddDialog(false);
+      const bulk_value_field = document.getElementById('bulk_value_field');
+      if (bulk_value_field != null && bulk_value_field.value != null && bulk_value_field.value.length > 0) {
+        props.setValue('value', bulkAddMsg);
+        setGenericValueFieldDisabled(true);
+      } else {
+        props.setValue('value', '');
+        setGenericValueFieldDisabled(false);
+      }
+    };
+    function getOption() {
+      const selectElement = document.querySelector('#attributes');
+      const output = selectElement.value;
+      document.querySelector('.output').textContent = output;
+    }
+    return (
+      <React.Fragment>
+        <IconButton
+          onClick={handleOpenBulkAddDialog}
+          size="large"
+          color="primary" style={{ float: 'right', marginRight: 25 }}
+        >
+          <TextFieldsOutlined />
+        </IconButton>
+        <Dialog
+          PaperProps={{ elevation: 3 }}
+          open={openBulkAddDialog}
+          onClose={handleCloseBulkAddDialog}
+          fullWidth={true}
+        >
+          <DialogContent style={{ marginTop: 0, paddingTop: 10 }}>
+            <form name="formSelectAttributes" id="formSelectAttributes" style={{ border: '2px solid #FFA500', paddingLeft: 10 }} action="/action_page.php">
+              {t_i18n('Create Entities from multiple')}:
+              <select name="attributes" id="attributes" onSelect={getOption}>
+                <option selected disabled>Select attribute</option>
+                <option value="MD5">md5</option>
+                <option value="NAME">name</option>
+                <option value="SHA1">sha1</option>
+                <option value="SHA256">sha256</option>
+                <option value="SHA512">sha512</option>
+              </select>
+            </form>
+            <Typography style={{ float: 'left', marginTop: 10 }}>
+              <span className="output"></span>
+            </Typography>
+            <Field
+              component={TextField}
+              id="bulk_value_field"
+              variant="standard"
+              key="bulk_value_field"
+              name="bulk_value_field"
+              fullWidth={true}
+              multiline={true}
+              rows="5"
+            />
+            <DialogActions>
+              <Button color="secondary" onClick={handleCloseBulkAddDialog}>
+                {t_i18n('Validate')}
+              </Button>
+            </DialogActions>
+          </DialogContent>
+        </Dialog>
+      </React.Fragment>
+    );
+  }
+
   function BulkAddModal(props) {
+    console.log('inside bulkAddModal');
     const [openBulkModal, setOpenBulkModal] = React.useState(false);
     const handleOpenBulkModal = () => {
       const generic_value_field = document.getElementById('generic_value_field');
@@ -562,7 +641,8 @@ const StixCyberObservableCreation = ({
   };
 
   const renderForm = () => {
-    console.log("renderForm");
+    // console.log("renderForm");
+    // console.log("renderForm; status.type " + status.type);
     return (
       <QueryRenderer
         query={stixCyberObservablesLinesAttributesQuery}
@@ -755,15 +835,18 @@ const StixCyberObservableCreation = ({
                             />
                           );
                         }
-                        // if (status.type === 'StixFile') {
-                        //   console.log('inside file');
-                        //   return (
-                        //     <div key={attribute.value}>
-                        //       <p>THIS IS DIALOG!!!</p>
-                        //       <button id="opener">Open Dialog</button>
-                        //     </div>
-                        //   );
-                        // }
+                        if (status.type === 'StixFile') {
+                          // console.log('inside StixFile; attribute.value ' + attribute.value);
+                          return (
+                            <div key={attribute.value}>
+                              <Tooltip title="Copy/paste text content">
+                                <BulkAddDialog
+                                  setValue={(field_name, new_value) => setFieldValue(field_name, new_value)}
+                                />
+                              </Tooltip>
+                            </div>
+                          );
+                        }
                         // console.log('attribute.value ' + attribute.value);
                         if (attribute.value === 'value') {
                           return (
@@ -865,6 +948,7 @@ const StixCyberObservableCreation = ({
 
   const renderClassic = () => {
     if (status.type) {
+      console.log("inside renderClassic");
       console.log("status.type " + status.type);
     }
     return (

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Fab from '@mui/material/Fab';
+import Select from '@mui/material/Select';
 import { Add, Close, TextFieldsOutlined } from '@mui/icons-material';
 import { assoc, compose, dissoc, filter, fromPairs, includes, map, pipe, pluck, prop, propOr, sortBy, toLower, toPairs } from 'ramda';
 import * as Yup from 'yup';
@@ -17,7 +18,7 @@ import Dialog from '@mui/material/Dialog';
 import List from '@mui/material/List';
 import ListItemText from '@mui/material/ListItemText';
 import makeStyles from '@mui/styles/makeStyles';
-import { ListItemButton } from '@mui/material';
+import { ListItemButton, MenuItem } from '@mui/material';
 import * as PropTypes from 'prop-types';
 import { commitMutation, handleErrorInForm, QueryRenderer, MESSAGING$, commitMutationWithPromise } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -237,6 +238,7 @@ const StixCyberObservableCreation = ({
   const [genericValueFieldDisabled, setGenericValueFieldDisabled] = useState(false);
   const [keyFieldDisabled, setKeyFieldDisabled] = useState(false);
   const [selectedAttribute, setSelectedAttribute] = useState('');
+  const [openBulkAddDialog, setOpenBulkAddDialog] = React.useState(false);
   const bulkAddMsg = t_i18n('Multiple values entered. Edit with the TT button');
   const hashes_MD5_field = document.getElementById('hashes_MD5');
   const hashes_SHA1_field = document.getElementById('hashes_SHA-1');
@@ -594,7 +596,6 @@ const StixCyberObservableCreation = ({
   };
 
   function BulkAddDialog(props) {
-    const [openBulkAddDialog, setOpenBulkAddDialog] = React.useState(false);
     const handleOpenBulkAddDialog = () => {
       if (hashes_MD5_field != null && hashes_MD5_field.value != null
         && hashes_MD5_field.value.length > 0 && hashes_MD5_field.value !== bulkAddMsg) {
@@ -620,6 +621,7 @@ const StixCyberObservableCreation = ({
     };
 
     const handleCloseBulkAddDialog = () => {
+      console.log('BulkAddDialog is closing');
       setOpenBulkAddDialog(false);
       const bulk_hashes_field = document.getElementById('bulk_hashes_field');
 
@@ -643,12 +645,6 @@ const StixCyberObservableCreation = ({
     const handleSelectChange = (event) => {
       setSelectedAttribute(event.target.value);
     };
-
-    function getOption() {
-      const selectElement = document.querySelector('#attributes');
-      const output = selectElement.value;
-      document.querySelector('.output').textContent = output;
-    }
     return (
       <React.Fragment>
         <IconButton
@@ -663,19 +659,20 @@ const StixCyberObservableCreation = ({
           open={openBulkAddDialog}
           onClose={handleCloseBulkAddDialog}
           fullWidth={true}
+          // onClick={handleChildClick}
         >
-          <DialogContent style={{ marginTop: 0, paddingTop: 10 }} closeOnEscape={false}>
-            <form name="formSelectAttributes" id="formSelectAttributes" style={{ border: '2px solid #FFA500', paddingLeft: 10 }} action="/action_page.php">
-              {t_i18n('Create Entities from multiple')}:
-              <select name="attributes" id="attributes" onSelect={getOption} onChange={handleSelectChange}>
-                <option value="Selected" disabled>Select attribute</option>
-                <option value="NAME">name</option>
-                <option value="MD5">md5</option>
-                <option value="SHA-1">sha1</option>
-                <option value="SHA-256">sha256</option>
-                <option value="SHA-512">sha512</option>
-              </select>
-            </form>
+          <DialogContent style={{ marginTop: 0, paddingTop: 10 }}>
+            <div id="divSelectAttributes" style={{ border: '2px solid #FFA500', paddingLeft: 10 }}>
+              {t_i18n('Create Entities from multiple: ')}
+              <Select name="attributes" id="attributes" value={selectedAttribute} onChange={handleSelectChange}>
+                <MenuItem selected disabled>Select attribute</MenuItem>
+                <MenuItem value="NAME">name</MenuItem>
+                <MenuItem value="MD5">md5</MenuItem>
+                <MenuItem value="SHA-1">sha1</MenuItem>
+                <MenuItem value="SHA-256">sha256</MenuItem>
+                <MenuItem value="SHA-512">sha512</MenuItem>
+              </Select>
+            </div>
             <Typography style={{ float: 'left', marginTop: 10 }}>
               <span style={{ fontSize: '0.7em' }}>{selectedAttribute}</span>
               <span className="output"></span>
@@ -793,6 +790,7 @@ const StixCyberObservableCreation = ({
     setValue: PropTypes.func,
   };
   let stixFileBoolean = false;
+  let nameAttributeBoolean = false;
   const renderForm = () => {
     if (status.type === 'StixFile') {
       stixFileBoolean = true;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -235,18 +235,20 @@ const StixCyberObservableCreation = ({
   const localHandleClose = () => setStatus({ open: false, type: type ?? null });
   const selectType = (selected) => setStatus({ open: status.open, type: selected });
   const [genericValueFieldDisabled, setGenericValueFieldDisabled] = useState(false);
-  const [md5FieldDisabled, setMD5FieldDisabled] = useState(false);
-  const [sha1FieldDisabled, setSHA1FieldDisabled] = useState(false);
-  const [sha256FieldDisabled, setSHA256FieldDisabled] = useState(false);
-  const [sha512FieldDisabled, setSHA512FieldDisabled] = useState(false);
+  // const [md5FieldDisabled, setMD5FieldDisabled] = useState(false);
+  // const [sha1FieldDisabled, setSHA1FieldDisabled] = useState(false);
+  // const [sha256FieldDisabled, setSHA256FieldDisabled] = useState(false);
+  // const [sha512FieldDisabled, setSHA512FieldDisabled] = useState(false);
+  const [keyFieldDisabled, setKeyFieldDisabled] = useState(false);
   const bulkAddMsg = t_i18n('Multiple values entered. Edit with the TT button');
 
   const onSubmit = (values, { setSubmitting, setErrors, resetForm }) => {
     let adaptedValues = values;
-    console.log("adaptedValues " + adaptedValues);
     if (adaptedValues) { // Verify not null for DeepScan compliance
       // Bulk Add Modal was used
       if (adaptedValues.value && adaptedValues.bulk_value_field && adaptedValues.value === bulkAddMsg) {
+        console.log("adaptedValues " + adaptedValues);
+        console.log("inside bulk add, " + bulkAddMsg)
         const array_of_bulk_values = adaptedValues.bulk_value_field.split(/\r?\n/);
         // Trim them just to remove any extra spacing on front or rear of string
         const trimmed_bulk_values = array_of_bulk_values.map((s) => s.trim());
@@ -478,13 +480,36 @@ const StixCyberObservableCreation = ({
   };
 
   function BulkAddDialog(props) {
-    console.log('inside BulkAddDialog function');
+    // console.log('inside BulkAddDialog function');
     const [openBulkAddDialog, setOpenBulkAddDialog] = React.useState(false);
     const handleOpenBulkAddDialog = () => {
-      const generic_value_field = document.getElementById('generic_value_field');
-      if (generic_value_field != null && generic_value_field.value != null
-        && generic_value_field.value.length > 0 && generic_value_field.value !== bulkAddMsg) {
-        props.setValue('bulk_value_field', generic_value_field.value.trim());
+      const hashes_MD5_field = document.getElementById('hashes_MD5');
+      const hashes_SHA1_field = document.getElementById('hashes_SHA-1');
+      const hashes_SHA256_field = document.getElementById('hashes_SHA-256');
+      const hashes_SHA512_field = document.getElementById('hashes_SHA-512');
+      if (hashes_MD5_field != null && hashes_MD5_field.value != null
+        && hashes_MD5_field.value.length > 0 && hashes_MD5_field.value !== bulkAddMsg) {
+        // Trim the field to avoid inserting whitespace as a default population value
+        console.log('hashes_MD5_field');
+        props.setValue('bulk_value_field', hashes_MD5_field.value.trim());
+      }
+      if (hashes_SHA1_field != null && hashes_SHA1_field.value != null
+        && hashes_SHA1_field.value.length > 0 && hashes_SHA1_field.value !== bulkAddMsg) {
+        // Trim the field to avoid inserting whitespace as a default population value
+        console.log('hashes_SHA1_field');
+        props.setValue('bulk_value_field', hashes_SHA1_field.value.trim());
+      }
+      if (hashes_SHA256_field != null && hashes_SHA256_field.value != null
+        && hashes_SHA256_field.value.length > 0 && hashes_SHA256_field.value !== bulkAddMsg) {
+        // Trim the field to avoid inserting whitespace as a default population value
+        console.log('hashes_SHA256_field');
+        props.setValue('bulk_value_field', hashes_SHA256_field.value.trim());
+      }
+      if (hashes_SHA512_field != null && hashes_SHA512_field.value != null
+        && hashes_SHA512_field.value.length > 0 && hashes_SHA512_field.value !== bulkAddMsg) {
+        // Trim the field to avoid inserting whitespace as a default population value
+        console.log('hashes_SHA512_field');
+        props.setValue('bulk_value_field', hashes_SHA512_field.value.trim());
       }
       setOpenBulkAddDialog(true);
     };
@@ -493,18 +518,10 @@ const StixCyberObservableCreation = ({
       const bulk_value_field = document.getElementById('bulk_value_field');
       if (bulk_value_field != null && bulk_value_field.value != null && bulk_value_field.value.length > 0) {
         props.setValue('value', bulkAddMsg);
-        setGenericValueFieldDisabled(true);
-        setMD5FieldDisabled(true);
-        setSHA1FieldDisabled(true);
-        setSHA256FieldDisabled(true);
-        setSHA512FieldDisabled(true);
+        setKeyFieldDisabled(true);
       } else {
         props.setValue('value', '');
-        setGenericValueFieldDisabled(false);
-        setMD5FieldDisabled(false);
-        setSHA1FieldDisabled(false);
-        setSHA256FieldDisabled(false);
-        setSHA512FieldDisabled(false);
+        setKeyFieldDisabled(false);
       }
     };
     function getOption() {
@@ -749,7 +766,8 @@ const StixCyberObservableCreation = ({
                             <div key={attribute.value}>
                               {/* TODO: Disable these fields */}
                               <Field
-                                disabled={md5FieldDisabled}
+                                id="hashes_MD5"
+                                disabled={keyFieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_MD5"
@@ -758,7 +776,8 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
-                                disabled={sha1FieldDisabled}
+                                id="hashes_SHA-1"
+                                disabled={keyFieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-1"
@@ -767,7 +786,8 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
-                                disabled={sha256FieldDisabled}
+                                id="hashes_SHA-256"
+                                disabled={keyFieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-256"
@@ -776,7 +796,8 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
-                                disabled={sha512FieldDisabled}
+                                id="hashes_SHA-512"
+                                disabled={keyFieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-512"
@@ -860,6 +881,9 @@ const StixCyberObservableCreation = ({
                           // console.log('inside StixFile; attribute.value ' + attribute.value);
                           return (
                             <div key={attribute.value}>
+                              <Typography className={keyFieldDisabled ? classes.disabled : classes.active_typography} style={{ float: 'left', marginTop: 20 }}>
+                                {attribute.value}
+                              </Typography>
                               <Tooltip title="Copy/paste text content">
                                 <BulkAddDialog
                                   setValue={(field_name, new_value) => setFieldValue(field_name, new_value)}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -262,6 +262,8 @@ const StixCyberObservableCreation = ({
       }
 
       console.log("adaptedValues.hashes_SHA-256 " + adaptedValues['hashes_SHA-256']);
+      console.log("adaptedValues.hashes_SHA-256 value " + adaptedValues['hashes_SHA-256'].value());
+      console.log("adaptedValues.hashes_SHA-256 valueList " + adaptedValues['hashes_SHA-256'].valueList());
       // Potential dicts
       if (
         adaptedValues.hashes_MD5
@@ -491,37 +493,47 @@ const StixCyberObservableCreation = ({
       if (hashes_MD5_field != null && hashes_MD5_field.value != null
         && hashes_MD5_field.value.length > 0 && hashes_MD5_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
-        console.log('hashes_MD5_field');
-        props.setValue('bulk_value_field', hashes_MD5_field.value.trim());
+        console.log('hashes_MD5');
+        props.setValue('hashes_MD5', hashes_MD5_field.value.trim());
       }
       if (hashes_SHA1_field != null && hashes_SHA1_field.value != null
         && hashes_SHA1_field.value.length > 0 && hashes_SHA1_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
-        console.log('hashes_SHA1_field');
-        props.setValue('bulk_value_field', hashes_SHA1_field.value.trim());
+        console.log('hashes_SHA-1');
+        props.setValue('hashes_SHA-1', hashes_SHA1_field.value.trim());
       }
       if (hashes_SHA256_field != null && hashes_SHA256_field.value != null
         && hashes_SHA256_field.value.length > 0 && hashes_SHA256_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
-        console.log('hashes_SHA256_field');
-        props.setValue('bulk_value_field', hashes_SHA256_field.value.trim());
+        console.log('hashes_SHA-256');
+        props.setValue('hashes_SHA-256', hashes_SHA256_field.value.trim());
       }
       if (hashes_SHA512_field != null && hashes_SHA512_field.value != null
         && hashes_SHA512_field.value.length > 0 && hashes_SHA512_field.value !== bulkAddMsg) {
         // Trim the field to avoid inserting whitespace as a default population value
-        console.log('hashes_SHA512_field');
-        props.setValue('bulk_value_field', hashes_SHA512_field.value.trim());
+        console.log('hashes_SHA-512');
+        props.setValue('hashes_SHA-512', hashes_SHA512_field.value.trim());
       }
       setOpenBulkAddDialog(true);
     };
+
     const handleCloseBulkAddDialog = () => {
       setOpenBulkAddDialog(false);
-      const bulk_value_field = document.getElementById('bulk_value_field');
-      if (bulk_value_field != null && bulk_value_field.value != null && bulk_value_field.value.length > 0) {
-        props.setValue('hashes', bulkAddMsg);
+      const bulk_hashes_field = document.getElementById('bulk_hashes_field');
+
+      if (bulk_hashes_field != null && bulk_hashes_field.value != null && bulk_hashes_field.value.length > 0) {
+        props.setValue('hashes_MD5', bulkAddMsg);
+        props.setValue('hashes_SHA-1', bulkAddMsg);
+        props.setValue('hashes_SHA-256', bulkAddMsg);
+        props.setValue('hashes_SHA-512', bulkAddMsg);
+        props.setValue('name', bulkAddMsg);
         setKeyFieldDisabled(true);
       } else {
-        props.setValue('hashes', '');
+        props.setValue('hashes_MD5', '');
+        props.setValue('hashes_SHA-1', '');
+        props.setValue('hashes_SHA-256', '');
+        props.setValue('hashes_SHA-512', '');
+        props.setValue('name', '');
         setKeyFieldDisabled(false);
       }
     };
@@ -570,10 +582,10 @@ const StixCyberObservableCreation = ({
             </Typography>
             <Field
               component={TextField}
-              id="bulk_value_field"
+              id="bulk_hashes_field"
               variant="standard"
-              key="bulk_value_field"
-              name="bulk_value_field"
+              key="bulk_hashes_field"
+              name="bulk_hashes_field"
               fullWidth={true}
               multiline={true}
               rows="5"
@@ -594,7 +606,6 @@ const StixCyberObservableCreation = ({
   };
 
   function BulkAddModal(props) {
-    console.log('inside bulkAddModal');
     const [openBulkModal, setOpenBulkModal] = React.useState(false);
     const handleOpenBulkModal = () => {
       const generic_value_field = document.getElementById('generic_value_field');
@@ -824,6 +835,7 @@ const StixCyberObservableCreation = ({
                           );
                         }
                         if (isVocabularyField(status.type, attribute.value)) {
+                          console.log("attribute.value: " + attribute.value);
                           return (
                             <OpenVocabField
                               key={attribute.value}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -235,11 +235,15 @@ const StixCyberObservableCreation = ({
   const localHandleClose = () => setStatus({ open: false, type: type ?? null });
   const selectType = (selected) => setStatus({ open: status.open, type: selected });
   const [genericValueFieldDisabled, setGenericValueFieldDisabled] = useState(false);
+  const [md5FieldDisabled, setMD5FieldDisabled] = useState(false);
+  const [sha1FieldDisabled, setSHA1FieldDisabled] = useState(false);
+  const [sha256FieldDisabled, setSHA256FieldDisabled] = useState(false);
+  const [sha512FieldDisabled, setSHA512FieldDisabled] = useState(false);
   const bulkAddMsg = t_i18n('Multiple values entered. Edit with the TT button');
 
   const onSubmit = (values, { setSubmitting, setErrors, resetForm }) => {
     let adaptedValues = values;
-
+    console.log("adaptedValues " + adaptedValues);
     if (adaptedValues) { // Verify not null for DeepScan compliance
       // Bulk Add Modal was used
       if (adaptedValues.value && adaptedValues.bulk_value_field && adaptedValues.value === bulkAddMsg) {
@@ -490,9 +494,17 @@ const StixCyberObservableCreation = ({
       if (bulk_value_field != null && bulk_value_field.value != null && bulk_value_field.value.length > 0) {
         props.setValue('value', bulkAddMsg);
         setGenericValueFieldDisabled(true);
+        setMD5FieldDisabled(true);
+        setSHA1FieldDisabled(true);
+        setSHA256FieldDisabled(true);
+        setSHA512FieldDisabled(true);
       } else {
         props.setValue('value', '');
         setGenericValueFieldDisabled(false);
+        setMD5FieldDisabled(false);
+        setSHA1FieldDisabled(false);
+        setSHA256FieldDisabled(false);
+        setSHA512FieldDisabled(false);
       }
     };
     function getOption() {
@@ -550,6 +562,10 @@ const StixCyberObservableCreation = ({
       </React.Fragment>
     );
   }
+
+  BulkAddDialog.propTypes = {
+    setValue: PropTypes.func,
+  };
 
   function BulkAddModal(props) {
     console.log('inside bulkAddModal');
@@ -731,7 +747,9 @@ const StixCyberObservableCreation = ({
                         if (attribute.value === 'hashes') {
                           return (
                             <div key={attribute.value}>
+                              {/* TODO: Disable these fields */}
                               <Field
+                                disabled={md5FieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_MD5"
@@ -740,6 +758,7 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
+                                disabled={sha1FieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-1"
@@ -748,6 +767,7 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
+                                disabled={sha256FieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-256"
@@ -756,6 +776,7 @@ const StixCyberObservableCreation = ({
                                 style={{ marginTop: 20 }}
                               />
                               <Field
+                                disabled={sha512FieldDisabled}
                                 component={TextField}
                                 variant="standard"
                                 name="hashes_SHA-512"

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -242,7 +242,6 @@ const StixCyberObservableCreation = ({
   const hashes_SHA256_field = document.getElementById('hashes_SHA-256');
   const hashes_SHA512_field = document.getElementById('hashes_SHA-512');
   const divRowStyle = { display: 'flex', flexWrap: 'wrap' };
-  const [myValue, setMyValue] = useState("");
 
   const onSubmit = (values, { setSubmitting, setErrors, resetForm }) => {
     console.log('onSubmit was called');
@@ -526,6 +525,13 @@ const StixCyberObservableCreation = ({
         setKeyFieldDisabled(false);
       }
     };
+
+    const [selectedAttribute, setSelectedAttribute] = useState('');
+
+    const handleSelectChange = (event) => {
+      setSelectedAttribute(event.target.value);
+    };
+
     function getOption() {
       const selectElement = document.querySelector('#attributes');
       const output = selectElement.value;
@@ -549,7 +555,7 @@ const StixCyberObservableCreation = ({
           <DialogContent style={{ marginTop: 0, paddingTop: 10 }}>
             <form name="formSelectAttributes" id="formSelectAttributes" style={{ border: '2px solid #FFA500', paddingLeft: 10 }} action="/action_page.php">
               {t_i18n('Create Entities from multiple')}:
-              <select name="attributes" id="attributes" onSelect={getOption} onChange={(e) => setMyValue(e.target.value)}>
+              <select name="attributes" id="attributes" onSelect={getOption} onChange={handleSelectChange}>
                 <option selected disabled>Select attribute</option>
                 <option value="NAME">name</option>
                 <option value="MD5">md5</option>
@@ -559,7 +565,7 @@ const StixCyberObservableCreation = ({
               </select>
             </form>
             <Typography style={{ float: 'left', marginTop: 10 }}>
-              <span>{myValue}</span>
+              <span style={{ fontSize: '0.7em' }}>{selectedAttribute}</span>
               <span className="output"></span>
             </Typography>
             <Field

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -562,6 +562,7 @@ const StixCyberObservableCreation = ({
   };
 
   const renderForm = () => {
+    console.log("renderForm");
     return (
       <QueryRenderer
         query={stixCyberObservablesLinesAttributesQuery}
@@ -754,6 +755,16 @@ const StixCyberObservableCreation = ({
                             />
                           );
                         }
+                        // if (status.type === 'StixFile') {
+                        //   console.log('inside file');
+                        //   return (
+                        //     <div key={attribute.value}>
+                        //       <p>THIS IS DIALOG!!!</p>
+                        //       <button id="opener">Open Dialog</button>
+                        //     </div>
+                        //   );
+                        // }
+                        // console.log('attribute.value ' + attribute.value);
                         if (attribute.value === 'value') {
                           return (
                             <div key={attribute.value}>
@@ -853,6 +864,9 @@ const StixCyberObservableCreation = ({
   };
 
   const renderClassic = () => {
+    if (status.type) {
+      console.log("status.type " + status.type);
+    }
     return (
       <>
         <Fab

--- a/opencti-platform/opencti-front/src/relay/environment.jsx
+++ b/opencti-platform/opencti-front/src/relay/environment.jsx
@@ -105,6 +105,37 @@ export const defaultCommitMutation = {
   setSubmitting: undefined,
 };
 
+/**
+ * Perform a mutation and return any errors
+ */
+export const commitMutationWithPromise = ({
+  mutation,
+  variables,
+  updater,
+  optimisticUpdater,
+  optimisticResponse,
+  onCompleted,
+  onError,
+}) => new Promise((resolve, reject) => {
+  CM(environment, {
+    mutation,
+    variables,
+    updater,
+    optimisticUpdater,
+    optimisticResponse,
+    onCompleted: () => {
+      onCompleted();
+      resolve();
+    },
+    onError: (error) => {
+      onError();
+      if (error && error.res && error.res.errors) {
+        reject(buildErrorMessages(error));
+      }
+    },
+  });
+});
+
 // Relay functions
 export const commitMutation = ({
   mutation,

--- a/opencti-platform/opencti-front/tests_e2e/model/containerAddObservables.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/containerAddObservables.pageModel.ts
@@ -14,7 +14,7 @@ export default class ContainerAddObservablesPage {
   }
 
   getNewIPV4ValueInput() {
-    return this.page.getByLabel('value');
+    return this.page.getByLabel('generic_value_field');
   }
 
   async fillNewIPV4ValueInput(ipv4Value: string) {


### PR DESCRIPTION
### Proposed changes

* Ability to add via a TT button (like on the Import Text Page) multiple single dimension observables
* On the normal Create Observable form - a TT has been added as a new line above the score (only appears with File)
* Click the TT will launch the unique Dialog that has a dropdown for the desired Hash to Add Multiple Single Dimension Hashes - one per line
* Clicking Validate will update all the hash fields and name of the form to say "Multiple Values Entered Edit with the TT Button". These fields are now disabled and can only be updated via the TT Dialog window
* Blanking out the TT input field and clicking Continue with an empty Bulk Add form - will just leave the normal hash fields blank and enabled.
* Language translations have been added for the various dialog fields added that require translation.

### Related issues
* There was some thought of implementing a progress bar to this process, since it might be possible a user would insert say 1000 records, however on testing with normal amounts (10/20 records) they seemed to add instantaneously.
* On this point - it might be desired to limit the amount of records that can be added at one time to maybe sets of 50 or less? Currently, no limit is enabled.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments

