### PR TITLE
[backend/frontend] prevent delete CSV mappers if used by CSV ingesters (#6757)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "Möchten Sie dieses Land löschen?",
   "Do you want to delete this course of action?": "Möchten Sie diesen Vorgang löschen?",
   "Do you want to delete this CSV ingester?": "Möchten Sie diesen CSV-Importer löschen?",
-  "Do you want to delete this CSV mapper ?": "Möchten Sie diesen CSV-Mapper löschen?",
+  "Do you want to delete this CSV mapper?": "Möchten Sie diesen CSV-Mapper löschen?",
   "Do you want to delete this data component?": "Möchten Sie diese Datenkomponente löschen?",
   "Do you want to delete this data source?": "Möchten Sie diese Datenquelle löschen?",
   "Do you want to delete this entity?": "Möchten Sie diese Entität löschen?",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "Do you want to delete this country?",
   "Do you want to delete this course of action?": "Do you want to delete this course of action?",
   "Do you want to delete this CSV ingester?": "Do you want to delete this CSV ingester?",
-  "Do you want to delete this CSV mapper ?": "Do you want to delete this CSV mapper ?",
+  "Do you want to delete this CSV mapper?": "Do you want to delete this CSV mapper?",
   "Do you want to delete this data component?": "Do you want to delete this data component?",
   "Do you want to delete this data source?": "Do you want to delete this data source?",
   "Do you want to delete this entity?": "Do you want to delete this entity?",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "¿Quieres borrar este país?",
   "Do you want to delete this course of action?": "¿Quieres borrar esta contramedida?",
   "Do you want to delete this CSV ingester?": "¿Quieres eliminar este importador CSV?",
-  "Do you want to delete this CSV mapper ?": "¿Desea eliminar este mapeador CSV?",
+  "Do you want to delete this CSV mapper?": "¿Desea eliminar este mapeador CSV?",
   "Do you want to delete this data component?": "¿Quieres borrar este componente de datos?",
   "Do you want to delete this data source?": "¿Quieres eliminar esta fuente de datos?",
   "Do you want to delete this entity?": "¿Quieres borrar esta entidad?",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "Souhaitez-vous supprimer ce pays ?",
   "Do you want to delete this course of action?": "Souhaitez-vous supprimer cette conduite à suivre ?",
   "Do you want to delete this CSV ingester?": "Voulez-vous supprimer cet ingéreur CSV ?",
-  "Do you want to delete this CSV mapper ?": "Voulez-vous supprimer ce mappage CSV ?",
+  "Do you want to delete this CSV mapper?": "Voulez-vous supprimer ce mappage CSV ?",
   "Do you want to delete this data component?": "Souhaitez-vous supprimer ce composant de données ?",
   "Do you want to delete this data source?": "Souhaitez-vous supprimer cette source de données ?",
   "Do you want to delete this entity?": "Souhaitez-vous supprimer cette entité ?",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "この国を削除しますか？",
   "Do you want to delete this course of action?": "この行動指針を削除しますか？",
   "Do you want to delete this CSV ingester?": "このCSVインガスターを削除しますか？",
-  "Do you want to delete this CSV mapper ?": "このCSVマッパーを削除しますか？",
+  "Do you want to delete this CSV mapper?": "このCSVマッパーを削除しますか？",
   "Do you want to delete this data component?": "このデータコンポーネントを削除しますか?",
   "Do you want to delete this data source?": "このデータ ソースを削除しますか?",
   "Do you want to delete this entity?": "このエンティティを削除しますか？",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -657,7 +657,7 @@
   "Do you want to delete this country?": "是否要删除此国家/地区？",
   "Do you want to delete this course of action?": "是否要删除此应对措施？",
   "Do you want to delete this CSV ingester?": "您要删除此CSV导入程序吗？",
-  "Do you want to delete this CSV mapper ?": "您要删除此CSV映射吗？",
+  "Do you want to delete this CSV mapper?": "您要删除此CSV映射吗？",
   "Do you want to delete this data component?": "是否要删除此数据组件？",
   "Do you want to delete this data source?": "你想删除这个数据源吗?",
   "Do you want to delete this entity?": "是否要删除此实体？",

--- a/opencti-platform/opencti-front/src/components/DeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/DeleteDialog.tsx
@@ -8,14 +8,16 @@ import Transition from './Transition';
 import { useFormatter } from './i18n';
 import { Deletion } from '../utils/hooks/useDeletion';
 
-const DeleteDialog = ({
+type DeleteDialogProps = {
+  title: React.ReactNode
+  deletion: Deletion
+  submitDelete: () => void
+};
+
+const DeleteDialog: React.FC<DeleteDialogProps> = ({
   title,
   deletion,
   submitDelete,
-}: {
-  title: string
-  deletion: Deletion
-  submitDelete: () => void
 }) => {
   const { t_i18n } = useFormatter();
   return (

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
@@ -93,7 +93,7 @@ const CsvMapperPopover: FunctionComponent<CsvMapperPopoverProps> = ({
         </React.Suspense>
       )}
       <DeleteDialog
-        title={t_i18n('Do you want to delete this CSV mapper ?')}
+        title={t_i18n('Do you want to delete this CSV mapper?')}
         deletion={deletion}
         submitDelete={submitDelete}
       />

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -74,7 +74,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
   const [isCreateDisabled, setIsCreateDisabled] = useState(true);
 
   const ingestionCsvCreationValidation = () => Yup.object().shape({
-    name: Yup.string().required(t_i18n('This field is required')),
+    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     uri: Yup.string().required(t_i18n('This field is required')),
     authentication_type: Yup.string().required(t_i18n('This field is required')),
@@ -126,6 +126,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
       },
       onCompleted: () => {
         setSubmitting(false);
+        setIsCreateDisabled(true);
         resetForm();
       },
     });

--- a/opencti-platform/opencti-graphql/src/migrations/1715067563363-fix-csv-ingester-without-mapper.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1715067563363-fix-csv-ingester-without-mapper.js
@@ -1,0 +1,32 @@
+import { logApp } from '../config/conf';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { listAllEntities } from '../database/middleware-loader';
+import { ENTITY_TYPE_INGESTION_CSV } from '../modules/ingestion/ingestion-types';
+import { elDeleteElements, elFindByIds } from '../database/engine';
+
+const message = '[MIGRATION] delete CSV feeds that have inexisting CSV mapper';
+
+export const up = async (next) => {
+  const context = executionContext('migration');
+  logApp.info(`${message} > started`);
+
+  const allIngesters = await listAllEntities(context, SYSTEM_USER, [ENTITY_TYPE_INGESTION_CSV]);
+  const mappersUsedIds = allIngesters.map((ingester) => ingester.csv_mapper_id);
+  const mappersUsedAndValid = await elFindByIds(context, SYSTEM_USER, mappersUsedIds, { baseData: true });
+  const mappersUsedAndValidIds = mappersUsedAndValid.map((mapper) => mapper.id);
+
+  const ingestersToDelete = allIngesters.filter((ingester) => !mappersUsedAndValidIds.includes(ingester.csv_mapper_id));
+
+  if (ingestersToDelete.length === 0) {
+    logApp.info(`${message} > no invalid CSV feed detected`);
+  } else {
+    logApp.info(`${message} > deleting ${ingestersToDelete.length} IngestionCSV objects`);
+    await elDeleteElements(context, SYSTEM_USER, ingestersToDelete);
+  }
+  logApp.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/utils/migration-template.js
+++ b/opencti-platform/opencti-graphql/src/utils/migration-template.js
@@ -1,4 +1,11 @@
+import { logApp } from '../config/conf';
+
+const message = '[MIGRATION] migration title';
+
 export const up = async (next) => {
+  logApp.info(`${message} > started`);
+  // do your migration
+  logApp.info(`${message} > done`);
   next();
 };
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import gql from 'graphql-tag';
-import {ADMIN_USER, participantQuery, queryAsAdmin, USER_PARTICIPATE} from '../../utils/testQuery';
-import {FORBIDDEN_ACCESS} from '../../../src/config/errors';
+import { ADMIN_USER, participantQuery, queryAsAdmin, USER_PARTICIPATE } from '../../utils/testQuery';
+import { FORBIDDEN_ACCESS } from '../../../src/config/errors';
 
 describe('CSV ingestion resolver standard behavior', () => {
   let singleColumnCsvMapperId = '';
@@ -149,6 +149,20 @@ describe('CSV ingestion resolver standard behavior', () => {
       variables: CSV_FEED_INGESTER_TO_UPDATE
     });
     expect(stopSingleColumnCsvFeedsIngesterQueryResult?.data?.ingestionCsvFieldPatch?.name).toBe('Single column CSV feed ingester');
+  });
+
+  it('should fail to delete the mapper used by the ingester', async () => {
+    const deleteResult = await queryAsAdmin({
+      query: gql`
+        mutation CsvMapperDelete($id: ID!) {
+          csvMapperDelete(id: $id)
+        }
+      `,
+      variables: { id: singleColumnCsvMapperId },
+    });
+    const { errors } = deleteResult;
+    expect(errors).toBeDefined();
+    expect(errors?.[0].message).toBe('Cannot delete this CSV Mapper: it is used by one or more IngestionCsv ingester(s)');
   });
 
   it('should delete the CSV feeds ingester', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* when user deletes a CSV mapper, find and delete all csv ingesters that uses it. 
* add warning about feeds being deleted as part of the cascade deletion, in the confirm popover
* fix bad form validation and reset in `IngestionCsvCreation`


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #6757

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->