### PR TITLE
[backend] validate CSV mappers representations (#6886)

### DIFF
--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-domain.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-domain.ts
@@ -1,6 +1,6 @@
 import type { AuthContext, AuthUser } from '../../types/user';
 import { IMPORT_CSV_CONNECTOR } from './importCsv';
-import { errors } from '../../modules/internal/csvMapper/csvMapper-utils';
+import { getCsvMapperErrorMessage } from '../../modules/internal/csvMapper/csvMapper-utils';
 import type { BasicStoreEntityCsvMapper } from '../../modules/internal/csvMapper/csvMapper-types';
 
 export const importCsvConnector = () => {
@@ -12,7 +12,7 @@ export const importCsvConnectorRuntime = async (context: AuthContext, user: Auth
   const configurations = await connector.connector_schema_runtime_fn(context, user);
   const configurationsFiltered: BasicStoreEntityCsvMapper[] = [];
   await Promise.all(configurations.map(async (c) => {
-    const mapperErrors = await errors(context, user, c);
+    const mapperErrors = await getCsvMapperErrorMessage(context, user, c);
     if (mapperErrors === null) {
       configurationsFiltered.push(c);
     }

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -42,6 +42,8 @@ export const findAll = (context: AuthContext, user: AuthUser, opts: QueryCsvMapp
 };
 
 export const createCsvMapper = async (context: AuthContext, user: AuthUser, csvMapperInput: CsvMapperAddInput) => {
+  // attempt to parse the mapper representations ; this throws validation errors
+  parseCsvMapper(csvMapperInput);
   return createInternalObject<StoreEntityCsvMapper>(context, user, csvMapperInput, ENTITY_TYPE_CSV_MAPPER);
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -4,7 +4,7 @@ import { type BasicStoreEntityCsvMapper, ENTITY_TYPE_CSV_MAPPER, type StoreEntit
 import { type CsvMapperAddInput, type EditInput, FilterMode, type QueryCsvMappersArgs } from '../../../generated/graphql';
 import { createInternalObject, deleteInternalObject, editInternalObject } from '../../../domain/internalObject';
 import { bundleProcess } from '../../../parser/csv-bundler';
-import { type CsvMapperSchemaAttribute, type CsvMapperSchemaAttributes, parseCsvMapper, parseCsvMapperWithDefaultValues } from './csvMapper-utils';
+import { type CsvMapperSchemaAttribute, type CsvMapperSchemaAttributes, parseCsvMapper, parseCsvMapperWithDefaultValues, validateCsvMapper } from './csvMapper-utils';
 import { schemaAttributesDefinition } from '../../../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../../schema/schema-relationsRef';
 import { INTERNAL_ATTRIBUTES, INTERNAL_REFS } from '../../../domain/attribute-utils';
@@ -22,7 +22,13 @@ import { FunctionalError } from '../../../config/errors';
 
 export const csvMapperTest = async (context: AuthContext, user: AuthUser, configuration: string, content: string) => {
   const limitedTestingText = content.split(/\r?\n/).slice(0, 100).join('\n'); // Get 100 lines max
-  const csvMapper = parseCsvMapper(JSON.parse(configuration));
+  let parsedConfiguration;
+  try {
+    parsedConfiguration = JSON.parse(configuration);
+  } catch (error) {
+    throw FunctionalError('Could not parse CSV mapper configuration', { error });
+  }
+  const csvMapper = parseCsvMapper(parsedConfiguration);
   const bundle = await bundleProcess(context, user, Buffer.from(limitedTestingText), csvMapper);
   return {
     objects: JSON.stringify(bundle.objects, null, 2),
@@ -42,8 +48,10 @@ export const findAll = (context: AuthContext, user: AuthUser, opts: QueryCsvMapp
 };
 
 export const createCsvMapper = async (context: AuthContext, user: AuthUser, csvMapperInput: CsvMapperAddInput) => {
-  // attempt to parse the mapper representations ; this throws validation errors
-  parseCsvMapper(csvMapperInput);
+  // attempt to parse and validate the mapper representations ; this can throw errors
+  const parsedMapper = parseCsvMapper(csvMapperInput);
+  await validateCsvMapper(context, user, parsedMapper);
+
   return createInternalObject<StoreEntityCsvMapper>(context, user, csvMapperInput, ENTITY_TYPE_CSV_MAPPER);
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-resolvers.ts
@@ -1,6 +1,6 @@
 import type { Resolvers } from '../../../generated/graphql';
 import { createCsvMapper, csvMapperTest, deleteCsvMapper, fieldPatchCsvMapper, findAll, findById, csvMapperSchemaAttributes, getParsedRepresentations } from './csvMapper-domain';
-import { errors } from './csvMapper-utils';
+import { getCsvMapperErrorMessage } from './csvMapper-utils';
 
 const csvMapperResolvers: Resolvers = {
   Query: {
@@ -10,7 +10,7 @@ const csvMapperResolvers: Resolvers = {
     csvMapperSchemaAttributes: (_, __, context) => csvMapperSchemaAttributes(context, context.user),
   },
   CsvMapper: {
-    errors: (csvMapper, _, context) => errors(context, context.user, csvMapper),
+    errors: (csvMapper, _, context) => getCsvMapperErrorMessage(context, context.user, csvMapper),
     representations: (csvMapper, _, context) => getParsedRepresentations(context, context.user, csvMapper)
   },
   Mutation: {

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
@@ -126,7 +126,7 @@ export const isValidRepresentationType = (representation: CsvMapperRepresentatio
 
 export const validateCsvMapper = async (context: AuthContext, user: AuthUser, mapper: CsvMapperParsed) => {
   if (!Array.isArray(mapper.representations) || mapper.representations.some((rep) => !isCsvMapperRepresentation(rep))) {
-    throw FunctionalError('CSV mapper representations is not an array of CsvMapperRepresentation objects', { mapper_name: mapper?.name });
+    throw FunctionalError('CSV mapper representations is not an array of CsvMapperRepresentation objects', { mapper_name: mapper.name });
   }
 
   // consider empty csv mapper as invalid to avoid being used in the importer

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
@@ -55,7 +55,7 @@ export const parseCsvMapper = (mapper: any): CsvMapperParsed => {
     }
   }
   if (!Array.isArray(representations) || representations.some((rep) => !isCsvMapperRepresentation(rep))) {
-    throw FunctionalError('Could not parse CSV mapper: representations is not an array of CsvMapperRepresentation', { name: mapper?.name });
+    throw FunctionalError('Could not parse CSV mapper: representations is not an array of CsvMapperRepresentation objects', { name: mapper?.name });
   }
   return {
     ...mapper,

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
@@ -31,6 +31,12 @@ export interface CsvMapperSchemaAttributes {
   attributes: CsvMapperSchemaAttribute[]
 }
 
+// TS typeguard on CsvMapperRepresentation
+const isCsvMapperRepresentation = (object: any): object is CsvMapperRepresentation => {
+  // this is a basic validation; TODO: json validation
+  return object.id && (object.type === CsvMapperRepresentationType.Entity || object.type === CsvMapperRepresentationType.Relationship);
+};
+
 const representationLabel = (idx: number, representation: CsvMapperRepresentation) => {
   const number = `#${idx + 1}`;
   if (isEmptyField(representation.target.entity_type)) {
@@ -39,19 +45,30 @@ const representationLabel = (idx: number, representation: CsvMapperRepresentatio
   return `${number} ${representation.target.entity_type}`;
 };
 
-export const parseCsvMapper = (entity: any): CsvMapperParsed => {
+export const parseCsvMapper = (mapper: any): CsvMapperParsed => {
+  let representations: CsvMapperRepresentation[] = mapper?.representations ?? [];
+  if (typeof mapper?.representations === 'string') {
+    try {
+      representations = JSON.parse(mapper.representations);
+    } catch (error) {
+      throw FunctionalError('Could not parse CSV mapper: representations is not a valid JSON', { name: mapper?.name, error });
+    }
+  }
+  if (!Array.isArray(representations) || representations.some((rep) => !isCsvMapperRepresentation(rep))) {
+    throw FunctionalError('Could not parse CSV mapper: representations is not an array of CsvMapperRepresentation', { name: mapper?.name });
+  }
   return {
-    ...entity,
-    representations: typeof entity.representations === 'string' ? JSON.parse(entity.representations) : entity.representations,
+    ...mapper,
+    representations,
   };
 };
 
-export const parseCsvMapperWithDefaultValues = async (context: AuthContext, user: AuthUser, entity: any): Promise<CsvMapperResolved> => {
-  if (typeof entity?.representations !== 'string') {
-    return entity;
+export const parseCsvMapperWithDefaultValues = async (context: AuthContext, user: AuthUser, mapper: any): Promise<CsvMapperResolved> => {
+  if (typeof mapper?.representations !== 'string') {
+    return mapper;
   }
 
-  const parsedRepresentations: CsvMapperRepresentation[] = JSON.parse(entity.representations);
+  const { representations: parsedRepresentations } = parseCsvMapper(mapper);
   const refAttributesIndexes: string[] = [];
   const refDefaultValues = parsedRepresentations.flatMap((representation, i) => {
     const refsDefinition = schemaRelationsRefDefinition
@@ -72,7 +89,7 @@ export const parseCsvMapperWithDefaultValues = async (context: AuthContext, user
 
   const entities = await internalFindByIds<BasicStoreEntity>(context, user, refDefaultValues);
   return {
-    ...entity,
+    ...mapper,
     representations: parsedRepresentations.map((representation, i) => ({
       ...representation,
       attributes: representation.attributes.map((attribute, j) => ({

--- a/opencti-platform/opencti-graphql/src/parser/csv-bundler.ts
+++ b/opencti-platform/opencti-graphql/src/parser/csv-bundler.ts
@@ -1,7 +1,7 @@
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
 import type { AuthContext, AuthUser } from '../types/user';
 import type { CsvMapperParsed } from '../modules/internal/csvMapper/csvMapper-types';
-import { sanitized, validate } from '../modules/internal/csvMapper/csvMapper-utils';
+import { sanitized, validateCsvMapper } from '../modules/internal/csvMapper/csvMapper-utils';
 import { BundleBuilder } from './bundle-creator';
 import { type InputType, mappingProcess } from './csv-mapper';
 import { convertStoreToStix } from '../database/stix-converter';
@@ -35,7 +35,7 @@ export const bundleProcess = async (
   mapper: CsvMapperParsed,
   entity?: BasicStoreBase
 ) => {
-  await validate(context, user, mapper);
+  await validateCsvMapper(context, user, mapper);
   const sanitizedMapper = sanitized(mapper);
 
   const bundleBuilder = new BundleBuilder();

--- a/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
@@ -11,7 +11,7 @@ import { extractValueFromCsv } from './csv-helper';
 import { isStixRelationshipExceptRef } from '../schema/stixRelationship';
 import type { AttributeColumn, CsvMapperParsed, CsvMapperRepresentation, CsvMapperRepresentationAttribute } from '../modules/internal/csvMapper/csvMapper-types';
 import { CsvMapperRepresentationType, Operator } from '../modules/internal/csvMapper/csvMapper-types';
-import { getHashesNames, isValidTargetType } from '../modules/internal/csvMapper/csvMapper-utils';
+import { getHashesNames, isValidRepresentationType } from '../modules/internal/csvMapper/csvMapper-utils';
 import { fillDefaultValues, getAttributesConfiguration, getEntitySettingFromCache } from '../modules/entitySetting/entitySetting-utils';
 import type { AuthContext, AuthUser } from '../types/user';
 import { UnsupportedError } from '../config/errors';
@@ -88,7 +88,7 @@ const computeDefaultValue = (
 
 const isValidTarget = (record: string[], representation: CsvMapperRepresentation) => {
   // Target type
-  isValidTargetType(representation);
+  isValidRepresentationType(representation);
 
   // Column based
   const columnBased = representation.target.column_based;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-utils-test.ts
@@ -1,12 +1,12 @@
 import { assert, describe, expect, it } from 'vitest';
 import { csvMapperMockSimpleDifferentEntities } from '../../data/csv-mapper-mock-simple-different-entities';
-import { validate } from '../../../src/modules/internal/csvMapper/csvMapper-utils';
+import { validateCsvMapper } from '../../../src/modules/internal/csvMapper/csvMapper-utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import type { CsvMapperParsed } from '../../../src/modules/internal/csvMapper/csvMapper-types';
 
 describe('CSV Mapper', () => {
   it('validate a valid mapper', async () => {
-    await validate(testContext, ADMIN_USER, {
+    await validateCsvMapper(testContext, ADMIN_USER, {
       ...csvMapperMockSimpleDifferentEntities as CsvMapperParsed,
       name: 'Valid Mapper'
     });
@@ -14,13 +14,13 @@ describe('CSV Mapper', () => {
   });
   it('invalidate a invalid mapper', async () => {
     const mapper = csvMapperMockSimpleDifferentEntities as CsvMapperParsed;
-    await expect(() => validate(testContext, ADMIN_USER, {
+    await expect(() => validateCsvMapper(testContext, ADMIN_USER, {
       ...mapper,
       name: 'Invalid Mapper',
       representations: [], // cannot have 0 representations
     })).rejects.toThrowError('CSV Mapper \'Invalid Mapper\' has no representation');
 
-    await expect(() => validate(testContext, ADMIN_USER, {
+    await expect(() => validateCsvMapper(testContext, ADMIN_USER, {
       ...mapper,
       name: 'Invalid Mapper',
       representations: [

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-utils-test.ts
@@ -18,7 +18,7 @@ describe('CSV Mapper', () => {
       ...mapper,
       name: 'Invalid Mapper',
       representations: [], // cannot have 0 representations
-    })).rejects.toThrowError('CSV Mapper \'Invalid Mapper\' has no representation');
+    })).rejects.toThrowError('CSV Mapper has no representation');
 
     await expect(() => validateCsvMapper(testContext, ADMIN_USER, {
       ...mapper,

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
@@ -290,6 +290,34 @@ describe('CSV Mapper Resolver', () => {
     addedMapper = csvMapperAdd;
   });
 
+  it('should fail to create a mapper with malformed JSON representations', async () => {
+    const { errors } = await queryAsAdmin({
+      query: CREATE_QUERY,
+      variables: {
+        input: {
+          ...MAPPER_INPUT,
+          representations: '{ invalid // json --',
+        }
+      },
+    });
+    expect(errors).toBeDefined();
+    expect(errors[0].message).toBe('Could not parse CSV mapper: representations is not a valid JSON');
+  });
+
+  it('should fail to create a mapper with invalid representations', async () => {
+    const { errors } = await queryAsAdmin({
+      query: CREATE_QUERY,
+      variables: {
+        input: {
+          ...MAPPER_INPUT,
+          representations: JSON.stringify('{ "id": "test", "type": "InvalidType" }'),
+        }
+      },
+    });
+    expect(errors).toBeDefined();
+    expect(errors[0].message).toBe('Could not parse CSV mapper: representations is not an array of CsvMapperRepresentation objects');
+  });
+
   it('should retrieve a mapper by internal id', async () => {
     const { data } = await queryAsAdmin({
       query: READ_QUERY,

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvMapper-test.js
@@ -315,7 +315,7 @@ describe('CSV Mapper Resolver', () => {
       },
     });
     expect(errors).toBeDefined();
-    expect(errors[0].message).toBe('Could not parse CSV mapper: representations is not an array of CsvMapperRepresentation objects');
+    expect(errors[0].message).toBe('CSV mapper representations is not an array of CsvMapperRepresentation objects');
   });
 
   it('should retrieve a mapper by internal id', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add a validation step when parsing the representation (opaque JSON field) of a CSV mapper, to throw a meaningful error if there is an issue.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #6886

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
