### PR TITLE
[frontend] Remove copy/paste button for simpleError component (#5548-fix-frontend)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -360,7 +360,6 @@
   "Copy": "Kopieren",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "Kopieren deaktiviert: zu viele ausgewählte Elemente (maximale Anzahl von Elementen für eine Kopie:",
   "Copy link": "Link kopieren",
-  "Copy stack trace errors": "Stacktrace-Fehler kopieren",
   "Copy uri to clipboard for your csv client": "Kopiere uri in die Zwischenablage für deinen csv Client",
   "Copy uri to clipboard for your Taxii client": "Kopiere uri in die Zwischenablage für deinen Taxii-Client",
   "Copy/paste text content": "Kopieren/Einfügen von Textinhalten",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -360,7 +360,6 @@
   "copy": "copy",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "Copy disabled: too many selected elements (maximum number of elements for a copy: ",
   "Copy link": "Copy link",
-  "Copy stack trace errors": "Copy stack trace errors",
   "Copy uri to clipboard for your csv client": "Copy uri to clipboard for your csv client",
   "Copy uri to clipboard for your Taxii client": "Copy uri to clipboard for your Taxii client",
   "Copy/paste text content": "Copy/paste text content",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -360,7 +360,6 @@
   "copy": "copia",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "Copia deshabilitada: demasiados elementos seleccionados (número máximo de elementos para una copia: ",
   "Copy link": "Copiar enlace",
-  "Copy stack trace errors": "Copiar errores de seguimiento de pila",
   "Copy uri to clipboard for your csv client": "Copiar uri al portapapeles para su cliente csv",
   "Copy uri to clipboard for your Taxii client": "Copiar uri al portapapeles para su cliente Taxii",
   "Copy/paste text content": "Copiar o pegar contenido textual",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -360,7 +360,6 @@
   "copy": "copie",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "Copie désactivée : trop d’éléments sélectionnés (nombre maximum d'éléments pour une copie: ",
   "Copy link": "Copier le lien",
-  "Copy stack trace errors": "Copier les erreurs de la trace de pile",
   "Copy uri to clipboard for your csv client": "Copier l'uri dans le presse-papier pour votre client csv",
   "Copy uri to clipboard for your Taxii client": "Copier l'uri dans le presse-papier pour votre client Taxii",
   "Copy/paste text content": "Copier/coller du contenu textuel",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -360,7 +360,6 @@
   "copy": "コピー",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "コピー無効:選択した要素が多すぎます(コピーの要素の最大数:",
   "Copy link": "リンクをコピー",
-  "Copy stack trace errors": "スタックトレースエラーのコピー",
   "Copy uri to clipboard for your csv client": "csvクライアント用にuriをクリップボードにコピーする",
   "Copy uri to clipboard for your Taxii client": "TaxiiクライアントのURIをクリップボードにコピーする",
   "Copy/paste text content": "コンテンツのコピー/ペースト",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -360,7 +360,6 @@
   "copy": "复制",
   "Copy disabled: too many selected elements (maximum number of elements for a copy: ": "复制已关闭：选取元素过多（复制的最大元素数：",
   "Copy link": "复制链接",
-  "Copy stack trace errors": "复制堆栈跟踪错误",
   "Copy uri to clipboard for your csv client": "将 uri 复制到剪贴板，供 csv 客户端使用",
   "Copy uri to clipboard for your Taxii client": "为 Taxii 客户端复制 uri 到剪贴板",
   "Copy/paste text content": "复制/粘贴文本内容",

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -3,19 +3,13 @@ import { includes, map } from 'ramda';
 import * as PropTypes from 'prop-types';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import { IconButton, Tooltip } from '@mui/material';
-import { ContentCopyOutlined } from '@mui/icons-material';
 import ErrorNotFound from '../../components/ErrorNotFound';
 import { useFormatter } from '../../components/i18n';
-import { copyToClipboard } from '../../utils/utils';
 
 // Really simple error display
-export const SimpleError = ({ errorData }) => {
+export const SimpleError = () => {
   const { t_i18n } = useFormatter();
-  const errorDetails = JSON.stringify(errorData, null, 2);
-  const copyClick = () => {
-    copyToClipboard(t_i18n, errorDetails);
-  };
+
   return (
     <div style={{ paddingTop: 28 }}>
       <Alert severity="error">
@@ -23,11 +17,6 @@ export const SimpleError = ({ errorData }) => {
         <span style={{ marginRight: 10 }}>
           {t_i18n('An unknown error occurred. Please contact your administrator or the OpenCTI maintainers.')}
         </span>
-        <Tooltip title={t_i18n('Copy stack trace errors')}>
-          <IconButton onClick={copyClick} size="small" color="error">
-            <ContentCopyOutlined/>
-          </IconButton>
-        </Tooltip>
       </Alert>
     </div>
   );
@@ -63,7 +52,7 @@ class ErrorBoundaryComponent extends React.Component {
         throw this.state.error;
       }
       const DisplayComponent = this.props.display || SimpleError;
-      return <DisplayComponent errorData={retroErrors} />;
+      return <DisplayComponent />;
     }
     return this.props.children;
   }


### PR DESCRIPTION
### Proposed changes

* As the feature was not really understood and is not ready yet, we've decided to remove the button of the copy/paste in frontend error and changes will be made in the releated issue

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6904

