### PR TITLE
[frontend/backend] Fix incorrect use of stixCoreRelationshipDistribution queries (#6873)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -170,7 +170,6 @@ const GroupingDetailsComponent = (props) => {
               dataSelection={entitiesDistributionDataSelection}
               parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
-              withExportPopover={true}
               isReadOnly={true}
             />
           </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -19,6 +19,7 @@ import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const styles = (theme) => ({
   paper: {
@@ -112,7 +113,7 @@ const GroupingDetailsComponent = (props) => {
   });
   const expandable = grouping.relatedContainers.edges.length > 5;
 
-  const entitiesDidstributionDataSelection = [
+  const entitiesDistributionDataSelection = [
     {
       label: '',
       attribute: 'entity_type',
@@ -133,16 +134,8 @@ const GroupingDetailsComponent = (props) => {
         ],
         filterGroups: [],
       },
-      dynamicFrom: {
-        mode: 'and',
-        filters: [],
-        filterGroups: [],
-      },
-      dynamicTo: {
-        mode: 'and',
-        filters: [],
-        filterGroups: [],
-      },
+      dynamicFrom: emptyFilterGroup,
+      dynamicTo: emptyFilterGroup,
     },
   ];
 
@@ -174,8 +167,8 @@ const GroupingDetailsComponent = (props) => {
               startDate={null}
               endDate={null}
               relationshipType="object"
-              dataSelection={entitiesDidstributionDataSelection}
-              parameters={'Entities distribution'}
+              dataSelection={entitiesDistributionDataSelection}
+              parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
               withExportPopover={true}
               isReadOnly={true}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -14,9 +14,9 @@ import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
+import StixRelationshipsHorizontalBars from '@components/common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
-import EntityStixCoreRelationshipsHorizontalBars from '../../common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 
@@ -111,6 +111,41 @@ const GroupingDetailsComponent = (props) => {
     setHeight(ref.current.clientHeight);
   });
   const expandable = grouping.relatedContainers.edges.length > 5;
+
+  const dataSelection = [
+    {
+      label: '',
+      attribute: 'entity_type',
+      date_attribute: 'first_seen',
+      perspective: 'relationships',
+      isTo: true,
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'relationship_type',
+            values: [
+              'object',
+            ],
+            operator: 'eq',
+            mode: 'or',
+          },
+        ],
+        filterGroups: [],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [],
+        filterGroups: [],
+      },
+      dynamicTo: {
+        mode: 'and',
+        filters: [],
+        filterGroups: [],
+      },
+    },
+  ];
+
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>
@@ -133,15 +168,17 @@ const GroupingDetailsComponent = (props) => {
             <Chip classes={{ root: classes.chip }} label={grouping.context} />
           </Grid>
           <Grid item={true} xs={6} style={{ minHeight: 200, maxHeight: height }}>
-            <EntityStixCoreRelationshipsHorizontalBars
-              title={t('Entities distribution')}
-              variant="inEntity"
+            <StixRelationshipsHorizontalBars
+              isWidget={false}
               fromId={grouping.id}
-              toTypes={['Stix-Core-Object']}
+              startDate={null}
+              endDate={null}
               relationshipType="object"
-              field="entity_type"
-              seriesName={t('Number of entities')}
-              isTo={true}
+              dataSelection={dataSelection}
+              parameters={'Entities distribution'}
+              variant="inLine"
+              withExportPopover={true}
+              isReadOnly={true}
             />
           </Grid>
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -14,7 +14,7 @@ import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
-import StixRelationshipsHorizontalBars from '@components/common/stix_relationships/StixRelationshipsHorizontalBars';
+import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -112,7 +112,7 @@ const GroupingDetailsComponent = (props) => {
   });
   const expandable = grouping.relatedContainers.edges.length > 5;
 
-  const dataSelection = [
+  const entitiesDidstributionDataSelection = [
     {
       label: '',
       attribute: 'entity_type',
@@ -174,9 +174,9 @@ const GroupingDetailsComponent = (props) => {
               startDate={null}
               endDate={null}
               relationshipType="object"
-              dataSelection={dataSelection}
+              dataSelection={entitiesDidstributionDataSelection}
               parameters={'Entities distribution'}
-              variant="inLine"
+              variant="inEntity"
               withExportPopover={true}
               isReadOnly={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -14,9 +14,9 @@ import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
+import StixRelationshipsHorizontalBars from '@components/common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
-import EntityStixCoreRelationshipsHorizontalBars from '../../common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
@@ -122,6 +122,41 @@ const ReportDetailsComponent = (props) => {
   ).filter(
     (relatedContainerEdge) => relatedContainerEdge.node.id !== report.id,
   );
+
+  const dataSelection = [
+    {
+      label: '',
+      attribute: 'entity_type',
+      date_attribute: 'first_seen',
+      perspective: 'relationships',
+      isTo: true,
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'relationship_type',
+            values: [
+              'object',
+            ],
+            operator: 'eq',
+            mode: 'or',
+          },
+        ],
+        filterGroups: [],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [],
+        filterGroups: [],
+      },
+      dynamicTo: {
+        mode: 'and',
+        filters: [],
+        filterGroups: [],
+      },
+    },
+  ];
+
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>
@@ -164,15 +199,17 @@ const ReportDetailsComponent = (props) => {
             xs={6}
             style={{ minHeight: 200, maxHeight: height }}
           >
-            <EntityStixCoreRelationshipsHorizontalBars
-              title={t('Entities distribution')}
-              variant="inEntity"
+            <StixRelationshipsHorizontalBars
+              isWidget={false}
               fromId={report.id}
-              toTypes={['Stix-Core-Object']}
+              startDate={null}
+              endDate={null}
               relationshipType="object"
-              field="entity_type"
-              seriesName={t('Number of entities')}
-              isTo={true}
+              dataSelection={dataSelection}
+              parameters={'Entities distribution'}
+              variant="inLine"
+              withExportPopover={true}
+              isReadOnly={true}
             />
           </Grid>
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -201,7 +201,6 @@ const ReportDetailsComponent = (props) => {
               dataSelection={entitiesDistributionDataSelection}
               parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
-              withExportPopover={true}
               isReadOnly={true}
             />
           </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -14,7 +14,7 @@ import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
-import StixRelationshipsHorizontalBars from '@components/common/stix_relationships/StixRelationshipsHorizontalBars';
+import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -123,7 +123,7 @@ const ReportDetailsComponent = (props) => {
     (relatedContainerEdge) => relatedContainerEdge.node.id !== report.id,
   );
 
-  const dataSelection = [
+  const entitiesDidstributionDataSelection = [
     {
       label: '',
       attribute: 'entity_type',
@@ -205,9 +205,9 @@ const ReportDetailsComponent = (props) => {
               startDate={null}
               endDate={null}
               relationshipType="object"
-              dataSelection={dataSelection}
+              dataSelection={entitiesDidstributionDataSelection}
               parameters={'Entities distribution'}
-              variant="inLine"
+              variant="inEntity"
               withExportPopover={true}
               isReadOnly={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -20,6 +20,7 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 
 const styles = (theme) => ({
   paper: {
@@ -123,7 +124,7 @@ const ReportDetailsComponent = (props) => {
     (relatedContainerEdge) => relatedContainerEdge.node.id !== report.id,
   );
 
-  const entitiesDidstributionDataSelection = [
+  const entitiesDistributionDataSelection = [
     {
       label: '',
       attribute: 'entity_type',
@@ -144,16 +145,8 @@ const ReportDetailsComponent = (props) => {
         ],
         filterGroups: [],
       },
-      dynamicFrom: {
-        mode: 'and',
-        filters: [],
-        filterGroups: [],
-      },
-      dynamicTo: {
-        mode: 'and',
-        filters: [],
-        filterGroups: [],
-      },
+      dynamicFrom: emptyFilterGroup,
+      dynamicTo: emptyFilterGroup,
     },
   ];
 
@@ -205,8 +198,8 @@ const ReportDetailsComponent = (props) => {
               startDate={null}
               endDate={null}
               relationshipType="object"
-              dataSelection={entitiesDidstributionDataSelection}
-              parameters={'Entities distribution'}
+              dataSelection={entitiesDistributionDataSelection}
+              parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
               withExportPopover={true}
               isReadOnly={true}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.jsx
@@ -9,7 +9,7 @@ import WidgetLoader from '../../../../components/dashboard/WidgetLoader';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
 import useDistributionGraphData from '../../../../utils/hooks/useDistributionGraphData';
 
-const stixRelationshipsHorizontalBarsDistributionQuery = graphql`
+export const stixRelationshipsHorizontalBarsDistributionQuery = graphql`
   query StixRelationshipsHorizontalBarsDistributionQuery(
     $field: String!
     $operation: StatsOperation!
@@ -108,10 +108,13 @@ const StixRelationshipsHorizontalBars = ({
   withoutTitle,
   height,
   field,
+  isWidget = true,
   startDate,
   endDate,
   dateAttribute,
   dataSelection,
+  fromId,
+  relationshipType,
   parameters = {},
   withExportPopover = false,
   isReadOnly = false,
@@ -136,6 +139,9 @@ const StixRelationshipsHorizontalBars = ({
       operation: 'count',
       startDate,
       endDate,
+      fromId,
+      toTypes: !isWidget ? ['Stix-Core-Object'] : null,
+      relationship_type: !isWidget ? relationshipType : null,
       dateAttribute: dateAttribute || dataSelectionDateAttribute,
       limit: selection.number ?? 10,
       filters: filtersAndOptions?.filters,

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -1,4 +1,5 @@
 import * as R from 'ramda';
+import { UserInputError } from 'apollo-server-express';
 import { delEditContext, notify, setEditContext } from '../database/redis';
 import { createRelation, deleteElementById, deleteRelationsByFromAndTo, timeSeriesRelations, updateAttribute } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
@@ -29,9 +30,7 @@ const buildStixCoreRelationshipTypes = (relationshipTypes) => {
   }
   const isValidRelationshipTypes = relationshipTypes.every((type) => isStixCoreRelationship(type));
   if (!isValidRelationshipTypes) {
-    // TODO: we disable this error because query stixCoreRelationshipsDistribution is used
-    // in widgets that should call stixRelationshipsDistribution instead
-    // throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship');
+    throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship');
   }
   return relationshipTypes;
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -74,7 +74,7 @@ const buildRelationshipTypes = (relationshipTypes) => {
   const isValidRelationshipTypes = relationshipTypes.every((type) => isStixRelationship(type));
 
   if (!isValidRelationshipTypes) {
-    throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship, stix-sighting-relationship or object');
+    throw new UserInputError('Invalid argument: relationship_type is not a stix-relationship');
   }
   return relationshipTypes;
 };

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
@@ -77,6 +77,10 @@ describe('StixCoreRelationship resolver standard behavior', () => {
     expect(queryResult.data.stixCoreRelationshipsNumber.total).toEqual(1);
     const queryResult2 = await queryAsAdmin({ query: NUMBER_QUERY, variables: { relationship_type: 'stix-core-relationship' } });
     expect(queryResult2.data.stixCoreRelationshipsNumber.total).toEqual(25);
+    const queryResult3 = await queryAsAdmin({ query: NUMBER_QUERY, variables: { relationship_type: 'stix-relationship' } });
+    expect(queryResult3).not.toBeNull();
+    expect(queryResult3.errors.length).toEqual(1);
+    expect(queryResult3.errors.at(0).message).toEqual('Invalid argument: relationship_type is not a stix-core-relationship');
   });
   it('should update stixCoreRelationship', async () => {
     const UPDATE_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
@@ -75,7 +75,7 @@ describe('StixCoreRelationship resolver standard behavior', () => {
       variables: { relationship_type: ['uses'], fromId: [campaign.internal_id] },
     });
     expect(queryResult.data.stixCoreRelationshipsNumber.total).toEqual(1);
-    const queryResult2 = await queryAsAdmin({ query: NUMBER_QUERY, variables: { relationship_type: 'stix-relationship' } });
+    const queryResult2 = await queryAsAdmin({ query: NUMBER_QUERY, variables: { relationship_type: 'stix-core-relationship' } });
     expect(queryResult2.data.stixCoreRelationshipsNumber.total).toEqual(25);
   });
   it('should update stixCoreRelationship', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use `StixRelationshipsHorizontalBars` instead of ` EntityStixCoreRelationshipsHorizontalBars` in `GroupingDetails` and `reportDetails` components => these were the only 2 components where  `EntityStixCoreRelationshipsHorizontalBars` used an `object` relationshipType
*  error  throws for stixCoreRelationshipDistribution query is not commented any more.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [issue/6873](https://github.com/OpenCTI-Platform/opencti/issues/6873)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
