### PR TITLE
[frontend] displays ContainerStixCoreObjectPopover if update capability (#6920)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
@@ -20,6 +20,8 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import ContainerStixCoreObjectPopover from './ContainerStixCoreObjectPopover';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -148,16 +150,18 @@ const ContainerStixCoreObjectLineComponent = (props) => {
             <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
           </Tooltip>
         ) : (
-          <ContainerStixCoreObjectPopover
-            containerId={containerId}
-            toId={node.id}
-            toStandardId={node.standard_id}
-            relationshipType="object"
-            paginationKey="Pagination_objects"
-            paginationOptions={paginationOptions}
-            contentMappingData={contentMappingData}
-            mapping={contentMapping[node.standard_id]}
-          />
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <ContainerStixCoreObjectPopover
+              containerId={containerId}
+              toId={node.id}
+              toStandardId={node.standard_id}
+              relationshipType="object"
+              paginationKey="Pagination_objects"
+              paginationOptions={paginationOptions}
+              contentMappingData={contentMappingData}
+              mapping={contentMapping[node.standard_id]}
+            />
+          </Security>
         )}
       </ListItemSecondaryAction>
     </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
@@ -21,6 +21,8 @@ import { renderObservableValue } from '../../../../utils/String';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import ItemIcon from '../../../../components/ItemIcon';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -215,17 +217,19 @@ const ContainerStixCyberObservableLineComponent = (props) => {
             <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
           </Tooltip>
         ) : (
-          <ContainerStixCoreObjectPopover
-            containerId={containerId}
-            toId={node.id}
-            toStandardId={node.standard_id}
-            menuDisable={isOnlyThroughInference}
-            relationshipType="object"
-            paginationKey="Pagination_objects"
-            paginationOptions={paginationOptions}
-            selectedElements={selectedElements}
-            setSelectedElements={setSelectedElements}
-          />
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <ContainerStixCoreObjectPopover
+              containerId={containerId}
+              toId={node.id}
+              toStandardId={node.standard_id}
+              menuDisable={isOnlyThroughInference}
+              relationshipType="object"
+              paginationKey="Pagination_objects"
+              paginationOptions={paginationOptions}
+              selectedElements={selectedElements}
+              setSelectedElements={setSelectedElements}
+            />
+          </Security>
         )}
       </ListItemSecondaryAction>
     </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -22,6 +22,8 @@ import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -215,14 +217,16 @@ const ContainerStixDomainObjectLineComponent = (props) => {
             <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
           </Tooltip>
         ) : (
-          <ContainerStixCoreObjectPopover
-            containerId={containerId}
-            toId={node.id}
-            toStandardId={node.standard_id}
-            relationshipType="object"
-            paginationKey="Pagination_objects"
-            paginationOptions={paginationOptions}
-          />
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <ContainerStixCoreObjectPopover
+              containerId={containerId}
+              toId={node.id}
+              toStandardId={node.standard_id}
+              relationshipType="object"
+              paginationKey="Pagination_objects"
+              paginationOptions={paginationOptions}
+            />
+          </Security>
         )}
       </ListItemSecondaryAction>
     </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -22,7 +22,7 @@ import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
@@ -19,6 +19,8 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import { hexToRGB, itemColor } from '../../../../utils/Colors';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -148,14 +150,16 @@ const ContainerStixObjectOrStixRelationshipLineComponent = ({
         }
       />
       <ListItemSecondaryAction>
-        <ContainerStixCoreObjectPopover
-          containerId={containerId}
-          toId={node.id}
-          toStandardId={node.standard_id}
-          relationshipType="object"
-          paginationKey="Pagination_objects"
-          paginationOptions={paginationOptions}
-        />
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <ContainerStixCoreObjectPopover
+            containerId={containerId}
+            toId={node.id}
+            toStandardId={node.standard_id}
+            relationshipType="object"
+            paginationKey="Pagination_objects"
+            paginationOptions={paginationOptions}
+          />
+        </Security>
       </ListItemSecondaryAction>
     </ListItem>
   );


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* wrap `ContainerStixCoreObjectPopover` with `<Security/>` component to avoid popover display if no right to update container


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [issue/6920](https://github.com/OpenCTI-Platform/opencti/issues/6920)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
