### PR TITLE
[api] Add 'family' option to Redis client initialisation (#6944)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -120,7 +120,7 @@ export const createRedisClient = async (provider: string, autoReconnect = false)
     client = new Redis(sentinelOpts);
   } else {
     const singleOptions = await redisOptions(autoReconnect);
-    client = new Redis({ ...singleOptions, port: conf.get('redis:port'), host: conf.get('redis:hostname') });
+    client = new Redis({ ...singleOptions, port: conf.get('redis:port'), host: conf.get('redis:hostname'), family: conf.get('redis:host_ip_family') ?? 4} });
   }
 
   client.on('close', () => logApp.info(`[REDIS] Redis '${provider}' client closed`));


### PR DESCRIPTION
### Proposed changes

Add extra parameter for setting IP-address family in ioredis client. It allows to work with Redis servers having only IPv6 address.

### Related issues
* https://github.com/OpenCTI-Platform/opencti/issues/6944