### PR TITLE
[frontend] always enable confidence level field in admin screens (#6718)

### DIFF
--- a/opencti-platform/opencti-front/src/components/InputSliderField.tsx
+++ b/opencti-platform/opencti-front/src/components/InputSliderField.tsx
@@ -61,6 +61,8 @@ const InputSliderField: FunctionComponent<InputSliderFieldProps & FieldProps> = 
 
   const [initialValue] = useState(value);
   if (variant === 'edit') {
+    // disabled prop is "forced", be it true or false
+    const finalDisabled = (disabled === true || disabled === false) ? disabled : initialValue > max;
     return (
       <>
         <Grid container={true} spacing={3} >
@@ -73,7 +75,7 @@ const InputSliderField: FunctionComponent<InputSliderFieldProps & FieldProps> = 
               label={label}
               onSubmit={onSubmit}
               onFocus={onFocus}
-              disabled={disabled || initialValue > max}
+              disabled={finalDisabled}
               helpertext={
                 <SubscriptionFocus context={editContext} fieldName={name} />
               }
@@ -85,7 +87,7 @@ const InputSliderField: FunctionComponent<InputSliderFieldProps & FieldProps> = 
               labelId={name}
               value={currentLevel.level.value?.toString() ?? ''}
               onChange={updateFromSelect}
-              disabled={disabled || initialValue > max}
+              disabled={finalDisabled}
               sx={{ marginTop: 2 }} // to align field with the number input, that has a label
             >
               {marks.map((mark, i: number) => {
@@ -112,7 +114,7 @@ const InputSliderField: FunctionComponent<InputSliderFieldProps & FieldProps> = 
           valueLabelDisplay="off"
           size="small"
           valueLabelFormat={() => currentLevel.level.label}
-          disabled={disabled || initialValue > max}
+          disabled={finalDisabled}
         />
       </>
     );

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -49,7 +49,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   const finalLabel = label || t_i18n('Confidence level');
   const classes = useStyles();
   const { getEffectiveConfidenceLevel } = useConfidenceLevel();
-  const getConfidenceLevel = getEffectiveConfidenceLevel(entityType);
+  const userEffectiveMaxConfidence = getEffectiveConfidenceLevel(entityType);
   return (
     <Alert
       classes={{ root: classes.alert, message: classes.message }}
@@ -72,7 +72,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
         onSubmit={onSubmit}
         editContext={editContext}
         disabled={disabled}
-        maxLimit={getConfidenceLevel}
+        maxLimit={userEffectiveMaxConfidence}
       />
     </Alert>
   );

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionOverview.tsx
@@ -238,6 +238,7 @@ const GroupEditionOverviewComponent: FunctionComponent<GroupEditionOverviewCompo
                   containerStyle={fieldSpacingContainerStyle}
                   editContext={context}
                   variant="edit"
+                  disabled={false}
                 />
               )
             }

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserConfidenceLevelField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserConfidenceLevelField.tsx
@@ -128,7 +128,7 @@ const UserConfidenceLevelField: FunctionComponent<UserConfidenceLevelFieldProps>
         onFocus={onFocus}
         onSubmit={onSubmit}
         editContext={editContext}
-        disabled={!switchValue || disabled}
+        disabled={Boolean(!switchValue || disabled)}
         variant="edit"
       />
     </Alert>


### PR DESCRIPTION
When incorrectly set (through API), confidence level can be greater than 100. This caused the edition field to be disabled (as your own level is 100, which would be lower).

### Proposed changes

* make sure to never disable the confidence field in user and group admin screens, even if the value is greater than the max

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #6718 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
