### PR TITLE
[backend] improve report cascade delete algorithm to prevent Already deleted error (#6874)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -136,11 +136,11 @@ const buildReportDeleteElementsFilter = (reportId) => {
   };
 };
 export const reportDeleteWithElements = async (context, user, reportId) => {
-  // Load all report objects
+  // Load all entities & relationships contained only in this report (orphans)
   const args = { filters: buildReportDeleteElementsFilter(reportId) };
-  const reportObjects = await listAllThings(context, user, [ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP], args);
+  const reportOrphanObjects = await listAllThings(context, user, [ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP], args);
   // Filter out relationships that will already be deleted with the deletion of the source or target element
-  const objectsToDelete = reportObjects.filter((filterObject) => !reportObjects.some((o) => filterObject.fromId === o.internal_id || filterObject.toId === o.internal_id));
+  const objectsToDelete = reportOrphanObjects.filter((fo) => !reportOrphanObjects.some((o) => fo.fromId === o.internal_id || fo.toId === o.internal_id));
   await BluePromise.map(objectsToDelete, (object) => {
     return internalDeleteElementById(context, context.user, object.id);
   }, { concurrency: ES_MAX_CONCURRENCY });

--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -1,4 +1,5 @@
 import * as R from 'ramda';
+import BluePromise from 'bluebird';
 import { createEntity, distributionEntities, internalDeleteElementById, listAllThings, timeSeriesEntities } from '../database/middleware';
 import { countAllThings, internalLoadById, listEntities, storeLoadById } from '../database/middleware-loader';
 import { BUS_TOPICS } from '../config/conf';
@@ -6,7 +7,7 @@ import { notify } from '../database/redis';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../schema/stixDomainObject';
 import { RELATION_CREATED_BY, RELATION_OBJECT } from '../schema/stixRefRelationship';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_DOMAIN_OBJECT, ABSTRACT_STIX_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
-import { elCount } from '../database/engine';
+import { elCount, ES_MAX_CONCURRENCY } from '../database/engine';
 import { READ_DATA_INDICES_WITHOUT_INFERRED, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { isStixId } from '../schema/schemaUtils';
 import { stixDomainObjectDelete } from './stixDomainObject';
@@ -135,16 +136,14 @@ const buildReportDeleteElementsFilter = (reportId) => {
   };
 };
 export const reportDeleteWithElements = async (context, user, reportId) => {
-  // Load all entities and see if they no longer have any report
-  const callback = async (objects) => {
-    for (let i = 0; i < objects.length; i += 1) {
-      const object = objects[i];
-      await internalDeleteElementById(context, context.user, object.id);
-    }
-  };
-  // Load all report objects with a callback
-  const args = { filters: buildReportDeleteElementsFilter(reportId), callback };
-  await listAllThings(context, user, [ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP], args);
+  // Load all report objects
+  const args = { filters: buildReportDeleteElementsFilter(reportId) };
+  const reportObjects = await listAllThings(context, user, [ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP], args);
+  // Filter out relationships that will already be deleted with the deletion of the source or target element
+  const objectsToDelete = reportObjects.filter((filterObject) => !reportObjects.some((o) => filterObject.fromId === o.internal_id || filterObject.toId === o.internal_id));
+  await BluePromise.map(objectsToDelete, (object) => {
+    return internalDeleteElementById(context, context.user, object.id);
+  }, { concurrency: ES_MAX_CONCURRENCY });
   // Delete the report
   await stixDomainObjectDelete(context, user, reportId);
   return reportId;

--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import BluePromise from 'bluebird';
+import { Promise as BluePromise } from 'bluebird';
 import { createEntity, distributionEntities, internalDeleteElementById, listAllThings, timeSeriesEntities } from '../database/middleware';
 import { countAllThings, internalLoadById, listEntities, storeLoadById } from '../database/middleware-loader';
 import { BUS_TOPICS } from '../config/conf';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When cascade deleting in a report, we now check that relationships from or to are not already included in the list of elements to delete. If that is the case, we don't need to delete this relationship because it will be deleted during the deletion of the source element


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6874 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
