### PR TITLE
[frontend] fix incorrect query used in RuleList (#6873)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/RulesList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/RulesList.jsx
@@ -288,7 +288,7 @@ const RulesListComponent = ({ relay, data, keyword }) => {
       y: entry.value,
     };
   });
-  const chartDataRelations = data.stixCoreRelationshipsTimeSeries.map(
+  const chartDataRelations = data.stixRelationshipsTimeSeries.map(
     (entry) => {
       const date = new Date(entry.date);
       date.setDate(date.getDate() + 15);
@@ -298,8 +298,8 @@ const RulesListComponent = ({ relay, data, keyword }) => {
       };
     },
   );
-  const totalRelations = data.stixCoreRelationshipsNumber.total;
-  const differenceRelations = totalRelations - data.stixCoreRelationshipsNumber.count;
+  const totalRelations = data.stixRelationshipsNumber.total;
+  const differenceRelations = totalRelations - data.stixRelationshipsNumber.count;
   const totalEntities = data.stixDomainObjectsNumber.total;
   const differenceEntities = totalEntities - data.stixDomainObjectsNumber.count;
   return (
@@ -725,7 +725,7 @@ export default createRefetchContainer(
           date
           value
         }
-        stixCoreRelationshipsTimeSeries(
+        stixRelationshipsTimeSeries(
           field: "created_at"
           relationship_type: ["stix-relationship"]
           operation: count
@@ -744,7 +744,7 @@ export default createRefetchContainer(
           total
           count
         }
-        stixCoreRelationshipsNumber(
+        stixRelationshipsNumber(
           relationship_type: ["stix-relationship"]
           onlyInferred: true
           endDate: $endDate

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -35,6 +35,8 @@ test('Report CRUD', async ({ page }) => {
   const reportForm = new ReportFormPage(page);
 
   await page.goto('/dashboard/analyses/reports');
+  // open nav bar once and for all
+  await leftNavigation.open();
 
   // region Check is displayed
   // -------------------------
@@ -285,7 +287,6 @@ test('Report CRUD', async ({ page }) => {
   // ------------------------
 
   await reportDetailsPage.delete();
-  await leftNavigation.open();
   await leftNavigation.clickOnMenu('Analyses', 'Reports');
   await expect(reportPage.getItemFromList('Updated test e2e')).toBeHidden();
 
@@ -318,8 +319,10 @@ test('Report live entities creation and relationships', async ({ page }) => {
   const entitiesTab = new EntitiesTabPageModel(page);
 
   await page.goto('/dashboard/analyses/reports');
-  await reportPage.openNewReportForm();
+  // open nav bar once and for all
+  await leftNavigation.open();
 
+  await reportPage.openNewReportForm();
   const reportName = `Report with created entities - ${uuid()}`;
   await reportForm.nameField.fill(reportName);
 
@@ -412,8 +415,6 @@ test('Report live entities creation and relationships', async ({ page }) => {
 
   // region Delete report
   // --------------------
-
-  await leftNavigation.open();
   await leftNavigation.clickOnMenu('Analyses', 'Reports');
   await reportPage.checkItemInList(reportName);
   await toolbar.launchDelete();

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -1,4 +1,5 @@
 import * as R from 'ramda';
+import { UserInputError } from 'apollo-server-express';
 import { delEditContext, notify, setEditContext } from '../database/redis';
 import { createRelation, deleteElementById, deleteRelationsByFromAndTo, timeSeriesRelations, updateAttribute } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
@@ -29,10 +30,7 @@ const buildStixCoreRelationshipTypes = (relationshipTypes) => {
   }
   const isValidRelationshipTypes = relationshipTypes.every((type) => isStixCoreRelationship(type));
   if (!isValidRelationshipTypes) {
-    // TODO: we disable this error because query stixCoreRelationshipsDistribution is used
-    // WARNING, WE NEED TO CHECK ALL USAGE BEFORE REMOVING THIS
-    // in widgets that should call stixRelationshipsDistribution instead
-    // throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship');
+    throw new UserInputError('Invalid argument: relationship_type is not a stix-core-relationship');
   }
   return relationshipTypes;
 };

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreRelationship-test.js
@@ -79,8 +79,8 @@ describe('StixCoreRelationship resolver standard behavior', () => {
     expect(queryResult2.data.stixCoreRelationshipsNumber.total).toEqual(25);
     const queryResult3 = await queryAsAdmin({ query: NUMBER_QUERY, variables: { relationship_type: 'stix-relationship' } });
     expect(queryResult3).not.toBeNull();
-    // expect(queryResult3.errors.length).toEqual(1);
-    // expect(queryResult3.errors.at(0).message).toEqual('Invalid argument: relationship_type is not a stix-core-relationship');
+    expect(queryResult3.errors.length).toEqual(1);
+    expect(queryResult3.errors.at(0).message).toEqual('Invalid argument: relationship_type is not a stix-core-relationship');
   });
   it('should update stixCoreRelationship', async () => {
     const UPDATE_QUERY = gql`


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

stixCoreRelationshipsNumber was also wrongly used with relationship_type `stix-relationship` ; we simply use the right query stixRelationshipsNumber instead.

We found no other mention of this query (or used with default relationship_type, so `stix-core-relationship`, which is ok).

Also, stixCoreRelationshipsTimeSeries is never used, so no worry of using it with the wrong relationship_type.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #6873 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

