### PR TITLE
[frontend ] Changes e2e tests for Report update to avoid flaky tests

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -61,12 +61,13 @@ test('Report CRUD', async ({ page }) => {
   // region Check fields validation
   // ------------------------------
 
+  const reportName = `Report - ${uuid()}`;
   await reportForm.nameField.fill('');
   await reportForm.getCreateButton().click();
   await expect(page.getByText('This field is required')).toBeVisible();
   await reportForm.nameField.fill('t');
   await expect(page.getByText('Name must be at least 2 characters')).toBeVisible();
-  await reportForm.nameField.fill('Test e2e');
+  await reportForm.nameField.fill(reportName);
   await expect(page.getByText('Name must be at least 2 characters')).toBeHidden();
 
   await reportForm.publicationDateField.clear();
@@ -116,7 +117,7 @@ test('Report CRUD', async ({ page }) => {
   await expect(reportForm.associatedFileField.getByText('report.test.md')).toBeVisible();
 
   await reportForm.getCreateButton().click();
-  await reportPage.getItemFromList('Test e2e').click();
+  await reportPage.getItemFromList(reportName).click();
   await expect(reportDetailsPage.getReportDetailsPage()).toBeVisible();
 
   // ---------
@@ -179,7 +180,7 @@ test('Report CRUD', async ({ page }) => {
   const updateDate = reportDetailsPage.getTextForHeading('Modification date', now);
   await expect(updateDate).toBeVisible();
 
-  const historyDescription = reportDetailsPage.getTextForHeading('Most recent history', 'admin creates a Report Test e2e');
+  const historyDescription = reportDetailsPage.getTextForHeading('Most recent history', `admin creates a Report ${reportName}`);
   await expect(historyDescription).toBeVisible();
   const historyDate = reportDetailsPage.getTextForHeading('Most recent history', format(new Date(), 'MMM d, yyyy'));
   await expect(historyDate).toBeVisible();
@@ -195,45 +196,64 @@ test('Report CRUD', async ({ page }) => {
   // ------------------------
 
   await reportDetailsPage.goToOverviewTab();
-  await reportDetailsPage.getEditButton().click();
 
-  await reportForm.nameField.fill('Updated test e2e');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.publicationDateField.fill('2023-12-25 18:00 PM');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.reportTypesAutocomplete.selectOption('threat-report');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.reliabilityAutocomplete.selectOption('B - Usually reliable');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.confidenceLevelField.fillInput('50');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.descriptionField.fill('Updated test e2e Description');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.authorAutocomplete.selectOption('ANSSI');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.markingsAutocomplete.selectOption('PAP:CLEAR');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.markingsAutocomplete.selectOption('PAP:GREEN');
-  await reportForm.getUpdateTitle().click();
-  await reportForm.statusAutocomplete.selectOption('IN_PROGRESS');
+  const reportNameUpdate = `Report updated - ${uuid()}`;
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.nameField.fill(reportNameUpdate);
   await reportForm.getUpdateTitle().click();
   await reportForm.getCloseButton().click();
 
-  await reportDetailsPage.openLabelsSelect();
-  await reportDetailsPage.labelsSelect.selectOption('covid-19');
-  await reportDetailsPage.addLabels();
-
-  description = reportDetailsPage.getTextForHeading('Description', 'Updated test e2e Description');
-  await expect(description).toBeVisible();
-
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.publicationDateField.fill('2023-12-25 18:00 PM');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
   publicationDate = reportDetailsPage.getTextForHeading('Publication date', 'December 25, 2023');
   await expect(publicationDate).toBeVisible();
+  originalCreationDate = reportDetailsPage.getTextForHeading('Original creation date', 'December 5, 2023');
+  await expect(originalCreationDate).toBeVisible();
 
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.reportTypesAutocomplete.selectOption('threat-report');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
   reportTypeThreat = reportDetailsPage.getTextForHeading('Report types', 'THREAT-REPORT');
   await expect(reportTypeThreat).toBeHidden();
   reportTypeMalware = reportDetailsPage.getTextForHeading('Report types', 'MALWARE');
   await expect(reportTypeMalware).toBeVisible();
 
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.reliabilityAutocomplete.selectOption('B - Usually reliable');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
+  reliability = reportDetailsPage.getTextForHeading('Reliability', 'B - Usually reliable');
+  await expect(reliability).toBeVisible();
+
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.confidenceLevelField.fillInput('50');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
+  confidenceLevel = reportDetailsPage.getTextForHeading('Confidence level', '3 - Possibly True');
+  await expect(confidenceLevel).toBeVisible();
+
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.descriptionField.fill('Updated test e2e Description');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
+  description = reportDetailsPage.getTextForHeading('Description', 'Updated test e2e Description');
+  await expect(description).toBeVisible();
+
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.authorAutocomplete.selectOption('ANSSI');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
+  author = reportDetailsPage.getTextForHeading('Author', 'ANSSI');
+  await expect(author).toBeVisible();
+
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.markingsAutocomplete.selectOption('PAP:CLEAR');
+  await reportForm.markingsAutocomplete.selectOption('PAP:GREEN');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
   markingClear = reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR');
   await expect(markingClear).toBeHidden();
   const markingPapGreen = reportDetailsPage.getTextForHeading('Marking', 'PAP:GREEN');
@@ -241,21 +261,16 @@ test('Report CRUD', async ({ page }) => {
   markingGreen = reportDetailsPage.getTextForHeading('Marking', 'TLP:GREEN');
   await expect(markingGreen).toBeVisible();
 
-  author = reportDetailsPage.getTextForHeading('Author', 'ANSSI');
-  await expect(author).toBeVisible();
-
-  reliability = reportDetailsPage.getTextForHeading('Reliability', 'B - Usually reliable');
-  await expect(reliability).toBeVisible();
-
-  confidenceLevel = reportDetailsPage.getTextForHeading('Confidence level', '3 - Possibly True');
-  await expect(confidenceLevel).toBeVisible();
-
-  originalCreationDate = reportDetailsPage.getTextForHeading('Original creation date', 'December 5, 2023');
-  await expect(originalCreationDate).toBeVisible();
-
+  await reportDetailsPage.getEditButton().click();
+  await reportForm.statusAutocomplete.selectOption('IN_PROGRESS');
+  await reportForm.getUpdateTitle().click();
+  await reportForm.getCloseButton().click();
   processingStatus = reportDetailsPage.getTextForHeading('Processing status', 'IN_PROGRESS');
   await expect(processingStatus).toBeVisible();
 
+  await reportDetailsPage.openLabelsSelect();
+  await reportDetailsPage.labelsSelect.selectOption('covid-19');
+  await reportDetailsPage.addLabels();
   labelCampaign = reportDetailsPage.getTextForHeading('Labels', 'campaign');
   await expect(labelCampaign).toBeVisible();
   labelReport = reportDetailsPage.getTextForHeading('Labels', 'report');


### PR DESCRIPTION
### Proposed changes

* An other implementation for e2e test which tests report update to try something not flaky

### Related issues

* Flaky tests for reports update

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

