### PR TITLE
[frontend] TTPs export from knowledge tab does not work as expected (#6824)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -69,6 +69,7 @@ const StixCoreObjectsExportCreationComponent = ({
   paginationOptions,
   exportContext,
   onExportAsk,
+  exportType,
   data,
 }) => {
   const { t_i18n } = useFormatter();
@@ -86,7 +87,7 @@ const StixCoreObjectsExportCreationComponent = ({
         input: {
           exportContext,
           format: values.format,
-          exportType: 'full',
+          exportType: exportType ?? 'full',
           selectedIds,
           orderBy,
           filters,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExports.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExports.jsx
@@ -10,6 +10,7 @@ const StixCoreObjectsExports = ({
   paginationOptions,
   open,
   handleToggle,
+  exportType,
 }) => {
   const { t_i18n } = useFormatter();
   return (
@@ -25,6 +26,7 @@ const StixCoreObjectsExports = ({
           <StixCoreObjectsExportsContent
             handleToggle={handleToggle}
             data={props}
+            exportType={exportType}
             paginationOptions={paginationOptions}
             exportContext={exportContext}
             isOpen={open}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
@@ -17,6 +17,7 @@ const StixCoreObjectsExportsContentComponent = ({
   data,
   exportContext,
   paginationOptions,
+  exportType,
 }) => {
   const { t_i18n } = useFormatter();
   useEffect(() => {
@@ -65,6 +66,7 @@ const StixCoreObjectsExportsContentComponent = ({
           data={data}
           exportContext={exportContext}
           paginationOptions={paginationOptions}
+          exportType={exportType}
           onExportAsk={() => relay.refetch({ count: 25, exportContext })}
         />
       </Security>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
@@ -9,7 +9,7 @@ import { ProgressWrench } from 'mdi-material-ui';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
 import IconButton from '@mui/material/IconButton';
-import StixCoreObjectsExports from '@components/common/stix_core_objects/StixCoreObjectsExports';
+import StixCoreObjectsExports from '../stix_core_objects/StixCoreObjectsExports';
 import inject18n from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import Security from '../../../../utils/Security';
@@ -18,7 +18,6 @@ import StixCoreRelationshipCreationFromEntity from '../stix_core_relationships/S
 import StixDomainObjectAttackPatternsKillChainMatrix from './StixDomainObjectAttackPatternsKillChainMatrix';
 import StixDomainObjectAttackPatternsKillChainLines from './StixDomainObjectAttackPatternsKillChainLines';
 import ExportButtons from '../../../../components/ExportButtons';
-import StixCoreRelationshipsExports from '../stix_core_relationships/StixCoreRelationshipsExports';
 import Filters from '../lists/Filters';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { export_max_size } from '../../../../utils/utils';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
@@ -335,6 +335,7 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
           <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
             <StixCoreObjectsExports
               open={openExports}
+              exportType='simple'
               handleToggle={handleToggleExports.bind(this)}
               paginationOptions={newPaginationOptions}
               exportContext={newExportContext}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
@@ -9,6 +9,7 @@ import { ProgressWrench } from 'mdi-material-ui';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
 import IconButton from '@mui/material/IconButton';
+import StixCoreObjectsExports from '@components/common/stix_core_objects/StixCoreObjectsExports';
 import inject18n from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import Security from '../../../../utils/Security';
@@ -117,6 +118,8 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
       )(data.stixCoreRelationships.edges);
     }
     const exportDisabled = targetEntities.length > export_max_size;
+    console.log('exportContext : ', exportContext);
+    const newExportContext = { ...exportContext, entity_type: 'Stix-Core-Objects' };
     return (
       <>
         <div
@@ -313,11 +316,17 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
             />
           </Security>
           <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
-            <StixCoreRelationshipsExports
+            {/* <StixCoreRelationshipsExports */}
+            {/*  open={openExports} */}
+            {/*  handleToggle={handleToggleExports.bind(this)} */}
+            {/*  paginationOptions={paginationOptions} */}
+            {/*  exportContext={exportContext} */}
+            {/* /> */}
+            <StixCoreObjectsExports
               open={openExports}
               handleToggle={handleToggleExports.bind(this)}
               paginationOptions={paginationOptions}
-              exportContext={exportContext}
+              exportContext={newExportContext}
             />
           </Security>
         </div>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.jsx
@@ -118,8 +118,26 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
       )(data.stixCoreRelationships.edges);
     }
     const exportDisabled = targetEntities.length > export_max_size;
-    console.log('exportContext : ', exportContext);
-    const newExportContext = { ...exportContext, entity_type: 'Stix-Core-Objects' };
+
+    const newExportContext = { ...exportContext, entity_type: 'Attack-Pattern' };
+    const newPaginationOptions = {
+      orderBy: 'name',
+      orderMode: 'desc',
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'regardingOf',
+            values: [{
+              key: 'id',
+              values: [stixDomainObjectId],
+            }],
+          },
+        ],
+        filterGroups: [],
+      },
+    };
+
     return (
       <>
         <div
@@ -155,10 +173,10 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
             </Tooltip>
             <Tooltip
               title={
-                                currentColorsReversed
-                                  ? t('Disable invert colors')
-                                  : t('Enable invert colors')
-                            }
+                    currentColorsReversed
+                      ? t('Disable invert colors')
+                      : t('Enable invert colors')
+                }
             >
               <span>
                 <IconButton
@@ -316,16 +334,10 @@ class StixDomainObjectAttackPatternsKillChainComponent extends Component {
             />
           </Security>
           <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
-            {/* <StixCoreRelationshipsExports */}
-            {/*  open={openExports} */}
-            {/*  handleToggle={handleToggleExports.bind(this)} */}
-            {/*  paginationOptions={paginationOptions} */}
-            {/*  exportContext={exportContext} */}
-            {/* /> */}
             <StixCoreObjectsExports
               open={openExports}
               handleToggle={handleToggleExports.bind(this)}
-              paginationOptions={paginationOptions}
+              paginationOptions={newPaginationOptions}
               exportContext={newExportContext}
             />
           </Security>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* StixCoreObjectsExports added on attack pattern export
* new filter and export context created

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6824
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
