### PR TITLE
[frontend] Add ability to override confidence per entity type in Group (#6878)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -312,7 +312,7 @@
   "confidence_gt": "Confiance supérieure à",
   "confidence_lte": "Confiance inférieure ou égale à",
   "confidence_unknown": "Inconnue",
-  "Confidences": "Confidences",
+  "Confidences": "Confiances",
   "Configuration": "Configuration",
   "Configuration version": "Version de la configuration",
   "Configuration_version": "Version de la configuration",

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
@@ -42,9 +42,9 @@ const GroupConfidenceLevel: React.FC<GroupConfidenceLevelProps> = ({ confidenceL
   return (
     <Box component={'span'} sx={{ display: 'inline-flex', alignItems: 'center' }}>
       <span>{`${confidenceLevel.max_confidence ?? '-'}`}</span>
-      {confidenceLevel.max_confidence
-          && <ConfidenceTooltip confidenceLevel={confidenceLevel}/>
-        }
+      {!!confidenceLevel.max_confidence
+        && <ConfidenceTooltip confidenceLevel={confidenceLevel}/>
+      }
     </Box>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
@@ -192,6 +192,7 @@ const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceP
                       component={ConfidenceOverrideField}
                       onDelete={() => arrayHelpers.remove(idx)}
                       onSubmit={handleSubmitOverride}
+                      currentOverrides={values.overrides}
                     />
                   ))}
                 </div>

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
@@ -175,9 +175,10 @@ const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceP
                   <IconButton
                     color="primary"
                     aria-label="Add"
-                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: 0 })}
+                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: group.group_confidence_level?.max_confidence })}
                     style={{ marginTop: '5px' }}
                     size="large"
+                    disabled={values.overrides.some((o) => o.entity_type === '')}
                   >
                     <Add fontSize="small" />
                   </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
@@ -1,0 +1,224 @@
+import React, { FunctionComponent } from 'react';
+import { Field, FieldArray, Form, Formik } from 'formik';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import { Add } from '@mui/icons-material';
+import * as Yup from 'yup';
+import UserConfidenceOverrideField from '@components/settings/users/edition/UserConfidenceOverrideField';
+import { createFragmentContainer, graphql } from 'react-relay';
+import ConfidenceField from '@components/common/form/ConfidenceField';
+import { GroupEditionConfidence_group$data } from './__generated__/GroupEditionConfidence_group.graphql';
+import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import { useFormatter } from '../../../../components/i18n';
+import { isEmptyField, isNotEmptyField } from '../../../../utils/utils';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+export const groupConfidenceMutationFieldPatch = graphql`
+  mutation GroupEditionConfidenceFieldPatchMutation(
+    $id: ID!
+    $input: [EditInput]!
+  ) {
+    groupEdit(id: $id) {
+      fieldPatch(input: $input) {
+        ...GroupEditionConfidence_group
+      }
+    }
+  }
+`;
+export interface OverrideFormData {
+  max_confidence: string;
+  entity_type: string;
+}
+
+export interface ConfidenceFormData {
+  group_confidence_level: number | null | undefined;
+  overrides: OverrideFormData[]
+}
+
+interface GroupEditionConfidenceProps {
+  group: GroupEditionConfidence_group$data;
+  context:
+  | readonly ({
+    readonly focusOn: string | null | undefined;
+    readonly name: string;
+  } | null)[]
+  | null | undefined;
+}
+
+const userConfidenceValidation = (t: (value: string) => string) => {
+  const maxConfidenceValidator = Yup.number()
+    .min(0, t('The value must be greater than or equal to 0'))
+    .max(100, t('The value must be less than or equal to 100'));
+
+  return Yup.object().shape({
+    group_confidence_level: maxConfidenceValidator,
+    overrides: Yup.array().of(
+      Yup.object().shape({
+        entity_type: Yup.string(),
+        max_confidence: maxConfidenceValidator,
+      }),
+    ),
+  });
+};
+
+const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceProps> = ({ group, context }) => {
+  const { t_i18n } = useFormatter();
+
+  const initialValues: ConfidenceFormData = {
+    group_confidence_level: group.group_confidence_level?.max_confidence,
+    overrides: group.group_confidence_level?.overrides?.map((override) => ({
+      ...override,
+      max_confidence: override.max_confidence.toString(),
+    })) ?? [] };
+
+  const [commitFieldPatch] = useApiMutation(groupConfidenceMutationFieldPatch);
+
+  const handleSubmitMaxConfidence = (name: string, value: string) => {
+    userConfidenceValidation(t_i18n)
+      .validateAt(name, { [name]: value })
+      .then(() => {
+        if (name === 'group_confidence_level') {
+          if (group.group_confidence_level) {
+            commitFieldPatch({
+              variables: {
+                id: group.id,
+                input: {
+                  key: 'group_confidence_level',
+                  object_path: '/group_confidence_level/max_confidence',
+                  value: parseInt(value, 10),
+                },
+              },
+            });
+          } else {
+            commitFieldPatch({
+              variables: {
+                id: group.id,
+                input: {
+                  key: 'group_confidence_level',
+                  value: {
+                    max_confidence: parseInt(value, 10),
+                    overrides: [],
+                  },
+                },
+              },
+            });
+          }
+        }
+      })
+      .catch(() => false);
+  };
+
+  const handleSubmitOverride = (index: number, value: OverrideFormData | null) => {
+    if (isNotEmptyField(value?.entity_type) && isNotEmptyField(value?.max_confidence)) {
+      const object_path = `/group_confidence_level/overrides/${index}`;
+      const finalValue = [{
+        entity_type: value.entity_type,
+        max_confidence: parseInt(value.max_confidence ?? '0', 10),
+      }];
+      const name = `overrides[${index}]`;
+      userConfidenceValidation(t_i18n)
+        .validateAt(name, { [name]: value })
+        .then(() => {
+          commitFieldPatch({
+            variables: {
+              id: group.id,
+              input: {
+                key: 'group_confidence_level',
+                object_path,
+                value: finalValue,
+              },
+            },
+          });
+        })
+        .catch(() => false);
+    } else if (isEmptyField(value)) {
+      commitFieldPatch({
+        variables: {
+          id: group.id,
+          input: {
+            key: 'group_confidence_level',
+            operation: 'remove',
+            object_path: `/group_confidence_level/overrides/${index}`,
+            value: [null],
+          },
+        },
+      });
+    }
+  };
+
+  return (
+    <>
+      <Formik<ConfidenceFormData>
+        enableReinitialize={true}
+        initialValues={initialValues}
+        onSubmit={() => {}}
+      >
+        {({ values }) => (
+          <Form>
+            <ConfidenceField
+              name="group_confidence_level"
+              label={t_i18n('Max Confidence Level')}
+              onSubmit={handleSubmitMaxConfidence}
+              entityType="Group"
+              containerStyle={fieldSpacingContainerStyle}
+              editContext={context}
+              variant="edit"
+              disabled={false}
+            />
+            <FieldArray
+              name="overrides"
+              render={(arrayHelpers) => (
+                <div>
+                  <Typography variant="h4" gutterBottom={true} style={{ float: 'left', marginTop: '20px' }}>
+                    {t_i18n('Add a specific max confidence level for an entity type')}
+                  </Typography>
+                  <IconButton
+                    color="primary"
+                    aria-label="Add"
+                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: 0 })}
+                    style={{ marginTop: '5px' }}
+                    size="large"
+                  >
+                    <Add fontSize="small" />
+                  </IconButton>
+                  {values.overrides.map((_, idx) => (
+                    <Field
+                      // Field props
+                      key={idx}
+                      index={idx}
+                      name={`overrides[${idx}]`}
+                      // rendered components and its props
+                      component={UserConfidenceOverrideField}
+                      onDelete={() => arrayHelpers.remove(idx)}
+                      onSubmit={handleSubmitOverride}
+                    />
+                  ))}
+                </div>
+              )}
+            />
+          </Form>
+        )}
+      </Formik>
+    </>
+  );
+};
+
+const GroupEditionConfidence = createFragmentContainer(
+  GroupEditionConfidenceComponent,
+  {
+    group: graphql`
+      fragment GroupEditionConfidence_group on Group {
+        id
+        group_confidence_level {
+          max_confidence
+          overrides {
+            max_confidence
+            entity_type
+          }
+        }
+        ...GroupHiddenTypesField_group
+      }
+    `,
+  },
+);
+export default GroupEditionConfidence;

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import { Add } from '@mui/icons-material';
 import * as Yup from 'yup';
-import UserConfidenceOverrideField from '@components/settings/users/edition/UserConfidenceOverrideField';
+import ConfidenceOverrideField from '@components/settings/users/edition/ConfidenceOverrideField';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ConfidenceField from '@components/common/form/ConfidenceField';
 import { GroupEditionConfidence_group$data } from './__generated__/GroupEditionConfidence_group.graphql';
@@ -188,7 +188,7 @@ const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceP
                       index={idx}
                       name={`overrides[${idx}]`}
                       // rendered components and its props
-                      component={UserConfidenceOverrideField}
+                      component={ConfidenceOverrideField}
                       onDelete={() => arrayHelpers.remove(idx)}
                       onSubmit={handleSubmitOverride}
                     />

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionConfidence.tsx
@@ -45,7 +45,7 @@ interface GroupEditionConfidenceProps {
   | null | undefined;
 }
 
-const userConfidenceValidation = (t: (value: string) => string) => {
+const groupConfidenceValidation = (t: (value: string) => string) => {
   const maxConfidenceValidator = Yup.number()
     .min(0, t('The value must be greater than or equal to 0'))
     .max(100, t('The value must be less than or equal to 100'));
@@ -74,7 +74,7 @@ const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceP
   const [commitFieldPatch] = useApiMutation(groupConfidenceMutationFieldPatch);
 
   const handleSubmitMaxConfidence = (name: string, value: string) => {
-    userConfidenceValidation(t_i18n)
+    groupConfidenceValidation(t_i18n)
       .validateAt(name, { [name]: value })
       .then(() => {
         if (name === 'group_confidence_level') {
@@ -116,7 +116,7 @@ const GroupEditionConfidenceComponent: FunctionComponent<GroupEditionConfidenceP
         max_confidence: parseInt(value.max_confidence ?? '0', 10),
       }];
       const name = `overrides[${index}]`;
-      userConfidenceValidation(t_i18n)
+      groupConfidenceValidation(t_i18n)
         .validateAt(name, { [name]: value })
         .then(() => {
           commitFieldPatch({

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -8,6 +8,7 @@ import { usersLinesSearchQuery } from '@components/settings/users/UsersLines';
 import { UsersLinesSearchQuery } from '@components/settings/users/__generated__/UsersLinesSearchQuery.graphql';
 import { GroupUsersLinesQuery$variables } from '@components/settings/users/__generated__/GroupUsersLinesQuery.graphql';
 import { initialStaticPaginationForGroupUsers } from '@components/settings/users/GroupUsers';
+import GroupEditionConfidence from './GroupEditionConfidence';
 import GroupEditionOverview from './GroupEditionOverview';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import GroupEditionRoles, { groupEditionRolesLinesSearchQuery } from './GroupEditionRoles';
@@ -20,6 +21,7 @@ import { GroupEditionContainer_group$key } from './__generated__/GroupEditionCon
 import GroupEditionMarkings from './GroupEditionMarkings';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
+import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
 
 export const groupEditionContainerQuery = graphql`
   query GroupEditionContainerQuery($id: String!) {
@@ -46,6 +48,7 @@ const GroupEditionContainerFragment = graphql`
     }
     ...GroupEditionOverview_group
     ...GroupEditionMarkings_group
+    ...GroupEditionConfidence_group
     ...GroupEditionRoles_group
     @arguments(
       orderBy: $rolesOrderBy
@@ -72,6 +75,7 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
 
   const [currentTab, setTab] = useState(0);
 
+  const hasSetAccess = useGranted([SETTINGS_SETACCESSES]);
   const groupData = usePreloadedQuery<GroupEditionContainerQuery>(groupEditionContainerQuery, groupQueryRef);
   const roleQueryRef = useQueryLoading<GroupEditionRolesLinesSearchQuery>(groupEditionRolesLinesSearchQuery);
   const userQueryRef = useQueryLoading<UsersLinesSearchQuery>(usersLinesSearchQuery);
@@ -110,6 +114,7 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
             <Tab label={t_i18n('Roles')} />
             <Tab label={t_i18n('Markings')} />
             <Tab label={t_i18n('Members')} />
+            <Tab label={t_i18n('Confidences')} />
           </Tabs>
         </Box>
         {currentTab === 0 && (
@@ -129,6 +134,9 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
           >
             <GroupEditionUsers group={group} queryRef={userQueryRef} paginationOptionsForUpdater={paginationOptionsForUserEdition} />
           </React.Suspense>
+        )}
+        {hasSetAccess && currentTab === 4 && (
+          <GroupEditionConfidence group={group} context={editContext} />
         )}
       </>
     </Drawer>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
@@ -28,7 +28,7 @@ interface UserConfidenceOverridesFieldComponentProps
   onSubmit: (index: number, value: OverrideFormData | null) => void;
 }
 
-const UserConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldComponentProps> = ({
+const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldComponentProps> = ({
   form,
   field,
   index,
@@ -191,4 +191,4 @@ const UserConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFiel
   );
 };
 
-export default UserConfidenceOverrideField;
+export default ConfidenceOverrideField;

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
@@ -128,14 +128,14 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
         </AccordionSummary>
         <AccordionDetails style={{ width: '100%' }}>
           <>
-            <MUIAutocomplete<AvailableEntityOption>
+            <MUIAutocomplete<AvailableEntityOption, false, boolean>
               selectOnFocus
               openOnFocus
               autoHighlight
               getOptionLabel={(option) => t_i18n(`entity_${option.label}`)}
               noOptionsText={t_i18n('No available options')}
               options={entityTypesToOverride}
-              disableClearable={true as never}
+              disableClearable
               getOptionDisabled={(option) => currentOverrides?.some((selectedOption) => selectedOption.entity_type === option.id)}
               groupBy={(option) => t_i18n(option.type) ?? t_i18n('Unknown')}
               value={entityTypesToOverride.find((e) => e.id === value.entity_type) || null}
@@ -149,8 +149,13 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
                   size="small"
                 />
               )}
-              renderOption={(props, option) => (
-                <li {...props}>
+              // Need to ignore because there is a property key in the object but the
+              // type given by MUI does not reference it
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              renderOption={({ key, ...props }, option) => (
+                // Separate key and other props because asked by React to avoid warnings.
+                <li key={key} {...props}>
                   <div style={{
                     paddingTop: 4,
                     display: 'inline-block',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
@@ -38,7 +38,7 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const { availableEntityTypes } = useSchema();
-  const entityTypesToOverride = availableEntityTypes.filter((entity_type) => entity_type.type !== 'entity_Stix-Meta-Objects');
+  const entityTypesToOverride = availableEntityTypes.filter((entity_type) => entity_type.type !== 'entity_Stix-Meta-Objects' && entity_type.type !== 'entity_Stix-Cyber-Observables');
   const deletion = useDeletion({});
   const { setDeleting, handleCloseDelete, handleOpenDelete } = deletion;
   const { value, name } = field;

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
@@ -29,6 +29,10 @@ interface UserConfidenceOverridesFieldComponentProps
   currentOverrides: OverrideFormData[];
 }
 
+const filterOverridableEntityTypes = (entity_type: string | null) => {
+  return entity_type !== 'entity_Stix-Meta-Objects' && entity_type !== 'entity_Stix-Cyber-Observables';
+};
+
 const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldComponentProps> = ({
   form,
   field,
@@ -40,7 +44,7 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const { availableEntityTypes } = useSchema();
-  const entityTypesToOverride = availableEntityTypes.filter((entity_type) => entity_type.type !== 'entity_Stix-Meta-Objects' && entity_type.type !== 'entity_Stix-Cyber-Observables');
+  const entityTypesToOverride = availableEntityTypes.filter((entity_type) => filterOverridableEntityTypes(entity_type.type));
   const deletion = useDeletion({});
   const { setDeleting, handleCloseDelete, handleOpenDelete } = deletion;
   const { value, name } = field;
@@ -131,6 +135,7 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
               getOptionLabel={(option) => t_i18n(`entity_${option.label}`)}
               noOptionsText={t_i18n('No available options')}
               options={entityTypesToOverride}
+              disableClearable={true as never}
               getOptionDisabled={(option) => currentOverrides?.some((selectedOption) => selectedOption.entity_type === option.id)}
               groupBy={(option) => t_i18n(option.type) ?? t_i18n('Unknown')}
               value={entityTypesToOverride.find((e) => e.id === value.entity_type) || null}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/ConfidenceOverrideField.tsx
@@ -26,6 +26,7 @@ interface UserConfidenceOverridesFieldComponentProps
   index: number;
   onDelete: () => void;
   onSubmit: (index: number, value: OverrideFormData | null) => void;
+  currentOverrides: OverrideFormData[];
 }
 
 const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldComponentProps> = ({
@@ -34,6 +35,7 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
   index,
   onDelete,
   onSubmit,
+  currentOverrides,
 }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
@@ -129,6 +131,7 @@ const ConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFieldCom
               getOptionLabel={(option) => t_i18n(`entity_${option.label}`)}
               noOptionsText={t_i18n('No available options')}
               options={entityTypesToOverride}
+              getOptionDisabled={(option) => currentOverrides?.some((selectedOption) => selectedOption.entity_type === option.id)}
               groupBy={(option) => t_i18n(option.type) ?? t_i18n('Unknown')}
               value={entityTypesToOverride.find((e) => e.id === value.entity_type) || null}
               onInputChange={(event) => searchType(event)}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserConfidenceOverrideField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserConfidenceOverrideField.tsx
@@ -38,6 +38,7 @@ const UserConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFiel
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const { availableEntityTypes } = useSchema();
+  const entityTypesToOverride = availableEntityTypes.filter((entity_type) => entity_type.type !== 'entity_Stix-Meta-Objects');
   const deletion = useDeletion({});
   const { setDeleting, handleCloseDelete, handleOpenDelete } = deletion;
   const { value, name } = field;
@@ -82,7 +83,7 @@ const UserConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFiel
   const searchType = (event: React.SyntheticEvent) => {
     const selectChangeEvent = event as SelectChangeEvent;
     const val = selectChangeEvent?.target.value ?? '';
-    return availableEntityTypes.filter(
+    return entityTypesToOverride.filter(
       (type) => type.value.includes(val)
         || t_i18n(`entity_${type.label}`).includes(val),
     );
@@ -127,9 +128,9 @@ const UserConfidenceOverrideField: FunctionComponent<UserConfidenceOverridesFiel
               autoHighlight
               getOptionLabel={(option) => t_i18n(`entity_${option.label}`)}
               noOptionsText={t_i18n('No available options')}
-              options={availableEntityTypes}
+              options={entityTypesToOverride}
               groupBy={(option) => t_i18n(option.type) ?? t_i18n('Unknown')}
-              value={availableEntityTypes.find((e) => e.id === value.entity_type) || null}
+              value={entityTypesToOverride.find((e) => e.id === value.entity_type) || null}
               onInputChange={(event) => searchType(event)}
               onChange={(_, selectedValue) => handleSubmitEntityType(selectedValue)}
               renderInput={(params) => (

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
@@ -187,7 +187,7 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
                   <IconButton
                     color="primary"
                     aria-label="Add"
-                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: user.user_confidence_level && user.user_confidence_level.max_confidence ? user.user_confidence_level.max_confidence : 0 })}
+                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: user.effective_confidence_level && user.effective_confidence_level.max_confidence ? user.effective_confidence_level.max_confidence : 0 })}
                     style={{ marginTop: '5px' }}
                     size="large"
                     disabled={values.overrides.some((o) => o.entity_type === '')}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
@@ -187,10 +187,10 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
                   <IconButton
                     color="primary"
                     aria-label="Add"
-                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: 0 })}
+                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: user.user_confidence_level && user.user_confidence_level.max_confidence ? user.user_confidence_level.max_confidence : 0 })}
                     style={{ marginTop: '5px' }}
                     size="large"
-                    disabled={user.effective_confidence_level === null}
+                    disabled={values.overrides.some((o) => o.entity_type === '')}
                   >
                     <Add fontSize="small" />
                   </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
@@ -160,6 +160,7 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
     }
   };
 
+  const defaultOverrideConfidence = user.effective_confidence_level && user.effective_confidence_level.max_confidence ? user.effective_confidence_level.max_confidence : 0;
   return (
     <>
       <Formik<ConfidenceFormData>
@@ -187,7 +188,7 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
                   <IconButton
                     color="primary"
                     aria-label="Add"
-                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: user.effective_confidence_level && user.effective_confidence_level.max_confidence ? user.effective_confidence_level.max_confidence : 0 })}
+                    onClick={() => arrayHelpers.push({ entity_type: '', max_confidence: defaultOverrideConfidence })}
                     style={{ marginTop: '5px' }}
                     size="large"
                     disabled={values.overrides.some((o) => o.entity_type === '')}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
@@ -7,7 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import { Add } from '@mui/icons-material';
 import * as Yup from 'yup';
 import { userMutationFieldPatch } from '@components/settings/users/edition/UserEditionOverview';
-import UserConfidenceOverrideField from '@components/settings/users/edition/UserConfidenceOverrideField';
+import ConfidenceOverrideField from '@components/settings/users/edition/ConfidenceOverrideField';
 import { fieldSpacingContainerStyle } from '../../../../../utils/field';
 import { useFormatter } from '../../../../../components/i18n';
 import { isEmptyField, isNotEmptyField } from '../../../../../utils/utils';
@@ -201,7 +201,7 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
                       index={idx}
                       name={`overrides[${idx}]`}
                       // rendered components and its props
-                      component={UserConfidenceOverrideField}
+                      component={ConfidenceOverrideField}
                       onDelete={() => arrayHelpers.remove(idx)}
                       onSubmit={handleSubmitOverride}
                     />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionConfidence.tsx
@@ -204,6 +204,7 @@ const UserEditionConfidence: FunctionComponent<UserEditionConfidenceProps> = ({ 
                       component={ConfidenceOverrideField}
                       onDelete={() => arrayHelpers.remove(idx)}
                       onSubmit={handleSubmitOverride}
+                      currentOverrides={values.overrides}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  [x]  add Capabilities tab to group edition
*  [ ] fix behavior in user and group capabilities tab:
   *  [x]  prevent adding multiple overrides without an entity type
   *  [x] add current max_confidence of user/group to initial override confidence value
   *  [x]  prevent adding the same entity type twice
   *  [x]  restrict entity type selection 
   *  [ ]  refactor user and group component to prevent code duplication

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6878 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
