### PR TITLE
[frontend] use i18n properly to insert links in text

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": "(umgedreht)",
   " & ": "&",
-  " to your administrator or OpenCTI maintainers": "an Ihren Administrator oder die OpenCTI-Maintainer",
   "0 equals no maximum": "0 entspricht keinem Maximum",
   "24 hours": "24 Stunden",
   "24h": "24h",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "Es ist ein unbekannter Fehler aufgetreten!  Bitte versuchen Sie es später noch einmal.",
   "An unknown error has occurred! Please try again later.": "Es ist ein unbekannter Fehler aufgetreten! Bitte versuchen Sie es später noch einmal.",
   "An unknown error occurred. Please provide a": "Ein unbekannter Fehler ist aufgetreten. Bitte geben Sie einen",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "Ein unbekannter Fehler ist aufgetreten. Bitte geben Sie einen {link_support_package} an Ihren Administrator oder die OpenCTI-Maintainer",
   "Analyses": "Auswertungen",
   "Analysis": "Analyse",
   "Analysis definition version": "Version der Analysedefinition",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": " (reversed)",
   " & ": " & ",
-  " to your administrator or OpenCTI maintainers": " to your administrator or OpenCTI maintainers",
   "0 equals no maximum": "0 equals no maximum",
   "24 hours": "24 hours",
   "24h": "24h",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "An unknown error has occurred!  Please try again later.",
   "An unknown error has occurred! Please try again later.": "An unknown error has occurred! Please try again later.",
   "An unknown error occurred. Please provide a": "An unknown error occurred. Please provide a",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "An unknown error occurred. Please provide a {link_support_package} to your administrator or OpenCTI maintainers",
   "Analyses": "Analyses",
   "Analysis": "Analysis",
   "Analysis definition version": "Analysis definition version",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": "(invertido)",
   " & ": "&",
-  " to your administrator or OpenCTI maintainers": "a su administrador o a los mantenedores de OpenCTI",
   "0 equals no maximum": "0 es igual a ningún máximo",
   "24 hours": "24 horas",
   "24h": "24 h",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "Ha ocurrido un error desconocido. Inténtalo de nuevo más tarde.",
   "An unknown error has occurred! Please try again later.": "Se ha producido un error desconocido Vuelva a intentarlo más tarde.",
   "An unknown error occurred. Please provide a": "Se ha producido un error desconocido. Please provide a",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "Se ha producido un error desconocido. Por favor, proporcione un {link_support_package} a su administrador o a los mantenedores de OpenCTI",
   "Analyses": "Análisis",
   "Analysis": "Análisis",
   "Analysis definition version": "Versión de la definición del análisis",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": "(inversé)",
   " & ": "& ;",
-  " to your administrator or OpenCTI maintainers": "à votre administrateur ou aux responsables d'OpenCTI",
   "0 equals no maximum": "0 pour aucun maximum",
   "24 hours": "24 heures",
   "24h": "24h",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "Une erreur est survenue ! Merci de rééssayer plus tard.",
   "An unknown error has occurred! Please try again later.": "Une erreur inconnue s'est produite ! Veuillez réessayer plus tard.",
   "An unknown error occurred. Please provide a": "Une erreur inconnue s'est produite. Veuillez fournir un",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "Une erreur inconnue s'est produite. Veuillez fournir un {link_support_package} à votre administrateur ou aux responsables d'OpenCTI",
   "Analyses": "Analyses",
   "Analysis": "Analysis",
   "Analysis definition version": "Version de la définition de l'analyse",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": "(逆)",
   " & ": "&；",
-  " to your administrator or OpenCTI maintainers": "を管理者または OpenCTI メンテナに連絡してください。",
   "0 equals no maximum": "0 は最大値なし",
   "24 hours": "24時間",
   "24h": "24時間",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "不明なエラーが発生しました。後でもう一度お試しください。",
   "An unknown error has occurred! Please try again later.": "不明なエラーが発生しました！後で再試行してください。",
   "An unknown error occurred. Please provide a": "不明なエラーが発生しました。を入力してください。",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "不明なエラーが発生しました。管理者または OpenCTI メンテナに {link_support_package} を提供してください。",
   "Analyses": "分析",
   "Analysis": "分析",
   "Analysis definition version": "解析定義バージョン",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1,7 +1,6 @@
 {
   " (reversed)": "（反向）",
   " & ": "&；",
-  " to your administrator or OpenCTI maintainers": "给您的管理员或 OpenCTI 维护者",
   "0 equals no maximum": "0 等于没有最大值",
   "24 hours": "24小时",
   "24h": "24小时",
@@ -121,6 +120,7 @@
   "An unknown error has occurred!  Please try again later.": "发生未知错误，请稍后再试。",
   "An unknown error has occurred! Please try again later.": "出现未知错误！请稍后再试。",
   "An unknown error occurred. Please provide a": "出现未知错误。请提供",
+  "An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers": "出现未知错误。请向管理员或 OpenCTI 维护人员提供 {link_support_package}",
   "Analyses": "分析",
   "Analysis": "分析",
   "Analysis definition version": "分析定义版本",

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -17,9 +17,13 @@ export const SimpleError = () => {
     <div style={{ paddingTop: 10 }}>
       <Alert severity="error">
         <span style={{ marginRight: 10 }}>
-          {t_i18n('An unknown error occurred. Please provide a')}&nbsp;
-          <Link to="/dashboard/settings/support">{t_i18n('support package')}</Link>&nbsp;
-          {t_i18n(' to your administrator or OpenCTI maintainers')}
+          {t_i18n(
+            '',
+            {
+              id: 'An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers',
+              values: { link_support_package: <Link to="/dashboard/settings/support">{t_i18n('support package')}</Link> },
+            },
+          )}
         </span>
       </Alert>
     </div>


### PR DESCRIPTION
Inserting links in translated texts should be done with `{token}` and values, as you can tailor where the link appears in the phrase depending on the language.