### PR TITLE
[frontend] Tooltip on group confidence level, displaying overrides

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Overrides.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Overrides.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useFormatter } from '../../../components/i18n';
+
+type OverridesProps = {
+  overrides: ReadonlyArray<{
+    entity_type: string;
+    max_confidence: number;
+  }> | undefined;
+};
+
+const Overrides: React.FC<OverridesProps> = ({ overrides }) => {
+  const { t_i18n } = useFormatter();
+  return overrides?.length ? (
+    <div style={{ marginTop: '5px' }}>
+      <div>{t_i18n('Max Confidence is overridden for some entity types:')}</div>
+      {overrides.map((override, index) => (
+        <div key={index}>
+          {`- ${t_i18n(`entity_${override.entity_type}`)}: ${override.max_confidence}`}
+        </div>
+      ))}
+    </div>
+  ) : null;
+};
+
+export default Overrides;

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -317,6 +317,14 @@ const Group = ({ groupData }: { groupData: Group_group$key }) => {
                 </FieldOrEmpty>
               </Grid>
               <Grid item={true} xs={12}>
+                <Typography
+                  variant="h3"
+                  gutterBottom={true}
+                  style={{ float: 'left' }}
+                >
+                  {t_i18n('Max Confidence Level')}
+                </Typography>
+                <div className="clearfix"/>
                 <GroupConfidenceLevel
                   confidenceLevel={group.group_confidence_level}
                 />

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -68,6 +68,10 @@ const groupFragment = graphql`
     auto_new_marking
     group_confidence_level {
       max_confidence
+      overrides{
+        max_confidence
+        entity_type
+      }
     }
     description
     members {

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
@@ -3,8 +3,8 @@ import { Group_group$data } from '@components/settings/groups/__generated__/Grou
 import { ReportGmailerrorred } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
-import { Link } from 'react-router-dom';
 import { InformationOutline } from 'mdi-material-ui';
+import Overrides from '@components/settings/Overrides';
 import { useFormatter } from '../../../../components/i18n';
 
 type Data_GroupConfidenceLevel = Group_group$data['group_confidence_level'];
@@ -13,34 +13,17 @@ type GroupConfidenceLevelProps = {
   confidenceLevel?: Data_GroupConfidenceLevel
 };
 
-const ConfidenceSource: React.FC<GroupConfidenceLevelProps> = ({ confidenceLevel }) => {
-  const source = confidenceLevel?.max_confidence;
+const ConfidenceTooltip: React.FC<GroupConfidenceLevelProps> = ({ confidenceLevel }) => {
+  const overrides = confidenceLevel?.overrides ?? [];
 
-  const { t_i18n } = useFormatter();
-
-  return (
+  return overrides.length > 0 ? (
     <Tooltip
       sx={{ marginLeft: 1 }}
-      title={
-        <>
-          {t_i18n('', {
-            id: 'The Max Confidence Level is currently inherited from...',
-            values: {
-              link: (
-                <Link to={`/dashboard/settings/accesses/groups/${source}`}>
-                  {}
-                </Link>
-              ),
-            },
-          })}
-          {/* <Overrides overrides={overrides} /> */}
-        </>
-          }
+      title={<Overrides overrides={overrides}/>}
     >
       <InformationOutline fontSize={'small'} color={'info'}/>
     </Tooltip>
-  );
-  return null;
+  ) : null;
 };
 
 const GroupConfidenceLevel: React.FC<GroupConfidenceLevelProps> = ({ confidenceLevel }) => {
@@ -56,13 +39,11 @@ const GroupConfidenceLevel: React.FC<GroupConfidenceLevelProps> = ({ confidenceL
     );
   }
 
-  // TODO: add overrides in a tooltip when in use
-
   return (
     <Box component={'span'} sx={{ display: 'inline-flex', alignItems: 'center' }}>
       <span>{`${confidenceLevel.max_confidence ?? '-'}`}</span>
       {confidenceLevel.max_confidence
-            && <ConfidenceSource confidenceLevel={confidenceLevel}/>
+          && <ConfidenceTooltip confidenceLevel={confidenceLevel}/>
         }
     </Box>
   );

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import Typography from '@mui/material/Typography';
 import { Group_group$data } from '@components/settings/groups/__generated__/Group_group.graphql';
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
+import { ReportGmailerrorred } from '@mui/icons-material';
+import Tooltip from '@mui/material/Tooltip';
+import Box from '@mui/material/Box';
+import { Link } from 'react-router-dom';
+import { InformationOutline } from 'mdi-material-ui';
 import { useFormatter } from '../../../../components/i18n';
 
 type Data_GroupConfidenceLevel = Group_group$data['group_confidence_level'];
@@ -11,33 +13,58 @@ type GroupConfidenceLevelProps = {
   confidenceLevel?: Data_GroupConfidenceLevel
 };
 
+const ConfidenceSource: React.FC<GroupConfidenceLevelProps> = ({ confidenceLevel }) => {
+  const source = confidenceLevel?.max_confidence;
+
+  const { t_i18n } = useFormatter();
+
+  return (
+    <Tooltip
+      sx={{ marginLeft: 1 }}
+      title={
+        <>
+          {t_i18n('', {
+            id: 'The Max Confidence Level is currently inherited from...',
+            values: {
+              link: (
+                <Link to={`/dashboard/settings/accesses/groups/${source}`}>
+                  {}
+                </Link>
+              ),
+            },
+          })}
+          {/* <Overrides overrides={overrides} /> */}
+        </>
+          }
+    >
+      <InformationOutline fontSize={'small'} color={'info'}/>
+    </Tooltip>
+  );
+  return null;
+};
+
 const GroupConfidenceLevel: React.FC<GroupConfidenceLevelProps> = ({ confidenceLevel }) => {
   const { t_i18n } = useFormatter();
 
   if (!confidenceLevel) {
     return (
-      <Alert severity={'error'} variant={'outlined'}>
-        <AlertTitle>
-          {t_i18n('This group does not have a Max Confidence Level, members might not be able to create data.')}
-        </AlertTitle>
-      </Alert>
+      <Tooltip
+        title={t_i18n('This group does not have a Max Confidence Level, members might not be able to create data.')}
+      >
+        <ReportGmailerrorred fontSize={'small'} color={'error'}/>
+      </Tooltip>
     );
   }
 
   // TODO: add overrides in a tooltip when in use
 
   return (
-    <div style={{ float: 'left', marginRight: 5 }}>
-      <Typography
-        variant="h3"
-        gutterBottom={true}
-        style={{ float: 'left' }}
-      >
-        {t_i18n('Max Confidence Level')}
-      </Typography>
-      <div className="clearfix"/>
-      {`${confidenceLevel.max_confidence}`}
-    </div>
+    <Box component={'span'} sx={{ display: 'inline-flex', alignItems: 'center' }}>
+      <span>{`${confidenceLevel.max_confidence ?? '-'}`}</span>
+      {confidenceLevel.max_confidence
+            && <ConfidenceSource confidenceLevel={confidenceLevel}/>
+        }
+    </Box>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupConfidenceLevel.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Group_group$data } from '@components/settings/groups/__generated__/Group_group.graphql';
-import { ReportGmailerrorred } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
 import { InformationOutline } from 'mdi-material-ui';
 import Overrides from '@components/settings/Overrides';
+import { Alert, AlertTitle } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 
 type Data_GroupConfidenceLevel = Group_group$data['group_confidence_level'];
@@ -31,11 +31,11 @@ const GroupConfidenceLevel: React.FC<GroupConfidenceLevelProps> = ({ confidenceL
 
   if (!confidenceLevel) {
     return (
-      <Tooltip
-        title={t_i18n('This group does not have a Max Confidence Level, members might not be able to create data.')}
-      >
-        <ReportGmailerrorred fontSize={'small'} color={'error'}/>
-      </Tooltip>
+      <Alert severity={'error'} variant={'outlined'}>
+        <AlertTitle>
+          {t_i18n('This group does not have a Max Confidence Level, members might not be able to create data.')}
+        </AlertTitle>
+      </Alert>
     );
   }
 

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
@@ -5,31 +5,11 @@ import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import Box from '@mui/material/Box';
 import { User_user$data } from '@components/settings/users/__generated__/User_user.graphql';
+import Overrides from '@components/settings/Overrides';
 import { useFormatter } from '../../../../components/i18n';
 
 type UserConfidenceLevelProps = {
   user: Pick<User_user$data, 'user_confidence_level' | 'effective_confidence_level'>
-};
-
-type OverridesProps = {
-  overrides: ReadonlyArray<{
-    entity_type: string;
-    max_confidence: number;
-  }> | undefined;
-};
-
-const Overrides: React.FC<OverridesProps> = ({ overrides }) => {
-  const { t_i18n } = useFormatter();
-  return overrides?.length ? (
-    <div style={{ marginTop: '5px' }}>
-      <div>{t_i18n('Max Confidence is overridden for some entity types:')}</div>
-      {overrides.map((override, index) => (
-        <div key={index}>
-          {`- ${t_i18n(`entity_${override.entity_type}`)}: ${override.max_confidence}`}
-        </div>
-      ))}
-    </div>
-  ) : null;
 };
 
 const ConfidenceSource: React.FC<UserConfidenceLevelProps> = ({ user }) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Extraction of Overrides
* Creation of GroupConfidenceLevel component

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6878 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
