### PR TITLE
[frontend] add content tab on all entities (#5651)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1678,6 +1678,7 @@
   "Observable types": "Beobachtbare Typen",
   "Observable value": "Beobachtbarer Wert",
   "observable(s)": "beobachtung(en)",
+  "observableName": "name",
   "Observables": "Observables",
   "Observables and indicators conversion": "Konvertierung von Observablen und Indikatoren",
   "Observables distribution": "Verteilung der Observablen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1678,6 +1678,7 @@
   "Observable types": "Observable types",
   "Observable value": "Observable value",
   "observable(s)": "observable(s)",
+  "observableName": "name",
   "Observables": "Observables",
   "Observables and indicators conversion": "Observables and indicators conversion",
   "Observables distribution": "Observables distribution",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1678,6 +1678,7 @@
   "Observable types": "Tipos de observable",
   "Observable value": "Valor del observable",
   "observable(s)": "observable(s)",
+  "observableName": "Nombre",
   "Observables": "Observables",
   "Observables and indicators conversion": "Conversión entre observables e indicadores",
   "Observables distribution": "Distribución de observables",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1678,6 +1678,7 @@
   "Observable types": "Types d'observable",
   "Observable value": "Valeur de l'observable",
   "observable(s)": "observable(s)",
+  "observableName": "Nom",
   "Observables": "Observables",
   "Observables and indicators conversion": "Conversion entre observables et indicateurs",
   "Observables distribution": "Distribution des observables",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1678,6 +1678,7 @@
   "Observable types": "観測結果の種別",
   "Observable value": "観測結果の値",
   "observable(s)": "観測結果",
+  "observableName": "名前",
   "Observables": "観測結果",
   "Observables and indicators conversion": "観測結果とインジケータの変換",
   "Observables distribution": "観測結果の分布",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1678,6 +1678,7 @@
   "Observable types": "可观测类型",
   "Observable value": "可观测值",
   "observable(s)": "可观测数据",
+  "observableName": "名称",
   "Observables": "可观测数据",
   "Observables and indicators conversion": "可观测数据和指标转换",
   "Observables distribution": "可观测数据分布",

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -11,7 +11,7 @@ import Tab from '@mui/material/Tab';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootReportSubscription } from '@components/analyses/reports/__generated__/RootReportSubscription.graphql';
 import StixCoreObjectSimulationResult from '@components/common/stix_core_objects/StixCoreObjectSimulationResult';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import { QueryRenderer } from '../../../../relay/environment';
 import Grouping from './Grouping';
 import GroupingPopover from './GroupingPopover';
@@ -34,7 +34,7 @@ const subscription = graphql`
         ...Grouping_grouping
         ...GroupingKnowledgeGraph_grouping
         ...GroupingEditionContainer_grouping
-        ...StixDomainObjectContent_stixDomainObject
+        ...StixCoreObjectContent_stixCoreObject
       }
       ...FileImportViewer_entity
       ...FileExportViewer_entity
@@ -57,7 +57,7 @@ const groupingQuery = graphql`
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
@@ -215,8 +215,8 @@ const RootGrouping = () => {
                     <Route
                       path="/content"
                       element={
-                        <StixDomainObjectContent
-                          stixDomainObject={grouping}
+                        <StixCoreObjectContent
+                          stixCoreObject={grouping}
                         />
                       }
                     />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -22,7 +22,7 @@ import ContainerStixDomainObjects from '../../common/containers/ContainerStixDom
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
@@ -35,7 +35,7 @@ const subscription = graphql`
         ...Report_report
         ...ReportKnowledgeGraph_report
         ...ReportEditionContainer_report
-        ...StixDomainObjectContent_stixDomainObject
+        ...StixCoreObjectContent_stixCoreObject
       }
       ...FileImportViewer_entity
       ...FileExportViewer_entity
@@ -58,7 +58,7 @@ const reportQuery = graphql`
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
@@ -226,8 +226,8 @@ const RootReport = () => {
                     <Route
                       path="/content"
                       element={
-                        <StixDomainObjectContent
-                          stixDomainObject={report}
+                        <StixCoreObjectContent
+                          stixCoreObject={report}
                         />
                       }
                     />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
@@ -52,6 +52,7 @@ const channelQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.jsx
@@ -10,6 +10,7 @@ import { QueryRenderer, requestSubscription } from '../../../../relay/environmen
 import Channel from './Channel';
 import ChannelKnowledge from './ChannelKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import FileManager from '../../common/files/FileManager';
 import ChannelPopover from './ChannelPopover';
 import Loader from '../../../../components/Loader';
@@ -165,6 +166,12 @@ class RootChannel extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/arsenal/channels/${channel.id}/content`}
+                          value={`/dashboard/arsenal/channels/${channel.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/arsenal/channels/${channel.id}/analyses`}
                           value={`/dashboard/arsenal/channels/${channel.id}/analyses`}
                           label={t('Analyses')}
@@ -204,6 +211,14 @@ class RootChannel extends Component {
                         element={(
                           <ChannelKnowledge
                             channel={props.channel}
+                          />
+                        )}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={props.channel}
                           />
                         )}
                       />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
@@ -53,6 +53,7 @@ const malwareQuery = graphql`
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
+      ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
       ...StixCoreObjectContent_stixCoreObject
     }

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
@@ -53,8 +53,8 @@ const malwareQuery = graphql`
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
-      ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.jsx
@@ -7,6 +7,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
 import StixCoreObjectSimulationResult from '../../common/stix_core_objects/StixCoreObjectSimulationResult';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Malware from './Malware';
@@ -172,6 +173,12 @@ class RootMalware extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/arsenal/malwares/${malware.id}/content`}
+                          value={`/dashboard/arsenal/malwares/${malware.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/arsenal/malwares/${malware.id}/analyses`}
                           value={`/dashboard/arsenal/malwares/${malware.id}/analyses`}
                           label={t('Analyses')}
@@ -213,6 +220,14 @@ class RootMalware extends Component {
                           <MalwareKnowledge
                             malware={malware}
                           />}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={malware}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
@@ -11,6 +11,7 @@ import { QueryRenderer, requestSubscription } from '../../../../relay/environmen
 import Tool from './Tool';
 import ToolKnowledge from './ToolKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import FileManager from '../../common/files/FileManager';
 import ToolPopover from './ToolPopover';
 import Loader from '../../../../components/Loader';
@@ -166,6 +167,12 @@ class RootTool extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/arsenal/tools/${tool.id}/content`}
+                          value={`/dashboard/arsenal/tools/${tool.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/arsenal/tools/${tool.id}/analyses`}
                           value={`/dashboard/arsenal/tools/${tool.id}/analyses`}
                           label={t('Analyses')}
@@ -204,6 +211,14 @@ class RootTool extends Component {
                         path="/knowledge/*"
                         element={(
                           <ToolKnowledge tool={tool} />
+                        )}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={tool}
+                          />
                         )}
                       />
                       <Route

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.jsx
@@ -54,6 +54,7 @@ const toolQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
@@ -52,6 +52,7 @@ const vulnerabilityQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.jsx
@@ -11,6 +11,7 @@ import { QueryRenderer, requestSubscription } from '../../../../relay/environmen
 import Vulnerability from './Vulnerability';
 import VulnerabilityKnowledge from './VulnerabilityKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import FileManager from '../../common/files/FileManager';
 import VulnerabilityPopover from './VulnerabilityPopover';
 import Loader from '../../../../components/Loader';
@@ -167,6 +168,12 @@ class RootVulnerability extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/content`}
+                          value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/analyses`}
                           value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/analyses`}
                           label={t('Analyses')}
@@ -208,6 +215,14 @@ class RootVulnerability extends Component {
                         element={(
                           <VulnerabilityKnowledge
                             vulnerability={vulnerability}
+                          />
+                        )}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={vulnerability}
                           />
                         )}
                       />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -17,7 +17,7 @@ import ContainerHeader from '../../common/containers/ContainerHeader';
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
 import ContainerStixDomainObjects from '../../common/containers/ContainerStixDomainObjects';
 import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import { RootIncidentCaseQuery } from './__generated__/RootIncidentCaseQuery.graphql';
 import CaseIncident from './CaseIncident';
 import CaseIncidentPopover from './CaseIncidentPopover';
@@ -56,7 +56,7 @@ const caseIncidentQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
@@ -215,8 +215,8 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
             <Route
               path="/content"
               element={
-                <StixDomainObjectContent
-                  stixDomainObject={caseData}
+                <StixCoreObjectContent
+                  stixCoreObject={caseData}
                 />}
             />
             <Route

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -13,7 +13,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import ContainerHeader from '../../common/containers/ContainerHeader';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
 import CaseRfiPopover from './CaseRfiPopover';
 import CaseRfi from './CaseRfi';
@@ -56,7 +56,7 @@ const caseRfiQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
@@ -209,8 +209,8 @@ const RootCaseRfiComponent = ({ queryRef, caseId }) => {
             <Route
               path="/content"
               element={
-                <StixDomainObjectContent
-                  stixDomainObject={caseData}
+                <StixCoreObjectContent
+                  stixCoreObject={caseData}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -13,7 +13,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import ContainerHeader from '../../common/containers/ContainerHeader';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import CaseRft from './CaseRft';
@@ -55,7 +55,7 @@ const caseRftQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...ContainerHeader_container
       ...ContainerStixDomainObjects_container
       ...ContainerStixCyberObservables_container
@@ -202,8 +202,8 @@ const RootCaseRftComponent = ({ queryRef, caseId }) => {
             <Route
               path="/content"
               element={(
-                <StixDomainObjectContent
-                  stixDomainObject={caseData}
+                <StixCoreObjectContent
+                  stixCoreObject={caseData}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -19,7 +19,7 @@ import ContainerHeader from '../../common/containers/ContainerHeader';
 import FileManager from '../../common/files/FileManager';
 import FeedbackPopover from './FeedbackPopover';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import Feedback from './Feedback';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
@@ -62,7 +62,7 @@ const feedbackQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForExport {
       ...FileManager_connectorsExport
@@ -191,8 +191,8 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
             <Route
               path="/content"
               element={
-                <StixDomainObjectContent
-                  stixDomainObject={feedbackData}
+                <StixCoreObjectContent
+                  stixCoreObject={feedbackData}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -13,7 +13,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import ContainerHeader from '../../common/containers/ContainerHeader';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import StixCoreObjectFilesAndHistory from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import CaseTask from './Task';
@@ -49,7 +49,7 @@ const TaskQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForExport {
       ...StixCoreObjectFilesAndHistory_connectorsExport
@@ -149,7 +149,7 @@ const RootTaskComponent = ({ queryRef, taskId }) => {
             <Route
               path="/content"
               element={
-                <StixDomainObjectContent stixDomainObject={data} />
+                <StixCoreObjectContent stixCoreObject={data} />
               }
             />
             <Route

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
@@ -36,8 +36,8 @@ import {
   StixCoreObjectAskAIConvertFilesToStixMutation,
   StixCoreObjectAskAIConvertFilesToStixMutation$data,
 } from '@components/common/stix_core_objects/__generated__/StixCoreObjectAskAIConvertFilesToStixMutation.graphql';
-import { stixDomainObjectContentFilesUploadStixDomainObjectMutation } from '../stix_domain_objects/StixDomainObjectContentFiles';
-import { stixDomainObjectContentFieldPatchMutation } from '../stix_domain_objects/StixDomainObjectContent';
+import { stixCoreObjectContentFilesUploadStixCoreObjectMutation } from './StixCoreObjectContentFiles';
+import { stixDomainObjectContentFieldPatchMutation } from './StixCoreObjectContent';
 import FilesNativeField from '../form/FilesNativeField';
 import type {
   StixDomainObjectContentFilesUploadStixDomainObjectMutation,
@@ -141,7 +141,7 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({ inst
   const handleOpenAskAI = () => setDisplayAskAI(true);
   const handleCloseAskAI = () => setDisplayAskAI(false);
   const [commitMutationUpdateContent] = useApiMutation<StixDomainObjectContentFieldPatchMutation>(stixDomainObjectContentFieldPatchMutation);
-  const [commitMutationCreateFile] = useApiMutation<StixDomainObjectContentFilesUploadStixDomainObjectMutation>(stixDomainObjectContentFilesUploadStixDomainObjectMutation);
+  const [commitMutationCreateFile] = useApiMutation<StixDomainObjectContentFilesUploadStixDomainObjectMutation>(stixCoreObjectContentFilesUploadStixCoreObjectMutation);
   const [commitMutationContainerReport] = useApiMutation<StixCoreObjectAskAIContainerReportMutation>(stixCoreObjectAskAIContainerReportMutation);
   const [commitMutationSummarizeFiles] = useApiMutation<StixCoreObjectAskAISummarizeFilesMutation>(stixCoreObjectAskAISummarizeFilesMutation);
   const [commitMutationConvertFilesToStix] = useApiMutation<StixCoreObjectAskAIConvertFilesToStixMutation>(stixCoreObjectAskAIConvertFilesToStixMutation);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
@@ -27,7 +27,7 @@ import {
   StixCoreObjectAskAISummarizeFilesMutation,
   StixCoreObjectAskAISummarizeFilesMutation$data,
 } from '@components/common/stix_core_objects/__generated__/StixCoreObjectAskAISummarizeFilesMutation.graphql';
-import { StixDomainObjectContentFieldPatchMutation } from '@components/common/stix_domain_objects/__generated__/StixDomainObjectContentFieldPatchMutation.graphql';
+import { StixCoreObjectContentFieldPatchMutation } from '@components/common/stix_core_objects/__generated__/StixCoreObjectContentFieldPatchMutation.graphql';
 import {
   StixCoreObjectAskAIContainerReportMutation,
   StixCoreObjectAskAIContainerReportMutation$data,
@@ -36,13 +36,13 @@ import {
   StixCoreObjectAskAIConvertFilesToStixMutation,
   StixCoreObjectAskAIConvertFilesToStixMutation$data,
 } from '@components/common/stix_core_objects/__generated__/StixCoreObjectAskAIConvertFilesToStixMutation.graphql';
+import type {
+  StixCoreObjectContentFilesUploadStixCoreObjectMutation,
+  StixCoreObjectContentFilesUploadStixCoreObjectMutation$data,
+} from '@components/common/stix_core_objects/__generated__/StixCoreObjectContentFilesUploadStixCoreObjectMutation.graphql';
 import { stixCoreObjectContentFilesUploadStixCoreObjectMutation } from './StixCoreObjectContentFiles';
 import { stixDomainObjectContentFieldPatchMutation } from './StixCoreObjectContent';
 import FilesNativeField from '../form/FilesNativeField';
-import type {
-  StixDomainObjectContentFilesUploadStixDomainObjectMutation,
-  StixDomainObjectContentFilesUploadStixDomainObjectMutation$data,
-} from '../stix_domain_objects/__generated__/StixDomainObjectContentFilesUploadStixDomainObjectMutation.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import ResponseDialog from '../../../../utils/ai/ResponseDialog';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
@@ -140,8 +140,8 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({ inst
   };
   const handleOpenAskAI = () => setDisplayAskAI(true);
   const handleCloseAskAI = () => setDisplayAskAI(false);
-  const [commitMutationUpdateContent] = useApiMutation<StixDomainObjectContentFieldPatchMutation>(stixDomainObjectContentFieldPatchMutation);
-  const [commitMutationCreateFile] = useApiMutation<StixDomainObjectContentFilesUploadStixDomainObjectMutation>(stixCoreObjectContentFilesUploadStixCoreObjectMutation);
+  const [commitMutationUpdateContent] = useApiMutation<StixCoreObjectContentFieldPatchMutation>(stixDomainObjectContentFieldPatchMutation);
+  const [commitMutationCreateFile] = useApiMutation<StixCoreObjectContentFilesUploadStixCoreObjectMutation>(stixCoreObjectContentFilesUploadStixCoreObjectMutation);
   const [commitMutationContainerReport] = useApiMutation<StixCoreObjectAskAIContainerReportMutation>(stixCoreObjectAskAIContainerReportMutation);
   const [commitMutationSummarizeFiles] = useApiMutation<StixCoreObjectAskAISummarizeFilesMutation>(stixCoreObjectAskAISummarizeFilesMutation);
   const [commitMutationConvertFilesToStix] = useApiMutation<StixCoreObjectAskAIConvertFilesToStixMutation>(stixCoreObjectAskAIConvertFilesToStixMutation);
@@ -260,12 +260,12 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({ inst
         fileMarkings,
         noTriggerImport: false,
       },
-      onCompleted: (response: StixDomainObjectContentFilesUploadStixDomainObjectMutation$data) => {
+      onCompleted: (response: StixCoreObjectContentFilesUploadStixCoreObjectMutation$data) => {
         setAcceptedResult(null);
         setIsSubmitting(false);
         navigate({
           pathname: `${resolveLink(instanceType)}/${instanceId}/${type === 'container' && format !== 'json' ? 'content' : 'files'}`,
-          search: `${createSearchParams({ forceFile: 'true', currentFileId: response?.stixDomainObjectEdit?.importPush?.id ?? '' })}`,
+          search: `${createSearchParams({ forceFile: 'true', currentFileId: response?.stixCoreObjectEdit?.importPush?.id ?? '' })}`,
         });
       },
     });

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -9,7 +9,7 @@ import TextField from '@mui/material/TextField';
 import htmlToPdfmake from 'html-to-pdfmake';
 import pdfMake from 'pdfmake';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
-import Editor from 'ckeditor5-custom-build';
+import Editor from 'ckeditor5-custom-build/build/ckeditor';
 import 'ckeditor5-custom-build/build/translations/fr';
 import 'ckeditor5-custom-build/build/translations/zh-cn';
 import { Document, Page, pdfjs } from 'react-pdf';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -9,7 +9,7 @@ import TextField from '@mui/material/TextField';
 import htmlToPdfmake from 'html-to-pdfmake';
 import pdfMake from 'pdfmake';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
-import Editor from 'ckeditor5-custom-build/build/ckeditor';
+import Editor from 'ckeditor5-custom-build';
 import 'ckeditor5-custom-build/build/translations/fr';
 import 'ckeditor5-custom-build/build/translations/zh-cn';
 import { Document, Page, pdfjs } from 'react-pdf';
@@ -19,11 +19,11 @@ import ReactMde from 'react-mde';
 import { interval } from 'rxjs';
 import TextFieldAskAI from '../form/TextFieldAskAI';
 import inject18n from '../../../../components/i18n';
-import StixDomainObjectContentFiles, { stixDomainObjectContentFilesUploadStixDomainObjectMutation } from './StixDomainObjectContentFiles';
+import StixCoreObjectContentFiles, { stixCoreObjectContentFilesUploadStixCoreObjectMutation } from './StixCoreObjectContentFiles';
 import { APP_BASE_PATH, commitMutation, MESSAGING$ } from '../../../../relay/environment';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../../utils/ListParameters';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import StixDomainObjectContentBar from './StixDomainObjectContentBar';
+import StixCoreObjectContentBar from './StixCoreObjectContentBar';
 import { isEmptyField } from '../../../../utils/utils';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { FIVE_SECONDS } from '../../../../utils/Time';
@@ -104,7 +104,7 @@ const styles = () => ({
 const interval$ = interval(FIVE_SECONDS);
 
 export const stixDomainObjectContentFieldPatchMutation = graphql`
-  mutation StixDomainObjectContentFieldPatchMutation(
+  mutation StixCoreObjectContentFieldPatchMutation(
     $id: ID!
     $input: [EditInput]!
     $commitMessage: String
@@ -112,19 +112,19 @@ export const stixDomainObjectContentFieldPatchMutation = graphql`
   ) {
     stixDomainObjectEdit(id: $id) {
       fieldPatch(input: $input, commitMessage: $commitMessage, references: $references) {
-        ...StixDomainObjectContent_stixDomainObject
+        ...StixCoreObjectContent_stixCoreObject
       }
     }
   }
 `;
 
-const stixDomainObjectContentUploadExternalReferenceMutation = graphql`
-  mutation StixDomainObjectContentUploadExternalReferenceMutation(
+const stixCoreObjectContentUploadExternalReferenceMutation = graphql`
+  mutation StixCoreObjectContentUploadExternalReferenceMutation(
     $id: ID!
     $file: Upload!
     $fileMarkings: [String]
   ) {
-    stixDomainObjectEdit(id: $id) {
+    stixCoreObjectEdit(id: $id) {
       importPush(file: $file, noTriggerImport: true, fileMarkings: $fileMarkings) {
         id
         name
@@ -153,11 +153,11 @@ const stixDomainObjectContentUploadExternalReferenceMutation = graphql`
 
 const sortByLastModified = R.sortBy(R.prop('lastModified'));
 
-const getFiles = (stixDomainObject) => {
-  const importFiles = stixDomainObject.importFiles?.edges
+const getFiles = (stixCoreObject) => {
+  const importFiles = stixCoreObject.importFiles?.edges
     ?.filter((n) => !!n?.node)
     .map((n) => n.node) ?? [];
-  const externalReferencesFiles = stixDomainObject.externalReferences?.edges
+  const externalReferencesFiles = stixCoreObject.externalReferences?.edges
     ?.map((n) => n?.node?.importFiles?.edges)
     .flat()
     .filter((n) => !!n?.node)
@@ -177,8 +177,8 @@ const getFiles = (stixDomainObject) => {
   );
 };
 
-const getExportFiles = (stixDomainObject) => {
-  const exportFiles = stixDomainObject.exportFiles?.edges
+const getExportFiles = (stixCoreObject) => {
+  const exportFiles = stixCoreObject.exportFiles?.edges
     ?.filter((n) => !!n?.node)
     .map((n) => n.node) ?? [];
   return sortByLastModified(
@@ -193,20 +193,20 @@ const getExportFiles = (stixDomainObject) => {
 
 const isContainerWithContent = (type) => ['Report', 'Grouping', 'Case-Incident', 'Case-Rfi', 'Case-Rft'].includes(type);
 
-class StixDomainObjectContentComponent extends Component {
+class StixCoreObjectContentComponent extends Component {
   constructor(props) {
-    const LOCAL_STORAGE_KEY = `stix-domain-object-content-${props.stixDomainObject.id}`;
+    const LOCAL_STORAGE_KEY = `stix-core-object-content-${props.stixCoreObject.id}`;
     super(props);
     const params = buildViewParamsFromUrlAndStorage(
       props.navigate,
       props.location,
       LOCAL_STORAGE_KEY,
     );
-    const { stixDomainObject } = props;
-    const isContentCompatible = isContainerWithContent(stixDomainObject.entity_type);
-    const files = getFiles(stixDomainObject);
-    const exportFiles = getExportFiles(stixDomainObject);
-    let currentFileId = isEmptyField(stixDomainObject.contentField) ? R.head(files)?.id : null;
+    const { stixCoreObject } = props;
+    const isContentCompatible = isContainerWithContent(stixCoreObject.entity_type);
+    const files = getFiles(stixCoreObject);
+    const exportFiles = getExportFiles(stixCoreObject);
+    let currentFileId = isEmptyField(stixCoreObject.contentField) ? R.head(files)?.id : null;
     let isLoading = false;
     let onProgressExportFileName;
     if (params.currentFileId && (!params.contentSelected || params.forceFile)) {
@@ -226,8 +226,8 @@ class StixDomainObjectContentComponent extends Component {
       currentPdfPageNumber: 1,
       pdfViewerZoom: 1.2,
       markdownSelectedTab: 'write',
-      initialContent: isContentCompatible ? stixDomainObject.contentField : props.t('Write something awesome...'),
-      currentContent: isContentCompatible ? stixDomainObject.contentField : props.t('Write something awesome...'),
+      initialContent: isContentCompatible ? stixCoreObject.contentField : props.t('Write something awesome...'),
+      currentContent: isContentCompatible ? stixCoreObject.contentField : props.t('Write something awesome...'),
       navOpen: localStorage.getItem('navOpen') === 'true',
       changed: false,
       isLoading,
@@ -236,7 +236,7 @@ class StixDomainObjectContentComponent extends Component {
   }
 
   saveView() {
-    const LOCAL_STORAGE_KEY = `stix-domain-object-content-${this.props.stixDomainObject.id}`;
+    const LOCAL_STORAGE_KEY = `stix-core-object-content-${this.props.stixCoreObject.id}`;
     saveViewParameters(
       this.props.navigate,
       this.props.location,
@@ -246,10 +246,10 @@ class StixDomainObjectContentComponent extends Component {
   }
 
   loadFileContent() {
-    const { stixDomainObject } = this.props;
+    const { stixCoreObject } = this.props;
     const files = [
-      ...getFiles(stixDomainObject),
-      ...getExportFiles(stixDomainObject),
+      ...getFiles(stixCoreObject),
+      ...getExportFiles(stixCoreObject),
     ];
     this.setState({ isLoading: true }, () => {
       const { currentFileId } = this.state;
@@ -280,14 +280,14 @@ class StixDomainObjectContentComponent extends Component {
       next: () => this.setState({ navOpen: localStorage.getItem('navOpen') === 'true' }),
     });
     this.subscription = interval$.subscribe(() => {
-      this.props.relay.refetch({ id: this.props.stixDomainObject.id });
+      this.props.relay.refetch({ id: this.props.stixCoreObject.id });
     });
 
-    const { stixDomainObject } = this.props;
+    const { stixCoreObject } = this.props;
     const { currentFileId } = this.state;
     const files = [
-      ...getFiles(stixDomainObject),
-      ...getExportFiles(stixDomainObject),
+      ...getFiles(stixCoreObject),
+      ...getExportFiles(stixCoreObject),
     ];
     const currentFile = files.find((f) => f.id === currentFileId);
 
@@ -298,8 +298,8 @@ class StixDomainObjectContentComponent extends Component {
 
   componentDidUpdate() {
     const { onProgressExportFileName } = this.state;
-    const { stixDomainObject } = this.props;
-    const exportFiles = getExportFiles(stixDomainObject);
+    const { stixCoreObject } = this.props;
+    const exportFiles = getExportFiles(stixCoreObject);
 
     if (onProgressExportFileName) {
       const exportFile = exportFiles.find(
@@ -321,8 +321,8 @@ class StixDomainObjectContentComponent extends Component {
   }
 
   handleSelectContent() {
-    const { stixDomainObject, t } = this.props;
-    this.setState({ currentFileId: null, changed: false, contentSelected: true, currentContent: stixDomainObject.contentField ?? t('Write something awesome...') }, () => {
+    const { stixCoreObject, t } = this.props;
+    this.setState({ currentFileId: null, changed: false, contentSelected: true, currentContent: stixCoreObject.contentField ?? t('Write something awesome...') }, () => {
       this.saveView();
     });
   }
@@ -335,13 +335,13 @@ class StixDomainObjectContentComponent extends Component {
   }
 
   handleFileChange(fileName = null, isDelete = false) {
-    const { t, stixDomainObject } = this.props;
-    this.props.relay.refetch({ id: stixDomainObject.id });
+    const { t, stixCoreObject } = this.props;
+    this.props.relay.refetch({ id: stixCoreObject.id });
     if (fileName && fileName === this.state.currentFileId && isDelete) {
       this.setState({
         currentFileId: null,
-        contentSelected: isContainerWithContent(stixDomainObject.entity_type),
-        currentContent: isContainerWithContent(stixDomainObject.entity_type) ? stixDomainObject.contentField ?? t('Write something awesome...') : '',
+        contentSelected: isContainerWithContent(stixCoreObject.entity_type),
+        currentContent: isContainerWithContent(stixCoreObject.entity_type) ? stixCoreObject.contentField ?? t('Write something awesome...') : '',
       }, () => this.saveView());
     } else if (fileName && !isDelete) {
       this.setState({ currentFileId: fileName, contentSelected: false }, () => {
@@ -367,9 +367,9 @@ class StixDomainObjectContentComponent extends Component {
   // END OF PDF SECTION
 
   prepareSaveFile() {
-    const { stixDomainObject } = this.props;
+    const { stixCoreObject } = this.props;
     const { currentFileId } = this.state;
-    const files = getFiles(stixDomainObject);
+    const files = getFiles(stixCoreObject);
     const currentFile = currentFileId && R.head(R.filter((n) => n.id === currentFileId, files));
     const currentFileType = currentFile && currentFile.metaData.mimetype;
     const fragment = currentFileId.split('/');
@@ -393,16 +393,18 @@ class StixDomainObjectContentComponent extends Component {
 
     commitMutation({
       mutation: isExternalReference
-        ? stixDomainObjectContentUploadExternalReferenceMutation
-        : stixDomainObjectContentFilesUploadStixDomainObjectMutation,
+        ? stixCoreObjectContentUploadExternalReferenceMutation
+        : stixCoreObjectContentFilesUploadStixCoreObjectMutation,
       variables: { file, id: currentId, noTriggerImport: true, fileMarkings },
       onCompleted: () => this.setState({ changed: false }),
     });
   }
 
   saveContent() {
-    const { id } = this.props.stixDomainObject;
+    const { id } = this.props.stixCoreObject;
     const inputValues = [{ key: 'content', value: this.state.currentContent }];
+    // Currently, only containers have a content available, so this mutation targets SDOs only. If content is added to all Stix Core Objects,
+    // this mutation will need to be updated to a stixCoreObjectEdit instead of a stixDomainObjectEdit
     commitMutation({
       mutation: stixDomainObjectContentFieldPatchMutation,
       variables: {
@@ -431,7 +433,7 @@ class StixDomainObjectContentComponent extends Component {
 
   handleDownloadPdf() {
     const { currentFileId, currentContent } = this.state;
-    const { stixDomainObject } = this.props;
+    const { stixCoreObject } = this.props;
     const regex = /<img[^>]+src=(\\?["'])[^'"]+\.gif\1[^>]*\/?>/gi;
     const htmlData = currentContent
       .replaceAll('id="undefined" ', '')
@@ -521,14 +523,14 @@ class StixDomainObjectContentComponent extends Component {
           bolditalics: `${url}${APP_BASE_PATH}/static/ext/Roboto-BoldItalic.ttf`,
         },
       };
-      const fragment = (currentFileId ?? stixDomainObject.name).split('/');
+      const fragment = (currentFileId ?? stixCoreObject.name).split('/');
       const currentName = R.last(fragment);
       pdfMake.createPdf(pdfData, null, fonts).download(`${currentName}.pdf`);
     });
   }
 
   render() {
-    const { classes, stixDomainObject, t } = this.props;
+    const { classes, stixCoreObject, t } = this.props;
     const {
       currentFileId,
       totalPdfPageNumber,
@@ -539,8 +541,8 @@ class StixDomainObjectContentComponent extends Component {
       changed,
       contentSelected,
     } = this.state;
-    const files = getFiles(stixDomainObject);
-    const exportFiles = getExportFiles(stixDomainObject);
+    const files = getFiles(stixCoreObject);
+    const exportFiles = getExportFiles(stixCoreObject);
     const currentUrl = currentFileId
       && `${APP_BASE_PATH}/storage/view/${encodeURIComponent(currentFileId)}`;
     const currentGetUrl = currentFileId
@@ -550,12 +552,12 @@ class StixDomainObjectContentComponent extends Component {
     const currentFileType = currentFile && currentFile.metaData.mimetype;
     const { innerHeight } = window;
     const height = innerHeight - 270;
-    const isContentCompatible = isContainerWithContent(stixDomainObject.entity_type);
+    const isContentCompatible = isContainerWithContent(stixCoreObject.entity_type);
     return (
       <div className={classes.container} data-testid="sdo-content-page">
-        <StixDomainObjectContentFiles
-          stixDomainObjectId={stixDomainObject.id}
-          content={isContentCompatible ? stixDomainObject.contentField ?? '' : null}
+        <StixCoreObjectContentFiles
+          stixCoreObjectId={stixCoreObject.id}
+          content={isContentCompatible ? stixCoreObject.contentField ?? '' : null}
           contentSelected={contentSelected}
           files={files}
           exportFiles={exportFiles}
@@ -571,7 +573,7 @@ class StixDomainObjectContentComponent extends Component {
           <>
             {currentFileType === 'text/plain' && (
               <>
-                <StixDomainObjectContentBar
+                <StixCoreObjectContentBar
                   directDownload={currentGetUrl}
                   handleDownloadPdf={this.handleDownloadPdf.bind(this)}
                   navOpen={navOpen}
@@ -608,7 +610,7 @@ class StixDomainObjectContentComponent extends Component {
             )}
             {(currentFileType === 'text/html' || contentSelected) && (
               <>
-                <StixDomainObjectContentBar
+                <StixCoreObjectContentBar
                   directDownload={currentGetUrl}
                   handleDownloadPdf={this.handleDownloadPdf.bind(this)}
                   handleSave={() => (contentSelected ? this.saveContent() : this.saveFile())}
@@ -647,7 +649,7 @@ class StixDomainObjectContentComponent extends Component {
             )}
             {currentFileType === 'text/markdown' && (
               <>
-                <StixDomainObjectContentBar
+                <StixCoreObjectContentBar
                   directDownload={currentGetUrl}
                   handleDownloadPdf={this.handleDownloadPdf.bind(this)}
                   navOpen={navOpen}
@@ -693,7 +695,7 @@ class StixDomainObjectContentComponent extends Component {
             )}
             {currentFileType === 'application/pdf' && (
               <>
-                <StixDomainObjectContentBar
+                <StixCoreObjectContentBar
                   handleZoomIn={this.handleZoomIn.bind(this)}
                   handleZoomOut={this.handleZoomOut.bind(this)}
                   directDownload={currentGetUrl}
@@ -758,26 +760,26 @@ class StixDomainObjectContentComponent extends Component {
   }
 }
 
-StixDomainObjectContentComponent.propTypes = {
-  stixDomainObject: PropTypes.object,
+StixCoreObjectContentComponent.propTypes = {
+  stixCoreObject: PropTypes.object,
   theme: PropTypes.object,
   classes: PropTypes.object,
   t: PropTypes.func,
 };
 
-export const stixDomainObjectContentRefetchQuery = graphql`
-  query StixDomainObjectContentRefetchQuery($id: String!) {
-    stixDomainObject(id: $id) {
-      ...StixDomainObjectContent_stixDomainObject
+export const stixCoreObjectContentRefetchQuery = graphql`
+  query StixCoreObjectContentRefetchQuery($id: String!) {
+    stixCoreObject(id: $id) {
+      ...StixCoreObjectContent_stixCoreObject
     }
   }
 `;
 
-const StixDomainObjectContent = createRefetchContainer(
-  StixDomainObjectContentComponent,
+const StixCoreObjectContent = createRefetchContainer(
+  StixCoreObjectContentComponent,
   {
-    stixDomainObject: graphql`
-      fragment StixDomainObjectContent_stixDomainObject on StixDomainObject {
+    stixCoreObject: graphql`
+      fragment StixCoreObjectContent_stixCoreObject on StixCoreObject {
         id
         entity_type
         ... on Report {
@@ -892,7 +894,7 @@ const StixDomainObjectContent = createRefetchContainer(
       }
     `,
   },
-  stixDomainObjectContentRefetchQuery,
+  stixCoreObjectContentRefetchQuery,
 );
 
 export default R.compose(
@@ -900,4 +902,4 @@ export default R.compose(
   withTheme,
   withRouter,
   withStyles(styles),
-)(StixDomainObjectContent);
+)(StixCoreObjectContent);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentBar.tsx
@@ -28,7 +28,7 @@ const Transition = React.forwardRef((props: SlideProps, ref) => (
 ));
 Transition.displayName = 'TransitionSlide';
 
-interface StixDomainObjectContentBarProps {
+interface StixCoreObjectContentBarProps {
   handleZoomIn?: () => void;
   handleZoomOut?: () => void;
   currentZoom?: number;
@@ -40,8 +40,8 @@ interface StixDomainObjectContentBarProps {
   navOpen: boolean;
 }
 
-const StixDomainObjectContentBar: FunctionComponent<
-StixDomainObjectContentBarProps
+const StixCoreObjectContentBar: FunctionComponent<
+StixCoreObjectContentBarProps
 > = ({
   handleZoomIn,
   handleZoomOut,
@@ -162,4 +162,4 @@ StixDomainObjectContentBarProps
   );
 };
 
-export default StixDomainObjectContentBar;
+export default StixCoreObjectContentBar;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.jsx
@@ -49,14 +49,14 @@ const styles = (theme) => ({
   },
 });
 
-export const stixDomainObjectContentFilesUploadStixDomainObjectMutation = graphql`
-  mutation StixDomainObjectContentFilesUploadStixDomainObjectMutation(
+export const stixCoreObjectContentFilesUploadStixCoreObjectMutation = graphql`
+  mutation StixCoreObjectContentFilesUploadStixDomainObjectMutation(
     $id: ID!
     $file: Upload!
     $fileMarkings: [String]
     $noTriggerImport: Boolean
   ) {
-    stixDomainObjectEdit(id: $id) {
+    stixCoreObjectEdit(id: $id) {
       importPush(file: $file, noTriggerImport: $noTriggerImport, fileMarkings: $fileMarkings) {
         id
         name
@@ -87,7 +87,7 @@ const fileValidation = (t) => Yup.object().shape({
   name: Yup.string().required(t('This field is required')),
 });
 
-class StixDomainObjectContentFiles extends Component {
+class StixCoreObjectContentFiles extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -134,7 +134,7 @@ class StixDomainObjectContentFiles extends Component {
   }
 
   onSubmit(values, { setSubmitting, resetForm }) {
-    const { t, stixDomainObjectId } = this.props;
+    const { t, stixCoreObjectId } = this.props;
     // eslint-disable-next-line prefer-const
     let { name, type } = values;
     if (type === 'text/plain' && !name.endsWith('.txt')) {
@@ -160,14 +160,14 @@ class StixDomainObjectContentFiles extends Component {
     const fileMarkings = values.fileMarkings.map(({ value }) => value);
 
     commitMutation({
-      mutation: stixDomainObjectContentFilesUploadStixDomainObjectMutation,
-      variables: { file, id: stixDomainObjectId, fileMarkings },
+      mutation: stixCoreObjectContentFilesUploadStixCoreObjectMutation,
+      variables: { file, id: stixCoreObjectId, fileMarkings },
       setSubmitting,
       onCompleted: (result) => {
         setSubmitting(false);
         resetForm();
         this.handleCloseCreate();
-        this.props.onFileChange(result.stixDomainObjectEdit.importPush.id);
+        this.props.onFileChange(result.stixCoreObjectEdit.importPush.id);
       },
     });
   }
@@ -193,7 +193,7 @@ class StixDomainObjectContentFiles extends Component {
       classes,
       t,
       files,
-      stixDomainObjectId,
+      stixCoreObjectId,
       content,
       handleSelectFile,
       handleSelectContent,
@@ -241,7 +241,7 @@ class StixDomainObjectContentFiles extends Component {
           <Typography variant="body2" style={{ margin: '5px 0 0 15px', float: 'left' }}>{t('Files')}</Typography>
           <div style={{ float: 'right', display: 'flex', margin: '-4px 15px 0 0' }}>
             <FileUploader
-              entityId={stixDomainObjectId}
+              entityId={stixCoreObjectId}
               onUploadSuccess={onFileChange.bind(this)}
               size="small"
               nameInCallback={true}
@@ -357,8 +357,8 @@ class StixDomainObjectContentFiles extends Component {
   }
 }
 
-StixDomainObjectContentFiles.propTypes = {
-  stixDomainObjectId: PropTypes.string,
+StixCoreObjectContentFiles.propTypes = {
+  stixCoreObjectId: PropTypes.string,
   classes: PropTypes.object,
   t: PropTypes.func,
   files: PropTypes.array,
@@ -373,4 +373,4 @@ export default R.compose(
   inject18n,
   withStyles(styles),
   withHooksSettingsMessagesBannerHeight,
-)(StixDomainObjectContentFiles);
+)(StixCoreObjectContentFiles);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.jsx
@@ -50,7 +50,7 @@ const styles = (theme) => ({
 });
 
 export const stixCoreObjectContentFilesUploadStixCoreObjectMutation = graphql`
-  mutation StixCoreObjectContentFilesUploadStixDomainObjectMutation(
+  mutation StixCoreObjectContentFilesUploadStixCoreObjectMutation(
     $id: ID!
     $file: Upload!
     $fileMarkings: [String]

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.jsx
@@ -51,6 +51,7 @@ const eventQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.jsx
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Event from './Event';
@@ -164,6 +165,12 @@ class RootEvent extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/entities/events/${event.id}/content`}
+                          value={`/dashboard/entities/events/${event.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/entities/events/${event.id}/analyses`}
                           value={`/dashboard/entities/events/${event.id}/analyses`}
                           label={t('Analyses')}
@@ -209,6 +216,14 @@ class RootEvent extends Component {
                         element={
                           <EventKnowledge event={event} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={event}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.jsx
@@ -7,6 +7,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Individual from './Individual';
@@ -203,6 +204,12 @@ class RootIndividual extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/entities/individuals/${individual.id}/content`}
+                          value={`/dashboard/entities/individuals/${individual.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/entities/individuals/${individual.id}/analyses`}
                           value={`/dashboard/entities/individuals/${individual.id}/analyses`}
                           label={t('Analyses')}
@@ -254,6 +261,14 @@ class RootIndividual extends Component {
                             viewAs={viewAs}
                           />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={individual}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.jsx
@@ -55,6 +55,7 @@ const individualQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.jsx
@@ -7,6 +7,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Organization from './Organization';
@@ -206,6 +207,12 @@ class RootOrganization extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/entities/organizations/${organization.id}/content`}
+                          value={`/dashboard/entities/organizations/${organization.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/entities/organizations/${organization.id}/analyses`}
                           value={`/dashboard/entities/organizations/${organization.id}/analyses`}
                           label={t('Analyses')}
@@ -257,6 +264,14 @@ class RootOrganization extends Component {
                             viewAs={viewAs}
                           />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={organization}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.jsx
@@ -55,6 +55,7 @@ const organizationQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.jsx
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Sector from './Sector';
@@ -167,6 +168,12 @@ class RootSector extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/entities/sectors/${sector.id}/content`}
+                          value={`/dashboard/entities/sectors/${sector.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/entities/sectors/${sector.id}/analyses`}
                           value={`/dashboard/entities/sectors/${sector.id}/analyses`}
                           label={t('Analyses')}
@@ -211,6 +218,14 @@ class RootSector extends Component {
                         path="/knowledge/*"
                         element={(
                           <SectorKnowledge sector={sector} />
+                        )}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={sector}
+                          />
                         )}
                       />
                       <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.jsx
@@ -53,6 +53,7 @@ const sectorQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.jsx
@@ -7,6 +7,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import System from './System';
@@ -200,6 +201,12 @@ class RootSystem extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/entities/systems/${system.id}/content`}
+                          value={`/dashboard/entities/systems/${system.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/entities/systems/${system.id}/analyses`}
                           value={`/dashboard/entities/systems/${system.id}/analyses`}
                           label={t('Analyses')}
@@ -251,6 +258,14 @@ class RootSystem extends Component {
                             viewAs={viewAs}
                           />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={system}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses/*"

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.jsx
@@ -53,6 +53,7 @@ const systemQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -19,7 +19,7 @@ import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObject
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
-import StixDomainObjectContent from '../../common/stix_domain_objects/StixDomainObjectContent';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 
 import { RootIncidentQuery } from './__generated__/RootIncidentQuery.graphql';
@@ -53,7 +53,7 @@ const incidentQuery = graphql`
       x_opencti_graph_data
       ...Incident_incident
       ...IncidentKnowledge_incident
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
@@ -180,8 +180,8 @@ const RootIncidentComponent = ({ queryRef }) => {
             <Route
               path="/content"
               element={(
-                <StixDomainObjectContent
-                  stixDomainObject={incident}
+                <StixCoreObjectContent
+                  stixCoreObject={incident}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -54,6 +54,7 @@ const administrativeAreaQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -8,6 +8,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import AdministrativeArea from './AdministrativeArea';
 import AdministrativeAreaKnowledge from './AdministrativeAreaKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
@@ -140,6 +141,12 @@ const RootAdministrativeAreaComponent = ({
               />
               <Tab
                 component={Link}
+                to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/content`}
+                value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/analyses`}
                 value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/analyses`}
                 label={t_i18n('Analyses')}
@@ -182,6 +189,14 @@ const RootAdministrativeAreaComponent = ({
               element={
                 <AdministrativeAreaKnowledge administrativeAreaData={administrativeArea} />
               }
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={administrativeArea}
+                />
+              )}
             />
             <Route
               path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -54,6 +54,7 @@ const cityQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -8,6 +8,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import City from './City';
 import CityKnowledge from './CityKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
@@ -132,6 +133,12 @@ const RootCityComponent = ({ queryRef, cityId, link }) => {
               />
               <Tab
                 component={Link}
+                to={`/dashboard/locations/cities/${city.id}/content`}
+                value={`/dashboard/locations/cities/${city.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/locations/cities/${city.id}/analyses`}
                 value={`/dashboard/locations/cities/${city.id}/analyses`}
                 label={t_i18n('Analyses')}
@@ -170,6 +177,14 @@ const RootCityComponent = ({ queryRef, cityId, link }) => {
             <Route
               path="/knowledge/*"
               element={<CityKnowledge cityData={city} />}
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={city}
+                />
+              )}
             />
             <Route
               path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -8,6 +8,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import Country from './Country';
 import CountryKnowledge from './CountryKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
@@ -134,6 +135,12 @@ const RootCountryComponent = ({ queryRef, countryId, link }) => {
               />
               <Tab
                 component={Link}
+                to={`/dashboard/locations/countries/${country.id}/content`}
+                value={`/dashboard/locations/countries/${country.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/locations/countries/${country.id}/analyses`}
                 value={`/dashboard/locations/countries/${country.id}/analyses`}
                 label={t_i18n('Analyses')}
@@ -172,6 +179,14 @@ const RootCountryComponent = ({ queryRef, countryId, link }) => {
             <Route
               path="/knowledge/*"
               element={<CountryKnowledge countryData={country} />}
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={country}
+                />
+              )}
             />
             <Route
               path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -54,6 +54,7 @@ const countryQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Position from './Position';
@@ -171,6 +172,12 @@ class RootPosition extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/locations/positions/${position.id}/content`}
+                          value={`/dashboard/locations/positions/${position.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/locations/positions/${position.id}/analyses`}
                           value={`/dashboard/locations/positions/${position.id}/analyses`}
                           label={t('Analyses')}
@@ -213,6 +220,14 @@ class RootPosition extends Component {
                         element={
                           <PositionKnowledge position={props.position} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={position}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.jsx
@@ -51,6 +51,7 @@ const positionQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -9,6 +9,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import Region from './Region';
 import RegionKnowledge from './RegionKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
@@ -135,6 +136,12 @@ const RootRegionComponent = ({ queryRef, regionId, link }) => {
               />
               <Tab
                 component={Link}
+                to={`/dashboard/locations/regions/${region.id}/content`}
+                value={`/dashboard/locations/regions/${region.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/locations/regions/${region.id}/analyses`}
                 value={`/dashboard/locations/regions/${region.id}/analyses`}
                 label={t_i18n('Analyses')}
@@ -173,6 +180,14 @@ const RootRegionComponent = ({ queryRef, regionId, link }) => {
             <Route
               path="/knowledge/*"
               element={<RegionKnowledge regionData={region} />}
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={region}
+                />
+              )}
             />
             <Route
               path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -55,6 +55,7 @@ const regionQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -135,6 +136,12 @@ class RootArtifact extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/content`}
+                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/analyses`}
                           value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/analyses`}
                           label={t('Analyses')}
@@ -176,6 +183,14 @@ class RootArtifact extends Component {
                             connectorsForImport={props.connectorsForImport}
                           />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={stixCyberObservable}
+                          />
+                        )}
                       />
                       <Route
                         path="/sightings"

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
@@ -52,6 +52,7 @@ const rootArtifactQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.jsx
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import Indicator from './Indicator';
@@ -137,6 +138,12 @@ class RootIndicator extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/observations/indicators/${indicator.id}/content`}
+                          value={`/dashboard/observations/indicators/${indicator.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/observations/indicators/${indicator.id}/analyses`}
                           value={`/dashboard/observations/indicators/${indicator.id}/analyses`}
                           label={t('Analyses')}
@@ -165,6 +172,14 @@ class RootIndicator extends Component {
                       <Route
                         path="/"
                         element={(<Indicator indicator={indicator} />)}
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={indicator}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.jsx
@@ -53,6 +53,7 @@ const indicatorQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -11,6 +11,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import InfrastructureKnowledge from './InfrastructureKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import FileManager from '../../common/files/FileManager';
 import InfrastructurePopover from './InfrastructurePopover';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -126,6 +127,12 @@ const RootInfrastructureComponent = ({ queryRef, infrastructureId }) => {
               />
               <Tab
                 component={Link}
+                to={`/dashboard/observations/infrastructures/${infrastructure.id}/content`}
+                value={`/dashboard/observations/infrastructures/${infrastructure.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/observations/infrastructures/${infrastructure.id}/analyses`}
                 value={`/dashboard/observations/infrastructures/${infrastructure.id}/analyses`}
                 label={t_i18n('Analyses')}
@@ -162,6 +169,14 @@ const RootInfrastructureComponent = ({ queryRef, infrastructureId }) => {
             <Route
               path="/knowledge/*"
               element={<InfrastructureKnowledge infrastructure={infrastructure} />}
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={infrastructure}
+                />
+              )}
             />
             <Route
               path="/analyses/*"

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -54,6 +54,7 @@ const infrastructureQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.jsx
@@ -53,6 +53,7 @@ const stixCyberObservableQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.jsx
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -135,6 +136,12 @@ class RootStixCyberObservable extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/observations/observables/${stixCyberObservable.id}/content`}
+                          value={`/dashboard/observations/observables/${stixCyberObservable.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/observations/observables/${stixCyberObservable.id}/analyses`}
                           value={`/dashboard/observations/observables/${stixCyberObservable.id}/analyses`}
                           label={t('Analyses')}
@@ -175,6 +182,14 @@ class RootStixCyberObservable extends Component {
                             stixCyberObservable={props.stixCyberObservable}
                           />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={props.stixCyberObservable}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
@@ -226,7 +226,7 @@ const StixCyberObservableDetails = createFragmentContainer(
         observable_value
         ... on AutonomousSystem {
           number
-          name
+          observableName: name
           rir
         }
         ... on Directory {
@@ -279,7 +279,7 @@ const StixCyberObservableDetails = createFragmentContainer(
         ... on StixFile {
           extensions
           size
-          name
+          observableName: name
           name_enc
           magic_number_hex
           mime_type
@@ -338,7 +338,7 @@ const StixCyberObservableDetails = createFragmentContainer(
           value
         }
         ... on Mutex {
-          name
+          observableName: name
         }
         ... on NetworkTraffic {
           extensions
@@ -382,7 +382,7 @@ const StixCyberObservableDetails = createFragmentContainer(
           service_status
         }
         ... on Software {
-          name
+          observableName: name
           cpe
           swid
           languages
@@ -415,7 +415,7 @@ const StixCyberObservableDetails = createFragmentContainer(
           number_of_subkeys
         }
         ... on WindowsRegistryValueType {
-          name
+          observableName: name
           data
           data_type
         }

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import AttackPattern from './AttackPattern';
@@ -167,6 +168,12 @@ class RootAttackPattern extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/content`}
+                          value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/analyses`}
                           value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/analyses`}
                           label={t('Analyses')}
@@ -203,6 +210,14 @@ class RootAttackPattern extends Component {
                         element={
                           <AttackPatternKnowledge attackPattern={props.attackPattern} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={attackPattern}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
@@ -52,6 +52,7 @@ const attackPatternQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -48,6 +48,7 @@ const courseOfActionQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import CourseOfAction from './CourseOfAction';
@@ -127,6 +128,12 @@ class RootCourseOfAction extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/content`}
+                          value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/files`}
                           value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/files`}
                           label={t('Data')}
@@ -151,6 +158,14 @@ class RootCourseOfAction extends Component {
                         element={
                           <CourseOfActionKnowledge courseOfAction={props.courseOfAction} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={courseOfAction}
+                          />
+                        )}
                       />
                       <Route
                         path="/files"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -53,6 +53,7 @@ const dataComponentQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -9,6 +9,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import { QueryRenderer } from '../../../../relay/environment';
 import Loader from '../../../../components/Loader';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -133,6 +134,12 @@ const RootDataComponent = () => {
                       />
                       <Tab
                         component={Link}
+                        to={`/dashboard/techniques/data_components/${dataComponent.id}/content`}
+                        value={`/dashboard/techniques/data_components/${dataComponent.id}/content`}
+                        label={t_i18n('Content')}
+                      />
+                      <Tab
+                        component={Link}
                         to={`/dashboard/techniques/data_components/${dataComponent.id}/files`}
                         value={`/dashboard/techniques/data_components/${dataComponent.id}/files`}
                         label={t_i18n('Data')}
@@ -157,6 +164,14 @@ const RootDataComponent = () => {
                       element={
                         <DataComponentKnowledge data={dataComponent} />
                       }
+                    />
+                    <Route
+                      path="/content"
+                      element={(
+                        <StixCoreObjectContent
+                          stixCoreObject={dataComponent}
+                        />
+                      )}
                     />
                     <Route
                       path="/files"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -9,6 +9,7 @@ import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import FileManager from '../../common/files/FileManager';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
@@ -121,6 +122,12 @@ const RootDataSourceComponent = ({ queryRef, dataSourceId }) => {
               />
               <Tab
                 component={Link}
+                to={`/dashboard/techniques/data_sources/${dataSource.id}/content`}
+                value={`/dashboard/techniques/data_sources/${dataSource.id}/content`}
+                label={t_i18n('Content')}
+              />
+              <Tab
+                component={Link}
                 to={`/dashboard/techniques/data_sources/${dataSource.id}/files`}
                 value={`/dashboard/techniques/data_sources/${dataSource.id}/files`}
                 label={t_i18n('Data')}
@@ -150,6 +157,14 @@ const RootDataSourceComponent = ({ queryRef, dataSourceId }) => {
                   )}
                 />
               }
+            />
+            <Route
+              path="/content"
+              element={(
+                <StixCoreObjectContent
+                  stixCoreObject={dataSource}
+                />
+              )}
             />
             <Route
               path="/files"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -52,6 +52,7 @@ const dataSourceQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Narrative from './Narrative';
@@ -164,6 +165,12 @@ class RootNarrative extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/techniques/narratives/${narrative.id}/content`}
+                          value={`/dashboard/techniques/narratives/${narrative.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/techniques/narratives/${narrative.id}/analyses`}
                           value={`/dashboard/techniques/narratives/${narrative.id}/analyses`}
                           label={t('Analyses')}
@@ -200,6 +207,14 @@ class RootNarrative extends Component {
                         element={
                           <NarrativeKnowledge narrative={props.narrative} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={narrative}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
@@ -52,6 +52,7 @@ const narrativeQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
@@ -7,6 +7,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
 import StixCoreObjectSimulationResult from '../../common/stix_core_objects/StixCoreObjectSimulationResult';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import Campaign from './Campaign';
@@ -172,6 +173,12 @@ class RootCampaign extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/threats/campaigns/${campaign.id}/content`}
+                          value={`/dashboard/threats/campaigns/${campaign.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/threats/campaigns/${campaign.id}/analyses`}
                           value={`/dashboard/threats/campaigns/${campaign.id}/analyses`}
                           label={t('Analyses')}
@@ -211,6 +218,14 @@ class RootCampaign extends Component {
                         element={
                           <CampaignKnowledge campaign={props.campaign} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={props.campaign}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.jsx
@@ -53,6 +53,7 @@ const campaignQuery = graphql`
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
@@ -58,6 +58,7 @@ const intrusionSetQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.jsx
@@ -7,6 +7,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
 import StixCoreObjectSimulationResult from '../../common/stix_core_objects/StixCoreObjectSimulationResult';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import IntrusionSet from './IntrusionSet';
@@ -180,6 +181,12 @@ class RootIntrusionSet extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/content`}
+                          value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/analyses`}
                           value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/analyses`}
                           label={t('Analyses')}
@@ -221,6 +228,14 @@ class RootIntrusionSet extends Component {
                             <IntrusionSetKnowledge intrusionSet={props.intrusionSet} />
                           </div>
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={props.intrusionSet}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
@@ -55,6 +55,7 @@ const ThreatActorGroupQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForImport {
       ...FileManager_connectorsImport

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.jsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectSimulationResult from '../../common/stix_core_objects/StixCoreObjectSimulationResult';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import ThreatActorGroup from './ThreatActorGroup';
@@ -176,6 +177,12 @@ class RootThreatActorGroup extends Component {
                         />
                         <Tab
                           component={Link}
+                          to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/content`}
+                          value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/content`}
+                          label={t('Content')}
+                        />
+                        <Tab
+                          component={Link}
                           to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/analyses`}
                           value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/analyses`}
                           label={t('Analyses')}
@@ -215,6 +222,14 @@ class RootThreatActorGroup extends Component {
                         element={
                           <ThreatActorGroupKnowledge threatActorGroup={props.threatActorGroup} />
                         }
+                      />
+                      <Route
+                        path="/content"
+                        element={(
+                          <StixCoreObjectContent
+                            stixCoreObject={props.threatActorGroup}
+                          />
+                        )}
                       />
                       <Route
                         path="/analyses"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -10,6 +10,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectSimulationResult from '../../common/stix_core_objects/StixCoreObjectSimulationResult';
+import StixCoreObjectContent from '../../common/stix_core_objects/StixCoreObjectContent';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -58,7 +59,7 @@ const ThreatActorIndividualQuery = graphql`
       ...FileExternalReferencesViewer_entity
       ...WorkbenchFileViewer_entity
       ...PictureManagementViewer_entity
-      ...StixDomainObjectContent_stixDomainObject
+      ...StixCoreObjectContent_stixCoreObject
     }
     connectorsForExport {
       ...FileManager_connectorsExport
@@ -175,6 +176,12 @@ const RootThreatActorIndividualComponent = ({
                 />
                 <Tab
                   component={Link}
+                  to={`/dashboard/threats/threat_actors_individual/${data.id}/content`}
+                  value={`/dashboard/threats/threat_actors_individual/${data.id}/content`}
+                  label={t_i18n('Content')}
+                />
+                <Tab
+                  component={Link}
                   to={`/dashboard/threats/threat_actors_individual/${data.id}/analyses`}
                   value={`/dashboard/threats/threat_actors_individual/${data.id}/analyses`}
                   label={t_i18n('Analyses')}
@@ -214,6 +221,14 @@ const RootThreatActorIndividualComponent = ({
                 element={
                   <ThreatActorIndividualKnowledge threatActorIndividualData={data} />
                 }
+              />
+              <Route
+                path="/content"
+                element={(
+                  <StixCoreObjectContent
+                    stixCoreObject={data}
+                  />
+                )}
               />
               <Route
                 path="/analyses"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add content tab on all entities
* refacto => `stixDomainObjectContent` to  `stixCoreObjectContent`
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [issue/5651](https://github.com/OpenCTI-Platform/opencti/issues/5651)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
