### PR TITLE
[backend] remove concurrency in reportDeleteWithElements (#7015)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -141,9 +141,10 @@ export const reportDeleteWithElements = async (context, user, reportId) => {
   const reportOrphanObjects = await listAllThings(context, user, [ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_RELATIONSHIP], args);
   // Filter out relationships that will already be deleted with the deletion of the source or target element
   const objectsToDelete = reportOrphanObjects.filter((fo) => !reportOrphanObjects.some((o) => fo.fromId === o.internal_id || fo.toId === o.internal_id));
-  await BluePromise.map(objectsToDelete, (object) => {
-    return internalDeleteElementById(context, context.user, object.id);
-  }, { concurrency: ES_MAX_CONCURRENCY });
+  for (let i = 0; i < objectsToDelete.length; i += 1) {
+    const object = objectsToDelete[i];
+    await internalDeleteElementById(context, context.user, object.id);
+  }
   // Delete the report
   await stixDomainObjectDelete(context, user, reportId);
   return reportId;

--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -1,5 +1,4 @@
 import * as R from 'ramda';
-import { Promise as BluePromise } from 'bluebird';
 import { createEntity, distributionEntities, internalDeleteElementById, listAllThings, timeSeriesEntities } from '../database/middleware';
 import { countAllThings, internalLoadById, listEntities, storeLoadById } from '../database/middleware-loader';
 import { BUS_TOPICS } from '../config/conf';
@@ -7,7 +6,7 @@ import { notify } from '../database/redis';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../schema/stixDomainObject';
 import { RELATION_CREATED_BY, RELATION_OBJECT } from '../schema/stixRefRelationship';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_DOMAIN_OBJECT, ABSTRACT_STIX_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
-import { elCount, ES_MAX_CONCURRENCY } from '../database/engine';
+import { elCount } from '../database/engine';
 import { READ_DATA_INDICES_WITHOUT_INFERRED, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { isStixId } from '../schema/schemaUtils';
 import { stixDomainObjectDelete } from './stixDomainObject';

--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation.ts
@@ -29,7 +29,10 @@ const DELETE_OPERATION_DEFINITION: ModuleDefinition<StoreEntityDeleteOperation, 
     { name: 'deleted_elements', label: 'Deleted elements', type: 'object', format: 'flat', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
   ],
   relations: [],
-  relationsRefs: [objectOrganization, objectMarking],
+  relationsRefs: [
+    objectMarking,
+    { ...objectOrganization, isFilterable: false },
+  ],
   representative: (stix: StixDeleteOperation) => {
     return stix.main_entity_name;
   },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* concurrency in reportDeleteWithElements could cause problem in some conditions: if two entities are orphans and are deleted in concurrency, and the entities have a relationship between them, both entities could try to delete this relationship at the same time

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7015 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
