### PR TITLE
[frontend] Drone e2e wait longer for API to inject data (fix flaky tests)

### DIFF
--- a/opencti-platform/opencti-graphql/script/script-wait-for-api.js
+++ b/opencti-platform/opencti-graphql/script/script-wait-for-api.js
@@ -3,7 +3,7 @@ import conf, { logApp } from '../src/config/conf';
 
 const API_URI = `http://localhost:${conf.get('app:port')}`;
 
-const MAX_ATTEMPTS = 30;
+const MAX_ATTEMPTS = 60;
 const DELAY_BETWEEN_ATTEMPTS = 5000;
 
 const checkApiAvailability = async () => {


### PR DESCRIPTION
### Proposed changes

* Augment the time we wait to inject data

### Related issues

* Flaky e2e because init data was not injected

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
