### PR TITLE
[frontend] Fix workbench SDO deduplication (#6797)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -243,6 +243,8 @@ const importValidation = (t) => Yup.object().shape({
   connector_id: Yup.string().trim().required(t('This field is required')),
 });
 
+const uniqStixDomainObjectsFields = ['name', 'type', 'pattern', 'identity_class', 'x_opencti_location_type'];
+
 const WorkbenchFileContentComponent = ({
   connectorsImport,
   file,
@@ -1065,7 +1067,7 @@ const WorkbenchFileContentComponent = ({
     }
     setStixDomainObjects(
       uniqWithByFields(
-        ['name', 'type'],
+        uniqStixDomainObjectsFields,
         R.uniqBy(R.prop('id'), [
           ...stixDomainObjects.filter((n) => n.id !== updatedEntity.id),
           ...markingDefinitions,
@@ -1172,7 +1174,7 @@ const WorkbenchFileContentComponent = ({
     );
     setStixDomainObjects(
       uniqWithByFields(
-        ['name', 'type', 'identity_class', 'x_opencti_location_type'],
+        uniqStixDomainObjectsFields,
         R.uniqBy(R.prop('id'), [
           ...stixDomainObjects.filter(
             (n) => !stixDomainObjectsToDeleteIds.includes(n.id),
@@ -1247,7 +1249,7 @@ const WorkbenchFileContentComponent = ({
     );
     setStixDomainObjects(
       uniqWithByFields(
-        ['name', 'type'],
+        uniqStixDomainObjectsFields,
         R.uniqBy(R.prop('id'), [
           ...stixDomainObjects,
           ...markingDefinitions,
@@ -1371,7 +1373,7 @@ const WorkbenchFileContentComponent = ({
     ]);
     setStixDomainObjects(
       uniqWithByFields(
-        ['name', 'type'],
+        uniqStixDomainObjectsFields,
         R.uniqBy(R.prop('id'), [
           ...stixDomainObjects,
           ...markingDefinitions,
@@ -1453,7 +1455,7 @@ const WorkbenchFileContentComponent = ({
     setContainerStep(1);
     setStixDomainObjects(
       uniqWithByFields(
-        ['name', 'type'],
+        uniqStixDomainObjectsFields,
         R.uniqBy(R.prop('id'), [
           ...stixDomainObjects,
           ...markingDefinitions,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix stix domain objects update deduplication : adding missing fields (pattern for indicators).

### Related issues
Issue was happening with indicators because we were deduplicating them based only on name (and we didn't have a name, so the two entities were considered the same).
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6797 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->