### PR TITLE
[backend] fix stream sync handling of loss of entity visibility 

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncPopover.jsx
@@ -237,10 +237,10 @@ class SyncPopover extends Component {
               {t('Stop')}
             </MenuItem>
           )}
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
+          <MenuItem disabled={running} onClick={this.handleOpenUpdate.bind(this)}>
             {t('Update')}
           </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
+          <MenuItem disabled={running} onClick={this.handleOpenDelete.bind(this)}>
             {t('Delete')}
           </MenuItem>
         </Menu>

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -576,7 +576,7 @@ const createSseMiddleware = () => {
                 if (type === EVENT_TYPE_UPDATE) {
                   const { newDocument: previous } = jsonpatch.applyPatch(structuredClone(stix), evenContext.reverse_patch);
                   const isPreviouslyVisible = await isStixMatchFilterGroup(context, user, previous, streamFilters);
-                  if (isPreviouslyVisible && !isCurrentlyVisible) { // No longer visible
+                  if (isPreviouslyVisible && !isCurrentlyVisible && publishDeletion) { // No longer visible
                     client.sendEvent(eventId, EVENT_TYPE_DELETE, eventData);
                     cache.set(stix.id, 'hit');
                   } else if (!isPreviouslyVisible && isCurrentlyVisible) { // Newly visible


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we now check for listen-delete configuration before deleting an item that is no longer visible following an update event

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6951

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
