### PR TITLE
[frontend] Workbench: use octi observable type instead of stix type to compute observable value (#6996)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -1336,7 +1336,7 @@ const WorkbenchFileContentComponent = ({
       observable_value: observableValue({
         ...observable,
         ...finalValues,
-        entity_type: stixType,
+        entity_type: observableType,
       }),
     };
     const observableDefaultKey = defaultKey(updatedObservable);


### PR DESCRIPTION
### Proposed changes

* Invalid type was given to the function that determines observable value to display (we were using stix type instead of type from octi)

### Related issues

* #6996 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality