### PR TITLE
[backend] Handle external refs files upload by import document (#7080)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -10,12 +10,12 @@ import { deleteWorkForSource } from '../domain/work';
 import { ENTITY_TYPE_SUPPORT_PACKAGE } from '../modules/support/support-types';
 
 interface FileUploadOpts {
-  entity?:BasicStoreBase | unknown,
+  entity?:BasicStoreBase | unknown, // entity on which the file is uploaded
   meta? : any,
   noTriggerImport?: boolean,
   errorOnExisting?: boolean,
   file_markings?: string[],
-  container?: BasicStoreEntity,
+  importContextEntities?: BasicStoreEntity[], // entities used for import context
 }
 
 interface FileUploadData {

--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -15,6 +15,7 @@ interface FileUploadOpts {
   noTriggerImport?: boolean,
   errorOnExisting?: boolean,
   file_markings?: string[],
+  containerId?: string,
 }
 
 interface FileUploadData {

--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import fs from 'node:fs';
 import { deleteFiles, loadedFilesListing, upload } from './file-storage';
 import type { AuthContext, AuthUser } from '../types/user';
-import type { BasicStoreBase } from '../types/store';
+import type { BasicStoreBase, BasicStoreEntity } from '../types/store';
 import { logApp } from '../config/conf';
 import { allFilesForPaths } from '../modules/internal/document/document-domain';
 import { deleteWorkForSource } from '../domain/work';
@@ -15,7 +15,7 @@ interface FileUploadOpts {
   noTriggerImport?: boolean,
   errorOnExisting?: boolean,
   file_markings?: string[],
-  containerId?: string,
+  container?: BasicStoreEntity,
 }
 
 interface FileUploadData {

--- a/opencti-platform/opencti-graphql/src/domain/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/domain/externalReference.js
@@ -9,7 +9,7 @@ import { ABSTRACT_STIX_REF_RELATIONSHIP, buildRefRelationKey } from '../schema/g
 import { isStixRefRelationship, RELATION_EXTERNAL_REFERENCE } from '../schema/stixRefRelationship';
 import { isEmptyField } from '../database/utils';
 import { BYPASS, BYPASS_REFERENCE } from '../utils/access';
-import { stixCoreObjectImportDelete } from './stixCoreObject';
+import { stixCoreObjectImportDelete, stixCoreObjectImportPush } from './stixCoreObject';
 import { addFilter } from '../utils/filtering/filtering-utils';
 
 export const findById = (context, user, externalReferenceId) => {
@@ -31,6 +31,16 @@ export const references = async (context, user, externalReferenceId, args) => {
     return paginateAllThings(context, user, types, R.assoc('filters', filters, args));
   }
   return listThings(context, user, types, R.assoc('filters', filters, args));
+};
+
+export const externalReferenceImportPush = async (context, user, externalReferenceId, file, args = {}) => {
+  const containersRefs = await references(context, user, externalReferenceId, { types: ['Container'], connectionFormat: false, first: 2 });
+  let finalArgs = { ...args };
+  if (containersRefs.length === 1) {
+    // if externalRef is contained in one container only, we want to send this context container id for import
+    finalArgs = { ...finalArgs, containerId: containersRefs[0]?.id };
+  }
+  return stixCoreObjectImportPush(context, user, externalReferenceId, file, finalArgs);
 };
 
 export const addExternalReference = async (context, user, externalReference) => {

--- a/opencti-platform/opencti-graphql/src/domain/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/domain/externalReference.js
@@ -34,12 +34,8 @@ export const references = async (context, user, externalReferenceId, args) => {
 };
 
 export const externalReferenceImportPush = async (context, user, externalReferenceId, file, args = {}) => {
-  const containersRefs = await references(context, user, externalReferenceId, { types: ['Container'], connectionFormat: false, first: 2 });
-  let finalArgs = { ...args };
-  if (containersRefs.length === 1) {
-    // if externalRef is contained in one container only, we want to send this context container id for import
-    finalArgs = { ...finalArgs, container: containersRefs[0] };
-  }
+  const entitiesReferences = await references(context, user, externalReferenceId, { types: ['Stix-Domain-Object'], connectionFormat: false, first: 50 });
+  const finalArgs = { ...args, importContextEntities: entitiesReferences };
   return stixCoreObjectImportPush(context, user, externalReferenceId, file, finalArgs);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/domain/externalReference.js
@@ -38,7 +38,7 @@ export const externalReferenceImportPush = async (context, user, externalReferen
   let finalArgs = { ...args };
   if (containersRefs.length === 1) {
     // if externalRef is contained in one container only, we want to send this context container id for import
-    finalArgs = { ...finalArgs, containerId: containersRefs[0]?.id };
+    finalArgs = { ...finalArgs, container: containersRefs[0] };
   }
   return stixCoreObjectImportPush(context, user, externalReferenceId, file, finalArgs);
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -389,7 +389,7 @@ export const stixCoreObjectExportPush = async (context, user, entityId, args) =>
 
 export const stixCoreObjectImportPush = async (context, user, id, file, args = {}) => {
   let lock;
-  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings, container } = args;
+  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings, importContextEntities } = args;
   const previous = await storeLoadByIdWithRefs(context, user, id);
   if (!previous) {
     throw UnsupportedError('Cant upload a file an none existing element', { id });
@@ -409,7 +409,7 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
       const key = `${filePath}/${filename}`;
       meta.external_reference_id = generateStandardId(ENTITY_TYPE_EXTERNAL_REFERENCE, { url: `/storage/get/${key}` });
     }
-    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings, container });
+    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings, importContextEntities });
     if (untouched) {
       // When synchronizing the version can be the same.
       // If it's the case, just return without any x_opencti_files modifications

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -389,7 +389,7 @@ export const stixCoreObjectExportPush = async (context, user, entityId, args) =>
 
 export const stixCoreObjectImportPush = async (context, user, id, file, args = {}) => {
   let lock;
-  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings } = args;
+  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings, containerId } = args;
   const previous = await storeLoadByIdWithRefs(context, user, id);
   if (!previous) {
     throw UnsupportedError('Cant upload a file an none existing element', { id });
@@ -409,7 +409,7 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
       const key = `${filePath}/${filename}`;
       meta.external_reference_id = generateStandardId(ENTITY_TYPE_EXTERNAL_REFERENCE, { url: `/storage/get/${key}` });
     }
-    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings });
+    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings, containerId });
     if (untouched) {
       // When synchronizing the version can be the same.
       // If it's the case, just return without any x_opencti_files modifications

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -389,7 +389,7 @@ export const stixCoreObjectExportPush = async (context, user, entityId, args) =>
 
 export const stixCoreObjectImportPush = async (context, user, id, file, args = {}) => {
   let lock;
-  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings, containerId } = args;
+  const { noTriggerImport, version: fileVersion, fileMarkings: file_markings, container } = args;
   const previous = await storeLoadByIdWithRefs(context, user, id);
   if (!previous) {
     throw UnsupportedError('Cant upload a file an none existing element', { id });
@@ -409,7 +409,7 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
       const key = `${filePath}/${filename}`;
       meta.external_reference_id = generateStandardId(ENTITY_TYPE_EXTERNAL_REFERENCE, { url: `/storage/get/${key}` });
     }
-    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings, containerId });
+    const { upload: up, untouched } = await uploadToStorage(context, user, filePath, file, { meta, noTriggerImport, entity: previous, file_markings, container });
     if (untouched) {
       // When synchronizing the version can be the same.
       // If it's the case, just return without any x_opencti_files modifications

--- a/opencti-platform/opencti-graphql/src/resolvers/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/externalReference.js
@@ -7,6 +7,7 @@ import {
   externalReferenceDeleteRelation,
   externalReferenceEditContext,
   externalReferenceEditField,
+  externalReferenceImportPush,
   findAll,
   findById,
   references,
@@ -15,7 +16,7 @@ import { fetchEditContext } from '../database/redis';
 import { subscribeToInstanceEvents } from '../graphql/subscriptionWrapper';
 import { worksForSource } from '../domain/work';
 import { loadFile } from '../database/file-storage';
-import { askElementEnrichmentForConnector, stixCoreObjectImportPush } from '../domain/stixCoreObject';
+import { askElementEnrichmentForConnector } from '../domain/stixCoreObject';
 import { connectorsForEnrichment } from '../database/repository';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
 import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
@@ -65,7 +66,7 @@ const externalReferenceResolvers = {
         return externalReferenceDeleteRelation(context, context.user, id, fromId, relationshipType);
       },
       askEnrichment: ({ connectorId }) => askElementEnrichmentForConnector(context, context.user, id, connectorId),
-      importPush: (args) => stixCoreObjectImportPush(context, context.user, id, args.file, args),
+      importPush: (args) => externalReferenceImportPush(context, context.user, id, args.file, args),
     }),
     externalReferenceAdd: (_, { input }, context) => addExternalReference(context, context.user, input),
   },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Include external reference files for document import
* When uploading a file in external reference, get the entities (stix domain objects) linked to the external ref to be used for document import (importContextEntities). We list all entities, but in the vast majority of cases external refs are only linked to one entity. This will create a workbench on the context entity, with extracted objects linked to this entity.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7080 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

To test this PR, you need to run import-document and import-external-reference connectors locally. For import-external-reference, you will need to install wkhtmltopdf https://wkhtmltopdf.org/downloads.html and in config.yml set 
`wkhtmltopdf_path: 'C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe'`

When you test import-document, set your config with `auto: true` and `validate_before_import: true`, then make sure the workbench is created on the container of the external-ref. 

![image](https://github.com/OpenCTI-Platform/opencti/assets/668192/1d360305-10fc-402e-9ac8-6d46c4387284)
