### PR TITLE
[backend] do not check confidence of indicator when creating observable from it (#7112)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -51,7 +51,6 @@ import {
 import { isModuleActivated } from '../../domain/settings';
 import { stixDomainObjectEditField } from '../../domain/stixDomainObject';
 import { prepareDate, utcDate } from '../../utils/format';
-import { controlUserConfidenceAgainstElement } from '../../utils/confidence-level';
 
 export const findById = (context: AuthContext, user: AuthUser, indicatorId: string) => {
   return storeLoadById<BasicStoreEntityIndicator>(context, user, indicatorId, ENTITY_TYPE_INDICATOR);
@@ -159,7 +158,6 @@ export const createObservablesFromIndicator = async (
   input: { objectLabel?: string[] | null; objectMarking?: string[] | null; objectOrganization?: string[] | null; createdBy?: string | null; externalReferences?: string[] | null; },
   indicator: StoreEntityIndicator,
 ) => {
-  controlUserConfidenceAgainstElement(user, indicator);
   const { pattern } = indicator;
   const observables = extractValidObservablesFromIndicatorPattern(pattern);
   const observablesToLink = [];
@@ -201,7 +199,6 @@ export const createObservablesFromIndicator = async (
 
 export const promoteIndicatorToObservable = async (context: AuthContext, user: AuthUser, indicatorId: string) => {
   const indicator: StoreEntityIndicator = await storeLoadByIdWithRefs(context, user, indicatorId) as StoreEntityIndicator;
-  controlUserConfidenceAgainstElement(user, indicator);
   const objectLabel = (indicator[INPUT_LABELS] ?? []).map((n) => n.internal_id);
   const objectMarking = (indicator[INPUT_MARKINGS] ?? []).map((n) => n.internal_id);
   const objectOrganization = (indicator[INPUT_GRANTED_REFS] ?? []).map((n) => n.internal_id);


### PR DESCRIPTION
### Proposed changes

* Remove confidence check when creating observable from indicator

### Related issues
* closes #7112 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
 
 Creating an observable from indicator should not be under confidence check over the indicator. We are basically creating an observable + relationship between the 2 entities. This is not a ref, this is a stix-core-relationship. This is simply knowledge creation.
