### PR TITLE
[backend/frontend] API types ref mapping completed (#6281)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -188,7 +188,10 @@ const rootPrivateQuery = graphql`
     }
     schemaRelationsRefTypesMapping {
       key
-      values
+      values {
+        name
+        toTypes
+      }
     }
     filterKeysSchema {
       entity_type

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationExpandForm.tsx
@@ -256,8 +256,15 @@ const InvestigationExpandFormContent = ({
         });
       }
     });
+
     // relations refs involving the user are not expandable
-    const relationRefsWithUser = (schema.schemaRelationsRefTypesMapping.get('*_User') ?? []).map((ref) => ref.toLowerCase());
+    const relationRefsWithUser = new Set(
+      Array.from(schema.schemaRelationsRefTypesMapping.values())
+        .flat()
+        .filter((ref) => ref.toTypes.includes('User'))
+        .map((ref) => ref.name.toLowerCase()),
+    );
+
     const nonNullDistribution = (
       distributionRel.stixRelationshipsDistribution ?? []
     )
@@ -279,7 +286,7 @@ const InvestigationExpandFormContent = ({
         ]
         : []))
       // Remove from the list relations with nothing to add and relations ref involving the user
-      .filter(({ label, value }) => value > 0 && !relationRefsWithUser?.includes(label.replace('-', '')))
+      .filter(({ label, value }) => value > 0 && !relationRefsWithUser?.has(label.replace('-', '')))
       .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
     setRelationships(
       nonNullDistribution.map(({ label, value }) => ({

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7006,6 +7006,16 @@ type StixRelationshipSchema {
   values: [String!]!
 }
 
+type StixRelationshipRefSchemaValue {
+  name: String!
+  toTypes: [String!]!
+}
+
+type StixRelationshipRefSchema {
+  key: String!
+  values: [StixRelationshipRefSchemaValue!]!
+}
+
 enum StixCoreRelationshipsOrdering {
   entity_type
   relationship_type
@@ -7491,7 +7501,7 @@ type Query {
   stixRelationshipsDistribution(field: String!, operation: StatsOperation!, startDate: DateTime, endDate: DateTime, dateAttribute: String, isTo: Boolean, limit: Int, order: String, fromOrToId: [String], elementWithTargetTypes: [String], fromId: [String], fromRole: String, fromTypes: [String], toId: [String], toRole: String, toTypes: [String], relationship_type: [String], confidences: [Int], search: String, filters: FilterGroup, dynamicFrom: FilterGroup, dynamicTo: FilterGroup, aggregateOnConnections: Boolean): [Distribution]
   stixRelationshipsNumber(dateAttribute: String, authorId: String, noDirection: Boolean, endDate: DateTime, onlyInferred: Boolean, fromOrToId: [String], elementWithTargetTypes: [String], fromId: [String], fromRole: String, fromTypes: [String], toId: [String], toRole: String, toTypes: [String], relationship_type: [String], confidences: [Int], search: String, filters: FilterGroup, dynamicFrom: FilterGroup, dynamicTo: FilterGroup): Number
   schemaRelationsTypesMapping: [StixRelationshipSchema!]!
-  schemaRelationsRefTypesMapping: [StixRelationshipSchema!]!
+  schemaRelationsRefTypesMapping: [StixRelationshipRefSchema!]!
   filterKeysSchema: [FilterKeysSchema!]!
   stixCoreRelationship(id: String): StixCoreRelationship
   stixCoreRelationships(first: Int, after: ID, orderBy: StixCoreRelationshipsOrdering, orderMode: OrderingMode, fromOrToId: [String], elementWithTargetTypes: [String], fromId: [String], fromRole: String, fromTypes: [String], toId: [String], toRole: String, toTypes: [String], relationship_type: [String], startTimeStart: DateTime, startTimeStop: DateTime, stopTimeStart: DateTime, stopTimeStop: DateTime, firstSeenStart: DateTime, firstSeenStop: DateTime, lastSeenStart: DateTime, lastSeenStop: DateTime, startDate: DateTime, endDate: DateTime, confidences: [Int], search: String, filters: FilterGroup, stix: Boolean): StixCoreRelationshipConnection

--- a/opencti-platform/opencti-front/src/utils/Relation.ts
+++ b/opencti-platform/opencti-front/src/utils/Relation.ts
@@ -47,18 +47,12 @@ export const resolveTypesForRelationship = (
 };
 
 export const resolveTypesForRelationshipRef = (
-  schemaRelationsTypesMapping: Map<string, readonly string[]>,
+  schemaRelationsTypesMapping: Map<string, readonly { readonly name: string, readonly toTypes: readonly string[] }[]>,
   entityType: string,
   relationshipRefKey: string,
 ) => {
-  const types: string[] = [];
-  schemaRelationsTypesMapping.forEach((values, key) => {
-    if (values.includes(relationshipRefKey)) {
-      const [from, to] = key.split('_');
-      if (from.includes(entityType) || from === '*') {
-        types.push(to);
-      }
-    }
-  });
-  return uniq(types);
+  return schemaRelationsTypesMapping
+    .get(entityType)
+    ?.find((ref) => ref.name === relationshipRefKey)
+    ?.toTypes ?? [];
 };

--- a/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
@@ -34,7 +34,7 @@ export interface UserContextType {
     smos: { id: string, label: string }[]
     scrs: { id: string, label: string }[]
     schemaRelationsTypesMapping: Map<string, readonly string[]>
-    schemaRelationsRefTypesMapping: Map<string, readonly string[]>
+    schemaRelationsRefTypesMapping: Map<string, readonly { readonly name: string, readonly toTypes: readonly string[] }[]>
     filterKeysSchema: Map<string, Map<string, FilterDefinition>>
   } | undefined;
 }

--- a/opencti-platform/opencti-front/src/utils/tests/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/filtersUtils.test.tsx
@@ -30,7 +30,7 @@ describe('Filters utils', () => {
                 smos: [{ id: '', label: '' }],
                 scrs: [{ id: '', label: '' }],
                 schemaRelationsTypesMapping: new Map<string, readonly string[]>(),
-                schemaRelationsRefTypesMapping: new Map<string, readonly string[]>(),
+                schemaRelationsRefTypesMapping: new Map<string, readonly { name: string, toTypes: string[] }[]>(),
                 filterKeysSchema,
               },
             })

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -10756,6 +10756,15 @@ type StixRelationshipSchema {
   values: [String!]!
 }
 
+type StixRelationshipRefSchemaValue {
+  name: String!
+  toTypes: [String!]!
+}
+type StixRelationshipRefSchema {
+  key: String!
+  values: [StixRelationshipRefSchemaValue!]!
+}
+
 ############## StixCoreRelationships
 enum StixCoreRelationshipsOrdering {
   entity_type
@@ -12010,7 +12019,7 @@ type Query {
     dynamicTo: FilterGroup
   ): Number @auth(for: [KNOWLEDGE, EXPLORE])
   schemaRelationsTypesMapping: [StixRelationshipSchema!]! @auth
-  schemaRelationsRefTypesMapping: [StixRelationshipSchema!]! @auth
+  schemaRelationsRefTypesMapping: [StixRelationshipRefSchema!]! @auth
   filterKeysSchema: [FilterKeysSchema!]! @auth
 
   ######## STIX CORE RELATIONSHIPS

--- a/opencti-platform/opencti-graphql/src/database/stix-ref.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-ref.ts
@@ -1,46 +1,13 @@
-import type { RelationshipMappings } from './stix';
-import { REL_NEW } from './stix';
-import {
-  ENTITY_TYPE_CONTAINER,
-  ENTITY_TYPE_IDENTITY,
-  INPUT_ASSIGNEE,
-  INPUT_CREATED_BY,
-  INPUT_EXTERNAL_REFS,
-  INPUT_KILLCHAIN,
-  INPUT_LABELS,
-  INPUT_MARKINGS,
-  INPUT_OBJECTS,
-  INPUT_PARTICIPANT
-} from '../schema/general';
-import { ENTITY_TYPE_EXTERNAL_REFERENCE, ENTITY_TYPE_KILL_CHAIN_PHASE, ENTITY_TYPE_LABEL, ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
-import { ENTITY_TYPE_USER } from '../schema/internalObject';
-import { schemaTypesMapping } from '../domain/stixRelationship';
-
-export const stixRefRelationshipsMapping: RelationshipMappings = {
-  [`*_${ENTITY_TYPE_IDENTITY}`]: [
-    { name: INPUT_CREATED_BY, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_MARKING_DEFINITION}`]: [
-    { name: INPUT_MARKINGS, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_CONTAINER}`]: [
-    { name: INPUT_OBJECTS, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_USER}`]: [
-    { name: INPUT_ASSIGNEE, type: REL_NEW },
-    { name: INPUT_PARTICIPANT, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_LABEL}`]: [
-    { name: INPUT_LABELS, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_EXTERNAL_REFERENCE}`]: [
-    { name: INPUT_EXTERNAL_REFS, type: REL_NEW }
-  ],
-  [`*_${ENTITY_TYPE_KILL_CHAIN_PHASE}`]: [
-    { name: INPUT_KILLCHAIN, type: REL_NEW }
-  ],
-};
+import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 
 export const schemaRelationsRefTypesMapping = () => {
-  return schemaTypesMapping(stixRefRelationshipsMapping);
+  return Array.from(schemaRelationsRefDefinition.relationsRefCacheArray.entries()).map(([key, refs]) => {
+    return {
+      key,
+      values: refs.map((ref) => ({
+        name: ref.name,
+        toTypes: ref.toTypes
+      }))
+    };
+  });
 };

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17975,7 +17975,7 @@ export type Query = {
   rules?: Maybe<Array<Maybe<Rule>>>;
   runtimeAttributes?: Maybe<AttributeConnection>;
   schemaAttributeNames?: Maybe<AttributeConnection>;
-  schemaRelationsRefTypesMapping: Array<StixRelationshipSchema>;
+  schemaRelationsRefTypesMapping: Array<StixRelationshipRefSchema>;
   schemaRelationsTypesMapping: Array<StixRelationshipSchema>;
   sector?: Maybe<Sector>;
   sectors?: Maybe<SectorConnection>;
@@ -23829,6 +23829,18 @@ export type StixRelationshipEditMutations = {
   delete?: Maybe<Scalars['ID']['output']>;
 };
 
+export type StixRelationshipRefSchema = {
+  __typename?: 'StixRelationshipRefSchema';
+  key: Scalars['String']['output'];
+  values: Array<StixRelationshipRefSchemaValue>;
+};
+
+export type StixRelationshipRefSchemaValue = {
+  __typename?: 'StixRelationshipRefSchemaValue';
+  name: Scalars['String']['output'];
+  toTypes: Array<Scalars['String']['output']>;
+};
+
 export type StixRelationshipSchema = {
   __typename?: 'StixRelationshipSchema';
   key: Scalars['String']['output'];
@@ -29277,6 +29289,8 @@ export type ResolversTypes = ResolversObject<{
   StixRelationshipConnection: ResolverTypeWrapper<Omit<StixRelationshipConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversTypes['StixRelationshipEdge']>>> }>;
   StixRelationshipEdge: ResolverTypeWrapper<Omit<StixRelationshipEdge, 'node'> & { node: ResolversTypes['StixRelationship'] }>;
   StixRelationshipEditMutations: ResolverTypeWrapper<StixRelationshipEditMutations>;
+  StixRelationshipRefSchema: ResolverTypeWrapper<StixRelationshipRefSchema>;
+  StixRelationshipRefSchemaValue: ResolverTypeWrapper<StixRelationshipRefSchemaValue>;
   StixRelationshipSchema: ResolverTypeWrapper<StixRelationshipSchema>;
   StixRelationshipsOrdering: StixRelationshipsOrdering;
   StixRelationshipsTimeSeriesParameters: StixRelationshipsTimeSeriesParameters;
@@ -29992,6 +30006,8 @@ export type ResolversParentTypes = ResolversObject<{
   StixRelationshipConnection: Omit<StixRelationshipConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['StixRelationshipEdge']>>> };
   StixRelationshipEdge: Omit<StixRelationshipEdge, 'node'> & { node: ResolversParentTypes['StixRelationship'] };
   StixRelationshipEditMutations: StixRelationshipEditMutations;
+  StixRelationshipRefSchema: StixRelationshipRefSchema;
+  StixRelationshipRefSchemaValue: StixRelationshipRefSchemaValue;
   StixRelationshipSchema: StixRelationshipSchema;
   StixRelationshipsTimeSeriesParameters: StixRelationshipsTimeSeriesParameters;
   StixSightingRelationship: Omit<StixSightingRelationship, 'cases' | 'containers' | 'createdBy' | 'from' | 'groupings' | 'notes' | 'objectOrganization' | 'opinions' | 'reports' | 'to'> & { cases?: Maybe<ResolversParentTypes['CaseConnection']>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, from?: Maybe<ResolversParentTypes['StixObjectOrStixRelationshipOrCreator']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, to?: Maybe<ResolversParentTypes['StixObjectOrStixRelationshipOrCreator']> };
@@ -35910,7 +35926,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   rules?: Resolver<Maybe<Array<Maybe<ResolversTypes['Rule']>>>, ParentType, ContextType>;
   runtimeAttributes?: Resolver<Maybe<ResolversTypes['AttributeConnection']>, ParentType, ContextType, RequireFields<QueryRuntimeAttributesArgs, 'attributeName'>>;
   schemaAttributeNames?: Resolver<Maybe<ResolversTypes['AttributeConnection']>, ParentType, ContextType, RequireFields<QuerySchemaAttributeNamesArgs, 'elementType'>>;
-  schemaRelationsRefTypesMapping?: Resolver<Array<ResolversTypes['StixRelationshipSchema']>, ParentType, ContextType>;
+  schemaRelationsRefTypesMapping?: Resolver<Array<ResolversTypes['StixRelationshipRefSchema']>, ParentType, ContextType>;
   schemaRelationsTypesMapping?: Resolver<Array<ResolversTypes['StixRelationshipSchema']>, ParentType, ContextType>;
   sector?: Resolver<Maybe<ResolversTypes['Sector']>, ParentType, ContextType, Partial<QuerySectorArgs>>;
   sectors?: Resolver<Maybe<ResolversTypes['SectorConnection']>, ParentType, ContextType, Partial<QuerySectorsArgs>>;
@@ -37245,6 +37261,18 @@ export type StixRelationshipEdgeResolvers<ContextType = any, ParentType extends 
 
 export type StixRelationshipEditMutationsResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixRelationshipEditMutations'] = ResolversParentTypes['StixRelationshipEditMutations']> = ResolversObject<{
   delete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StixRelationshipRefSchemaResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixRelationshipRefSchema'] = ResolversParentTypes['StixRelationshipRefSchema']> = ResolversObject<{
+  key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  values?: Resolver<Array<ResolversTypes['StixRelationshipRefSchemaValue']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StixRelationshipRefSchemaValueResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixRelationshipRefSchemaValue'] = ResolversParentTypes['StixRelationshipRefSchemaValue']> = ResolversObject<{
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  toTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -39204,6 +39232,8 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   StixRelationshipConnection?: StixRelationshipConnectionResolvers<ContextType>;
   StixRelationshipEdge?: StixRelationshipEdgeResolvers<ContextType>;
   StixRelationshipEditMutations?: StixRelationshipEditMutationsResolvers<ContextType>;
+  StixRelationshipRefSchema?: StixRelationshipRefSchemaResolvers<ContextType>;
+  StixRelationshipRefSchemaValue?: StixRelationshipRefSchemaValueResolvers<ContextType>;
   StixRelationshipSchema?: StixRelationshipSchemaResolvers<ContextType>;
   StixSightingRelationship?: StixSightingRelationshipResolvers<ContextType>;
   StixSightingRelationshipConnection?: StixSightingRelationshipConnectionResolvers<ContextType>;


### PR DESCRIPTION
### Proposed changes

* Refactor the API schemaRelationsRefTypesMapping to return a complete mapping based on the cache.

### Related issues

* #6281 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
