### PR TITLE
[frontend] Clean up entity-type filter in Correlation Graphs

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -854,6 +854,9 @@ class GroupingKnowledgeCorrelationComponent extends Component {
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
     const stixCoreObjectsTypes = R.pipe(
+      R.filter((n) => n.node.entity_type
+          && n.node.entity_type.length > 1
+          && n.node.entity_type[0] !== n.node.entity_type[0].toLowerCase()),
       R.map((n) => R.assoc(
         'tlabel',
         t(

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -846,6 +846,9 @@ class ReportKnowledgeCorrelationComponent extends Component {
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
     const stixCoreObjectsTypes = R.pipe(
+      R.filter((n) => n.node.entity_type
+          && n.node.entity_type.length > 1
+          && n.node.entity_type[0] !== n.node.entity_type[0].toLowerCase()),
       R.map((n) => R.assoc(
         'tlabel',
         t(
@@ -858,7 +861,6 @@ class ReportKnowledgeCorrelationComponent extends Component {
       sortByLabel,
       R.map((n) => n.node.entity_type),
       R.filter((n) => n && n.length > 0),
-      R.concat(['Report', 'reported-in']),
       R.uniq,
     )(report.objects.edges);
     const markedBy = R.uniqBy(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -853,6 +853,9 @@ class IncidentKnowledgeCorrelationComponent extends Component {
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
     const stixCoreObjectsTypes = R.pipe(
+      R.filter((n) => n.node.entity_type
+          && n.node.entity_type.length > 1
+          && n.node.entity_type[0] !== n.node.entity_type[0].toLowerCase()),
       R.map((n) => R.assoc(
         'tlabel',
         t(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -853,6 +853,9 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
     const stixCoreObjectsTypes = R.pipe(
+      R.filter((n) => n.node.entity_type
+          && n.node.entity_type.length > 1
+          && n.node.entity_type[0] !== n.node.entity_type[0].toLowerCase()),
       R.map((n) => R.assoc(
         'tlabel',
         t(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -854,6 +854,9 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
     const stixCoreObjectsTypes = R.pipe(
+      R.filter((n) => n.node.entity_type
+          && n.node.entity_type.length > 1
+          && n.node.entity_type[0] !== n.node.entity_type[0].toLowerCase()),
       R.map((n) => R.assoc(
         'tlabel',
         t(


### PR DESCRIPTION
### Proposed changes

* Remove the relational options from the entity-types filter on Correlation Graphs
* Remove the `Report` and `Reported in` from the entity-types filter in Analysis Reports Correlation Graphs

This is done because the purpose of the Correlation Graph view for a particular entity is to chart relationships to other instances of the same entity type, in order to discover/explore relationships visually. Because of this, an Analysis Report should never allow the `Report` entity type to be filtered out.

![image](https://github.com/OpenCTI-Platform/opencti/assets/3454769/ba3b2443-1d05-4cb3-956a-174d3a0fb26e)

Additionally, the entity type filters were also presenting options for relationship types (`based-on`, `reported-in`, etc...) as filterable entity types. These did not appear to change the visualization, and also do not make sense as options in this view. These have been filtered out by looking for cases where the `n.node.entity_type` begins with a lowercase letter.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality