### PR TITLE
[frontend] Fix Add height / weight do not work (#7118)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
@@ -15,6 +15,7 @@ import TextField from '../../../../components/TextField';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
+import { isNotEmptyField } from '../../../../utils/utils';
 
 export const individualHeightMutation = graphql`
   mutation HeightFieldIndividualMutation($id: ID!, $input: [EditInput]!) {
@@ -73,19 +74,21 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
                       name={`${name}.${index}.measure`}
                       label={t_i18n(`Height (${lengthPrimaryUnit})`)}
                       onSubmit={(_: string, measure: string) => {
-                        commitMutation({
-                          ...defaultCommitMutation,
-                          mutation: individualHeightMutation,
-                          variables: {
-                            id,
-                            input: {
-                              key: 'height',
-                              value: [heightToPivotFormat(measure)],
-                              object_path: `/height/${height.index}/measure`,
-                              operation: 'replace',
+                        if (isNotEmptyField(measure)) {
+                          commitMutation({
+                            ...defaultCommitMutation,
+                            mutation: individualHeightMutation,
+                            variables: {
+                              id,
+                              input: {
+                                key: 'height',
+                                value: [heightToPivotFormat(measure)],
+                                object_path: `/height/${height.index}/measure`,
+                                operation: 'replace',
+                              },
                             },
-                          },
-                        });
+                          });
+                        }
                       }}
                     />
                     <Field
@@ -93,19 +96,21 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
                       id={`height_date_${index}`}
                       name={`${name}.${index}.date_seen`}
                       onSubmit={(_: string, date_seen: string) => {
-                        commitMutation({
-                          ...defaultCommitMutation,
-                          mutation: individualHeightMutation,
-                          variables: {
-                            id,
-                            input: {
-                              key: 'height',
-                              value: [date_seen],
-                              object_path: `/height/${height.index}/date_seen`,
-                              operation: 'replace',
+                        if (isNotEmptyField(date_seen)) {
+                          commitMutation({
+                            ...defaultCommitMutation,
+                            mutation: individualHeightMutation,
+                            variables: {
+                              id,
+                              input: {
+                                key: 'height',
+                                value: [date_seen],
+                                object_path: `/height/${height.index}/date_seen`,
+                                operation: 'replace',
+                              },
                             },
-                          },
-                        });
+                          });
+                        }
                       }}
                       textFieldProps={{
                         label: t_i18n('Date Seen'),

--- a/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
@@ -154,6 +154,8 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
               aria-label="Add"
               id="addHeight"
               onClick={() => {
+                const newHeight = { measure: 0, date_seen: new Date().toISOString() };
+                arrayHelpers.push(newHeight);
                 commitMutation({
                   ...defaultCommitMutation,
                   mutation: individualHeightMutation,
@@ -161,7 +163,7 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
                     id,
                     input: {
                       key: 'height',
-                      value: [{ measure: null, date_seen: null }],
+                      value: [newHeight],
                       operation: 'add',
                     },
                   },
@@ -251,7 +253,7 @@ export const HeightFieldAdd: FunctionComponent<HeightFieldAddProps> = ({
                 aria-label="Add"
                 id="addHeight"
                 onClick={() => {
-                  arrayHelpers.push({ date_seen: null });
+                  arrayHelpers.push({ measure: 0, date_seen: new Date().toISOString() });
                 }}
                 style={{ marginTop: (values?.length ?? 0) > 0 ? 20 : 0 }}
               >

--- a/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
@@ -99,7 +99,7 @@ export const WeightFieldAdd: FunctionComponent<WeightFieldAddProps> = ({
               aria-label="Add"
               id="addHeight"
               onClick={() => {
-                arrayHelpers.push({ date_seen: null });
+                arrayHelpers.push({ measure: 0, date_seen: new Date().toISOString() });
               }}
               style={{ marginTop: (values?.length ?? 0) > 0 ? 20 : 0 }}
             >
@@ -241,6 +241,8 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
               aria-label="Add"
               id="addHeight"
               onClick={() => {
+                const newWeight = { measure: 0, date_seen: new Date().toISOString() };
+                arrayHelpers.push(newWeight);
                 commitMutation({
                   ...defaultCommitMutation,
                   mutation: individualWeightMutation,
@@ -248,7 +250,7 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
                     id,
                     input: {
                       key: 'weight',
-                      value: [{ measure: null, date_seen: null }],
+                      value: [newWeight],
                       operation: 'add',
                     },
                   },

--- a/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
@@ -15,6 +15,7 @@ import { commitMutation, defaultCommitMutation } from '../../../../relay/environ
 import useUserMetric from '../../../../utils/hooks/useUserMetric';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { GenericContext } from '../model/GenericContextModel';
+import { isNotEmptyField } from '../../../../utils/utils';
 
 export const individualWeightMutation = graphql`
   mutation WeightFieldIndividualMutation($id: ID!, $input: [EditInput]!) {
@@ -160,19 +161,21 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
                       name={`${name}.${index}.measure`}
                       label={t_i18n(`Weight (${weightPrimaryUnit})`)}
                       onSubmit={(_: string, measure: string) => {
-                        commitMutation({
-                          ...defaultCommitMutation,
-                          mutation: individualWeightMutation,
-                          variables: {
-                            id,
-                            input: {
-                              key: 'weight',
-                              value: [weightToPivotFormat(measure)],
-                              object_path: `/weight/${weight.index}/measure`,
-                              operation: 'replace',
+                        if (isNotEmptyField(measure)) {
+                          commitMutation({
+                            ...defaultCommitMutation,
+                            mutation: individualWeightMutation,
+                            variables: {
+                              id,
+                              input: {
+                                key: 'weight',
+                                value: [weightToPivotFormat(measure)],
+                                object_path: `/weight/${weight.index}/measure`,
+                                operation: 'replace',
+                              },
                             },
-                          },
-                        });
+                          });
+                        }
                       }}
                     />
                     <Field
@@ -180,19 +183,21 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
                       name={`${name}.${index}.date_seen`}
                       id={`weight_date_${index}`}
                       onSubmit={(_: string, date_seen: string) => {
-                        commitMutation({
-                          ...defaultCommitMutation,
-                          mutation: individualWeightMutation,
-                          variables: {
-                            id,
-                            input: {
-                              key: 'weight',
-                              value: [date_seen],
-                              object_path: `/weight/${weight.index}/date_seen`,
-                              operation: 'replace',
+                        if (isNotEmptyField(date_seen)) {
+                          commitMutation({
+                            ...defaultCommitMutation,
+                            mutation: individualWeightMutation,
+                            variables: {
+                              id,
+                              input: {
+                                key: 'weight',
+                                value: [date_seen],
+                                object_path: `/weight/${weight.index}/date_seen`,
+                                operation: 'replace',
+                              },
                             },
-                          },
-                        });
+                          });
+                        }
                       }}
                       textFieldProps={{
                         label: t_i18n('Date Seen'),

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
@@ -90,12 +90,6 @@ ThreatActorIndividualEditionBiographicsComponentProps
     threatActorIndividualEditionBiographicsFragment,
     threatActorIndividualRef,
   );
-  const dateSeenValidator = Yup.date()
-    .when('measure', {
-      is: (value: number) => value !== undefined && value !== null,
-      then: (schema) => schema.required(t_i18n('This field is required')),
-    })
-    .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'));
 
   const basicShape = {
     eye_color: Yup.string()
@@ -107,13 +101,15 @@ ThreatActorIndividualEditionBiographicsComponentProps
     weight: Yup.array().of(
       Yup.object().shape({
         measure: Yup.number().required(t_i18n('This field is required')),
-        date_seen: dateSeenValidator,
+        date_seen: Yup.date().required(t_i18n('This field is required'))
+          .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
       }),
     ),
     height: Yup.array().of(
       Yup.object().shape({
         measure: Yup.number().required(t_i18n('This field is required')),
-        date_seen: dateSeenValidator,
+        date_seen: Yup.date().required(t_i18n('This field is required'))
+          .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
       }),
     ),
   };

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
@@ -90,6 +90,11 @@ ThreatActorIndividualEditionBiographicsComponentProps
     threatActorIndividualEditionBiographicsFragment,
     threatActorIndividualRef,
   );
+  const dateSeenValidator = Yup.date()
+    .when('measure', {
+      is: (value: number) => value !== undefined && value !== null,
+      then: (schema) => schema.required(t_i18n('This field is required')),
+    });
 
   const basicShape = {
     eye_color: Yup.string()
@@ -98,8 +103,18 @@ ThreatActorIndividualEditionBiographicsComponentProps
     hair_color: Yup.string()
       .nullable()
       .typeError(t_i18n('The value must be a string')),
-    weight: Yup.array(),
-    height: Yup.array(),
+    weight: Yup.array().of(
+      Yup.object().shape({
+        measure: Yup.number().required(t_i18n('This field is required')),
+        date_seen: dateSeenValidator,
+      }),
+    ),
+    height: Yup.array().of(
+      Yup.object().shape({
+        measure: Yup.number().required(t_i18n('This field is required')),
+        date_seen: dateSeenValidator,
+      }),
+    ),
   };
   const threatActorIndividualValidator = useSchemaEditionValidation(
     'Threat-Actor-Individual',

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionBiographics.tsx
@@ -94,7 +94,8 @@ ThreatActorIndividualEditionBiographicsComponentProps
     .when('measure', {
       is: (value: number) => value !== undefined && value !== null,
       then: (schema) => schema.required(t_i18n('This field is required')),
-    });
+    })
+    .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'));
 
   const basicShape = {
     eye_color: Yup.string()


### PR DESCRIPTION
### Proposed changes

* Add a validator check to help the user knowing the field is mandatory
* On edit form, when pushes a new height or weight line, put a value instead of null to avoid errors 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7118

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
