### PR TITLE
[worker] fix opentelemetry worker dependencies

### DIFF
--- a/opencti-worker/src/requirements.txt
+++ b/opencti-worker/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.1.5
-opentelemetry-api==1.22.0
-opentelemetry-sdk==1.22.0
+opentelemetry-api<=1.24.0
+opentelemetry-sdk<=1.24.0
 opentelemetry-exporter-prometheus==0.43b0

--- a/opencti-worker/src/requirements.txt
+++ b/opencti-worker/src/requirements.txt
@@ -1,4 +1,4 @@
 pycti==6.1.5
-opentelemetry-api<=1.24.0
-opentelemetry-sdk<=1.24.0
+opentelemetry-api>=1.22.0
+opentelemetry-sdk>=1.22.0
 opentelemetry-exporter-prometheus==0.43b0


### PR DESCRIPTION
fix the running of 'pip install -r requirements.txt' in worker/src
--> update opentelemetry worker dependencies to be consistant with client-python and opencti (version 1.24)