### PR TITLE
[frontend/backend] show effective max confidence with creators (#6878)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": "(umgedreht)",
   " & ": "&",
+  "+ N override(s)": "+ {count} Überschreibung(en)",
   "0 equals no maximum": "0 entspricht keinem Maximum",
   "24 hours": "24 Stunden",
   "24h": "24h",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": " (reversed)",
   " & ": " & ",
+  "+ N override(s)": "+ {count} override(s)",
   "0 equals no maximum": "0 equals no maximum",
   "24 hours": "24 hours",
   "24h": "24h",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": "(invertido)",
   " & ": "&",
+  "+ N override(s)": "+ {count} anulación(es)",
   "0 equals no maximum": "0 es igual a ningún máximo",
   "24 hours": "24 horas",
   "24h": "24 h",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1,7 +1,7 @@
 {
   " (reversed)": "(inversé)",
   " & ": " & ",
-  "+ N override(s)": "+ {count}} surcharge(s)",
+  "+ N override(s)": "+ {count} surcharge(s)",
   "0 equals no maximum": "0 pour aucun maximum",
   "24 hours": "24 heures",
   "24h": "24h",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": "(inversé)",
   " & ": " & ",
+  "+ N override(s)": "+ {count}} surcharge(s)",
   "0 equals no maximum": "0 pour aucun maximum",
   "24 hours": "24 heures",
   "24h": "24h",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": "(逆)",
   " & ": "&；",
+  "+ N override(s)": "+ {count} オーバーライド（複数可）",
   "0 equals no maximum": "0 は最大値なし",
   "24 hours": "24時間",
   "24h": "24時間",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1,6 +1,7 @@
 {
   " (reversed)": "（反向）",
   " & ": "&；",
+  "+ N override(s)": "+ {count} 覆盖",
   "0 equals no maximum": "0 等于没有最大值",
   "24 hours": "24小时",
   "24h": "24小时",

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -286,11 +286,9 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
               )}
               <CreatorField
                 name="user_id"
-                label={t_i18n(
-                  'User responsible for data creation (empty = System)',
-                )}
-                isOptionEqualToValue={(option: Option, value: string) => option.value === value}
+                label={t_i18n('User responsible for data creation (empty = System)')}
                 containerStyle={fieldSpacingContainerStyle}
+                showConfidence
               />
               <Box sx={{ width: '100%', marginTop: 5 }}>
                 <Alert

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
@@ -326,9 +326,9 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
           <CreatorField
             name="user_id"
             label={t_i18n('User responsible for data creation (empty = System)')}
-            isOptionEqualToValue={(option: Option, value: string) => option.value === value}
             onChange={handleSubmitField}
             containerStyle={fieldSpacingContainerStyle}
+            showConfidence
           />
           {enableReferences && (
             <CommitMessage

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssCreation.jsx
@@ -153,6 +153,7 @@ const IngestionRssCreation = (props) => {
                 name="user_id"
                 label={t('User responsible for data creation (empty = System)')}
                 containerStyle={fieldSpacingContainerStyle}
+                showConfidence
               />
               <Field
                 component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssEdition.jsx
@@ -136,6 +136,7 @@ const IngestionRssEditionContainer = ({
               label={t('User responsible for data creation (empty = System)')}
               onChange={handleSubmitField}
               containerStyle={fieldSpacingContainerStyle}
+              showConfidence
             />
             <Field
               component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiCreation.jsx
@@ -258,10 +258,9 @@ const IngestionTaxiiCreation = (props) => {
               )}
               <CreatorField
                 name="user_id"
-                label={t(
-                  'User responsible for data creation (empty = System)',
-                )}
+                label={t('User responsible for data creation (empty = System)')}
                 containerStyle={fieldSpacingContainerStyle}
+                showConfidence
               />
               <Field
                 component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiEdition.jsx
@@ -319,6 +319,7 @@ const IngestionTaxiiEditionContainer = ({
               label={t('User responsible for data creation (empty = System)')}
               onChange={handleSubmitField}
               containerStyle={fieldSpacingContainerStyle}
+              showConfidence
             />
           </Form>
         )}

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncCreation.jsx
@@ -339,10 +339,9 @@ const SyncCreation = ({ paginationOptions }) => {
                 </Alert>
                 <CreatorField
                   name="user_id"
-                  label={t_i18n(
-                    'User responsible for data creation (empty = System)',
-                  )}
+                  label={t_i18n('User responsible for data creation (empty = System)')}
                   containerStyle={fieldSpacingContainerStyle}
+                  showConfidence
                 />
                 <Field
                   component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncEdition.jsx
@@ -235,6 +235,7 @@ const SyncEditionContainer = ({ synchronizer }) => {
             label={t_i18n('User responsible for data creation (empty = System)')}
             containerStyle={fieldSpacingContainerStyle}
             onChange={handleSubmitField}
+            showConfidence
           />
           <Field
             component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -1392,6 +1392,8 @@ type Member {
   id: ID!
   name: String!
   entity_type: String!
+  effective_confidence_level: EffectiveConfidenceLevel
+  group_confidence_level: ConfidenceLevel
 }
 
 type MemberAccess {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1331,7 +1331,12 @@ type Member {
   id: ID! # internal_id
   name: String!
   entity_type: String!
+  # entity_type == User
+  effective_confidence_level: EffectiveConfidenceLevel
+  # entity_type == Group
+  group_confidence_level: ConfidenceLevel
 }
+
 type MemberAccess {
   id: ID! # internal_id
   name: String!

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -12382,7 +12382,9 @@ export type MediaContentAddInput = {
 
 export type Member = {
   __typename?: 'Member';
+  effective_confidence_level?: Maybe<EffectiveConfidenceLevel>;
   entity_type: Scalars['String']['output'];
+  group_confidence_level?: Maybe<ConfidenceLevel>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
 };
@@ -34317,7 +34319,9 @@ export type MediaContentResolvers<ContextType = any, ParentType extends Resolver
 }>;
 
 export type MemberResolvers<ContextType = any, ParentType extends ResolversParentTypes['Member'] = ResolversParentTypes['Member']> = ResolversObject<{
+  effective_confidence_level?: Resolver<Maybe<ResolversTypes['EffectiveConfidenceLevel']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  group_confidence_level?: Resolver<Maybe<ResolversTypes['ConfidenceLevel']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -94,6 +94,12 @@ const userResolvers = {
       }
       return (ENABLED_DEMO_MODE && context.user.id !== current.id) ? REDACTED_USER.name : current.name;
     },
+    effective_confidence_level: (current, _, context) => {
+      if (current.entity_type === ENTITY_TYPE_USER) {
+        return getUserEffectiveConfidenceLevel(current, context);
+      }
+      return null;
+    },
   },
   MeUser: {
     language: (current) => current.language ?? 'auto',


### PR DESCRIPTION
### Proposed changes

* update `creators` API to be able to query `effective_confidence_level` in case of user creator, or `group_confidence_level` in case of group creator
* update CreatorField to show the confidence level of the user in the Autocomplete box

### Related issues

#6878

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

![image](https://github.com/OpenCTI-Platform/opencti/assets/146674147/99fff9ef-9358-4e7c-86b6-4a3dccbe56f1)

