### PR TITLE
[backend] Use index with inferred relation when sharing a report to an organization (#6990)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
@@ -409,7 +409,7 @@ class StixCoreRelationshipContainer extends Component {
                     <MarkdownDisplay
                       content={
                         stixCoreRelationship.x_opencti_inferences !== null ? (
-                          <i>{t('Inferred knowledge')}</i>
+                          t('Inferred knowledge')
                         ) : (
                           stixCoreRelationship.description
                         )

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -1,5 +1,5 @@
 import { elIndex, elPaginate } from '../database/engine';
-import { INDEX_INTERNAL_OBJECTS, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_INFERRED, } from '../database/utils';
+import { INDEX_INTERNAL_OBJECTS, READ_DATA_INDICES } from '../database/utils';
 import { ENTITY_TYPE_BACKGROUND_TASK } from '../schema/internalObject';
 import { deleteElementById, patchAttribute } from '../database/middleware';
 import { getUserAccessRight, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../utils/access';
@@ -61,7 +61,7 @@ const buildQueryFilters = async (filters, search, taskPosition) => {
 };
 export const executeTaskQuery = async (context, user, filters, search, start = null) => {
   const options = await buildQueryFilters(filters, search, start);
-  return elPaginate(context, user, READ_DATA_INDICES_WITHOUT_INFERRED, options);
+  return elPaginate(context, user, READ_DATA_INDICES, options);
 };
 
 export const createRuleTask = async (context, user, ruleDefinition, input) => {


### PR DESCRIPTION
### Proposed changes

- Use the index with inferred relationships when sharing a report with an organisation
- fix a front issue

### Related issues

- close #6990 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality