### PR TITLE
[backend] Ensure the valid_until date on Indicators is set to a greater value than valid_from when empty (#6836)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "Das Token fehlt in der Konfiguration Ihrer Plattform. Bitten Sie Ihren Filigran-Vertreter, es Ihnen zur Verfügung zu stellen oder eine Anleitung für den Einsatz vor Ort zu geben. Sie können dazu ein Support-Ticket eröffnen.",
   "The user has BYPASS capability, their max confidence level is set to 100.": "Der Benutzer ist BYPASS-fähig, sein maximales Vertrauensniveau ist auf 100 eingestellt.",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "Die maximale Konfidenzstufe des Benutzers hat Vorrang vor der von den Benutzergruppen geerbten maximalen Konfidenzstufe",
+  "The valid until date must be greater than the valid from date": "Das Gültig-bis-Datum muss größer sein als das Gültig-ab-Datum",
   "The value is too long": "Der Wert ist zu lang",
   "The value is too short": "Der Wert ist zu kurz",
   "The value must be a date (yyyy-MM-dd)": "Der Wert muss ein Datum sein (yyyy-MM-dd)",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.",
   "The user has BYPASS capability, their max confidence level is set to 100.": "The user has BYPASS capability, their max confidence level is set to 100.",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups",
+  "The valid until date must be greater than the valid from date": "The valid until date must be greater than the valid from date",
   "The value is too long": "The value is too long",
   "The value is too short": "The value is too short",
   "The value must be a date (yyyy-MM-dd)": "The value must be a date (yyyy-MM-dd)",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "Falta el token en la configuración de su plataforma, por favor solicite a su representante de Filigran que se lo proporcione o las instrucciones de despliegue on-premise. Puede abrir un ticket de soporte para ello.",
   "The user has BYPASS capability, their max confidence level is set to 100.": "El usuario tiene capacidad BYPASS, su nivel de confianza máximo está fijado en 100.",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "El nivel de confianza máximo del usuario anula el nivel de confianza máximo heredado de los grupos de usuarios",
+  "The valid until date must be greater than the valid from date": "La fecha válida hasta debe ser mayor que la fecha válida desde",
   "The value is too long": "El valor es demasiado largo",
   "The value is too short": "El valor es demasiado corto",
   "The value must be a date (yyyy-MM-dd)": "El valor debe ser una fecha (AAAA-MM-DD)",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "Le token est manquant dans la configuration de votre plateforme, veuillez demander à votre représentant Filigran de vous le fournir ou de vous donner des instructions pour le déploiement sur site. Vous pouvez ouvrir un ticket de support pour ce faire.",
   "The user has BYPASS capability, their max confidence level is set to 100.": "L'utilisateur a la capacité de BYPASS, son niveau de confiance maximum est fixé à 100.",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "Le niveau de confiance maximum de l'utilisateur prévaut sur le niveau de confiance maximum hérité des groupes de l'utilisateur",
+  "The valid until date must be greater than the valid from date": "La date de fin de validité doit être supérieure à la date de début de validité",
   "The value is too long": "La valeur est trop longue",
   "The value is too short": "La valeur est trop courte",
   "The value must be a date (yyyy-MM-dd)": "La valeur doit être une date (dd/mm/aaaaa)",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "お客様のプラットフォーム構成にトークンがありません。フィリグランの担当者にトークンの提供、またはオンプレミスでの展開方法をお問い合わせください。サポートチケットでお問い合わせください。",
   "The user has BYPASS capability, their max confidence level is set to 100.": "ユーザーはBYPASS能力を持っており、最大信頼度は100に設定されている。",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "ユーザーの最大信頼度はユーザーのグループから継承された最大信頼度より優先されます。",
+  "The valid until date must be greater than the valid from date": "有効期限の日付は、有効期限の日付より大きくなければならない。",
   "The value is too long": "文字数が上限を超えています",
   "The value is too short": "文字数が不足しています",
   "The value must be a date (yyyy-MM-dd)": "日付(yyyy-MM-dd)を入力してください",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2459,6 +2459,7 @@
   "The token is missing in your platform configuration, please ask your Filigran representative to provide you with it or with on-premise deployment instructions. Your can open a support ticket to do so.": "平台配置中缺少令牌，请要求 Filigran 代表提供令牌或内部部署说明。您可以打开支持票单进行申请。",
   "The user has BYPASS capability, their max confidence level is set to 100.": "用户具有 BYPASS 功能，其最大置信度设置为 100。",
   "The user’s Max Confidence Level overrides Max Confidence Level inherited from user’s groups": "用户的最大信任度高于从用户组继承的最大信任度",
+  "The valid until date must be greater than the valid from date": "有效期至日期必须大于有效期起日期",
   "The value is too long": "该值太长",
   "The value is too short": "该值太短",
   "The value must be a date (yyyy-MM-dd)": "该值必须是一个日期(yyyy-MM-dd)",

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -131,11 +131,11 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     valid_until: Yup.date()
       .nullable()
-      .min(
-        Yup.ref('valid_from'),
-        'The valid until date can\'t be before valid from date',
-      )
-      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
+      .test('is-greater', t_i18n('The valid until date must be greater than the valid from date'), function isGreater(value) {
+        const { valid_from } = this.parent;
+        return !valid_from || !value || value > valid_from;
+      }),
     x_mitre_platforms: Yup.array().nullable(),
     x_opencti_score: Yup.number().nullable(),
     description: Yup.string().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -93,11 +93,11 @@ const IndicatorEditionOverviewComponent = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     valid_until: Yup.date()
       .nullable()
-      .min(
-        Yup.ref('valid_from'),
-        "The valid until date can't be before valid from date",
-      )
-      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
+      .test('is-greater', t_i18n('The valid until date must be greater than the valid from date'), function isGreater(value) {
+        const { valid_from } = this.parent;
+        return !valid_from || !value || value > valid_from;
+      }),
     x_mitre_platforms: Yup.array().nullable(),
     x_opencti_score: Yup.number().nullable(),
     description: Yup.string().nullable(),
@@ -141,7 +141,7 @@ const IndicatorEditionOverviewComponent = ({
       ),
       R.assoc(
         'valid_until',
-        values.valid_from ? parse(values.valid_until).format() : null,
+        values.valid_until ? parse(values.valid_until).format() : null,
       ),
       R.toPairs,
       R.map((n) => ({ key: n[0], value: adaptFieldValue(n[1]) })),

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
@@ -2,15 +2,15 @@ import moment from 'moment';
 import { buildKillChainPhases, buildMITREExtensions, buildStixDomain, cleanObject, convertToStixDate } from '../../database/stix-converter';
 import { STIX_EXT_MITRE, STIX_EXT_OCTI } from '../../types/stix-extensions';
 import type { StixIndicator, StoreEntityIndicator } from './indicator-types';
+import { isNotEmptyField } from '../../database/utils';
 
 const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator => {
   const indicator = buildStixDomain(instance);
-  const computedValidUntil = () => {
-    if (instance.valid_from === instance.valid_until) {
-      return moment(instance.valid_from).add(1, 'seconds').toDate();
-    }
-    return instance.valid_until;
-  };
+  // Adding one second to the valid_until if valid_from and valid_until are equals,
+  // because according to STIX 2.1 specification the valid_until must be greater than the valid_from.
+  const computedValidUntil = (
+    isNotEmptyField(instance.valid_from) === isNotEmptyField(instance.valid_until)
+  ) ? moment(instance.valid_from).add(1, 'seconds').toDate() : instance.valid_until;
   return {
     ...indicator,
     name: instance.name,
@@ -20,7 +20,7 @@ const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator =
     pattern_type: instance.pattern_type,
     pattern_version: instance.pattern_version,
     valid_from: convertToStixDate(instance.valid_from),
-    valid_until: convertToStixDate(computedValidUntil()),
+    valid_until: convertToStixDate(computedValidUntil),
     kill_chain_phases: buildKillChainPhases(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
@@ -9,7 +9,7 @@ const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator =
   // Adding one second to the valid_until if valid_from and valid_until are equals,
   // because according to STIX 2.1 specification the valid_until must be greater than the valid_from.
   const computedValidUntil = (
-    isNotEmptyField(instance.valid_from) === isNotEmptyField(instance.valid_until)
+    isNotEmptyField(instance.valid_from) && isNotEmptyField(instance.valid_until) && instance.valid_until === instance.valid_from
   ) ? moment(instance.valid_from).add(1, 'seconds').toDate() : instance.valid_until;
   return {
     ...indicator,

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
@@ -1,9 +1,16 @@
+import moment from 'moment';
 import { buildKillChainPhases, buildMITREExtensions, buildStixDomain, cleanObject, convertToStixDate } from '../../database/stix-converter';
 import { STIX_EXT_MITRE, STIX_EXT_OCTI } from '../../types/stix-extensions';
 import type { StixIndicator, StoreEntityIndicator } from './indicator-types';
 
 const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator => {
   const indicator = buildStixDomain(instance);
+  const computedValidUntil = () => {
+    if (instance.valid_from === instance.valid_until) {
+      return moment(instance.valid_from).add(1, 'seconds').toDate();
+    }
+    return instance.valid_until;
+  };
   return {
     ...indicator,
     name: instance.name,
@@ -13,7 +20,7 @@ const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator =
     pattern_type: instance.pattern_type,
     pattern_version: instance.pattern_version,
     valid_from: convertToStixDate(instance.valid_from),
-    valid_until: convertToStixDate(instance.valid_until),
+    valid_until: convertToStixDate(computedValidUntil()),
     kill_chain_phases: buildKillChainPhases(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
@@ -90,7 +90,7 @@ const computeValidUntil = (indicator: IndicatorAddInput, validFrom: Moment, life
   } else if (isNotEmptyField(indicator.valid_until)) {
     // Ensure valid_until is strictly greater than valid_from
     if (indicator.valid_until <= validFrom) {
-      throw ValidationError('valid_until', { message: `Valid until date: ${indicator.valid_until} must be greater than valid from date: ${validFrom}` });
+      throw ValidationError('valid_until', { message: 'The valid until date must be greater than the valid from date' });
     } else {
       validUntil = utcDate(indicator.valid_until);
     }

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
@@ -82,7 +82,9 @@ const computeValidUntil = (indicator: IndicatorAddInput, validFrom: Moment, life
   if (indicator.revoked && isEmptyField(indicator.valid_until)) {
     // If indicator is explicitly revoked and not valid_until is specified
     // Ensure the valid_until will be revoked by the time computation.
-    return validFrom;
+    // Adding one second to the validFrom if valid_until is empty,
+    // because according to STIX 2.1 specification the valid_until must be greater than the valid_from.
+    return validFrom.clone().add(1, 'seconds');
   }
   if (isNotEmptyField(indicator.valid_until)) {
     return utcDate(indicator.valid_until);

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
@@ -107,6 +107,6 @@ export const computeValidPeriod = async (indicator: IndicatorAddInput, lifetimeI
     validFrom,
     validUntil,
     revoked: validUntil.isSameOrBefore(utcDate()),
-    validPeriod: validFrom.isSameOrBefore(validUntil)
+    validPeriod: validFrom.isBefore(validUntil),
   };
 };

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-utils.ts
@@ -7,6 +7,7 @@ import type { IndicatorAddInput } from '../../generated/graphql';
 import type { BasicStoreEntity } from '../../types/store';
 import { isEmptyField, isNotEmptyField } from '../../database/utils';
 import { utcDate } from '../../utils/format';
+import { ValidationError } from '../../config/errors';
 
 interface TTL_DEFINITION {
   target: Array<string>;
@@ -79,17 +80,24 @@ const computeValidFrom = (indicator: IndicatorAddInput): Moment => {
 };
 
 const computeValidUntil = (indicator: IndicatorAddInput, validFrom: Moment, lifetimeInDays: number): Moment => {
+  let validUntil: Moment;
   if (indicator.revoked && isEmptyField(indicator.valid_until)) {
     // If indicator is explicitly revoked and not valid_until is specified
     // Ensure the valid_until will be revoked by the time computation.
     // Adding one second to the validFrom if valid_until is empty,
     // because according to STIX 2.1 specification the valid_until must be greater than the valid_from.
-    return validFrom.clone().add(1, 'seconds');
+    validUntil = validFrom.clone().add(1, 'seconds');
+  } else if (isNotEmptyField(indicator.valid_until)) {
+    // Ensure valid_until is strictly greater than valid_from
+    if (indicator.valid_until <= validFrom) {
+      throw ValidationError('valid_until', { message: `Valid until date: ${indicator.valid_until} must be greater than valid from date: ${validFrom}` });
+    } else {
+      validUntil = utcDate(indicator.valid_until);
+    }
+  } else {
+    validUntil = validFrom.clone().add(lifetimeInDays, 'days');
   }
-  if (isNotEmptyField(indicator.valid_until)) {
-    return utcDate(indicator.valid_until);
-  }
-  return validFrom.clone().add(lifetimeInDays, 'days');
+  return validUntil;
 };
 
 export const computeValidPeriod = async (indicator: IndicatorAddInput, lifetimeInDays: number) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/indicator-test.ts
@@ -121,7 +121,7 @@ describe('indicator utils', () => {
     }, FALLBACK_DECAY_RULE.decay_lifetime);
     expect(revoked).toBe(true);
     expect(validFrom.toISOString()).toBe('2023-01-21T17:57:09.266Z');
-    expect(validUntil.toISOString()).toBe('2023-01-21T17:57:09.266Z');
+    expect(validUntil.toISOString()).toBe('2023-01-21T17:57:10.266Z');
   });
   it('should valid_from itself', async () => {
     const { validFrom, validUntil } = await computeValidPeriod({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* According to STIX 2.1 compliance, the until_date must be greater than the valid_from. However right now, if we do not put an until_date manually, we fill the field with the exact same date as valid_from.
* So I add one second to the valid_from if the field until_date is empty

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6836

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
