### PR TITLE
[backend] prevent wrong type for empty pid (#6968)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -42,6 +42,7 @@ import { addFilter } from '../utils/filtering/filtering-utils';
 import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { uploadToStorage } from '../database/file-storage-helper';
+import { isNumericAttribute } from '../schema/schema-attributes';
 
 export const findById = (context, user, stixCyberObservableId) => {
   return storeLoadById(context, user, stixCyberObservableId, ABSTRACT_STIX_CYBER_OBSERVABLE);
@@ -276,8 +277,9 @@ export const stixCyberObservableEditField = async (context, user, stixCyberObser
     input,
     opts
   );
+  // Delete the key when updating a numeric field with an empty value (e.g. to delete this value) to avoid a schema error
   Object.entries(stixCyberObservable).forEach(([key, value]) => {
-    if (value === '') delete stixCyberObservable[key];
+    if (isNumericAttribute(key) && value === '') delete stixCyberObservable[key];
   });
   if (input[0].key === 'x_opencti_score') {
     const indicators = await listAllFromEntitiesThroughRelations(

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -276,6 +276,7 @@ export const stixCyberObservableEditField = async (context, user, stixCyberObser
     input,
     opts
   );
+  if (isEmptyField(stixCyberObservable.pid)) stixCyberObservable.pid = undefined;
   if (input[0].key === 'x_opencti_score') {
     const indicators = await listAllFromEntitiesThroughRelations(
       context,

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -276,7 +276,9 @@ export const stixCyberObservableEditField = async (context, user, stixCyberObser
     input,
     opts
   );
-  if (isEmptyField(stixCyberObservable.pid)) stixCyberObservable.pid = undefined;
+  for (let key in stixCyberObservable) {
+    if (stixCyberObservable[key] === '') delete stixCyberObservable[key];
+  }
   if (input[0].key === 'x_opencti_score') {
     const indicators = await listAllFromEntitiesThroughRelations(
       context,

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -276,9 +276,9 @@ export const stixCyberObservableEditField = async (context, user, stixCyberObser
     input,
     opts
   );
-  for (let key in stixCyberObservable) {
-    if (stixCyberObservable[key] === '') delete stixCyberObservable[key];
-  }
+  Object.entries(stixCyberObservable).forEach(([key, value]) => {
+    if (value === '') delete stixCyberObservable[key];
+  });
   if (input[0].key === 'x_opencti_score') {
     const indicators = await listAllFromEntitiesThroughRelations(
       context,


### PR DESCRIPTION
### Proposed changes

- Manage value of PID (type number) when removing the value (empty string is sending)

### Related issues

- close #6968 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality