### PR TITLE
[backend] added limitQuerySize option on elFindByIds (#7250)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1351,7 +1351,7 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
       }
       const query = {
         index: computedIndices,
-        size: workingIds.length > ES_MAX_PAGINATION ? ES_MAX_PAGINATION : workingIds.length,
+        size: workingIds.length + 1 < ES_MAX_PAGINATION ? workingIds.length + 1 : ES_MAX_PAGINATION,
         _source: baseData ? baseFields : true,
         body,
       };
@@ -1361,6 +1361,7 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
         throw DatabaseError('Find direct ids fail', { cause: err, query });
       });
       const elements = data.hits.hits;
+      if (elements.length > workingIds.length) logApp.warn('Search query returned more elements than expected', workingIds);
       if (elements.length > 0) {
         const convertedHits = await elConvertHits(elements, { withoutRels });
         hits.push(...convertedHits);

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1351,7 +1351,7 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
       }
       const query = {
         index: computedIndices,
-        size: workingIds.length + 1 < ES_MAX_PAGINATION ? workingIds.length + 1 : ES_MAX_PAGINATION,
+        size: ES_MAX_PAGINATION,
         _source: baseData ? baseFields : true,
         body,
       };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* reverted search query size to ES_MAX_PAGINATION in elFindByIds, log warning message if more elements returned than expected

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*#7250

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
