### PR TITLE
[frontend] Ignore font-family while exporting report content (#6773)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -438,7 +438,10 @@ class StixCoreObjectContentComponent extends Component {
     const htmlData = currentContent
       .replaceAll('id="undefined" ', '')
       .replaceAll(regex, '');
-    const ret = htmlToPdfmake(htmlData, { imagesByReference: true });
+    const ret = htmlToPdfmake(htmlData, {
+      imagesByReference: true,
+      ignoreStyles: ['font-family'],
+    });
     Promise.all(
       R.pipe(
         R.toPairs,


### PR DESCRIPTION
### Proposed changes

* Ignore font family while exporting report content

### Related issues

* #6773 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

The custom fonts from CKEditor are not managed by the lib to export into PDF format
