### PR TITLE
[frontend] Fix Infrastructure breaking Investigation (#6801)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -344,14 +344,10 @@ const investigationGraphCountRelToQuery = graphql`
 
 const investigationGraphStixRelationshipsQuery = graphql`
   query InvestigationGraphStixRelationshipsQuery(
-    $fromOrToId: String!
-    $relationship_type: [String]
-    $elementWithTargetTypes: [String]
+    $filters: FilterGroup
   ) {
     stixRelationships(
-      fromOrToId: $fromOrToId
-      relationship_type: $relationship_type
-      elementWithTargetTypes: $elementWithTargetTypes
+      filters: $filters
     ) {
       edges {
         node {
@@ -1823,9 +1819,30 @@ class InvestigationGraphComponent extends Component {
       const newElements = await fetchQuery(
         investigationGraphStixRelationshipsQuery,
         {
-          fromOrToId: n,
-          relationship_type: filters.relationship_types.map((o) => o.value),
-          elementWithTargetTypes: filters.entity_types.map((o) => o.value),
+          filters: {
+            mode: 'or',
+            filterGroups: [
+              {
+                mode: 'and',
+                filterGroups: [],
+                filters: [
+                  { key: 'fromId', values: [n] },
+                  { key: 'toTypes', values: filters.entity_types.map((o) => o.value) },
+                  { key: 'relationship_type', values: filters.relationship_types.map((o) => o.value) },
+                ],
+              },
+              {
+                mode: 'and',
+                filterGroups: [],
+                filters: [
+                  { key: 'toId', values: [n] },
+                  { key: 'fromTypes', values: filters.entity_types.map((o) => o.value) },
+                  { key: 'relationship_type', values: filters.relationship_types.map((o) => o.value) },
+                ],
+              },
+            ],
+            filters: [],
+          },
         },
       )
         .toPromise()


### PR DESCRIPTION
In this issue, the user revealed that the expansion of an infrastructure with another infrastructure was breaking investigation. 
After research, the problem was global and every time we wanted to expand on the same entity type (example: Threat Actor A + Threat Actor B), the expansion displayed every relation related to the entity Threat Actor A and not just the one between A and B. 

### Proposed changes

* Adapt filters to be able to expand on the same entity type

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6801


