### PR TITLE
[frontend] Fix enrichment of multiple observables when shift-selecting (#7269)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservablesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservablesLines.tsx
@@ -87,6 +87,7 @@ const ContainerStixCyberObservablesLinesFragment = graphql`
             ... on StixCyberObservable {
               id
               observable_value
+              entity_type
             }
             ...ContainerStixCyberObservableLine_node
           }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectsLines.tsx
@@ -106,6 +106,7 @@ export const containerStixDomainObjectsLinesFragment = graphql`
           node {
             ... on BasicObject {
               id
+              entity_type
             }
             ...ContainerStixDomainObjectLine_node
           }

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -1242,9 +1242,9 @@ class ToolBar extends Component {
     } = this.props;
     const { actions, keptEntityId, mergingElement, actionsInputs, navOpen } = this.state;
     const isOpen = numberOfSelectedElements > 0;
-    const selectedTypes = R.uniq(
-      R.map((o) => o.entity_type, R.values(selectedElements || {})),
-    );
+    const selectedTypes = [...new Set(Object.values(selectedElements || {})
+      .map((o) => o.entity_type)
+      .filter((entity_type) => entity_type !== undefined))];
     const typesAreDifferent = selectedTypes.length > 1;
     const preventMerge = selectedTypes.at(0) === 'Vocabulary'
       && Object.values(selectedElements).some(({ builtIn }) => Boolean(builtIn));
@@ -1276,13 +1276,21 @@ class ToolBar extends Component {
     const notEnrichableTypes = ['Label', 'Vocabulary', 'Case-Template', 'Task', 'DeleteOperation'];
     const isManualEnrichSelect = !selectAll && selectedTypes.length === 1;
     const isAllEnrichSelect = selectAll
-      && entityTypeFilterValues.length === 1
-      && R.head(entityTypeFilterValues) !== 'Stix-Cyber-Observable'
-      && R.head(entityTypeFilterValues) !== 'Stix-Domain-Object';
-    const enrichDisable = notEnrichableTypes.includes(R.head(selectedTypes))
-      || (entityTypeFilterValues.length === 1
-        && notEnrichableTypes.includes(entityTypeFilterValues[0]))
-      || (!isManualEnrichSelect && !isAllEnrichSelect);
+        && entityTypeFilterValues.length === 1
+        && entityTypeFilterValues[0] !== 'Stix-Cyber-Observable'
+        && entityTypeFilterValues[0] !== 'Stix-Domain-Object';
+
+    // console.log('selectAll', selectAll);
+    // console.log('isManualEnrichSelect', isManualEnrichSelect);
+    // console.log('entityTypeFilterValues', entityTypeFilterValues);
+    // console.log('notEnrichableTypes', notEnrichableTypes);
+    // console.log('isAllEnrichSelect', isAllEnrichSelect);
+    console.log('selectedTypes', selectedTypes);
+
+    const enrichDisable = notEnrichableTypes.includes(selectedTypes[0])
+        || (entityTypeFilterValues.length === 1
+            && notEnrichableTypes.includes(entityTypeFilterValues[0]))
+        || (!isManualEnrichSelect && !isAllEnrichSelect);
     // endregion
     const typesAreNotMergable = R.includes(
       R.uniq(R.map((o) => o.entity_type, R.values(selectedElements || {})))[0],

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -1279,14 +1279,6 @@ class ToolBar extends Component {
         && entityTypeFilterValues.length === 1
         && entityTypeFilterValues[0] !== 'Stix-Cyber-Observable'
         && entityTypeFilterValues[0] !== 'Stix-Domain-Object';
-
-    // console.log('selectAll', selectAll);
-    // console.log('isManualEnrichSelect', isManualEnrichSelect);
-    // console.log('entityTypeFilterValues', entityTypeFilterValues);
-    // console.log('notEnrichableTypes', notEnrichableTypes);
-    // console.log('isAllEnrichSelect', isAllEnrichSelect);
-    console.log('selectedTypes', selectedTypes);
-
     const enrichDisable = notEnrichableTypes.includes(selectedTypes[0])
         || (entityTypeFilterValues.length === 1
             && notEnrichableTypes.includes(entityTypeFilterValues[0]))


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* remove Ramda
* filter 'undefined' type
* fix shift selecting in entities et observables list

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7269 

## Reproducible Steps

Steps to create the smallest reproducible scenario:
1. Create a report and add to it at least 4 domain names
2. Access the report and then go the Observables tab
3. Select the first domain name, press shift and select the last one

## Expected Output

Being able to enrich
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
