### PR TITLE
CI improvement: client-python build once and fail fast on test-api (#7359)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,6 @@ steps:
       SMTP__USERNAME: jennyfer.mraz@ethereal.email
       SMTP__PASSWORD: frhJ2mSPTfaEutpbug
       PYTHONUNBUFFERED: 1
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - apk add build-base git libffi-dev cargo curl
       - pip3 install --upgrade setuptools
@@ -54,11 +53,6 @@ steps:
       - yarn build
       - yarn check-ts
       - yarn lint
-      - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl --max-time 30 --retry-delay 30 --retry 4 "http://opencti-direct-start:4300/health?health_access_key=testHealth"
-      - curl --max-time 30 --retry-delay 30 --retry 4 "http://opencti-raw-start:4100/health?health_access_key=testHealth"
-      - curl --max-time 30 "http://opencti-live-start:4200/health?health_access_key=testHealth"
-      - curl --max-time 30 -fsS -o /dev/null "http://opencti-restore-start:4400/health?health_access_key=testHealth"
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
@@ -204,9 +198,9 @@ services:
       MINIO__ENDPOINT: minio
       MINIO__BUCKET_NAME: raw-start-bucket
       RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__QUEUE_PREFIX: raw-start
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - ls -lart
@@ -234,9 +228,9 @@ services:
       MINIO__ENDPOINT: minio
       MINIO__BUCKET_NAME: live-start-bucket
       RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__QUEUE_PREFIX: live-start
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/live-start-platform/
@@ -244,7 +238,7 @@ services:
       - cd /tmp/live-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - # NODE_OPTIONS=--max_old_space_size=8192 yarn start
+      - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-direct-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
@@ -263,9 +257,9 @@ services:
       MINIO__ENDPOINT: minio
       MINIO__BUCKET_NAME: direct-start-bucket
       RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__QUEUE_PREFIX: direct-start
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/direct-start-platform/
@@ -309,9 +303,9 @@ services:
       MINIO__ENDPOINT: minio
       MINIO__BUCKET_NAME: restore-start-bucket
       RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__QUEUE_PREFIX: restore-start
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/restore-start-platform/
@@ -339,9 +333,9 @@ services:
       MINIO__ENDPOINT: minio
       MINIO__BUCKET_NAME: e2e-start-bucket
       RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__QUEUE_PREFIX: e2e-start
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
-      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - cp -a opencti-platform/* /tmp/e2e-start-platform/
       - apk add build-base git libffi-dev cargo

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,10 +55,10 @@ steps:
       - yarn check-ts
       - yarn lint
       - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl -fsS -o /dev/null http://opencti-raw-start:4100/health?health_access_key=testHealth$?
-      - curl -fsS -o /dev/null http://opencti-live-start:4200/health?health_access_key=testHealth$?
-      - curl -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth$?
-      - curl -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth$?
+      - curl --max-time 30 -fsS -o /dev/null http://opencti-raw-start:4100/health?health_access_key=testHealth
+      - curl --max-time 30 -fsS -o /dev/null http://opencti-live-start:4200/health?health_access_key=testHealth
+      - curl --max-time 30 -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth
+      - curl --max-time 30 -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
@@ -106,7 +106,7 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional curl
-      - curl -fsS -o /dev/null  http://opencti-e2e-start:4500/health?health_access_key=testHealth$?
+      - curl --max-time 30 -fsS -o /dev/null  http://opencti-e2e-start:4500/health?health_access_key=testHealth
       - cd opencti-platform/opencti-front
       - yarn install
       - npx playwright install --with-deps chromium

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,8 +43,9 @@ steps:
       SMTP__USERNAME: jennyfer.mraz@ethereal.email
       SMTP__PASSWORD: frhJ2mSPTfaEutpbug
       PYTHONUNBUFFERED: 1
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
-      - apk add build-base git libffi-dev cargo
+      - apk add build-base git libffi-dev cargo curl
       - pip3 install --upgrade setuptools
       - echo "DRONE_WORKSPACE=$DRONE_WORKSPACE"
       - echo "DRONE_WORKSPACE=${DRONE_WORKSPACE}"
@@ -53,6 +54,10 @@ steps:
       - yarn build
       - yarn check-ts
       - yarn lint
+      - curl --max-time 10 --retry 3 http://opencti-raw-start:4100/health?health_access_key=testHealth
+      - curl --max-time 10 --retry 3 http://opencti-live-start:4200/health?health_access_key=testHealth
+      - curl --max-time 10 --retry 3 http://opencti-direct-start:4300/health?health_access_key=testHealth
+      - curl --max-time 10 --retry 3 http://opencti-restore-start:4400/health?health_access_key=testHealth
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
@@ -100,6 +105,7 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional
+      - curl --max-time 10 --retry 3 http://opencti-e2e-start:4500/health?health_access_key=testHealth
       - cd opencti-platform/opencti-front
       - yarn install
       - npx playwright install --with-deps chromium
@@ -199,6 +205,7 @@ services:
       RABBITMQ__HOSTNAME: rabbitmq
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - ls -lart
@@ -207,7 +214,7 @@ services:
       - cd /tmp/raw-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - NODE_OPTIONS=--max_old_space_size=8192 yarn start
+      - # NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-live-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
@@ -228,6 +235,7 @@ services:
       RABBITMQ__HOSTNAME: rabbitmq
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/live-start-platform/
@@ -256,6 +264,7 @@ services:
       RABBITMQ__HOSTNAME: rabbitmq
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/direct-start-platform/
@@ -301,6 +310,7 @@ services:
       RABBITMQ__HOSTNAME: rabbitmq
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - sleep 10
       - cp -a opencti-platform/* /tmp/restore-start-platform/
@@ -330,6 +340,7 @@ services:
       RABBITMQ__HOSTNAME: rabbitmq
       EXPIRATION_SCHEDULER__ENABLED: false
       SUBSCRIPTION_SCHEDULER__ENABLED: false
+      APP__HEALTH_ACCESS_KEY: testHealth
     commands:
       - cp -a opencti-platform/* /tmp/e2e-start-platform/
       - apk add build-base git libffi-dev cargo

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,7 @@ steps:
       SMTP__PASSWORD: frhJ2mSPTfaEutpbug
       PYTHONUNBUFFERED: 1
     commands:
-      - apk add build-base git libffi-dev cargo curl
+      - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools
       - echo "DRONE_WORKSPACE=$DRONE_WORKSPACE"
       - echo "DRONE_WORKSPACE=${DRONE_WORKSPACE}"
@@ -99,8 +99,7 @@ steps:
       TEAMS_WEBHOOK: teams-webhook-url
     commands:
       - apt-get update
-      - apt-get -y install netcat-traditional curl
-      - curl --max-time 30 http://opencti-e2e-start:4500/health?health_access_key=testHealth
+      - apt-get -y install netcat-traditional
       - cd opencti-platform/opencti-front
       - yarn install
       - npx playwright install --with-deps chromium

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,9 @@ steps:
       - chmod 777 scripts/*
       - ./scripts/clone-dependencies.sh ${DRONE_SOURCE_BRANCH} $(pwd) ${DRONE_PULL_REQUEST}
       - ls -lart
+      - cd "$DRONE_WORKSPACE/client-python"
+      - echo "[INFO] using client-python on branch $(git branch --show-current)"
+      - pip3 install --upgrade --force .
 
   - name: api-tests
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -50,9 +53,6 @@ steps:
       - yarn build
       - yarn check-ts
       - yarn lint
-      - cd "$DRONE_WORKSPACE/client-python"
-      - echo "[INFO] using client-python on branch $(git branch --show-current)"
-      - pip3 install --upgrade --force .
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
@@ -207,9 +207,6 @@ services:
       - cd /tmp/raw-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/raw-start-platform/opencti-graphql
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-live-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -238,9 +235,6 @@ services:
       - cd /tmp/live-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/live-start-platform/opencti-graphql
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-direct-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -269,9 +263,6 @@ services:
       - cd /tmp/direct-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/direct-start-platform/opencti-graphql
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-direct-worker
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -289,9 +280,6 @@ services:
       - while ! nc -z opencti-direct-start 4300 ; do sleep 1 ; done
       - cd /tmp/direct-start-worker
       - pip3 install -r src/requirements.txt
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/direct-start-worker
       - python3 src/worker.py
   - name: opencti-restore-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -320,9 +308,6 @@ services:
       - cd /tmp/restore-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/restore-start-platform/opencti-graphql
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-e2e-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -352,9 +337,6 @@ services:
       - yarn install
       - yarn install:python
       - BRANCH=$(echo $DRONE_COMMIT_BRANCH | cut -d "/" -f 2)
-      - cd "$DRONE_WORKSPACE/client-python"
-      - pip3 install --upgrade --force .
-      - cd /tmp/e2e-start-platform/opencti-graphql
       - yarn build:dev
       - yarn wait-api && node build/script-insert-dataset.js --datasets=DATA-TEST-STIX2_v2,data-test-stix-e2e,poisonivy &
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,10 +55,10 @@ steps:
       - yarn check-ts
       - yarn lint
       - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl --max-time 30 --retry-delay 30 --retry 4 http://opencti-raw-start:4100/health?health_access_key=testHealth
-      - curl --max-time 30 http://opencti-live-start:4200/health?health_access_key=testHealth
-      - curl --max-time 30 -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth
-      - curl --max-time 30 -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth
+      - curl --max-time 30 --retry-delay 30 --retry 4 "http://opencti-direct-start:4300/health?health_access_key=testHealth"
+      - curl --max-time 30 --retry-delay 30 --retry 4 "http://opencti-raw-start:4100/health?health_access_key=testHealth"
+      - curl --max-time 30 "http://opencti-live-start:4200/health?health_access_key=testHealth"
+      - curl --max-time 30 -fsS -o /dev/null "http://opencti-restore-start:4400/health?health_access_key=testHealth"
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,7 @@ steps:
       - yarn check-ts
       - yarn lint
       - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl --max-time 30 http://opencti-raw-start:4100/health?health_access_key=testHealth
+      - curl --max-time 300 http://opencti-raw-start:4100/health?health_access_key=testHealth
       - curl --max-time 30 http://opencti-live-start:4200/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,8 +55,8 @@ steps:
       - yarn check-ts
       - yarn lint
       - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl --max-time 30 -fsS -o /dev/null http://opencti-raw-start:4100/health?health_access_key=testHealth
-      - curl --max-time 30 -fsS -o /dev/null http://opencti-live-start:4200/health?health_access_key=testHealth
+      - curl --max-time 30 http://opencti-raw-start:4100/health?health_access_key=testHealth
+      - curl --max-time 30 http://opencti-live-start:4200/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,7 @@ steps:
       - yarn check-ts
       - yarn lint
       - # Healthcheck, keep linter before healthcheck to give time to services to start
-      - curl --max-time 300 http://opencti-raw-start:4100/health?health_access_key=testHealth
+      - curl --max-time 30 --retry-delay 30 --retry 4 http://opencti-raw-start:4100/health?health_access_key=testHealth
       - curl --max-time 30 http://opencti-live-start:4200/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth
       - curl --max-time 30 -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,10 +54,11 @@ steps:
       - yarn build
       - yarn check-ts
       - yarn lint
-      - curl --max-time 10 --retry 3 http://opencti-raw-start:4100/health?health_access_key=testHealth
-      - curl --max-time 10 --retry 3 http://opencti-live-start:4200/health?health_access_key=testHealth
-      - curl --max-time 10 --retry 3 http://opencti-direct-start:4300/health?health_access_key=testHealth
-      - curl --max-time 10 --retry 3 http://opencti-restore-start:4400/health?health_access_key=testHealth
+      - # Healthcheck, keep linter before healthcheck to give time to services to start
+      - curl -fsS -o /dev/null http://opencti-raw-start:4100/health?health_access_key=testHealth$?
+      - curl -fsS -o /dev/null http://opencti-live-start:4200/health?health_access_key=testHealth$?
+      - curl -fsS -o /dev/null http://opencti-direct-start:4300/health?health_access_key=testHealth$?
+      - curl -fsS -o /dev/null http://opencti-restore-start:4400/health?health_access_key=testHealth$?
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
@@ -104,8 +105,8 @@ steps:
       TEAMS_WEBHOOK: teams-webhook-url
     commands:
       - apt-get update
-      - apt-get -y install netcat-traditional
-      - curl --max-time 10 --retry 3 http://opencti-e2e-start:4500/health?health_access_key=testHealth
+      - apt-get -y install netcat-traditional curl
+      - curl -fsS -o /dev/null  http://opencti-e2e-start:4500/health?health_access_key=testHealth$?
       - cd opencti-platform/opencti-front
       - yarn install
       - npx playwright install --with-deps chromium
@@ -214,7 +215,7 @@ services:
       - cd /tmp/raw-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - # NODE_OPTIONS=--max_old_space_size=8192 yarn start
+      - NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-live-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
@@ -243,7 +244,7 @@ services:
       - cd /tmp/live-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
-      - NODE_OPTIONS=--max_old_space_size=8192 yarn start
+      - # NODE_OPTIONS=--max_old_space_size=8192 yarn start
   - name: opencti-direct-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional curl
-      - curl --max-time 30 -fsS -o /dev/null  http://opencti-e2e-start:4500/health?health_access_key=testHealth
+      - curl --max-time 30 http://opencti-e2e-start:4500/health?health_access_key=testHealth
       - cd opencti-platform/opencti-front
       - yarn install
       - npx playwright install --with-deps chromium

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -26,7 +26,7 @@
     "test:dev": "vitest run --config vitest.config.dev.ts",
     "test:watch:resume": "SKIP_CLEANUP_PLATFORM=true vitest watch --config vitest.config.dev.ts",
     "test:watch": "vitest watch --config vitest.config.dev.ts",
-    "test": "vitest --silent run --config vitest.config.test.ts --coverage",
+    "test": "vitest --silent --bail 1 run --config vitest.config.test.ts --coverage",
     "wait-api": "node build/script-wait-for-api.js"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -8,7 +8,7 @@ describe('prepareElementForIndexing testing', () => {
   });
   it('should inner trim applied', () => {
     const element = prepareElementForIndexing({ num: 10, data: { test: '  spacing   ' } });
-    expect(element.num).toBe(3); // FIXME test if this fail fast
+    expect(element.num).toBe(10);
     expect(element.data.test).toBe('spacing');
   });
   it('should array trim applied', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -8,7 +8,7 @@ describe('prepareElementForIndexing testing', () => {
   });
   it('should inner trim applied', () => {
     const element = prepareElementForIndexing({ num: 10, data: { test: '  spacing   ' } });
-    expect(element.num).toBe(10);
+    expect(element.num).toBe(3); // FIXME test if this fail fast
     expect(element.data.test).toBe('spacing');
   });
   it('should array trim applied', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

#7359:
* build client python once for all after having check if the master version must be used or a PR version (with multi-repository)

In addition:
* adding `--bail 1`  to `yarn test`  to stop on the first failing test (instead on running the whole suite).
* use a different rabbit prefix for each services (similar to elastic and minio configuration)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
Closes #7359

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
