### PR TITLE
Added steps to force python venv creation to ensure build

### DIFF
--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Build into Alpine
         run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
           cd opencti-platform/opencti-front
           yarn install
           yarn build


### PR DESCRIPTION

### Proposed changes

* Forced venv usage before build steps 

### Further comments

The issues was introduced because of a change in the behavior of Python after we updated the Alpine versions used to build OCTI