### PR TITLE
[backend] set x_opencti_workflow_id upsert attribute (#7114)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7239,6 +7239,7 @@ input StixSightingRelationshipAddInput {
   externalReferences: [String]
   clientMutationId: String
   update: Boolean
+  x_opencti_workflow_id: String
 }
 
 enum StixRefRelationshipsOrdering {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9197,6 +9197,7 @@ input DataComponentAddInput {
   aliases: [String]
   dataSource: String
   file: Upload
+  x_opencti_workflow_id: String
 }
 
 type DataSource implements BasicObject & StixObject & StixCoreObject & StixDomainObject {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8938,6 +8938,7 @@ input NarrativeAddInput {
   clientMutationId: String
   update: Boolean
   file: Upload
+  x_opencti_workflow_id: String
 }
 
 type ResolvedInstanceFilter {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9298,6 +9298,7 @@ input DataSourceAddInput {
   collection_layers: [String!]
   dataComponents: [String]
   file: Upload
+  x_opencti_workflow_id: String
 }
 
 enum VocabularyCategory {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -11019,6 +11019,7 @@ input StixSightingRelationshipAddInput {
   externalReferences: [String]
   clientMutationId: String
   update: Boolean
+  x_opencti_workflow_id: String
 }
 
 ############## StixRefRelationships

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15129,6 +15129,7 @@ export type NarrativeAddInput = {
   stix_id?: InputMaybe<Scalars['StixId']['input']>;
   update?: InputMaybe<Scalars['Boolean']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
+  x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type NarrativeConnection = {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -5176,6 +5176,7 @@ export type DataComponentAddInput = {
   stix_id?: InputMaybe<Scalars['StixId']['input']>;
   update?: InputMaybe<Scalars['Boolean']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
+  x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DataComponentConnection = {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -24040,6 +24040,7 @@ export type StixSightingRelationshipAddInput = {
   update?: InputMaybe<Scalars['Boolean']['input']>;
   x_opencti_negative?: InputMaybe<Scalars['Boolean']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
+  x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type StixSightingRelationshipConnection = {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -5410,6 +5410,7 @@ export type DataSourceAddInput = {
   update?: InputMaybe<Scalars['Boolean']['input']>;
   x_mitre_platforms?: InputMaybe<Array<Scalars['String']['input']>>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
+  x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DataSourceConnection = {

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixCoreRelationship-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixCoreRelationship-registrationAttributes.ts
@@ -35,7 +35,7 @@ export const stixCoreRelationshipsAttributes: Array<AttributeDefinition> = [
   { name: 'start_time', label: 'First observation', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
   { name: 'stop_time', label: 'Last observation', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
   { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
-  { name: 'x_opencti_workflow_id', label: 'Workflow status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+  { name: 'x_opencti_workflow_id', label: 'Workflow status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
 ];
 schemaAttributesDefinition.registerAttributes(ABSTRACT_STIX_CORE_RELATIONSHIP, stixCoreRelationshipsAttributes);
 STIX_CORE_RELATIONSHIPS.map((type) => schemaAttributesDefinition.registerAttributes(type, stixCoreRelationshipsAttributes));

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixSightingRelationship-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixSightingRelationship-registrationAttributes.ts
@@ -10,7 +10,7 @@ export const stixSightingRelationshipsAttributes: { [k: string]: Array<Attribute
     { name: 'last_seen', label: 'Last seen', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_negative', label: 'False positive', type: 'boolean', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: false, isFilterable: true },
-    { name: 'x_opencti_workflow_id', label: 'Workflow status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'x_opencti_workflow_id', label: 'Workflow status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ],
 };
 R.forEachObjIndexed((value, key) => schemaAttributesDefinition.registerAttributes(key as string, value), stixSightingRelationshipsAttributes);

--- a/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
@@ -170,6 +170,7 @@ input DataComponentAddInput {
     aliases: [String]
     dataSource: String
     file: Upload
+    x_opencti_workflow_id: String
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
@@ -172,6 +172,7 @@ input DataSourceAddInput {
     collection_layers: [String!]
     dataComponents: [String]
     file: Upload
+    x_opencti_workflow_id: String
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
@@ -172,6 +172,7 @@ input NarrativeAddInput {
     clientMutationId: String
     update: Boolean
     file: Upload
+    x_opencti_workflow_id: String
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -517,6 +517,7 @@ const attributePathMapping: any = {
   x_opencti_workflow_id: {
     [ABSTRACT_STIX_DOMAIN_OBJECT]: `/extensions/${STIX_EXT_OCTI}/workflow_id`,
     [ABSTRACT_STIX_CYBER_OBSERVABLE]: `/extensions/${STIX_EXT_OCTI}/workflow_id`,
+    [ABSTRACT_STIX_RELATIONSHIP]: `/extensions/${STIX_EXT_OCTI}/workflow_id`,
   }
 };
 interface UpdateValueConfiguration {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* set `x_opencti_workflow_id` upsert attribute to true
* add ABSTRACT_STIX_RELATIONSHIP in `attributePathMapping` for` x_opencti_workflow_id`
*  add missing `x_opencti_workflow_id` in some addInput : `Narrative` `Sighting` `DataComponent ``DataSource`

associatedclient python PR:
https://github.com/OpenCTI-Platform/client-python/pull/688

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*  #7114 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
