### PR TITLE
[backend] Fix handling of platform_entity_files_ref config (#7406)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
@@ -395,6 +395,7 @@ StixCoreObjectExternalReferencesLinesContainerProps
                             isExternalReferenceAttachment={isFileAttached}
                             handleRemove={() => handleOpenDialog(externalReferenceEdge)
                             }
+                            objectId={stixCoreObjectId}
                           />
                         </Security>
                       </ListItemSecondaryAction>

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
@@ -23,6 +23,7 @@ const stixMetaObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'url', label: 'URL', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'hash', label: 'Hash', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'fileId', label: 'File id', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'external_id', label: 'External id', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   ],
   [ENTITY_TYPE_KILL_CHAIN_PHASE]: [

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
@@ -23,7 +23,7 @@ const stixMetaObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'url', label: 'URL', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'hash', label: 'Hash', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'fileId', label: 'File id', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'fileId', label: 'File ID', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'external_id', label: 'External id', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   ],
   [ENTITY_TYPE_KILL_CHAIN_PHASE]: [


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added fileId to external reference schema attributes
* Fixed creation of external ref in createEntityRaw when platform_entity_files_ref is configured
* Fixed updater for external ref deletion

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7406 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
