### PR TITLE
[frontend] Modifies autocomplete which causes form visual validation discrepancy

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.jsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.jsx
@@ -81,8 +81,8 @@ const AutocompleteField = (props) => {
             value={value}
             name={name}
             fullWidth={true}
-            error={!isNil(meta.error) && meta.touched}
-            helperText={(meta.touched && meta.error) || textfieldprops.helperText}
+            error={!isNil(meta.error)}
+            helperText={meta.error || textfieldprops.helperText}
           />
         )}
         onChange={internalOnChange}


### PR DESCRIPTION
### Proposed changes

* The fix to the following issue (https://github.com/OpenCTI-Platform/opencti/issues/5741) introduced a code change in commit (https://github.com/OpenCTI-Platform/opencti/commit/830f8a6#diff-41901d9dfd3a5b179fe6b41d020dd46b8c40be2fed3db788e2b4d4f9f021df42)
* This change created an inconsistency in form validation behavior when a required field relies on the AutoCompletedField component. This inconsistency is discussed/described in this issue (https://github.com/OpenCTI-Platform/opencti/issues/7401)

This PR seeks to standardize the form validation behavior on required fields to flag all in red via Formik validation, even fields that depend on the AutoCompletedField component.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* N/A


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] N/A - I wrote test cases for the relevant uses case (coverage and e2e)
- [X] N/A -  I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
 None
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
