### PR TITLE
[backend] Change log level for S3 download file errors (#7467)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -145,15 +145,24 @@ export const deleteFiles = async (context, user, ids) => {
   return true;
 };
 
+/**
+ * Download a file from S3 at given S3 key (id)
+ * @param id
+ * @returns {Promise<*|null>} null when error occurs on download.
+ */
 export const downloadFile = async (id) => {
   try {
     const object = await s3Client.send(new s3.GetObjectCommand({
       Bucket: bucketName,
       Key: id
     }));
+    if (!object || !object.Body) {
+      logApp.error('[FILE STORAGE] Cannot retrieve file from S3, null body in response', { fileId: id });
+      return null;
+    }
     return object.Body;
   } catch (err) {
-    logApp.info('[FILE STORAGE] Cannot retrieve file from S3', { error: err });
+    logApp.error('[FILE STORAGE] Cannot retrieve file from S3', { error: err, fileId: id });
     return null;
   }
 };

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
@@ -89,6 +89,10 @@ describe('File storage file listing', () => {
     const user = head(jsonData.objects);
     expect(user.name).toEqual('Paradise Ransomware');
   });
+  it('should non existing download return null', async () => {
+    const fileStream = await downloadFile('ThisDoesNotExists');
+    expect(fileStream).toBeNull();
+  });
   it('should load file', async () => {
     const malware = await elLoadById(testContext, ADMIN_USER, 'malware--faa5b705-cf44-4e50-8472-29e5fec43c3c');
     const file = await loadFile(ADMIN_USER, exportFileId(malware));


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change log level to error when S3 throw error + add another log in case the response body from S3 is null to have different log in the 2 different situations.

I did not change the behavior (like throwing exception instead of just log it) because it's use at many places and I don't want to change it all. I just made the current behavior explicit in tests.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
Closes [7467](https://github.com/OpenCTI-Platform/opencti/issues/7467)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
