### PR TITLE
In CSV Feed Ingester, take into account Default Marking definition options from CSV Mapper - improvements

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvMapperTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvMapperTestDialog.tsx
@@ -50,7 +50,7 @@ const IngestionCsvMapperTestDialog: FunctionComponent<IngestionCsvMapperTestDial
 }) => {
   const { t_i18n } = useFormatter();
   const [result, setResult] = useState<IngestionCsvMapperTestDialogMutation$data | undefined>(undefined);
-  const [commitTest] = useApiMutation(ingestionCsvMapperTestMutation);
+  const [commitTest] = useApiMutation(ingestionCsvMapperTestMutation, undefined, { errorMessage: 'Something went wrong. Please check the configuration.' });
   const [loading, setLoading] = useState<boolean>(false);
 
   const handleClose = () => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -74,7 +74,7 @@ input IngestionCsvAddInput {
 }
 
 type Mutation {
-    ingestionCsvTester(input: IngestionCsvAddInput!): CsvMapperTestResult @auth(for: [CSVMAPPERS])
+    ingestionCsvTester(input: IngestionCsvAddInput!): CsvMapperTestResult @auth(for: [CSVMAPPERS, INGESTION_SETINGESTIONS])
     ingestionCsvAdd(input: IngestionCsvAddInput!): IngestionCsv @auth(for: [CSVMAPPERS])
     ingestionCsvDelete(id: ID!): ID @auth(for: [CSVMAPPERS])
     ingestionCsvFieldPatch(id: ID!, input: [EditInput!]!): IngestionCsv @auth(for: [CSVMAPPERS])


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Open CSV mapper test to CSV Ingestion capability
* Improve configuration error message

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6149

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
