### PR TITLE
[frontend] Fix [Bulk search] Sorting on the columns doesn't work (#7215)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -392,8 +392,6 @@ const SearchBulk = () => {
   const reverseBy = (field) => {
     setSortBy(field);
     setOrderAsc((prevOrderAsc) => !prevOrderAsc);
-    console.log('field', field);
-    console.log('resolvedEntities', resolvedEntities);
     const newOrder = !orderAsc;
     const sort = (a, b) => {
       if (a[field] < b[field]) {
@@ -543,7 +541,7 @@ const SearchBulk = () => {
                       {SortHeader('value', 'Value', true)}
                       {SortHeader('author', 'Author', true)}
                       {SortHeader('creator', 'Creators', true)}
-                      {SortHeader('labels', 'Labels', true)}
+                      {SortHeader('labels', 'Labels', false)}
                       {SortHeader('created_at', 'Creation date', true)}
                       {SortHeader('analyses', 'Analyses', true)}
                       {SortHeader('markings', 'Markings', true)}

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -153,6 +153,7 @@ const inlineStylesHeaders = {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     paddingRight: 10,
+    cursor: 'default',
   },
   created_at: {
     float: 'left',
@@ -347,9 +348,9 @@ const SearchBulk = () => {
                           labels: resolvedStixCoreObject.objectLabel,
                           markings: resolvedStixCoreObject.objectMarking,
                           analyses: resolvedStixCoreObject.containersNumber.total,
-                          updated_at: resolvedStixCoreObject.updated_at,
+                          created_at: resolvedStixCoreObject.created_at,
                           author: R.pathOr(
-                            '',
+                            '-',
                             ['createdBy', 'name'],
                             resolvedStixCoreObject,
                           ),

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -346,7 +346,7 @@ const SearchBulk = () => {
                           value: getMainRepresentative(resolvedStixCoreObject),
                           labels: resolvedStixCoreObject.objectLabel,
                           markings: resolvedStixCoreObject.objectMarking,
-                          containersNumber: resolvedStixCoreObject.containersNumber,
+                          analyses: resolvedStixCoreObject.containersNumber.total,
                           updated_at: resolvedStixCoreObject.updated_at,
                           author: R.pathOr(
                             '',
@@ -387,19 +387,23 @@ const SearchBulk = () => {
   });
 
   useEffect(() => {
-    if (sortBy) {
-      const sort = R.sortWith(
-        orderAsc ? [R.ascend(R.prop(sortBy))] : [R.descend(R.prop(sortBy))],
-      );
-      setResolvedEntities(sort(resolvedEntities));
-    }
-  }, [sortBy, orderAsc]);
-  useEffect(() => {
     SEARCH$.next({ action: 'Search' });
   }, [textFieldValue, setResolvedEntities]);
   const reverseBy = (field) => {
     setSortBy(field);
     setOrderAsc((prevOrderAsc) => !prevOrderAsc);
+    console.log('field', field);
+    console.log('resolvedEntities', resolvedEntities);
+    const newOrder = !orderAsc;
+    const sort = (a, b) => {
+      if (a[field] < b[field]) {
+        return newOrder ? -1 : 1;
+      } if (a[field] > b[field]) {
+        return newOrder ? 1 : -1;
+      }
+      return 0;
+    };
+    setResolvedEntities(resolvedEntities.sort(sort));
   };
   const SortHeader = (field, label, isSortable) => {
     const sortComponent = orderAsc ? (
@@ -645,12 +649,12 @@ const SearchBulk = () => {
                                 ].includes(entity.type) ? (
                                   <Chip
                                     classes={{ root: classes.chipNoLink }}
-                                    label={n(entity.containersNumber.total)}
+                                    label={n(entity.analyses)}
                                   />
                                   ) : (
                                     <Chip
                                       classes={{ root: classes.chip }}
-                                      label={n(entity.containersNumber.total)}
+                                      label={n(entity.analyses)}
                                       component={Link}
                                       to={linkAnalyses}
                                     />

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.jsx
@@ -385,12 +385,21 @@ const SearchBulk = () => {
       subscription.unsubscribe();
     };
   });
+
+  useEffect(() => {
+    if (sortBy) {
+      const sort = R.sortWith(
+        orderAsc ? [R.ascend(R.prop(sortBy))] : [R.descend(R.prop(sortBy))],
+      );
+      setResolvedEntities(sort(resolvedEntities));
+    }
+  }, [sortBy, orderAsc]);
   useEffect(() => {
     SEARCH$.next({ action: 'Search' });
   }, [textFieldValue, setResolvedEntities]);
   const reverseBy = (field) => {
     setSortBy(field);
-    setOrderAsc(!orderAsc);
+    setOrderAsc((prevOrderAsc) => !prevOrderAsc);
   };
   const SortHeader = (field, label, isSortable) => {
     const sortComponent = orderAsc ? (
@@ -428,12 +437,6 @@ const SearchBulk = () => {
         .join('\n'),
     );
   };
-  const sort = R.sortWith(
-    orderAsc ? [R.ascend(R.prop(sortBy))] : [R.descend(R.prop(sortBy))],
-  );
-  const sortedResolvedEntities = sortBy
-    ? sort(resolvedEntities)
-    : resolvedEntities;
   return (
     <>
       <Breadcrumbs variant="standard" elements={[{ label: t_i18n('Search') }, { label: t_i18n('Bulk search'), current: true }]} />
@@ -547,7 +550,7 @@ const SearchBulk = () => {
                 &nbsp;
                 </ListItemIcon>
               </ListItem>
-              {sortedResolvedEntities.map((entity) => {
+              {resolvedEntities.map((entity) => {
                 const inPlatform = entity.in_platform;
                 const link = inPlatform && `${resolveLink(entity.type)}/${entity.id}`;
                 const linkAnalyses = `${link}/analyses`;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adapt the reversedBy function
* Change resolvedStixCoreObjects field "containersNumber.total" to "analyses" for the sort to be taken into account.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7215

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
