### PR TITLE
[frontend] restore observable singular colors (#7538)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Colors.js
+++ b/opencti-platform/opencti-front/src/utils/Colors.js
@@ -276,8 +276,7 @@ export const itemColor = (type, dark = false, reversed = false) => {
       if (dark) {
         return '#84ffff';
       }
-      // return stringToColour(type);
-      return '#03a9f4';
+      return stringToColour(type);
     case 'Stix-Core-Relationship':
     case 'Relationship':
     case 'stix-core-relationship':


### PR DESCRIPTION
Cyber observable had a singular color scheme.
The UI rework for better accessibility introduced with ddd996c2 removed this color scheme in favor of one unique color for every observable.

While some of the old colors might still present accessibility issues, we agree it's not suitable to have a unique color and this can be considered a regression.

This PR reintroduces the color scheme for observables.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7546 
* #7538 
