### PR TITLE
[frontend] Incorrect space in the data / import section view between breadcrumb and content (#7529)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportContent.jsx
@@ -340,7 +340,7 @@ class ImportContentComponent extends Component {
           classes={{ container: classes.gridContainer }}
           style={{ marginTop: 0 }}
         >
-          <Grid item={true} xs={8}>
+          <Grid item={true} xs={8} style={{ paddingTop: 0 }}>
             <div style={{ height: '100%' }} className="break">
               <Typography
                 variant="h4"
@@ -392,7 +392,7 @@ class ImportContentComponent extends Component {
               </Paper>
             </div>
           </Grid>
-          <Grid item={true} xs={4}>
+          <Grid item={true} xs={4} style={{ paddingTop: 0 }}>
             <Typography variant="h4" gutterBottom={true}>
               {t('Enabled import connectors')}
             </Typography>


### PR DESCRIPTION
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7529

