### PR TITLE
[frontend] allow to create Malware-Analyses and Tasks from knowledge tab (#7581)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
@@ -68,13 +68,15 @@ interface TaskCreationProps {
     key: string,
   ) => void;
   onClose?: () => void;
-  defaultMarkings?: { value: string, label: string }[]
+  defaultMarkings?: { value: string, label: string }[];
+  inputValue?: string;
 }
 
-const TaskCreationForm: FunctionComponent<TaskCreationProps> = ({
+export const TaskCreationForm: FunctionComponent<TaskCreationProps> = ({
   updater,
   onClose,
   defaultMarkings,
+  inputValue,
 }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
@@ -93,7 +95,7 @@ const TaskCreationForm: FunctionComponent<TaskCreationProps> = ({
   const [commit] = useApiMutation<TaskCreationMutation>(taskAddMutation);
 
   const initialValues: FormikTaskAddInput = {
-    name: '',
+    name: inputValue ?? '',
     description: '',
     due_date: null,
     objectAssignee: [],

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -11,6 +11,7 @@ import { Select } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { ConnectionHandler } from 'relay-runtime';
 import { useFormatter } from '../../../../components/i18n';
+import { MalwareAnalysisCreationForm } from '../../analyses/malware_analyses/MalwareAnalysisCreation';
 import { MalwareCreationForm } from '../../arsenal/malwares/MalwareCreation';
 import { AdministrativeAreaCreationForm } from '../../locations/administrative_areas/AdministrativeAreaCreation';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -622,7 +623,20 @@ const StixDomainPanel = ({
         />
       );
     }
-    return <div>{t_i18n('Unsupported')}</div>;
+    if (type === 'Malware-Analysis') {
+      // Malware-Analysis
+      return (
+        <MalwareAnalysisCreationForm
+          inputValue={inputValue}
+          defaultConfidence={confidence}
+          defaultCreatedBy={baseCreatedBy}
+          defaultMarkingDefinitions={baseMarkingDefinitions}
+          onClose={onClose}
+          updater={creationUpdater}
+        />
+      );
+    }
+    return <div style={{ marginTop: 10 }}>{t_i18n('Unsupported')}</div>;
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -10,6 +10,7 @@ import { Add } from '@mui/icons-material';
 import { Select } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { ConnectionHandler } from 'relay-runtime';
+
 import { useFormatter } from '../../../../components/i18n';
 import { MalwareAnalysisCreationForm } from '../../analyses/malware_analyses/MalwareAnalysisCreation';
 import { MalwareCreationForm } from '../../arsenal/malwares/MalwareCreation';
@@ -18,6 +19,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { AttackPatternCreationForm } from '../../techniques/attack_patterns/AttackPatternCreation';
 import { CampaignCreationForm } from '../../threats/campaigns/CampaignCreation';
 import { ChannelCreationForm } from '../../arsenal/channels/ChannelCreation';
+import { TaskCreationForm } from '../../cases/tasks/TaskCreation';
 import { CityCreationForm } from '../../locations/cities/CityCreation';
 import { CountryCreationForm } from '../../locations/countries/CountryCreation';
 import { EventCreationForm } from '../../entities/events/EventCreation';
@@ -631,6 +633,17 @@ const StixDomainPanel = ({
           defaultConfidence={confidence}
           defaultCreatedBy={baseCreatedBy}
           defaultMarkingDefinitions={baseMarkingDefinitions}
+          onClose={onClose}
+          updater={creationUpdater}
+        />
+      );
+    }
+    if (type === 'Task') {
+      // Task
+      return (
+        <TaskCreationForm
+          inputValue={inputValue}
+          defaultMarkings={baseMarkingDefinitions}
           onClose={onClose}
           updater={creationUpdater}
         />


### PR DESCRIPTION
Add missing entity type in the creation panel.

Closes #7581