### PR TITLE
[backend] import from date not mandatory in Rss ingester (#7451)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-rss.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-rss.ts
@@ -42,7 +42,7 @@ const INGESTION_RSS_DEFINITION: ModuleDefinition<StoreEntityIngestionRss, StixIn
     { name: 'report_types', label: 'Report types', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: true, upsert: true, isFilterable: true },
     { name: 'created_by_ref', label: 'Created by', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: false },
     { name: 'object_marking_refs', label: 'Marking', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: true, upsert: true, isFilterable: false },
-    { name: 'current_state_date', label: 'Current state date', type: 'date', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'current_state_date', label: 'Current state date', type: 'date', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'ingestion_running', label: 'Ingestion running', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
   ],
   relations: [],


### PR DESCRIPTION
## Proposed changes

- import_from_date not mandatory in Rss ingester edition form

## Related issue
 https://github.com/OpenCTI-Platform/opencti/issues/7451