### PR TITLE
[backend] Next is not mandatory for taxii feed response (#7403)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -249,7 +249,7 @@ const taxiiV21DataHandler: TaxiiHandlerFn = async (context: AuthContext, ingesti
     await pushToSync({ type: 'bundle', applicant_id: ingestion.user_id ?? OPENCTI_SYSTEM_UUID, content, update: true });
     // Update the state
     await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
-      current_state_cursor: data.next ? String(data.next) : undefined,
+      current_state_cursor: data.next ? String(data.next) : '',
       added_after_start: data.next ? ingestion.added_after_start : utcDate(addedLast)
     });
   } else if (data.objects === undefined) {

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -248,10 +248,16 @@ const taxiiV21DataHandler: TaxiiHandlerFn = async (context: AuthContext, ingesti
     const content = Buffer.from(stixBundle, 'utf-8').toString('base64');
     await pushToSync({ type: 'bundle', applicant_id: ingestion.user_id ?? OPENCTI_SYSTEM_UUID, content, update: true });
     // Update the state
-    await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
-      current_state_cursor: data.next ? String(data.next) : '',
-      added_after_start: data.next ? ingestion.added_after_start : utcDate(addedLast)
-    });
+    if (data.next) {
+      await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
+        current_state_cursor: String(data.next),
+        added_after_start: ingestion.added_after_start
+      });
+    } else {
+      await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
+        added_after_start: utcDate(addedLast)
+      });
+    }
   } else if (data.objects === undefined) {
     const error = UnknownError('Undefined taxii objects', data);
     logApp.error(error, { name: ingestion.name, context: 'Taxii 2.1 transform' });

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -248,16 +248,10 @@ const taxiiV21DataHandler: TaxiiHandlerFn = async (context: AuthContext, ingesti
     const content = Buffer.from(stixBundle, 'utf-8').toString('base64');
     await pushToSync({ type: 'bundle', applicant_id: ingestion.user_id ?? OPENCTI_SYSTEM_UUID, content, update: true });
     // Update the state
-    if (data.next) {
-      await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
-        current_state_cursor: String(data.next),
-        added_after_start: ingestion.added_after_start
-      });
-    } else {
-      await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
-        added_after_start: utcDate(addedLast)
-      });
-    }
+    await patchTaxiiIngestion(context, SYSTEM_USER, ingestion.internal_id, {
+      current_state_cursor: data.next ? String(data.next) : undefined,
+      added_after_start: data.next ? ingestion.added_after_start : utcDate(addedLast)
+    });
   } else if (data.objects === undefined) {
     const error = UnknownError('Undefined taxii objects', data);
     logApp.error(error, { name: ingestion.name, context: 'Taxii 2.1 transform' });

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii.ts
@@ -47,7 +47,7 @@ const INGESTION_DEFINITION: ModuleDefinition<StoreEntityIngestionTaxii, StixInge
     { name: 'created_by_ref', label: 'Created by', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: false },
     { name: 'object_marking_refs', label: 'Marking', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: false },
     { name: 'added_after_start', label: 'Added after', type: 'date', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
-    { name: 'current_state_cursor', label: 'Current state cursor', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'current_state_cursor', label: 'Current state cursor', type: 'string', format: 'short', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'ingestion_running', label: 'Running', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
   ],
   relations: [],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
Fixes: `Validation against schema failed on attribute [current_state_cursor]: this mandatory field cannot be nil`

### Proposed changes

- "next" is not mandatory in taxii response from oasis documentation
https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107519

We have added validation on mandatory attribute since approximatively march 2024, but next can be missing from response.

I couldn't find a way to test this specific case with no "next" in taxii server response.

(Note that the first idea commented in issue: "returning a empty string instead of undefined" has been discarded by pair debugging with @SouadHadjiat)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #7403

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
