### PR TITLE
[backend] allow configuring Redis Sentinel options: failoverDetector/updateSentinels (#7631)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -107,6 +107,8 @@ const sentinelOptions = async (clusterNodes: Partial<SentinelAddress>[]): Promis
     preferredSlaves: conf.get('redis:sentinel_preferred_slaves'),
     sentinels: clusterNodes,
     enableTLSForSentinelMode: conf.get('redis:sentinel_tls') ?? false,
+    failoverDetector: conf.get('redis:sentinel_failover_detector') ?? false,
+    updateSentinels: conf.get('redis:sentinel_update_sentinels') ?? true,
   };
 };
 


### PR DESCRIPTION
Add support for two ioredis options related to Redis Sentinel