### PR TITLE
Revert "[backend/frontend] modify EntityStixCoreRelationshipsEntitiesComponent to list entities through relations (#6867)"

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
@@ -248,7 +248,7 @@ EntityStixCoreRelationshipsEntitiesViewProps
           defaultStartTime={defaultStartTime}
           defaultStopTime={defaultStopTime}
           paginationOptions={paginationOptions}
-          connectionKey="Pagination_stixCoreObjectsRegardingOf"
+          connectionKey="Pagination_stixCoreObjects"
           paddingRight={paddingRightButtonAdd ?? 220}
         />
       </Security>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
@@ -13,7 +13,7 @@ import { PaginationLocalStorage } from '../../../../../utils/hooks/useLocalStora
 import { DataColumns, PaginationOptions } from '../../../../../components/list_lines';
 import { EntityStixCoreRelationshipsEntitiesViewLinesPaginationQuery$variables } from './__generated__/EntityStixCoreRelationshipsEntitiesViewLinesPaginationQuery.graphql';
 import { isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../../utils/filters/filtersUtils';
-import { FilterGroup } from '../../../../../utils/filters/filtersHelpers-types';
+import { Filter, FilterGroup } from '../../../../../utils/filters/filtersHelpers-types';
 
 interface EntityStixCoreRelationshipsEntitiesViewProps {
   entityId: string;
@@ -110,16 +110,26 @@ EntityStixCoreRelationshipsEntitiesViewProps
 
   // Filters due to screen context
   const userFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, stixCoreObjectTypes.length > 0 ? stixCoreObjectTypes : ['Stix-Core-Object']);
+  const stixCoreObjectFilter: Filter[] = stixCoreObjectTypes.length > 0
+    ? [{ key: 'entity_type', operator: 'eq', mode: 'or', values: stixCoreObjectTypes }]
+    : [];
   const contextFilters: FilterGroup = {
     mode: 'and',
-    filters: [],
+    filters: [
+      ...stixCoreObjectFilter,
+      { key: 'regardingOf',
+        operator: 'eq',
+        mode: 'and',
+        values: [
+          { key: 'id', values: [entityId], operator: 'eq', mode: 'or' },
+          { key: 'relationship_type', values: relationshipTypes, operator: 'eq', mode: 'or' },
+        ] as unknown as string[], // Workaround for typescript waiting for better solution
+      },
+    ],
     filterGroups: userFilters && isFilterGroupNotEmpty(userFilters) ? [userFilters] : [],
   };
 
   const paginationOptions = {
-    entityId,
-    relationshipTypes,
-    types: stixCoreObjectTypes,
     search: searchTerm,
     orderBy: sortBy && sortBy in dataColumns && dataColumns[sortBy].isSortable ? sortBy : 'name',
     orderMode: orderAsc ? 'asc' : 'desc',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLines.tsx
@@ -32,8 +32,6 @@ interface EntityStixCoreRelationshipsEntitiesProps {
 const entityStixCoreRelationshipsEntitiesFragment = graphql`
   fragment EntityStixCoreRelationshipsEntitiesViewLines_data on Query
   @argumentDefinitions(
-    entityId: { type: "ID" }
-    relationshipTypes: { type: "[String]" }
     search: { type: "String" }
     count: { type: "Int", defaultValue: 25 }
     cursor: { type: "ID" }
@@ -43,9 +41,7 @@ const entityStixCoreRelationshipsEntitiesFragment = graphql`
     types: { type: "[String]" }
   )
   @refetchable(queryName: "EntityStixCoreRelationshipsEntities_refetch") {
-    stixCoreObjectsRegardingOf(
-      entityId: $entityId
-      relationshipTypes: $relationshipTypes
+    stixCoreObjects(
       search: $search
       first: $count
       after: $cursor
@@ -53,7 +49,7 @@ const entityStixCoreRelationshipsEntitiesFragment = graphql`
       orderMode: $orderMode
       filters: $filters
       types: $types
-    ) @connection(key: "Pagination_stixCoreObjectsRegardingOf") {
+    ) @connection(key: "Pagination_stixCoreObjects") {
       edges {
         node {
           id
@@ -71,8 +67,6 @@ const entityStixCoreRelationshipsEntitiesFragment = graphql`
 
 export const entityStixCoreRelationshipsEntitiesQuery = graphql`
   query EntityStixCoreRelationshipsEntitiesViewLinesPaginationQuery(
-    $entityId: ID
-    $relationshipTypes: [String]
     $search: String
     $count: Int!
     $cursor: ID
@@ -83,8 +77,6 @@ export const entityStixCoreRelationshipsEntitiesQuery = graphql`
   ) {
     ...EntityStixCoreRelationshipsEntitiesViewLines_data
     @arguments(
-      entityId: $entityId
-      relationshipTypes: $relationshipTypes
       search: $search
       count: $count
       cursor: $cursor
@@ -117,7 +109,7 @@ EntityStixCoreRelationshipsEntitiesProps
     queryRef,
     linesQuery: entityStixCoreRelationshipsEntitiesQuery,
     linesFragment: entityStixCoreRelationshipsEntitiesFragment,
-    nodePath: ['stixCoreObjectsRegardingOf', 'pageInfo', 'globalCount'],
+    nodePath: ['stixCoreObjects', 'pageInfo', 'globalCount'],
     setNumberOfElements,
   });
   return (
@@ -126,9 +118,9 @@ EntityStixCoreRelationshipsEntitiesProps
       loadMore={loadMore}
       hasMore={hasMore}
       isLoading={isLoadingMore}
-      dataList={data?.stixCoreObjectsRegardingOf?.edges ?? []}
+      dataList={data?.stixCoreObjects?.edges ?? []}
       globalCount={
-        data?.stixCoreObjectsRegardingOf?.pageInfo?.globalCount ?? nbOfRowsToLoad
+        data?.stixCoreObjects?.pageInfo?.globalCount ?? nbOfRowsToLoad
       }
       LineComponent={EntityStixCoreRelationshipsEntitiesViewLine}
       DummyLineComponent={EntityStixCoreRelationshipsEntitiesLineDummy}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7444,7 +7444,6 @@ type Query {
   stixCoreObject(id: String!): StixCoreObject
   stixCoreObjectAnalysis(id: ID!, contentSource: String!, contentType: AnalysisContentType!): Analysis
   stixCoreObjects(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
-  stixCoreObjectsRegardingOf(entityId: ID, relationshipTypes: [String], first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   globalSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection
   stixCoreObjectsTimeSeries(authorId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, types: [String], filters: FilterGroup, search: String): [TimeSeries]

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -11423,17 +11423,6 @@ type Query {
     filters: FilterGroup
     search: String
   ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
-  stixCoreObjectsRegardingOf(
-    entityId: ID,
-    relationshipTypes: [String],
-    first: Int
-    after: ID
-    types: [String]
-    orderBy: StixCoreObjectsOrdering
-    orderMode: OrderingMode
-    filters: FilterGroup
-    search: String
-  ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
   globalSearch(
     first: Int
     after: ID

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -23,11 +23,11 @@ export const addAttackPattern = async (context: AuthContext, user: AuthUser, att
 };
 
 export const parentAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false, args);
 };
 
 export const childAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, args);
 };
 
 export const isSubAttackPattern = async (context: AuthContext, user: AuthUser, attackPatternId: string) => {
@@ -36,9 +36,9 @@ export const isSubAttackPattern = async (context: AuthContext, user: AuthUser, a
 };
 
 export const coursesOfActionPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION, true, args);
 };
 
 export const dataComponentsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_DETECTS, ENTITY_TYPE_DATA_COMPONENT, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_DETECTS, ENTITY_TYPE_DATA_COMPONENT, true, args);
 };

--- a/opencti-platform/opencti-graphql/src/domain/container.js
+++ b/opencti-platform/opencti-graphql/src/domain/container.js
@@ -54,7 +54,7 @@ export const objects = async (context, user, containerId, args) => {
     while (hasNextPage) {
       // Force options to prevent connection format and manage search after
       const paginateOpts = { ...baseOpts, first: args.first ?? ES_DEFAULT_PAGINATION, after: searchAfter };
-      const currentPagination = await listEntitiesThroughRelationsPaginated(context, user, containerId, RELATION_OBJECT, types, false, false, paginateOpts);
+      const currentPagination = await listEntitiesThroughRelationsPaginated(context, user, containerId, RELATION_OBJECT, types, false, paginateOpts);
       const noMoreElements = currentPagination.edges.length === 0 || currentPagination.edges.length < paginateOpts.first;
       if (noMoreElements) {
         hasNextPage = false;
@@ -69,7 +69,7 @@ export const objects = async (context, user, containerId, args) => {
     }
     return paginatedElements;
   }
-  return listEntitiesThroughRelationsPaginated(context, user, containerId, RELATION_OBJECT, types, false, false, baseOpts);
+  return listEntitiesThroughRelationsPaginated(context, user, containerId, RELATION_OBJECT, types, false, baseOpts);
 };
 
 export const containersNumber = (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/courseOfAction.js
+++ b/opencti-platform/opencti-graphql/src/domain/courseOfAction.js
@@ -20,5 +20,5 @@ export const addCourseOfAction = async (context, user, courseOfAction) => {
 };
 
 export const attackPatternsPaginated = async (context, user, attackPatternId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_MITIGATES, ENTITY_TYPE_ATTACK_PATTERN, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_MITIGATES, ENTITY_TYPE_ATTACK_PATTERN, false, args);
 };

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -108,11 +108,11 @@ export const defaultMarkingDefinitionsFromGroups = async (context, groupIds) => 
 };
 
 export const rolesPaginated = async (context, user, groupId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_HAS_ROLE, ENTITY_TYPE_ROLE, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_HAS_ROLE, ENTITY_TYPE_ROLE, false, args);
 };
 
 export const membersPaginated = async (context, user, groupId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_MEMBER_OF, ENTITY_TYPE_USER, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_MEMBER_OF, ENTITY_TYPE_USER, true, args);
 };
 
 export const groupDelete = async (context, user, groupId) => {

--- a/opencti-platform/opencti-graphql/src/domain/individual.js
+++ b/opencti-platform/opencti-graphql/src/domain/individual.js
@@ -26,7 +26,7 @@ export const addIndividual = async (context, user, individual, opts = {}) => {
 };
 
 export const partOfOrganizationsPaginated = async (context, user, individualId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, individualId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, individualId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, args);
 };
 
 export const isUser = async (context, individualContactInformation) => {

--- a/opencti-platform/opencti-graphql/src/domain/intrusionSet.js
+++ b/opencti-platform/opencti-graphql/src/domain/intrusionSet.js
@@ -26,5 +26,5 @@ export const addIntrusionSet = async (context, user, intrusionSet) => {
 };
 
 export const locationsPaginated = async (context, user, intrusionSetId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, intrusionSetId, RELATION_ORIGINATES_FROM, ENTITY_TYPE_LOCATION, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, intrusionSetId, RELATION_ORIGINATES_FROM, ENTITY_TYPE_LOCATION, false, args);
 };

--- a/opencti-platform/opencti-graphql/src/domain/region.js
+++ b/opencti-platform/opencti-graphql/src/domain/region.js
@@ -16,19 +16,19 @@ export const findAll = (context, user, args) => {
 };
 
 export const parentRegionsPaginated = async (context, user, regionId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, regionId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_REGION, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, regionId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_REGION, false, args);
 };
 
 export const childRegionsPaginated = async (context, user, regionId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, regionId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_REGION, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, regionId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_REGION, true, args);
 };
 
 export const countriesPaginated = async (context, user, elementId, args) => {
   const element = await findById(context, user, elementId);
   if (element) {
-    return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, true, false, args);
+    return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, true, args);
   }
-  return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, elementId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, false, args);
 };
 
 export const addRegion = async (context, user, region) => {

--- a/opencti-platform/opencti-graphql/src/domain/sector.js
+++ b/opencti-platform/opencti-graphql/src/domain/sector.js
@@ -18,11 +18,11 @@ export const findAll = (context, user, args) => {
 };
 
 export const parentSectorsPaginated = async (context, user, groupId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, false, args);
 };
 
 export const childSectorsPaginated = async (context, user, groupId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, true, args);
 };
 
 export const isSubSector = async (context, user, sectorId) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -83,19 +83,6 @@ export const findById = async (context, user, stixCoreObjectId) => {
   return storeLoadById(context, user, stixCoreObjectId, ABSTRACT_STIX_CORE_OBJECT);
 };
 
-export const stixCoreObjectsPaginated = async (context, user, args) => {
-  let types = [];
-  if (isNotEmptyField(args.types)) {
-    types = args.types.filter((type) => isStixCoreObject(type));
-  }
-  if (types.length === 0) {
-    types.push(ABSTRACT_STIX_CORE_OBJECT);
-  }
-  const completeArgs = { ...args, bothDirection: true };
-
-  return listEntitiesThroughRelationsPaginated(context, user, args.entityId, args.relationshipTypes, types, false, true, completeArgs);
-};
-
 export const batchInternalRels = async (context, user, elements, opts = {}) => {
   const relIds = elements.map(({ element, definition }) => element[definition.databaseName]).flat().filter((id) => isNotEmptyField(id));
   // Get all rel resolutions with system user
@@ -157,35 +144,35 @@ export const containersPaginated = async (context, user, stixCoreObjectId, opts)
   if (!finalEntityTypes.every((t) => isStixDomainObjectContainer(t))) {
     throw FunctionalError(`Only ${ENTITY_TYPE_CONTAINER} can be query through this method.`);
   }
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, finalEntityTypes, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, finalEntityTypes, true, opts);
 };
 
 export const reportsPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_REPORT, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_REPORT, true, opts);
 };
 
 export const groupingsPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_GROUPING, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_GROUPING, true, opts);
 };
 
 export const casesPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_CASE, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_CASE, true, opts);
 };
 
 export const notesPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_NOTE, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_NOTE, true, opts);
 };
 
 export const opinionsPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_OPINION, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_OPINION, true, opts);
 };
 
 export const observedDataPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_OBSERVED_DATA, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_OBSERVED_DATA, true, opts);
 };
 
 export const externalReferencesPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_EXTERNAL_REFERENCE, ENTITY_TYPE_EXTERNAL_REFERENCE, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_EXTERNAL_REFERENCE, ENTITY_TYPE_EXTERNAL_REFERENCE, false, opts);
 };
 
 export const stixCoreRelationships = (context, user, stixCoreObjectId, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -408,15 +408,15 @@ export const artifactImport = async (context, user, args) => {
 };
 
 export const indicatorsPaginated = async (context, user, stixCyberObservableId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_BASED_ON, ENTITY_TYPE_INDICATOR, true, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_BASED_ON, ENTITY_TYPE_INDICATOR, true, args);
 };
 
 export const vulnerabilitiesPaginated = async (context, user, stixCyberObservableId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_HAS, ENTITY_TYPE_VULNERABILITY, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_HAS, ENTITY_TYPE_VULNERABILITY, false, args);
 };
 
 export const serviceDllsPaginated = async (context, user, stixCyberObservableId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_SERVICE_DLL, ENTITY_HASHED_OBSERVABLE_STIX_FILE, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCyberObservableId, RELATION_SERVICE_DLL, ENTITY_HASHED_OBSERVABLE_STIX_FILE, false, args);
 };
 
 export const stixFileObsArtifact = async (context, user, stixCyberObservableId) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -60,7 +60,7 @@ export const batchStixDomainObjects = async (context, user, objectsIds) => {
 };
 
 export const assigneesPaginated = async (context, user, stixDomainObjectId, args) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixDomainObjectId, RELATION_OBJECT_ASSIGNEE, ENTITY_TYPE_USER, false, false, args);
+  return listEntitiesThroughRelationsPaginated(context, user, stixDomainObjectId, RELATION_OBJECT_ASSIGNEE, ENTITY_TYPE_USER, false, args);
 };
 
 // region time series

--- a/opencti-platform/opencti-graphql/src/domain/system.js
+++ b/opencti-platform/opencti-graphql/src/domain/system.js
@@ -27,5 +27,5 @@ export const addSystem = async (context, user, system) => {
 };
 
 export const belongsToOrganizationsPaginated = async (context, user, stixCoreObjectId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_BELONGS_TO, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, stixCoreObjectId, RELATION_BELONGS_TO, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, opts);
 };

--- a/opencti-platform/opencti-graphql/src/domain/threatActor.js
+++ b/opencti-platform/opencti-graphql/src/domain/threatActor.js
@@ -12,9 +12,9 @@ export const findAll = (context, user, args) => {
 };
 
 export const threatActorLocationsPaginated = async (context, user, threatActorId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, threatActorId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, threatActorId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION, false, opts);
 };
 
 export const threatActorCountriesPaginated = async (context, user, threatActorId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, threatActorId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, threatActorId, RELATION_LOCATED_AT, ENTITY_TYPE_LOCATION_COUNTRY, true, opts);
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -227,15 +227,15 @@ export const batchCreators = async (context, user, userListIds) => {
 };
 
 export const userOrganizationsPaginated = async (context, user, userId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, userId, RELATION_PARTICIPATE_TO, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, userId, RELATION_PARTICIPATE_TO, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, opts);
 };
 
 export const userGroupsPaginated = async (context, user, userId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, userId, RELATION_MEMBER_OF, ENTITY_TYPE_GROUP, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, userId, RELATION_MEMBER_OF, ENTITY_TYPE_GROUP, false, opts);
 };
 
 export const groupRolesPaginated = async (context, user, groupId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_HAS_ROLE, ENTITY_TYPE_ROLE, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, groupId, RELATION_HAS_ROLE, ENTITY_TYPE_ROLE, false, opts);
 };
 
 export const batchRolesForUsers = async (context, user, userIds, opts = {}) => {

--- a/opencti-platform/opencti-graphql/src/domain/vulnerability.js
+++ b/opencti-platform/opencti-graphql/src/domain/vulnerability.js
@@ -21,5 +21,5 @@ export const addVulnerability = async (context, user, vulnerability) => {
 };
 
 export const softwarePaginated = async (context, user, vulnerabilityId, opts) => {
-  return listEntitiesThroughRelationsPaginated(context, user, vulnerabilityId, RELATION_HAS, ENTITY_SOFTWARE, true, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, vulnerabilityId, RELATION_HAS, ENTITY_SOFTWARE, true, opts);
 };

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -18067,7 +18067,6 @@ export type Query = {
   stixCoreObjectsMultiNumber?: Maybe<Array<Maybe<Number>>>;
   stixCoreObjectsMultiTimeSeries?: Maybe<Array<Maybe<MultiTimeSeries>>>;
   stixCoreObjectsNumber?: Maybe<Number>;
-  stixCoreObjectsRegardingOf?: Maybe<StixCoreObjectConnection>;
   stixCoreObjectsTimeSeries?: Maybe<Array<Maybe<TimeSeries>>>;
   stixCoreRelationship?: Maybe<StixCoreRelationship>;
   stixCoreRelationships?: Maybe<StixCoreRelationshipConnection>;
@@ -19753,19 +19752,6 @@ export type QueryStixCoreObjectsNumberArgs = {
   onlyInferred?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['DateTime']['input']>;
-  types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-};
-
-
-export type QueryStixCoreObjectsRegardingOfArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  entityId?: InputMaybe<Scalars['ID']['input']>;
-  filters?: InputMaybe<FilterGroup>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<StixCoreObjectsOrdering>;
-  orderMode?: InputMaybe<OrderingMode>;
-  relationshipTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  search?: InputMaybe<Scalars['String']['input']>;
   types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
@@ -36138,7 +36124,6 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   stixCoreObjectsMultiNumber?: Resolver<Maybe<Array<Maybe<ResolversTypes['Number']>>>, ParentType, ContextType, Partial<QueryStixCoreObjectsMultiNumberArgs>>;
   stixCoreObjectsMultiTimeSeries?: Resolver<Maybe<Array<Maybe<ResolversTypes['MultiTimeSeries']>>>, ParentType, ContextType, RequireFields<QueryStixCoreObjectsMultiTimeSeriesArgs, 'interval' | 'startDate'>>;
   stixCoreObjectsNumber?: Resolver<Maybe<ResolversTypes['Number']>, ParentType, ContextType, Partial<QueryStixCoreObjectsNumberArgs>>;
-  stixCoreObjectsRegardingOf?: Resolver<Maybe<ResolversTypes['StixCoreObjectConnection']>, ParentType, ContextType, Partial<QueryStixCoreObjectsRegardingOfArgs>>;
   stixCoreObjectsTimeSeries?: Resolver<Maybe<Array<Maybe<ResolversTypes['TimeSeries']>>>, ParentType, ContextType, RequireFields<QueryStixCoreObjectsTimeSeriesArgs, 'field' | 'interval' | 'operation' | 'startDate'>>;
   stixCoreRelationship?: Resolver<Maybe<ResolversTypes['StixCoreRelationship']>, ParentType, ContextType, Partial<QueryStixCoreRelationshipArgs>>;
   stixCoreRelationships?: Resolver<Maybe<ResolversTypes['StixCoreRelationshipConnection']>, ParentType, ContextType, Partial<QueryStixCoreRelationshipsArgs>>;

--- a/opencti-platform/opencti-graphql/src/modules/case/case-template/case-template-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-template/case-template-domain.ts
@@ -21,7 +21,7 @@ export const findAll = (context: AuthContext, user: AuthUser, opts: EntityOption
 };
 
 export const taskTemplatesPaginated = async (context: AuthContext, user: AuthUser, caseId: string, opts: EntityOptions<BasicStoreEntityCase>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, caseId, TEMPLATE_TASK_RELATION, ENTITY_TYPE_TASK_TEMPLATE, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, caseId, TEMPLATE_TASK_RELATION, ENTITY_TYPE_TASK_TEMPLATE, false, opts);
 };
 
 export const caseTemplateAdd = async (context: AuthContext, user: AuthUser, input: CaseTemplateAddInput) => {

--- a/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent-domain.ts
@@ -35,5 +35,5 @@ export const withDataSource = async <T extends BasicStoreCommon>(context: AuthCo
 };
 
 export const attackPatternsPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, dataComponentId: string, args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, dataComponentId, RELATION_DETECTS, ENTITY_TYPE_ATTACK_PATTERN, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, dataComponentId, RELATION_DETECTS, ENTITY_TYPE_ATTACK_PATTERN, false, args);
 };

--- a/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource-domain.ts
@@ -26,7 +26,7 @@ export const dataSourceAdd = async (context: AuthContext, user: AuthUser, dataSo
 };
 
 export const dataComponentsPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, dataSourceId: string, opts: QueryDataSourcesArgs) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, dataSourceId, RELATION_DATA_SOURCE, ENTITY_TYPE_DATA_COMPONENT, true, false, opts);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, dataSourceId, RELATION_DATA_SOURCE, ENTITY_TYPE_DATA_COMPONENT, true, opts);
 };
 
 export const dataSourceDataComponentAdd = async (context: AuthContext, user: AuthUser, dataSourceId: string, dataComponentId: string) => {

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -448,5 +448,5 @@ export const indicatorsDistributionByEntity = async (context: AuthContext, user:
 // endregion
 
 export const observablesPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, indicatorId: string, args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, indicatorId, RELATION_BASED_ON, ABSTRACT_STIX_CYBER_OBSERVABLE, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, indicatorId, RELATION_BASED_ON, ABSTRACT_STIX_CYBER_OBSERVABLE, false, args);
 };

--- a/opencti-platform/opencti-graphql/src/modules/malwareAnalysis/malwareAnalysis-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/malwareAnalysis/malwareAnalysis-domain.ts
@@ -51,9 +51,9 @@ export const sampleObservable = async <T extends BasicStoreCommon> (context: Aut
 
 export const installedSoftwarePaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, attackPatternId: string,
   args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, attackPatternId, RELATION_INSTALLED_SOFTWARE, ENTITY_SOFTWARE, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, attackPatternId, RELATION_INSTALLED_SOFTWARE, ENTITY_SOFTWARE, false, args);
 };
 
 export const analysisScoPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, attackPatternId, RELATION_ANALYSIS_SCO, ABSTRACT_STIX_CYBER_OBSERVABLE, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, attackPatternId, RELATION_ANALYSIS_SCO, ABSTRACT_STIX_CYBER_OBSERVABLE, false, args);
 };

--- a/opencti-platform/opencti-graphql/src/modules/narrative/narrative-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/narrative/narrative-domain.ts
@@ -23,11 +23,11 @@ export const addNarrative = async (context: AuthContext, user: AuthUser, narrati
 };
 
 export const parentNarrativesPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, narrativeId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, narrativeId, RELATION_SUBNARRATIVE_OF, ENTITY_TYPE_NARRATIVE, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, narrativeId, RELATION_SUBNARRATIVE_OF, ENTITY_TYPE_NARRATIVE, false, args);
 };
 
 export const childNarrativesPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, narrativeId: string, args: EntityOptions<BasicStoreCommon>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, narrativeId, RELATION_SUBNARRATIVE_OF, ENTITY_TYPE_NARRATIVE, true, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, narrativeId, RELATION_SUBNARRATIVE_OF, ENTITY_TYPE_NARRATIVE, true, args);
 };
 
 export const isSubNarrative = async (context: AuthContext, user: AuthUser, narrativeId: string) => {

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
@@ -110,22 +110,22 @@ export const buildAdministratedOrganizations = async (context: AuthContext, user
 
 export const organizationSectorsPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, organizationId: string,
   args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_SECTOR, false, args);
 };
 
 export const organizationMembersPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, organizationId: string,
   args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PARTICIPATE_TO, ENTITY_TYPE_USER, true, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PARTICIPATE_TO, ENTITY_TYPE_USER, true, args);
 };
 
 export const parentOrganizationsPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, organizationId: string,
   args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, false, args);
 };
 
 export const childOrganizationsPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, organizationId: string,
   args: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, true, false, args);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, organizationId, RELATION_PART_OF, ENTITY_TYPE_IDENTITY_ORGANIZATION, true, args);
 };
 
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/task/task-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/task/task-domain.ts
@@ -26,11 +26,11 @@ export const findAll = (context: AuthContext, user: AuthUser, opts: EntityOption
 };
 
 export const caseTasksPaginated = async <T extends BasicStoreCommon> (context: AuthContext, user: AuthUser, caseId: string, opts: EntityOptions<T>) => {
-  return listEntitiesThroughRelationsPaginated<T>(context, user, caseId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_TASK, true, false, opts);
+  return listEntitiesThroughRelationsPaginated<T>(context, user, caseId, RELATION_OBJECT, ENTITY_TYPE_CONTAINER_TASK, true, opts);
 };
 
 export const taskParticipantsPaginated = async (context: AuthContext, user: AuthUser, caseId: string, opts: EntityOptions<BasicStoreEntityCase>) => {
-  return listEntitiesThroughRelationsPaginated(context, user, caseId, RELATION_OBJECT_PARTICIPANT, ENTITY_TYPE_USER, false, false, opts);
+  return listEntitiesThroughRelationsPaginated(context, user, caseId, RELATION_OBJECT_PARTICIPANT, ENTITY_TYPE_USER, false, opts);
 };
 
 export const taskAdd = async (context: AuthContext, user: AuthUser, input: TaskAddInput) => {

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
@@ -34,7 +34,6 @@ import {
   stixCoreObjectsMultiNumber,
   stixCoreObjectsMultiTimeSeries,
   stixCoreObjectsNumber,
-  stixCoreObjectsPaginated,
   stixCoreObjectsTimeSeries,
   stixCoreObjectsTimeSeriesByAuthor,
   stixCoreRelationships
@@ -61,7 +60,6 @@ const stixCoreObjectResolvers = {
     stixCoreObjectRaw: (_, { id }, context) => stixLoadByIdStringify(context, context.user, id),
     globalSearch: (_, args, context) => findAll(context, context.user, { ...args, globalSearch: true }),
     stixCoreObjects: (_, args, context) => findAll(context, context.user, args),
-    stixCoreObjectsRegardingOf: (_, args, context) => stixCoreObjectsPaginated(context, context.user, args),
     stixCoreObjectsTimeSeries: (_, args, context) => {
       if (args.authorId && args.authorId.length > 0) {
         return stixCoreObjectsTimeSeriesByAuthor(context, context.user, args);


### PR DESCRIPTION

This reverts commit 2019c636a6f924ad82718e5ee3aad7ae83d6b76a.

It was causing this issue https://github.com/OpenCTI-Platform/opencti/issues/7625 and was breaking the toolbar (which had no more filters)
