### PR TITLE
[frontend] Remove TAXII 2.0 and 1.0 options from the UI (#7676)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2430,8 +2430,6 @@
   "Task start time": "Startzeit der Aufgabe",
   "TASK_MANAGER": "Hintergrund-Taskmanager",
   "Tasks": "Aufgaben",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "TAXII Sammlung",
   "TAXII collections": "TAXII-Sammlungen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2430,8 +2430,6 @@
   "Task start time": "Task start time",
   "TASK_MANAGER": "Background task manager",
   "Tasks": "Tasks",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "TAXII Collection",
   "TAXII collections": "TAXII collections",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2430,8 +2430,6 @@
   "Task start time": "Hora de inicio de la tarea",
   "TASK_MANAGER": "Gestor de tareas de fondo",
   "Tasks": "Tareas",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "Colección TAXII",
   "TAXII collections": "Colecciones de TAXII",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2430,8 +2430,6 @@
   "Task start time": "Début de la tâche",
   "TASK_MANAGER": "Manager des tâches de fond",
   "Tasks": "Tâches",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "TAXII Collection",
   "TAXII collections": "Collections TAXII",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2430,8 +2430,6 @@
   "Task start time": "タスク開始時刻",
   "TASK_MANAGER": "バックグラウンドタスクマネージャー",
   "Tasks": "タスク",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "TAXII コレクション",
   "TAXII collections": "TAXIIコレクション",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2430,8 +2430,6 @@
   "Task start time": "任务开始时间",
   "TASK_MANAGER": "后台任务管理器",
   "Tasks": "任务",
-  "TAXII 1.0": "TAXII 1.0",
-  "TAXII 2.0": "TAXII 2.0",
   "TAXII 2.1": "TAXII 2.1",
   "TAXII Collection": "TAXII 系列",
   "TAXII collections": "TAXII集合",

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiCreation.jsx
@@ -162,12 +162,6 @@ const IngestionTaxiiCreation = (props) => {
                   marginTop: 20,
                 }}
               >
-                <MenuItem value="v1" disabled={true}>
-                  {t('TAXII 1.0')}
-                </MenuItem>
-                <MenuItem value="v2" disabled={true}>
-                  {t('TAXII 2.0')}
-                </MenuItem>
                 <MenuItem value="v21">{t('TAXII 2.1')}</MenuItem>
               </Field>
               <Field

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiEdition.jsx
@@ -202,12 +202,6 @@ const IngestionTaxiiEditionContainer = ({
                 marginTop: 20,
               }}
             >
-              <MenuItem value="v1" disabled={true}>
-                {t('TAXII 1.0')}
-              </MenuItem>
-              <MenuItem value="v2" disabled={true}>
-                {t('TAXII 2.0')}
-              </MenuItem>
               <MenuItem value="v21">{t('TAXII 2.1')}</MenuItem>
             </Field>
             <Field


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
 
* TAXII 2.0 and 1.0 option removed
* translations removed 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7676
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
