### PR TITLE
[backend] Add a graphql api to send stix bundle in the ingestion process (#7696)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
@@ -199,9 +199,7 @@ const ConnectorWorksComponent: FunctionComponent<ConnectorWorksComponentProps> =
                       {t_i18n('Total number of operations')}
                     </Typography>
                     <span className={classes.number}>
-                      {work.status === 'wait'
-                        ? '-'
-                        : tracking?.import_expected_number ?? '-'}
+                      {tracking?.import_expected_number ?? '-'}
                     </span>
                   </Grid>
                   <Grid item={true} xs={11}>

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8224,6 +8224,7 @@ type Mutation {
   stixCoreObjectEdit(id: ID!): StixCoreObjectEditMutations
   stixCoreObjectsExportAsk(input: StixCoreObjectsExportAskInput!): [File!]
   stixCoreObjectsExportPush(entity_id: String, entity_type: String!, file: Upload!, file_markings: [String]!, listFilters: String): Boolean
+  stixBundlePush(connectorId: String!, bundle: String!): Boolean
   stixDomainObjectAdd(input: StixDomainObjectAddInput!): StixDomainObject
   stixDomainObjectEdit(id: ID!): StixDomainObjectEditMutations
   stixDomainObjectsExportAsk(format: String!, exportType: String!, contentMaxMarkings: [String], fileMarkings: [String], search: String, exportContext: ExportContext, relationship_type: [String], orderBy: StixDomainObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, selectedIds: [String]): [File!]

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -12878,7 +12878,7 @@ type Mutation {
   stixCoreObjectsExportPush(entity_id: String, entity_type: String!, file: Upload!, file_markings: [String]!, listFilters: String): Boolean @auth(for: [CONNECTORAPI])
 
   ######## STIX DOMAIN OBJECT ENTITIES
-  stixBundlePush(connectorId: String!, bundle: String!): Boolean @auth(for: [KNOWLEDGE_KNUPDATE])
+  stixBundlePush(connectorId: String!, bundle: String!): Boolean @auth(for: [CONNECTORAPI])
   stixDomainObjectAdd(input: StixDomainObjectAddInput!): StixDomainObject @auth(for: [KNOWLEDGE_KNUPDATE])
   stixDomainObjectEdit(id: ID!): StixDomainObjectEditMutations @auth
   stixDomainObjectsExportAsk(

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -12878,6 +12878,7 @@ type Mutation {
   stixCoreObjectsExportPush(entity_id: String, entity_type: String!, file: Upload!, file_markings: [String]!, listFilters: String): Boolean @auth(for: [CONNECTORAPI])
 
   ######## STIX DOMAIN OBJECT ENTITIES
+  stixBundlePush(connectorId: String!, bundle: String!): Boolean @auth(for: [KNOWLEDGE_KNUPDATE])
   stixDomainObjectAdd(input: StixDomainObjectAddInput!): StixDomainObject @auth(for: [KNOWLEDGE_KNUPDATE])
   stixDomainObjectEdit(id: ID!): StixDomainObjectEditMutations @auth
   stixDomainObjectsExportAsk(

--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
@@ -3,7 +3,7 @@ import type { SdkStream } from '@smithy/types/dist-types/serde';
 import conf, { logApp } from '../../config/conf';
 import { executionContext } from '../../utils/access';
 import type { AuthContext, AuthUser } from '../../types/user';
-import { consumeQueue, pushToSync, registerConnectorQueues } from '../../database/rabbitmq';
+import { consumeQueue, pushToWorkerForSync, registerConnectorQueues } from '../../database/rabbitmq';
 import { downloadFile } from '../../database/file-storage';
 import { reportExpectation, updateExpectationsNumber, updateProcessedTime, updateReceivedTime } from '../../domain/work';
 import { bundleProcess } from '../../parser/csv-bundler';
@@ -82,7 +82,7 @@ const initImportCsvConnector = () => {
             } else {
               await updateExpectationsNumber(context, applicantUser, workId, bundle.objects.length);
               const content = Buffer.from(JSON.stringify(bundle), 'utf-8').toString('base64');
-              await pushToSync({
+              await pushToWorkerForSync({
                 type: 'bundle',
                 update: true,
                 applicant_id: applicantId ?? OPENCTI_SYSTEM_UUID,

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -244,12 +244,17 @@ export const rabbitMQIsAlive = async () => {
   );
 };
 
-export const pushToSync = (message) => {
+export const pushToWorkerForSync = (message) => {
   return send(WORKER_EXCHANGE, pushRouting(INTERNAL_SYNC_QUEUE), JSON.stringify(message));
 };
 
-export const pushToPlaybook = (message) => {
+export const pushToWorkerForPlaybook = (message) => {
   return send(WORKER_EXCHANGE, pushRouting(INTERNAL_PLAYBOOK_QUEUE), JSON.stringify(message));
+};
+
+export const pushToWorkerForConnector = (connectorId, message) => {
+  const routingKey = pushRouting(connectorId);
+  return send(WORKER_EXCHANGE, routingKey, JSON.stringify(message));
 };
 
 export const pushToConnector = (connectorId, message) => {

--- a/opencti-platform/opencti-graphql/src/domain/stix.js
+++ b/opencti-platform/opencti-graphql/src/domain/stix.js
@@ -60,12 +60,12 @@ export const sendStixBundle = async (context, user, connectorId, bundle) => {
     // 01. Simple check bundle
     const jsonBundle = JSON.parse(bundle);
     if (jsonBundle.type !== 'bundle' || !jsonBundle.objects || jsonBundle.objects.length === 0) {
-      throw new UnsupportedError('Invalid stix bundle');
+      throw UnsupportedError('Invalid stix bundle');
     }
     // 02. Create work and send the bundle to ingestion
     const connector = await storeLoadById(context, user, connectorId, ENTITY_TYPE_CONNECTOR);
     if (!connector) {
-      throw new UnsupportedError('Invalid connector');
+      throw UnsupportedError('Invalid connector');
     }
     const workName = `${connector.name} run @ ${now()}`;
     const work = await createWork(context, user, connector, workName, connector.internal_id);

--- a/opencti-platform/opencti-graphql/src/domain/stix.js
+++ b/opencti-platform/opencti-graphql/src/domain/stix.js
@@ -7,8 +7,8 @@ import { FunctionalError, UnsupportedError } from '../config/errors';
 import { connectorsForExport } from './connector';
 import { findById as findMarkingDefinitionById } from './markingDefinition';
 import { now, observableValue } from '../utils/format';
-import { createWork } from './work';
-import { pushToConnector } from '../database/rabbitmq';
+import { createWork, updateExpectationsNumber } from './work';
+import { pushToConnector, pushToWorkerForConnector } from '../database/rabbitmq';
 import { ENTITY_TYPE_CONTAINER_NOTE, ENTITY_TYPE_CONTAINER_OPINION, isStixDomainObjectShareableContainer, STIX_ORGANIZATIONS_UNRESTRICTED } from '../schema/stixDomainObject';
 import {
   ABSTRACT_STIX_CORE_OBJECT,
@@ -17,7 +17,7 @@ import {
   ABSTRACT_STIX_OBJECT,
   ABSTRACT_STIX_RELATIONSHIP,
   CONNECTOR_INTERNAL_EXPORT_FILE,
-  INPUT_GRANTED_REFS
+  INPUT_GRANTED_REFS,
 } from '../schema/general';
 import { UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE } from '../database/utils';
 import { extractEntityRepresentativeName } from '../database/entity-representative';
@@ -34,6 +34,7 @@ import { getExportFilter } from '../utils/getExportFilter';
 import { getEntitiesListFromCache } from '../database/cache';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import { checkUserCanShareMarkings } from './user';
+import { ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
 
 export const stixDelete = async (context, user, id) => {
   const element = await internalLoadById(context, user, id);
@@ -52,6 +53,35 @@ export const stixDelete = async (context, user, id) => {
 
 export const stixObjectMerge = async (context, user, targetId, sourceIds) => {
   return mergeEntities(context, user, targetId, sourceIds);
+};
+
+export const sendStixBundle = async (context, user, connectorId, bundle) => {
+  try {
+    // 01. Simple check bundle
+    const jsonBundle = JSON.parse(bundle);
+    if (jsonBundle.type !== 'bundle' || !jsonBundle.objects || jsonBundle.objects.length === 0) {
+      throw new UnsupportedError('Invalid stix bundle');
+    }
+    // 02. Create work and send the bundle to ingestion
+    const connector = await storeLoadById(context, user, connectorId, ENTITY_TYPE_CONNECTOR);
+    if (!connector) {
+      throw new UnsupportedError('Invalid connector');
+    }
+    const workName = `${connector.name} run @ ${now()}`;
+    const work = await createWork(context, user, connector, workName, connector.internal_id);
+    const content = Buffer.from(bundle, 'utf-8').toString('base64');
+    await updateExpectationsNumber(context, context.user, work.id, jsonBundle.objects.length);
+    await pushToWorkerForConnector(connectorId, {
+      type: 'bundle',
+      applicant_id: user.internal_id,
+      content,
+      work_id: work.id,
+      update: true
+    });
+    return true;
+  } catch (err) {
+    throw UnsupportedError('Invalid bundle', { cause: err });
+  }
 };
 
 export const askListExport = async (context, user, exportContext, format, selectedIds, listParams, type, contentMaxMarkings, fileMarkings) => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -12758,6 +12758,7 @@ export type Mutation = {
   statusTemplateContextPatch: StatusTemplate;
   statusTemplateDelete: Scalars['ID']['output'];
   statusTemplateFieldPatch: StatusTemplate;
+  stixBundlePush?: Maybe<Scalars['Boolean']['output']>;
   stixCoreObjectEdit?: Maybe<StixCoreObjectEditMutations>;
   stixCoreObjectsExportAsk?: Maybe<Array<File>>;
   stixCoreObjectsExportPush?: Maybe<Scalars['Boolean']['output']>;
@@ -14222,6 +14223,12 @@ export type MutationStatusTemplateDeleteArgs = {
 export type MutationStatusTemplateFieldPatchArgs = {
   id: Scalars['ID']['input'];
   input: Array<EditInput>;
+};
+
+
+export type MutationStixBundlePushArgs = {
+  bundle: Scalars['String']['input'];
+  connectorId: Scalars['String']['input'];
 };
 
 
@@ -34790,6 +34797,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   statusTemplateContextPatch?: Resolver<ResolversTypes['StatusTemplate'], ParentType, ContextType, RequireFields<MutationStatusTemplateContextPatchArgs, 'id' | 'input'>>;
   statusTemplateDelete?: Resolver<ResolversTypes['ID'], ParentType, ContextType, RequireFields<MutationStatusTemplateDeleteArgs, 'id'>>;
   statusTemplateFieldPatch?: Resolver<ResolversTypes['StatusTemplate'], ParentType, ContextType, RequireFields<MutationStatusTemplateFieldPatchArgs, 'id' | 'input'>>;
+  stixBundlePush?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationStixBundlePushArgs, 'bundle' | 'connectorId'>>;
   stixCoreObjectEdit?: Resolver<Maybe<ResolversTypes['StixCoreObjectEditMutations']>, ParentType, ContextType, RequireFields<MutationStixCoreObjectEditArgs, 'id'>>;
   stixCoreObjectsExportAsk?: Resolver<Maybe<Array<ResolversTypes['File']>>, ParentType, ContextType, RequireFields<MutationStixCoreObjectsExportAskArgs, 'input'>>;
   stixCoreObjectsExportPush?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationStixCoreObjectsExportPushArgs, 'entity_type' | 'file' | 'file_markings'>>;

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -11,7 +11,7 @@ import { STIX_EXT_OCTI } from '../types/stix-extensions';
 import { utcDate } from '../utils/format';
 import { listEntities, storeLoadById } from '../database/middleware-loader';
 import { isEmptyField, wait } from '../database/utils';
-import { pushToSync } from '../database/rabbitmq';
+import { pushToWorkerForSync } from '../database/rabbitmq';
 import { OPENCTI_SYSTEM_UUID } from '../schema/general';
 import { getHttpClient } from '../utils/http-client';
 
@@ -137,7 +137,7 @@ const syncManagerInstance = (syncId) => {
               const enrichedEvent = JSON.stringify({ id: eventId, type: eventType, data: syncData, context: eventContext });
               const content = Buffer.from(enrichedEvent, 'utf-8').toString('base64');
               // Applicant_id should be a userId coming from synchronizer
-              await pushToSync({
+              await pushToWorkerForSync({
                 type: 'event',
                 synchronized,
                 previous_standard,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -18,7 +18,7 @@ import type { JSONSchemaType } from 'ajv';
 import * as jsonpatch from 'fast-json-patch';
 import { type BasicStoreEntityPlaybook, ENTITY_TYPE_PLAYBOOK, type PlaybookComponent } from './playbook-types';
 import { AUTOMATION_MANAGER_USER, AUTOMATION_MANAGER_USER_UUID, executionContext, INTERNAL_USERS, isUserCanAccessStixElement, SYSTEM_USER } from '../../utils/access';
-import { pushToConnector, pushToPlaybook } from '../../database/rabbitmq';
+import { pushToConnector, pushToWorkerForPlaybook } from '../../database/rabbitmq';
 import {
   ABSTRACT_STIX_CORE_OBJECT,
   ABSTRACT_STIX_CORE_RELATIONSHIP,
@@ -167,7 +167,7 @@ const PLAYBOOK_INGESTION_COMPONENT: PlaybookComponent<IngestionConfiguration> = 
   schema: async () => undefined,
   executor: async ({ eventId, bundle, playbookId }) => {
     const content = Buffer.from(JSON.stringify(bundle), 'utf-8').toString('base64');
-    await pushToPlaybook({
+    await pushToWorkerForPlaybook({
       type: 'bundle',
       event_id: eventId,
       playbook_id: playbookId,

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -1,4 +1,4 @@
-import { stixDelete, stixObjectMerge } from '../domain/stix';
+import {sendStixBundle, stixDelete, stixObjectMerge} from '../domain/stix';
 import { batchLoader, stixLoadByIdStringify } from '../database/middleware';
 import { connectorsForEnrichment } from '../database/repository';
 import { batchCreators } from '../domain/user';
@@ -38,6 +38,7 @@ const stixResolvers = {
       delete: () => stixDelete(context, context.user, id),
       merge: ({ stixObjectsIds }) => stixObjectMerge(context, context.user, id, stixObjectsIds),
     }),
+    stixBundlePush: (_, { connectorId, bundle }, context) => sendStixBundle(context, context.user, connectorId, bundle),
   },
   StixObject: {
     // eslint-disable-next-line

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -1,4 +1,4 @@
-import {sendStixBundle, stixDelete, stixObjectMerge} from '../domain/stix';
+import { sendStixBundle, stixDelete, stixObjectMerge } from '../domain/stix';
 import { batchLoader, stixLoadByIdStringify } from '../database/middleware';
 import { connectorsForEnrichment } from '../database/repository';
 import { batchCreators } from '../domain/user';


### PR DESCRIPTION
Introduce the stixBundlePush API.
Allow a connector to push a stix bundle for ingest directly through http.
There is no split inside the backend so if the connector wants to split he needs to do it on his side with the client-python splitter utility.