### PR TITLE
[backend] Add log on intialization to better understand failures (#7038)

### DIFF
--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -28,20 +28,22 @@ const PLATFORM_LOCK_ID = 'platform_init_lock';
 export const checkSystemDependencies = async () => {
   logApp.info('[OPENCTI] Checking dependencies statuses');
   // Check if elasticsearch is available
+  logApp.info('[CHECK] checking if Search engine is alive');
   await searchEngineInit();
-  logApp.info('[CHECK] Search engine is alive');
   // Check if minio is here
+  logApp.info('[CHECK] Search engine ok, checking if File storage is alive');
   await storageInit();
-  logApp.info('[CHECK] File engine is alive');
   // Check if RabbitMQ is here and create the logs exchange/queue
+  logApp.info('[CHECK] File storage ok, checking if RabbitMQ is alive');
   await rabbitMQIsAlive();
-  logApp.info('[CHECK] RabbitMQ engine is alive');
+  logApp.info('[CHECK] RabbitMQ ok, checking if Redis is alive');
   // Check if redis is here
   await redisInit();
-  logApp.info('[CHECK] Redis engine is alive');
+  logApp.info('[CHECK] Redis ok, checking if SMTP is alive');
   // Check if SMTP is here
   await smtpIsAlive();
   // Check if Python is available
+  logApp.info('[CHECK] SMTP done, checking if python is available');
   const context = executionContext('system_dependencies');
   await checkPythonAvailability(context, SYSTEM_USER);
   logApp.info('[CHECK] Python3 is available');


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When the SSL part of opencti is badly configured, add an explicit error message instead of just "Engine Unhandled Rejection".
* Add log before checks to know what is about to be checked at initialization.

Before change when SSL is badly configured:
```
{"category":"APP","level":"info","message":"[INIT] Platform initialization done","source":"backend","timestamp":"2024-07-16T07:28:17.695Z","version":"6.2.4"}
{"category":"APP","errors":[{"attributes":{"genre":"TECHNICAL","http_status":500,"promise":{},"reason":{"code":"ENOENT","errno":-4058,"path":"C:\\Users\\AngeliqueJard\\IdeaProjects\\test-cert\\openct.local.key","syscall":"open"}},"message":"Engine unhandled rejection","name":"UNKNOWN_ERROR","stack":"UNKNOWN
_ERROR: Engine unhandled rejection\n    at error (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\src\\config\\errors.js:8:10)\n    at UnknownError (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\src\\config\\errors.js:82:47)\n    at p
rocess.<anonymous> (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\src\\boot.js:60:16)\n    at process.emit (node:events:519:28)\n    at process.emit (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\node_modules\\source-map-support\\so
urce-map-support.js:516:21)\n    at emit (node:internal/process/promises:150:20)\n    at processPromiseRejections (node:internal/process/promises:284:27)\n    at processTicksAndRejections (node:internal/process/task_queues:96:32)"}],"level":"error","message":"Engine unhandled rejection","source":"backend","timestamp":"2024-07-16T07:28:18.283Z","version":"6.2.4"}
```
After change when SSL is badly configured:
```
{"category":"APP","level":"info","message":"[INIT] Platform initialization done","source":"backend","timestamp":"2024-07-16T07:28:17.695Z","version":"6.2.4"}
{"category":"APP","level":"info","message":"[INIT] Configuring HTTP/HTTPS server","source":"backend","timestamp":"2024-07-16T07:25:13.555Z","version":"6.2.4"}
{"category":"APP","level":"info","message":"[INIT] Configuring SSL for HTTPS server.","source":"backend","timestamp":"2024-07-16T07:25:14.090Z","version":"6.2.4"}
{"category":"APP","code":"ENOENT","errno":-4058,"level":"error","message":"[INIT] HTTPS server cannot start, please verify app.https_cert and other configurations","path":"C:\\Users\\AngeliqueJard\\IdeaProjects\\test-cert\\openct.local.key","source":"backend","syscall":"open","timestamp":"2024-07-16T07:25:14.091Z","version":"6.2.4"}
{"category":"APP","errors":[{"attributes":{"genre":"TECHNICAL","http_status":500,"promise":{},"reason":{}},"message":"Engine unhandled rejection","name":"UNKNOWN_ERROR","stack":"UNKNOWN_ERROR: Engine unhandled rejection\n    at error (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\openct
i-graphql\\src\\config\\errors.js:8:10)\n    at UnknownError (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\src\\config\\errors.js:82:47)\n    at process.<anonymous> (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\src\\boot.js:60:16)
\n    at process.emit (node:events:519:28)\n    at process.emit (C:\\Users\\AngeliqueJard\\IdeaProjects\\opencti\\opencti-platform\\opencti-graphql\\node_modules\\source-map-support\\source-map-support.js:516:21)\n    at emit (node:internal/process/promises:150:20)\n    at processPromiseRejections (node:internal/process/promises:284:27)\n    at processTicksAndRejections (node:internal/process/task_queues:96:32)"}],"level":"error","message":"Engine unhandled rejection","source":"backend","timestamp":"2024-07-16T07:25:14.093Z","version":"6.2.4"}
```

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #7038 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
