### PR TITLE
Replaced Edit Floating Action Buttons for Cases

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, useRef } from 'react';
 import { useFragment } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
+import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import { convertMarkings } from '../../../../utils/edition';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
@@ -50,6 +51,8 @@ const CaseIncidentComponent: FunctionComponent<CaseIncidentProps> = ({ data, ena
   const { t_i18n } = useFormatter();
   const ref = useRef(null);
   const caseIncidentData = useFragment(caseFragment, data);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const LOCAL_STORAGE_KEY_CASE_TASKS = `cases-${caseIncidentData.id}-caseTask`;
 
@@ -193,9 +196,11 @@ const CaseIncidentComponent: FunctionComponent<CaseIncidentProps> = ({ data, ena
           />
         </Grid>
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <CaseIncidentEdition caseId={caseIncidentData.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <CaseIncidentEdition caseId={caseIncidentData.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEdition.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { CaseIncidentEditionContainerCaseQuery } from './__generated__/CaseIncidentEditionContainerCaseQuery.graphql';
@@ -29,6 +30,7 @@ const CaseIncidentEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) 
           <CaseIncidentEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionContainer.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { CaseIncidentEditionOverview_case$key } from '@components/cases/case_incidents/__generated__/CaseIncidentEditionOverview_case.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
@@ -12,6 +13,7 @@ interface CaseIncidentEditionContainerProps {
   queryRef: PreloadedQuery<CaseIncidentEditionContainerCaseQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const caseIncidentEditionQuery = graphql`
@@ -28,8 +30,10 @@ export const caseIncidentEditionQuery = graphql`
 
 const CaseIncidentEditionContainer: FunctionComponent<
 CaseIncidentEditionContainerProps
-> = ({ queryRef, handleClose, open }) => {
+> = ({ queryRef, handleClose, open, controlledDial }) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { caseIncident } = usePreloadedQuery(caseIncidentEditionQuery, queryRef);
   if (caseIncident === null) {
     return <ErrorNotFound />;
@@ -37,10 +41,11 @@ CaseIncidentEditionContainerProps
   return (
     <Drawer
       title={t_i18n('Update an incident response')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={caseIncident?.editContext}
       onClose={handleClose}
       open={open}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
         <CaseIncidentEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -11,6 +11,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectSimulationResult from '@components/common/stix_core_objects/StixCoreObjectSimulationResult';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
@@ -27,8 +28,9 @@ import { RootIncidentSubscription } from '../../events/incidents/__generated__/R
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
+import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import CaseIncidentEdition from './CaseIncidentEdition';
 
 const subscription = graphql`
   subscription RootIncidentCaseSubscription($id: ID!) {
@@ -106,6 +108,9 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
           <ContainerHeader
             container={caseData}
             PopoverComponent={<CaseIncidentPopover id={caseData.id} />}
+            EditComponent={<Security needs={[KNOWLEDGE_KNUPDATE]}>
+              <CaseIncidentEdition caseId={caseData.id} />
+            </Security>}
             enableQuickSubscription={true}
             enableAskAi={true}
             redirectToContent={true}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, useRef } from 'react';
 import { useFragment } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
+import useHelper from 'src/utils/hooks/useHelper';
 import { convertMarkings } from '../../../../utils/edition';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
@@ -50,6 +51,8 @@ const CaseRfiComponent: FunctionComponent<CaseRfiProps> = ({ data, enableReferen
   const { t_i18n } = useFormatter();
   const ref = useRef(null);
   const caseRfiData = useFragment(caseFragment, data);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const LOCAL_STORAGE_KEY = `cases-${caseRfiData.id}-caseTask`;
   const { viewStorage, helpers, paginationOptions } = usePaginationLocalStorage<CaseTasksLinesQuery$variables>(
@@ -181,9 +184,11 @@ const CaseRfiComponent: FunctionComponent<CaseRfiProps> = ({ data, enableReferen
           />
         </Grid>
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <CaseRfiEdition caseId={caseRfiData.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <CaseRfiEdition caseId={caseRfiData.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEdition.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { CaseRfiEditionContainerCaseQuery } from './__generated__/CaseRfiEditionContainerCaseQuery.graphql';
@@ -29,6 +30,7 @@ const CaseRfiEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
           <CaseRfiEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionContainer.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { CaseRfiEditionOverview_case$key } from '@components/cases/case_rfis/__generated__/CaseRfiEditionOverview_case.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
@@ -12,6 +13,7 @@ interface CaseRfiEditionContainerProps {
   queryRef: PreloadedQuery<CaseRfiEditionContainerCaseQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const caseRfiEditionQuery = graphql`
@@ -26,8 +28,15 @@ export const caseRfiEditionQuery = graphql`
   }
 `;
 
-const CaseRfiEditionContainer: FunctionComponent<CaseRfiEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const CaseRfiEditionContainer: FunctionComponent<CaseRfiEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { caseRfi } = usePreloadedQuery(caseRfiEditionQuery, queryRef);
   if (caseRfi === null) {
     return <ErrorNotFound />;
@@ -35,10 +44,11 @@ const CaseRfiEditionContainer: FunctionComponent<CaseRfiEditionContainerProps> =
   return (
     <Drawer
       title={t_i18n('Update a request for information')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={caseRfi?.editContext}
       onClose={handleClose}
       open={open}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
         <CaseRfiEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -10,6 +10,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -26,8 +27,9 @@ import CaseRfiKnowledge from './CaseRfiKnowledge';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
+import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import CaseRfiEdition from './CaseRfiEdition';
 
 const subscription = graphql`
   subscription RootCaseRfiCaseSubscription($id: ID!) {
@@ -107,6 +109,9 @@ const RootCaseRfiComponent = ({ queryRef, caseId }) => {
           <ContainerHeader
             container={caseData}
             PopoverComponent={<CaseRfiPopover id={caseData.id} />}
+            EditComponent={<Security needs={[KNOWLEDGE_KNUPDATE]}>
+              <CaseRfiEdition caseId={caseData.id} />
+            </Security>}
             enableQuickSubscription={true}
             enableAskAi={true}
             redirectToContent={true}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRft.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRft.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, useRef } from 'react';
 import { useFragment } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
+import useHelper from 'src/utils/hooks/useHelper';
 import { convertMarkings } from '../../../../utils/edition';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
@@ -48,6 +49,8 @@ interface CaseRftProps {
 const CaseRftComponent: FunctionComponent<CaseRftProps> = ({ data, enableReferences }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const ref = useRef(null);
   const caseRftData = useFragment(caseFragment, data);
   const LOCAL_STORAGE_KEY_CASE_TASKS = `cases-${caseRftData.id}-caseTask`;
@@ -179,9 +182,11 @@ const CaseRftComponent: FunctionComponent<CaseRftProps> = ({ data, enableReferen
           />
         </Grid>
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <CaseRftEdition caseId={caseRftData.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <CaseRftEdition caseId={caseRftData.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEdition.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { CaseRftEditionContainerCaseQuery } from './__generated__/CaseRftEditionContainerCaseQuery.graphql';
@@ -29,6 +30,7 @@ const CaseRftEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
           <CaseRftEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionContainer.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { CaseRftEditionOverview_case$key } from '@components/cases/case_rfts/__generated__/CaseRftEditionOverview_case.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
@@ -12,6 +13,7 @@ interface CaseRftEditionContainerProps {
   queryRef: PreloadedQuery<CaseRftEditionContainerCaseQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const caseRftEditionQuery = graphql`
@@ -26,8 +28,15 @@ export const caseRftEditionQuery = graphql`
   }
 `;
 
-const CaseRftEditionContainer: FunctionComponent<CaseRftEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const CaseRftEditionContainer: FunctionComponent<CaseRftEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { caseRft } = usePreloadedQuery(caseRftEditionQuery, queryRef);
   if (caseRft === null) {
     return <ErrorNotFound />;
@@ -35,10 +44,11 @@ const CaseRftEditionContainer: FunctionComponent<CaseRftEditionContainerProps> =
   return (
     <Drawer
       title={t_i18n('Update a request for takedown')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={caseRft?.editContext}
       onClose={handleClose}
       open={open}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
         <CaseRftEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -10,6 +10,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -25,8 +26,9 @@ import { RootCaseRftCaseQuery } from './__generated__/RootCaseRftCaseQuery.graph
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
+import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import CaseRftEdition from './CaseRftEdition';
 
 const subscription = graphql`
   subscription RootCaseRftCaseSubscription($id: ID!) {
@@ -104,6 +106,9 @@ const RootCaseRftComponent = ({ queryRef, caseId }) => {
           <ContainerHeader
             container={caseData}
             PopoverComponent={<CaseRftPopover id={caseData.id} />}
+            EditComponent={<Security needs={[KNOWLEDGE_KNUPDATE]}>
+              <CaseRftEdition caseId={caseData.id} />
+            </Security>}
             enableQuickSubscription={true}
             enableAskAi={true}
             redirectToContent={true}

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import makeStyles from '@mui/styles/makeStyles';
+import useHelper from 'src/utils/hooks/useHelper';
 import FeedbackDetails from './FeedbackDetails';
 import StixDomainObjectOverview from '../../common/stix_domain_objects/StixDomainObjectOverview';
 import ContainerStixObjectsOrStixRelationships from '../../common/containers/ContainerStixObjectsOrStixRelationships';
@@ -88,6 +89,8 @@ interface FeedbackProps {
 const FeedbackComponent: FunctionComponent<FeedbackProps> = ({ data, enableReferences }) => {
   const classes = useStyles();
   const feedbackData = useFragment(feedbackFragment, data);
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const canManage = feedbackData.currentUserAccessRight === 'admin';
   const canEdit = canManage || feedbackData.currentUserAccessRight === 'edit';
@@ -125,9 +128,11 @@ const FeedbackComponent: FunctionComponent<FeedbackProps> = ({ data, enableRefer
           <StixCoreObjectLatestHistory stixCoreObjectId={feedbackData.id} />
         </Grid>
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]} hasAccess={canEdit}>
-        <FeedbackEdition feedbackId={feedbackData.id} />
-      </Security>
+      {!FABReplaced
+        && <Security needs={[KNOWLEDGE_KNUPDATE]} hasAccess={canEdit}>
+          <FeedbackEdition feedbackId={feedbackData.id} />
+        </Security>
+      }
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEdition.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { feedbackEditionOverviewFocus } from './FeedbackEditionOverview';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
@@ -29,6 +30,7 @@ const FeedbackEdition: FunctionComponent<{ feedbackId: string }> = ({ feedbackId
           <FeedbackEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionContainer.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { FeedbackEditionOverview_case$key } from '@components/cases/feedbacks/__generated__/FeedbackEditionOverview_case.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import FeedbackEditionOverview from './FeedbackEditionOverview';
@@ -12,6 +13,7 @@ interface FeedbackEditionContainerProps {
   queryRef: PreloadedQuery<FeedbackEditionContainerQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const feedbackEditionQuery = graphql`
@@ -26,8 +28,15 @@ export const feedbackEditionQuery = graphql`
   }
 `;
 
-const FeedbackEditionContainer: FunctionComponent<FeedbackEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const FeedbackEditionContainer: FunctionComponent<FeedbackEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { feedback } = usePreloadedQuery(feedbackEditionQuery, queryRef);
   if (feedback === null) {
     return <ErrorNotFound />;
@@ -35,10 +44,11 @@ const FeedbackEditionContainer: FunctionComponent<FeedbackEditionContainerProps>
   return (
     <Drawer
       title={t_i18n('Update a feedback')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={feedback?.editContext}
       onClose={handleClose}
       open={open}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
         <FeedbackEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -11,6 +11,8 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
+import { KNOWLEDGE_KNUPDATE } from 'src/utils/hooks/useGranted';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -26,6 +28,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import FeedbackEdition from './FeedbackEdition';
 
 const subscription = graphql`
   subscription RootFeedbackSubscription($id: ID!) {
@@ -115,6 +118,7 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
   } = usePreloadedQuery<RootFeedbackQuery>(feedbackQuery, queryRef);
   const paddingRight = getPaddingRight(location.pathname, feedbackData?.id, '/dashboard/cases/feedbacks');
   const canManage = feedbackData?.currentUserAccessRight === 'admin';
+  const canEdit = canManage || feedbackData.currentUserAccessRight === 'edit';
   return (
     <>
       {feedbackData ? (
@@ -128,6 +132,9 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
           <ContainerHeader
             container={feedbackData}
             PopoverComponent={<FeedbackPopover id={feedbackData.id} />}
+            EditComponent={<Security needs={[KNOWLEDGE_KNUPDATE]} hasAccess={canEdit}>
+              <FeedbackEdition feedbackId={feedbackData.id} />
+            </Security>}
             enableSuggestions={false}
             disableSharing={true}
             enableQuickSubscription

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -10,6 +10,8 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
+import { KNOWLEDGE_KNUPDATE } from 'src/utils/hooks/useGranted';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -25,6 +27,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import TaskEdition from './TaskEdition';
 
 const subscription = graphql`
   subscription RootTaskSubscription($id: ID!) {
@@ -94,6 +97,9 @@ const RootTaskComponent = ({ queryRef, taskId }) => {
           <ContainerHeader
             container={data}
             PopoverComponent={<TasksPopover id={data.id} />}
+            EditComponent={<Security needs={[KNOWLEDGE_KNUPDATE]}>
+              <TaskEdition caseId={data.id} />
+            </Security>}
             enableSuggestions={false}
             redirectToContent={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Task.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Task.tsx
@@ -2,6 +2,7 @@ import Grid from '@mui/material/Grid';
 import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
+import useHelper from 'src/utils/hooks/useHelper';
 import StixCoreObjectOrStixCoreRelationshipNotes from '../../analyses/notes/StixCoreObjectOrStixCoreRelationshipNotes';
 import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCoreObjectLatestHistory';
 import StixDomainObjectOverview from '../../common/stix_domain_objects/StixDomainObjectOverview';
@@ -81,6 +82,8 @@ export const taskFragment = graphql`
 const TaskComponent = ({ data, enableReferences }: { data: Tasks_tasks$key, enableReferences: boolean }) => {
   const classes = useStyles();
   const task = useFragment(taskFragment, data);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   return (
     <>
       <Grid
@@ -115,9 +118,11 @@ const TaskComponent = ({ data, enableReferences }: { data: Tasks_tasks$key, enab
           />
         </Grid>
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <TaskEdition caseId={task.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <TaskEdition caseId={task.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskEdition.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { tasksEditionOverviewFocus } from './TasksEditionOverview';
@@ -29,6 +30,7 @@ const TaskEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
           <TasksEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionContainer.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { TasksEditionOverview_task$key } from '@components/cases/tasks/__generated__/TasksEditionOverview_task.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
@@ -12,6 +13,7 @@ interface TasksEditionContainerProps {
   queryRef: PreloadedQuery<TasksEditionContainerQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const tasksEditionQuery = graphql`
@@ -26,8 +28,15 @@ export const tasksEditionQuery = graphql`
   }
 `;
 
-const TasksEditionContainer: FunctionComponent<TasksEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const TasksEditionContainer: FunctionComponent<TasksEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { task } = usePreloadedQuery(tasksEditionQuery, queryRef);
   if (task === null) {
     return <ErrorNotFound />;
@@ -35,10 +44,11 @@ const TasksEditionContainer: FunctionComponent<TasksEditionContainerProps> = ({ 
   return (
     <Drawer
       title={t_i18n('Update a task')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={task?.editContext}
       onClose={handleClose}
       open={open}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
         <TasksEditionOverview

--- a/opencti-platform/opencti-front/tests_e2e/model/incidentResponseDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/incidentResponseDetails.pageModel.ts
@@ -15,7 +15,7 @@ export default class IncidentResponseDetailsPage {
   }
 
   getEditButton() {
-    return this.page.getByLabel('Edit');
+    return this.page.getByLabel('Update', { exact: true });
   }
 
   goToOverviewTab() {


### PR DESCRIPTION
### Proposed changes

* Replace the floating action button for editing cases with a dedicated button in the top right the page.

### Related issues

- https://github.com/OpenCTI-Platform/opencti/pull/6738
- https://github.com/OpenCTI-Platform/opencti/pull/6756
- https://github.com/OpenCTI-Platform/opencti/pull/7032

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
