### PR TITLE
[frontend] no pointer mouse on non editable filters (#7647)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -77,12 +77,13 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   filtersRestrictions,
 }) => {
   const { t_i18n } = useFormatter();
+  const classes = useStyles();
+
   const filterKey = currentFilter.key;
   const filterOperator = currentFilter.operator;
   const filterValues = currentFilter.values;
   const isOperatorNil = ['nil', 'not_nil'].includes(filterOperator ?? 'eq');
-  const classes = useStyles();
-  const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues);
+  const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues) || !isReadWriteFilter;
   const onCLick = deactivatePopoverMenu ? () => {} : onClickLabel;
   const menuClassName = deactivatePopoverMenu ? '' : classes.label;
   if (isOperatorNil) {


### PR DESCRIPTION
### Proposed changes
Don't display a clickable mouse when hover a non editable filter (like filters display in retention rules lines)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7647
