### PR TITLE
[frontend] incident type chip UX in incident overview (#7709)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
@@ -14,7 +14,7 @@ import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
-const useStyles = makeStyles<Theme>(() => ({
+const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
     height: '100%',
     minHeight: '100%',
@@ -24,11 +24,12 @@ const useStyles = makeStyles<Theme>(() => ({
   },
   chip: {
     fontSize: 12,
-    height: 25,
-    marginRight: 7,
+    lineHeight: '12px',
+    backgroundColor: theme.palette.background.accent,
+    color: theme.palette.text?.primary,
     textTransform: 'uppercase',
     borderRadius: 4,
-    width: 120,
+    margin: '0 5px 5px 0',
   },
   chip2: {
     fontSize: 12,
@@ -134,8 +135,6 @@ const IncidentDetails: FunctionComponent<IncidentDetailsProps> = ({
             </Typography>
             <Chip
               classes={{ root: classes.chip }}
-              color="primary"
-              variant="outlined"
               label={incident.incident_type || t_i18n('Unknown')}
             />
             <Typography


### PR DESCRIPTION
### Proposed changes
Align incident type chip design (in incident overview) with other entity type chip design (exemple : incident response type)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7709