### PR TITLE
[backend] fixed inferred relations restoration when an entity is restored from trash (#7712)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
@@ -325,7 +325,7 @@ export const restoreDelete = async (context: AuthContext, user: AuthUser, id: st
       else {
         const rule = Object.keys(relationToRestore).find((k) => k.startsWith(RULE_PREFIX));
         if (rule === undefined) {
-          logApp.warn('Inferred rule could not be found');
+          logApp.warn('Inferred rule could not be found', { relation: relationToRestore });
         } else {
           const ruleID = rule.substring(RULE_PREFIX.length);
           const ruleValues = (relationToRestore as Record<string, any>)[rule][0];
@@ -335,11 +335,11 @@ export const restoreDelete = async (context: AuthContext, user: AuthUser, id: st
       }
       if (result.id && result.id !== relationshipInput.id) {
         upsertedElements[relationshipInput.id] = result.id;
-        logApp.warn('Relationship has been restored with with different id (upsert)');
+        logApp.warn('Relationship has been restored with different id (upsert)', { upsertId: result.id, originalId: relationshipInput.id });
       }
       if (result.element && result.element.id && result.element.id !== relationshipInput.id) {
         upsertedElements[relationshipInput.id] = result.element.id;
-        logApp.warn('Relationship has been restored with with different id (upsert)');
+        logApp.warn('Relationship has been restored with different id (upsert)', { upsertId: result.element.id, originalId: relationshipInput.id });
       }
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* inferred relations are now restored using createInferredRelation instead of createRelation
* we now check for upserted entities/relations during restore to be able to link remaining relations to restore to the correct id

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7712 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
