### PR TITLE
Replaced Edit Floating Action Buttons for Events

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEdition.tsx
@@ -38,7 +38,7 @@ const NoteEdition = ({ noteId }: { noteId: string }) => {
       query={noteEditionQuery}
       variables={{ id: noteId }}
       render={({ props }: { props: NoteEditionContainerQuery$data }) => {
-        if (props && props.note) {
+        if (props?.note) {
           return (
             <CollaborativeSecurity
               data={props.note}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Incident.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Incident.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 import Grid from '@mui/material/Grid';
+import useHelper from 'src/utils/hooks/useHelper';
 import IncidentDetails from './IncidentDetails';
 import IncidentEdition from './IncidentEdition';
 import Security from '../../../../utils/Security';
@@ -86,6 +87,8 @@ const Incident: React.FC<IncidentProps> = ({ incidentData }) => {
     incidentData,
   );
   const overviewLayoutCustomization = useOverviewLayoutCustomization(incident.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -161,9 +164,11 @@ const Incident: React.FC<IncidentProps> = ({ incidentData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <IncidentEdition incidentId={incident.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <IncidentEdition incidentId={incident.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEdition.tsx
@@ -5,6 +5,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { IncidentEditionContainerQuery } from './__generated__/IncidentEditionContainerQuery.graphql';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 const IncidentEdition = ({ incidentId }: { incidentId: string }) => {
   const [commit] = useApiMutation(incidentEditionOverviewFocus);
@@ -30,6 +31,7 @@ const IncidentEdition = ({ incidentId }: { incidentId: string }) => {
           <IncidentEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionContainer.tsx
@@ -3,9 +3,10 @@ import { createFragmentContainer, graphql, PreloadedQuery, usePreloadedQuery } f
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { IncidentEditionOverview_incident$key } from '@components/events/incidents/__generated__/IncidentEditionOverview_incident.graphql';
 import { IncidentEditionDetails_incident$key } from '@components/events/incidents/__generated__/IncidentEditionDetails_incident.graphql';
+import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import IncidentEditionOverview from './IncidentEditionOverview';
 import IncidentEditionDetails from './IncidentEditionDetails';
@@ -17,6 +18,7 @@ interface IncidentEditionContainerProps {
   queryRef: PreloadedQuery<IncidentEditionContainerQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
 export const IncidentEditionQuery = graphql`
@@ -33,9 +35,15 @@ export const IncidentEditionQuery = graphql`
   }
 `;
 
-const IncidentEditionContainer: FunctionComponent<IncidentEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const IncidentEditionContainer: FunctionComponent<IncidentEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { incident } = usePreloadedQuery(IncidentEditionQuery, queryRef);
   const [currentTab, setCurrentTab] = useState(0);
   const handleChangeTab = (event: React.SyntheticEvent, value: number) => setCurrentTab(value);
@@ -46,7 +54,8 @@ const IncidentEditionContainer: FunctionComponent<IncidentEditionContainerProps>
   return (
     <Drawer
       title={t_i18n('Update an incident')}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
       context={incident?.editContext}
       onClose={handleClose}
       open={open}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -10,6 +10,8 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import StixCoreObjectSimulationResult from '@components/common/stix_core_objects/StixCoreObjectSimulationResult';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import Security from 'src/utils/Security';
+import { KNOWLEDGE_KNUPDATE } from 'src/utils/hooks/useGranted';
 import Incident from './Incident';
 import IncidentKnowledge from './IncidentKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
@@ -26,6 +28,7 @@ import { RootIncidentSubscription } from './__generated__/RootIncidentSubscripti
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab } from '../../../../utils/utils';
+import IncidentEdition from './IncidentEdition';
 
 const subscription = graphql`
   subscription RootIncidentSubscription($id: ID!) {
@@ -133,6 +136,11 @@ const RootIncidentComponent = ({ queryRef }) => {
               entityType="Incident"
               stixDomainObject={incident}
               PopoverComponent={IncidentPopover}
+              EditComponent={(
+                <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                  <IncidentEdition incidentId={incident.id} />
+                </Security>
+              )}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedData.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedData.tsx
@@ -13,6 +13,7 @@ import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCore
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const observedDataFragment = graphql`
   fragment ObservedData_observedData on ObservedData {
@@ -72,6 +73,8 @@ interface ObservedDataProps {
 const ObservedData: React.FC<ObservedDataProps> = ({ observedDataData }) => {
   const observedData = useFragment <ObservedData_observedData$key>(observedDataFragment, observedDataData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(observedData.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -143,9 +146,11 @@ const ObservedData: React.FC<ObservedDataProps> = ({ observedDataData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <ObservedDataEdition observedDataId={observedData.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <ObservedDataEdition observedDataId={observedData.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEdition.jsx
@@ -5,6 +5,7 @@ import ObservedDataEditionContainer from './ObservedDataEditionContainer';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { observedDataEditionOverviewFocus } from './ObservedDataEditionOverview';
 import Loader from '../../../../components/Loader';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 export const observedDataEditionQuery = graphql`
   query ObservedDataEditionContainerQuery($id: String!) {
@@ -37,6 +38,7 @@ class ObservedDataEdition extends Component {
               <ObservedDataEditionContainer
                 observedData={props.observedData}
                 handleClose={this.handleClose.bind(this)}
+                controlledDial={EditEntityControlledDial}
               />
             );
           }

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionContainer.jsx
@@ -4,11 +4,13 @@ import { useFormatter } from '../../../../components/i18n';
 import ObservedDataEditionOverview from './ObservedDataEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ObservedDataEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
-
-  const { handleClose, observedData, open } = props;
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const { handleClose, observedData, open, controlledDial } = props;
   const { editContext } = observedData;
 
   return (
@@ -16,8 +18,9 @@ const ObservedDataEditionContainer = (props) => {
       title={t_i18n('Update an observed data')}
       open={open}
       onClose={handleClose}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       <ObservedDataEditionOverview
         observedData={observedData}

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -19,6 +19,9 @@ import ContainerStixDomainObjects from '../../common/containers/ContainerStixDom
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
+import ObservedDataEdition from './ObservedDataEdition';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 
 const subscription = graphql`
   subscription RootObservedDataSubscription($id: ID!) {
@@ -120,6 +123,11 @@ class RootObservedData extends Component {
                   <ContainerHeader
                     container={observedData}
                     PopoverComponent={<ObservedDataPopover />}
+                    EditComponent={(
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <ObservedDataEdition observedDataId={observedData.id} />
+                      </Security>
+                    )}
                     redirectToContent = {false}
                   />
                   <Box

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
@@ -1,19 +1,18 @@
-import React, { FunctionComponent } from 'react';
-import { useParams } from 'react-router-dom';
-import makeStyles from '@mui/styles/makeStyles';
+import React, { FunctionComponent, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { graphql } from 'react-relay';
-import StixSightingRelationshipOverview from './StixSightingRelationshipOverview';
-import Loader from '../../../../components/Loader';
+import Breadcrumbs from 'src/components/Breadcrumbs';
+import { useFormatter } from 'src/components/i18n';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, styled } from '@mui/material';
+import useHelper from 'src/utils/hooks/useHelper';
+import Transition from 'src/components/Transition';
+import Security from 'src/utils/Security';
+import { KNOWLEDGE_KNUPDATE } from 'src/utils/hooks/useGranted';
+import StixSightingRelationshipEdition, { stixSightingRelationshipEditionDeleteMutation } from './StixSightingRelationshipEdition';
+import { QueryRenderer, commitMutation, defaultCommitMutation } from '../../../../relay/environment';
 import { StixSightingRelationshipQuery$data } from './__generated__/StixSightingRelationshipQuery.graphql';
-import { QueryRenderer } from '../../../../relay/environment';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles(() => ({
-  container: {
-    marginTop: 10,
-  },
-}));
+import Loader from '../../../../components/Loader';
+import StixSightingRelationshipOverview from './StixSightingRelationshipOverview';
 
 const stixSightingRelationshipQuery = graphql`
   query StixSightingRelationshipQuery($id: String!) {
@@ -31,22 +30,117 @@ interface StixSightingRelationshipProps {
 const StixSightingRelationship: FunctionComponent<
 StixSightingRelationshipProps
 > = ({ entityId, paddingRight }) => {
-  const classes = useStyles();
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const [editOpen, setEditOpen] = useState<boolean>(false);
+  const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+  const [deleting, setDeleting] = useState<boolean>(false);
   const { sightingId } = useParams() as { sightingId: string };
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+
+  const handleOpenEdit = () => setEditOpen(true);
+  const handleCloseEdit = () => setEditOpen(false);
+  const handleOpenDelete = () => setDeleteOpen(true);
+  const handleCloseDelete = () => setDeleteOpen(false);
+  const submitDelete = () => {
+    setDeleting(true);
+    commitMutation({
+      ...defaultCommitMutation,
+      mutation: stixSightingRelationshipEditionDeleteMutation,
+      variables: {
+        id: sightingId,
+      },
+      onCompleted: () => {
+        handleCloseEdit();
+        navigate('/dashboard/events/sightings');
+      },
+    });
+  };
+
+  const SightingHeader = styled('div')({
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: 24,
+  });
+
   return (
-    <div className={classes.container}>
+    <div>
       <QueryRenderer
         query={stixSightingRelationshipQuery}
         variables={{ id: sightingId }}
         render={(result: { props: StixSightingRelationshipQuery$data }) => {
           if (result.props && result.props.stixSightingRelationship) {
-            return (
+            return (<>
+              <SightingHeader>
+                <Breadcrumbs variant="object" elements={[
+                  { label: t_i18n('Events') },
+                  { label: t_i18n('Sightings'), link: '/dashboard/events/sightings' },
+                  { label: t_i18n('Sighting'), current: true },
+                ]}
+                />
+                {isFABReplaced && (
+                  <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                    <Button
+                      variant='contained'
+                      size='small'
+                      aria-label={t_i18n('Update')}
+                      onClick={handleOpenEdit}
+                    >
+                      {t_i18n('Update')}
+                    </Button>
+                  </Security>
+                )}
+              </SightingHeader>
               <StixSightingRelationshipOverview
                 entityId={entityId}
                 stixSightingRelationship={result.props.stixSightingRelationship}
                 paddingRight={paddingRight}
+                isFABReplaced={isFABReplaced}
               />
-            );
+              {/* Edition Drawer, hidden by default */}
+              <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                <StixSightingRelationshipEdition
+                  open={editOpen}
+                  stixSightingRelationshipId={sightingId}
+                  // inferred={result.props.stixSightingRelationship.x_opencti_inferences !== null}
+                  inferred={false}
+                  handleClose={handleCloseEdit}
+                  handleDelete={handleOpenDelete}
+                  noStoreUpdate={undefined}
+                  inGraph={undefined}
+                />
+              </Security>
+              {/* Deletion Dialog, hidden by default */}
+              <Dialog
+                open={deleteOpen}
+                PaperProps={{ elevation: 1 }}
+                keepMounted={true}
+                TransitionComponent={Transition}
+                onClose={handleCloseDelete}
+              >
+                <DialogContent>
+                  <DialogContentText>
+                    {t_i18n('Do you want to delete this sighting?')}
+                  </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                  <Button
+                    onClick={handleCloseDelete}
+                    disabled={deleting}
+                  >
+                    {t_i18n('Cancel')}
+                  </Button>
+                  <Button
+                    color="secondary"
+                    onClick={submitDelete}
+                    disabled={deleting}
+                  >
+                    {t_i18n('Delete')}
+                  </Button>
+                </DialogActions>
+              </Dialog>
+            </>);
           }
           return <Loader />;
         }}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
@@ -211,6 +211,7 @@ class StixSightingRelationshipContainer extends Component {
       classes,
       stixSightingRelationship,
       paddingRight,
+      isFABReplaced = false,
     } = this.props;
     const { from } = stixSightingRelationship;
     const { to } = stixSightingRelationship;
@@ -584,25 +585,27 @@ class StixSightingRelationshipContainer extends Component {
             </>
           )}
         </Grid>
-        <Security needs={[KNOWLEDGE_KNUPDATE]}>
-          <Fab
-            onClick={this.handleOpenEdition.bind(this)}
-            color="secondary"
-            aria-label="Edit"
-            className={
-              paddingRight ? classes.editButtonWithPadding : classes.editButton
-            }
-          >
-            <Edit />
-          </Fab>
-          <StixSightingRelationshipEdition
-            open={this.state.openEdit}
-            stixSightingRelationshipId={stixSightingRelationship.id}
-            inferred={stixSightingRelationship.x_opencti_inferences !== null}
-            handleClose={this.handleCloseEdition.bind(this)}
-            handleDelete={this.handleOpenDelete.bind(this)}
-          />
-        </Security>
+        {!isFABReplaced && (
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <Fab
+              onClick={this.handleOpenEdition.bind(this)}
+              color="secondary"
+              aria-label="Edit"
+              className={
+                paddingRight ? classes.editButtonWithPadding : classes.editButton
+              }
+            >
+              <Edit />
+            </Fab>
+            <StixSightingRelationshipEdition
+              open={this.state.openEdit}
+              stixSightingRelationshipId={stixSightingRelationship.id}
+              inferred={stixSightingRelationship.x_opencti_inferences !== null}
+              handleClose={this.handleCloseEdition.bind(this)}
+              handleDelete={this.handleOpenDelete.bind(this)}
+            />
+          </Security>
+        )}
         <Dialog
           open={this.state.displayDelete}
           PaperProps={{ elevation: 1 }}
@@ -637,13 +640,11 @@ class StixSightingRelationshipContainer extends Component {
 }
 
 StixSightingRelationshipContainer.propTypes = {
-  entityId: PropTypes.string,
   stixSightingRelationship: PropTypes.object,
   paddingRight: PropTypes.bool,
   classes: PropTypes.object,
   t: PropTypes.func,
   nsdt: PropTypes.func,
-  match: PropTypes.object,
   navigate: PropTypes.func,
   location: PropTypes.object,
 };


### PR DESCRIPTION
### Proposed changes

* Replace the floating action button for editing events with a dedicated button in the top right the page.

### Related issues

- https://github.com/OpenCTI-Platform/opencti/pull/6738
- https://github.com/OpenCTI-Platform/opencti/pull/6756
- https://github.com/OpenCTI-Platform/opencti/pull/7032

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
