### PR TITLE
Replaced Edit Floating Action Buttons for Techniques

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
@@ -97,7 +97,7 @@ const dataComponentsLinesFragment = graphql`
 const DataComponents: FunctionComponent = () => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const isFABReplaced = isFeatureEnable('FAB_REPLACED');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const initialValues = {
     filters: emptyFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
@@ -102,7 +102,7 @@ const dataSourcesLinesFragment = graphql`
 const DataSources: FunctionComponent = () => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const isFABReplaced = isFeatureEnable('FAB_REPLACED');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const initialValues = {
     searchTerm: '',

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPattern.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPattern.tsx
@@ -13,6 +13,7 @@ import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCore
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const attackPatternFragment = graphql`
   fragment AttackPattern_attackPattern on AttackPattern {
@@ -73,6 +74,8 @@ interface AttackPatternProps {
 const AttackPattern: React.FC<AttackPatternProps> = ({ attackPatternData }) => {
   const attackPattern = useFragment<AttackPattern_attackPattern$key>(attackPatternFragment, attackPatternData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(attackPattern.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -144,9 +147,11 @@ const AttackPattern: React.FC<AttackPatternProps> = ({ attackPatternData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <AttackPatternEdition attackPatternId={attackPattern.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <AttackPatternEdition attackPatternId={attackPattern.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEdition.jsx
@@ -5,6 +5,7 @@ import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import AttackPatternEditionContainer from './AttackPatternEditionContainer';
 import { attackPatternEditionOverviewFocus } from './AttackPatternEditionOverview';
 import Loader from '../../../../components/Loader';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 export const attackPatternEditionQuery = graphql`
   query AttackPatternEditionContainerQuery($id: String!) {
@@ -38,6 +39,7 @@ class AttackPatternEdition extends Component {
               <AttackPatternEditionContainer
                 attackPattern={props.attackPattern}
                 handleClose={this.handleClose.bind(this)}
+                controlledDial={EditEntityControlledDial}
               />
             );
           }

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionContainer.jsx
@@ -8,11 +8,14 @@ import AttackPatternEditionDetails from './AttackPatternEditionDetails';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import { useFormatter } from '../../../../components/i18n';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const AttackPatternEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
-  const { handleClose, attackPattern, open } = props;
+  const { handleClose, attackPattern, open, controlledDial } = props;
   const { editContext } = attackPattern;
 
   const [currentTab, setCurrentTab] = useState(0);
@@ -24,8 +27,9 @@ const AttackPatternEditionContainer = (props) => {
       title={t_i18n('Update an attack pattern')}
       open={open}
       onClose={handleClose}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       <>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.jsx
@@ -22,6 +22,9 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import AttackPatternEdition from './AttackPatternEdition';
 
 const subscription = graphql`
   subscription RootAttackPatternSubscription($id: ID!) {
@@ -138,6 +141,11 @@ class RootAttackPattern extends Component {
                         entityType="Attack-Pattern"
                         stixDomainObject={props.attackPattern}
                         PopoverComponent={<AttackPatternPopover />}
+                        EditComponent={(
+                          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                            <AttackPatternEdition attackPatternId={attackPattern.id} />
+                          </Security>
+                        )}
                       />
                       <Box
                         sx={{

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfAction.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfAction.tsx
@@ -13,6 +13,7 @@ import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCore
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const courssOfActionFragment = graphql`
   fragment CourseOfAction_courseOfAction on CourseOfAction {
@@ -73,6 +74,8 @@ interface CourseOfActionProps {
 const CourseOfAction: React.FC<CourseOfActionProps> = ({ courseOfActionData }) => {
   const courseOfAction = useFragment<CourseOfAction_courseOfAction$key>(courssOfActionFragment, courseOfActionData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(courseOfAction.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -144,9 +147,11 @@ const CourseOfAction: React.FC<CourseOfActionProps> = ({ courseOfActionData }) =
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <CourseOfActionEdition courseOfActionId={courseOfAction.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <CourseOfActionEdition courseOfActionId={courseOfAction.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEdition.jsx
@@ -7,6 +7,7 @@ import inject18n from '../../../../components/i18n';
 import CourseOfActionEditionContainer from './CourseOfActionEditionContainer';
 import { courseOfActionEditionOverviewFocus } from './CourseOfActionEditionOverview';
 import Loader from '../../../../components/Loader';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 export const courseOfActionEditionQuery = graphql`
   query CourseOfActionEditionContainerQuery($id: String!) {
@@ -39,6 +40,7 @@ class CourseOfActionEdition extends Component {
               <CourseOfActionEditionContainer
                 courseOfAction={props.courseOfAction}
                 handleClose={this.handleClose.bind(this)}
+                controlledDial={EditEntityControlledDial}
               />
             );
           }

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionContainer.jsx
@@ -4,11 +4,14 @@ import { useFormatter } from '../../../../components/i18n';
 import CourseOfActionEditionOverview from './CourseOfActionEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const CourseOfActionEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
-  const { handleClose, courseOfAction, open } = props;
+  const { handleClose, courseOfAction, open, controlledDial } = props;
   const { editContext } = courseOfAction;
 
   return (
@@ -16,8 +19,9 @@ const CourseOfActionEditionContainer = (props) => {
       title={t_i18n('Update a course of action')}
       open={open}
       onClose={handleClose}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       <CourseOfActionEditionOverview
         courseOfAction={courseOfAction}

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -20,6 +20,9 @@ import CourseOfActionKnowledge from './CourseOfActionKnowledge';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import CourseOfActionEdition from './CourseOfActionEdition';
 
 const subscription = graphql`
   subscription RootCoursesOfActionSubscription($id: ID!) {
@@ -105,6 +108,11 @@ class RootCourseOfAction extends Component {
                       entityType="Course-Of-Action"
                       stixDomainObject={courseOfAction}
                       PopoverComponent={<CourseOfActionPopover/>}
+                      EditComponent={(
+                        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                          <CourseOfActionEdition courseOfActionId={courseOfAction.id} />
+                        </Security>
+                      )}
                       isOpenctiAlias={true}
                     />
                     <Box

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponent.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 import Grid from '@mui/material/Grid';
-import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
-import DataComponentEdition from './DataComponentEdition';
 import StixDomainObjectOverview from '../../common/stix_domain_objects/StixDomainObjectOverview';
 import DataComponentDetails from './DataComponentDetails';
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
@@ -13,6 +10,10 @@ import StixCoreObjectOrStixCoreRelationshipNotes from '../../analyses/notes/Stix
 import { DataComponent_dataComponent$key } from './__generated__/DataComponent_dataComponent.graphql';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import DataComponentEdition from './DataComponentEdition';
 
 const DataComponentFragment = graphql`
   fragment DataComponent_dataComponent on DataComponent {
@@ -73,6 +74,8 @@ interface DataComponentProps {
 const DataComponent: React.FC<DataComponentProps> = ({ dataComponentData }) => {
   const dataComponent = useFragment<DataComponent_dataComponent$key>(DataComponentFragment, dataComponentData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(dataComponent.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -144,9 +147,11 @@ const DataComponent: React.FC<DataComponentProps> = ({ dataComponentData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <DataComponentEdition dataComponentId={dataComponent.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <DataComponentEdition dataComponentId={dataComponent.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
@@ -336,7 +336,7 @@ const DataComponentCreation: FunctionComponent<{
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const [bulkOpen, setBulkOpen] = useState(false);
-  const isFABReplaced = isFeatureEnable('FAB_REPLACED');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEdition.tsx
@@ -5,6 +5,7 @@ import { dataComponentEditionOverviewFocus } from './DataComponentEditionOvervie
 import { DataComponentEditionContainerQuery } from './__generated__/DataComponentEditionContainerQuery.graphql';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 const DataComponentEdition: FunctionComponent<{ dataComponentId: string }> = ({
   dataComponentId,
@@ -34,6 +35,7 @@ const DataComponentEdition: FunctionComponent<{ dataComponentId: string }> = ({
           <DataComponentEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionContainer.tsx
@@ -1,11 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
 import DataComponentEditionOverview from './DataComponentEditionOverview';
 import { DataComponentEditionContainerQuery } from './__generated__/DataComponentEditionContainerQuery.graphql';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const dataComponentEditionQuery = graphql`
   query DataComponentEditionContainerQuery($id: String!) {
@@ -23,20 +24,29 @@ interface DataComponentEditionContainerProps {
   queryRef: PreloadedQuery<DataComponentEditionContainerQuery>
   handleClose: () => void
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
-const DataComponentEditionContainer: FunctionComponent<DataComponentEditionContainerProps> = ({ queryRef, handleClose, open }) => {
+const DataComponentEditionContainer: FunctionComponent<DataComponentEditionContainerProps> = ({
+  queryRef,
+  handleClose,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { dataComponent } = usePreloadedQuery(dataComponentEditionQuery, queryRef);
 
   if (dataComponent) {
     return (
       <Drawer
         title={t_i18n('Update a data component')}
-        variant={open == null ? DrawerVariant.update : undefined}
+        variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
         context={dataComponent.editContext}
         onClose={handleClose}
         open={open}
+        controlledDial={FABReplaced ? controlledDial : undefined}
       >
         {({ onClose }) => (
           <DataComponentEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -24,6 +24,9 @@ import { RootDataComponentSubscription } from './__generated__/RootDataComponent
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import Security from '../../../../utils/Security';
+import DataComponentEdition from './DataComponentEdition';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 
 const subscription = graphql`
   subscription RootDataComponentSubscription($id: ID!) {
@@ -103,6 +106,11 @@ const RootDataComponent = () => {
                     PopoverComponent={
                       <DataComponentPopover dataComponentId={dataComponentId}/>
                     }
+                    EditComponent={(
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <DataComponentEdition dataComponentId={dataComponent.id} />
+                      </Security>
+                    )}
                     noAliases={true}
                   />
                   <Box

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSource.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSource.tsx
@@ -9,10 +9,11 @@ import StixCoreObjectExternalReferences from '../../analyses/external_references
 import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCoreObjectLatestHistory';
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
 import { DataSource_dataSource$key } from './__generated__/DataSource_dataSource.graphql';
-import DataSourceEdition from './DataSourceEdition';
 import DataSourceDetailsComponent from './DataSourceDetails';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
+import DataSourceEdition from './DataSourceEdition';
 
 const dataSourceFragment = graphql`
   fragment DataSource_dataSource on DataSource {
@@ -74,6 +75,8 @@ interface DataSourceProps {
 const DataSourceComponent: React.FC<DataSourceProps> = ({ dataSourceData }) => {
   const dataSource = useFragment<DataSource_dataSource$key>(dataSourceFragment, dataSourceData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(dataSource.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -146,9 +149,11 @@ const DataSourceComponent: React.FC<DataSourceProps> = ({ dataSourceData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <DataSourceEdition dataSourceId={dataSource.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <DataSourceEdition dataSourceId={dataSource.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -343,7 +343,7 @@ const DataSourceCreation: FunctionComponent<DataSourceCreationProps> = ({
 }) => {
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
-  const isFABReplaced = isFeatureEnable('FAB_REPLACED');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [bulkOpen, setBulkOpen] = useState(false);
 
   const [open, setOpen] = useState(false);

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEdition.tsx
@@ -5,6 +5,7 @@ import { dataSourceEditionOverviewFocus } from './DataSourceEditionOverview';
 import DataSourceEditionContainer, { dataSourceEditionQuery } from './DataSourceEditionContainer';
 import { DataSourceEditionContainerQuery } from './__generated__/DataSourceEditionContainerQuery.graphql';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 const DataSourceEdition = ({ dataSourceId }: { dataSourceId: string }) => {
   const [commit] = useApiMutation(dataSourceEditionOverviewFocus);
@@ -32,6 +33,7 @@ const DataSourceEdition = ({ dataSourceId }: { dataSourceId: string }) => {
           <DataSourceEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}
+            controlledDial={EditEntityControlledDial}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionContainer.tsx
@@ -1,11 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import DataSourceEditionOverview from './DataSourceEditionOverview';
 import { DataSourceEditionContainerQuery } from './__generated__/DataSourceEditionContainerQuery.graphql';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const dataSourceEditionQuery = graphql`
   query DataSourceEditionContainerQuery($id: String!) {
@@ -23,10 +24,18 @@ interface DataSourceEditionContainerProps {
   handleClose: () => void
   queryRef: PreloadedQuery<DataSourceEditionContainerQuery>
   open?: boolean
+  controlledDial?: DrawerControlledDialType
 }
 
-const DataSourceEditionContainer: FunctionComponent<DataSourceEditionContainerProps> = ({ handleClose, queryRef, open }) => {
+const DataSourceEditionContainer: FunctionComponent<DataSourceEditionContainerProps> = ({
+  handleClose,
+  queryRef,
+  open,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { dataSource } = usePreloadedQuery(dataSourceEditionQuery, queryRef);
 
@@ -34,10 +43,11 @@ const DataSourceEditionContainer: FunctionComponent<DataSourceEditionContainerPr
     return (
       <Drawer
         title={t_i18n('Update a data source')}
-        variant={open == null ? DrawerVariant.update : undefined}
+        variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
         context={dataSource.editContext}
         onClose={handleClose}
         open={open}
+        controlledDial={FABReplaced ? controlledDial : undefined}
       >
         {({ onClose }) => (
           <DataSourceEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -24,6 +24,9 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import DataSourceEdition from './DataSourceEdition';
 
 const subscription = graphql`
   subscription RootDataSourcesSubscription($id: ID!) {
@@ -95,6 +98,11 @@ const RootDataSourceComponent = ({ queryRef, dataSourceId }) => {
             noAliases={true}
             stixDomainObject={dataSource}
             PopoverComponent={<DataSourcePopover id={dataSource.id}/>}
+            EditComponent={(
+              <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                <DataSourceEdition dataSourceId={dataSource.id} />
+              </Security>
+            )}
           />
           <Box
             sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 4 }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Narrative.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Narrative.tsx
@@ -13,6 +13,7 @@ import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCore
 import SimpleStixObjectOrStixRelationshipStixCoreRelationships from '../../common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationships';
 import StixCoreObjectOrStixRelationshipLastContainers from '../../common/containers/StixCoreObjectOrStixRelationshipLastContainers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const narrativeFragment = graphql`
   fragment Narrative_narrative on Narrative {
@@ -73,6 +74,8 @@ interface NarrativeProps {
 const Narrative: React.FC<NarrativeProps> = ({ narrativeData }) => {
   const narrative = useFragment<Narrative_narrative$key>(narrativeFragment, narrativeData);
   const overviewLayoutCustomization = useOverviewLayoutCustomization(narrative.entity_type);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <>
@@ -144,9 +147,11 @@ const Narrative: React.FC<NarrativeProps> = ({ narrativeData }) => {
           })
         }
       </Grid>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <NarrativeEdition narrativeId={narrative.id} />
-      </Security>
+      {!isFABReplaced && (
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <NarrativeEdition narrativeId={narrative.id} />
+        </Security>
+      )}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEdition.jsx
@@ -7,6 +7,7 @@ import inject18n from '../../../../components/i18n';
 import NarrativeEditionContainer from './NarrativeEditionContainer';
 import { narrativeEditionOverviewFocus } from './NarrativeEditionOverview';
 import Loader from '../../../../components/Loader';
+import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 
 export const narrativeEditionQuery = graphql`
   query NarrativeEditionContainerQuery($id: String!) {
@@ -39,6 +40,7 @@ class NarrativeEdition extends Component {
               <NarrativeEditionContainer
                 narrative={props.narrative}
                 handleClose={this.handleClose.bind(this)}
+                controlledDial={EditEntityControlledDial}
               />
             );
           }

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionContainer.jsx
@@ -4,11 +4,14 @@ import { useFormatter } from '../../../../components/i18n';
 import NarrativeEditionOverview from './NarrativeEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const NarrativeEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
-  const { handleClose, narrative, open } = props;
+  const { handleClose, narrative, open, controlledDial } = props;
   const { editContext } = narrative;
 
   return (
@@ -16,8 +19,9 @@ const NarrativeEditionContainer = (props) => {
       title={t_i18n('Update a narrative')}
       open={open}
       onClose={handleClose}
-      variant={open == null ? DrawerVariant.update : undefined}
+      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
+      controlledDial={FABReplaced ? controlledDial : undefined}
     >
       <NarrativeEditionOverview
         narrative={narrative}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.jsx
@@ -22,6 +22,9 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
+import NarrativeEdition from './NarrativeEdition';
 
 const subscription = graphql`
   subscription RootNarrativeSubscription($id: ID!) {
@@ -135,6 +138,11 @@ class RootNarrative extends Component {
                         entityType="Narrative"
                         stixDomainObject={props.narrative}
                         PopoverComponent={<NarrativePopover />}
+                        EditComponent={(
+                          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                            <NarrativeEdition narrativeId={narrative.id} />
+                          </Security>
+                        )}
                       />
                       <Box
                         sx={{


### PR DESCRIPTION
### Proposed changes

* Replace the floating action button for editing techniques with a dedicated button in the top right the page.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
