### PR TITLE
[CI] On multi-repository build, client python version is not taken during api-tests (#7763)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,9 @@ name: opencti-tests
 steps:
   - name: dependencies-checkout
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
+    volumes:
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       GITHUB_TOKEN:
           from_secret: github_token
@@ -15,15 +18,16 @@ steps:
       - ls -lart
       - cd "$DRONE_WORKSPACE/client-python"
       - echo "[INFO] using client-python on branch $(git branch --show-current)"
-      - pip3 install --upgrade --force .
+      - pip install -e .[dev,doc]
+      - pip3 show pycti
 
   - name: api-tests
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
     - name: cache-node-backend
       path: /drone/src/opencti-platform/opencti-graphql/node_modules
-    - name: cache-python-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__BASE_URL: http://api-tests:4010/
       APP__ADMIN__PASSWORD: admin
@@ -46,14 +50,12 @@ steps:
     commands:
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools
-      - echo "DRONE_WORKSPACE=$DRONE_WORKSPACE"
-      - echo "DRONE_WORKSPACE=${DRONE_WORKSPACE}"
+      - pip3 show pycti
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - yarn install
       - yarn build
       - yarn check-ts
       - yarn lint
-      - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
       - dependencies-checkout
@@ -73,8 +75,6 @@ steps:
     volumes:
     - name: cache-node-frontend
       path: /drone/src/opencti-platform/opencti-front/node_modules
-    - name: cache-python-frontend
-      path: /usr/lib/python3.11
     commands:
       - apk add git tini gcc g++ make musl-dev cargo python3 python3-dev postfix postfix-pcre
       - npm install -g node-gyp
@@ -182,13 +182,13 @@ services:
     volumes:
     - name: cache-node-raw-start-backend
       path: /tmp/raw-start-platform/opencti-graphql/node_modules
-    - name: cache-python-raw-start-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4100
       APP__ADMIN__PASSWORD: admin
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
-      APP_APP_LOG_EXTENDED_ERROR_MESSAGE: true
+      APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: raw-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -213,13 +213,13 @@ services:
     volumes:
     - name: cache-node-live-start-backend
       path: /tmp/live-start-platform/opencti-graphql/node_modules
-    - name: cache-python-live-start-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4200
       APP__ADMIN__PASSWORD: admin
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
-      APP_APP_LOG_EXTENDED_ERROR_MESSAGE: true
+      APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: live-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -243,13 +243,13 @@ services:
     volumes:
     - name: cache-node-direct-start-backend
       path: //tmp/direct-start-platform/opencti-graphql/node_modules
-    - name: cache-python-direct-start-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4300
       APP__ADMIN__PASSWORD: admin
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
-      APP_APP_LOG_EXTENDED_ERROR_MESSAGE: true
+      APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: direct-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -271,8 +271,10 @@ services:
   - name: opencti-direct-worker
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
-    - name: cache-python-worker
-      path: /usr/lib/python3.11
+    - name: cache-node-direct-start-backend
+      path: /tmp/direct-start-platform/node_modules
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       OPENCTI_URL: http://opencti-direct-start:4300
       OPENCTI_TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -290,13 +292,13 @@ services:
     volumes:
     - name: cache-node-restore-start-backend
       path: /tmp/restore-start-platform/node_modules
-    - name: cache-python-restore-start-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4400
       APP__ADMIN__PASSWORD: admin
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
-      APP_APP_LOG_EXTENDED_ERROR_MESSAGE: true
+      APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: restore-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -320,14 +322,14 @@ services:
     volumes:
     - name: cache-node-e2e-start-backend
       path: /tmp/e2e-start-platform/node_modules
-    - name: cache-python-e2e-start-backend
-      path: /usr/lib/python3.11
+    - name: cache-python-all-steps
+      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4500
       APP__DISABLED_DEV_FEATURES: '["4352_BULK_RELATIONS"]'
       APP__ADMIN__PASSWORD: admin
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
-      APP_APP_LOG_EXTENDED_ERROR_MESSAGE: true
+      APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: e2e-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -375,30 +377,5 @@ volumes:
   - name: cache-node-frontend-e2e
     host:
       path: /tmp/cache-node-frontend-e2e
-  - name: cache-python-worker
-    host:
-      path: /tmp/cache-python-worker      
-  - name: cache-python-backend
-    host:
-      path: /tmp/cache-python-backend
-  - name: cache-python-frontend
-    host:
-      path: /tmp/cache-python-frontend
-  - name: cache-python-frontend-e2e
-    host:
-      path: /tmp/cache-python-frontend-e2e
-  - name: cache-python-raw-start-backend
-    host:
-      path: /tmp/cache-python-raw-start-backend
-  - name: cache-python-live-start-backend
-    host:
-      path: /tmp/cache-python-live-start-backend
-  - name: cache-python-direct-start-backend
-    host:
-      path: /tmp/cache-python-direct-start-backend
-  - name: cache-python-restore-start-backend
-    host:
-      path: /tmp/cache-python-restore-start-backend
-  - name: cache-python-e2e-start-backend
-    host:
-      path: /tmp/cache-python-e2e-start-backend
+  - name: cache-python-all-steps
+    temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,9 +5,6 @@ name: opencti-tests
 steps:
   - name: dependencies-checkout
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
-    volumes:
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       GITHUB_TOKEN:
           from_secret: github_token
@@ -18,16 +15,12 @@ steps:
       - ls -lart
       - cd "$DRONE_WORKSPACE/client-python"
       - echo "[INFO] using client-python on branch $(git branch --show-current)"
-      - pip install -e .[dev,doc]
-      - pip3 show pycti
 
   - name: api-tests
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:
     - name: cache-node-backend
       path: /drone/src/opencti-platform/opencti-graphql/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__BASE_URL: http://api-tests:4010/
       APP__ADMIN__PASSWORD: admin
@@ -50,7 +43,8 @@ steps:
     commands:
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools
-      - pip3 show pycti
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - yarn install
       - yarn build
@@ -182,8 +176,6 @@ services:
     volumes:
     - name: cache-node-raw-start-backend
       path: /tmp/raw-start-platform/opencti-graphql/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4100
       APP__ADMIN__PASSWORD: admin
@@ -204,6 +196,8 @@ services:
       - ls -lart
       - cp -a opencti-platform/* /tmp/raw-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd /tmp/raw-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
@@ -213,8 +207,6 @@ services:
     volumes:
     - name: cache-node-live-start-backend
       path: /tmp/live-start-platform/opencti-graphql/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4200
       APP__ADMIN__PASSWORD: admin
@@ -234,6 +226,8 @@ services:
       - sleep 10
       - cp -a opencti-platform/* /tmp/live-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd /tmp/live-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
@@ -243,8 +237,6 @@ services:
     volumes:
     - name: cache-node-direct-start-backend
       path: //tmp/direct-start-platform/opencti-graphql/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4300
       APP__ADMIN__PASSWORD: admin
@@ -264,6 +256,8 @@ services:
       - sleep 10
       - cp -a opencti-platform/* /tmp/direct-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd /tmp/direct-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
@@ -273,8 +267,6 @@ services:
     volumes:
     - name: cache-node-direct-start-backend
       path: /tmp/direct-start-platform/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       OPENCTI_URL: http://opencti-direct-start:4300
       OPENCTI_TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -283,6 +275,8 @@ services:
       - sleep 10
       - cp -a opencti-worker /tmp/direct-start-worker
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - while ! nc -z opencti-direct-start 4300 ; do sleep 1 ; done
       - cd /tmp/direct-start-worker
       - pip3 install -r src/requirements.txt
@@ -292,8 +286,6 @@ services:
     volumes:
     - name: cache-node-restore-start-backend
       path: /tmp/restore-start-platform/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4400
       APP__ADMIN__PASSWORD: admin
@@ -313,6 +305,8 @@ services:
       - sleep 10
       - cp -a opencti-platform/* /tmp/restore-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd /tmp/restore-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
@@ -322,8 +316,6 @@ services:
     volumes:
     - name: cache-node-e2e-start-backend
       path: /tmp/e2e-start-platform/node_modules
-    - name: cache-python-all-steps
-      path: /usr/local/lib/python3.11
     environment:
       APP__PORT: 4500
       APP__DISABLED_DEV_FEATURES: '["4352_BULK_RELATIONS"]'
@@ -344,6 +336,8 @@ services:
     commands:
       - cp -a opencti-platform/* /tmp/e2e-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cd "$DRONE_WORKSPACE/client-python"
+      - pip install -e .[dev,doc]
       - cd /tmp/e2e-start-platform/opencti-graphql
       - yarn install
       - yarn install:python
@@ -377,5 +371,3 @@ volumes:
   - name: cache-node-frontend-e2e
     host:
       path: /tmp/cache-node-frontend-e2e
-  - name: cache-python-all-steps
-    temp: {}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove cache for python build
* build python client locally on every steps that requires pycti.
* use same pip command to build as we use for development

Also
* fix a typo on extended log env var

Tested on https://github.com/OpenCTI-Platform/opencti/pull/7764 (when issues, build is failling on loader-test step)

An alternative to build client python only once would be to use a temporary cache instead, since it's adviced for sharing volume accross steps. https://docs.drone.io/pipeline/kubernetes/syntax/volumes/temporary/

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #7763 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
