### PR TITLE
[frontend] Retain Search in UI for Indicator > Knowledge/Sightings (#7754)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
@@ -113,6 +113,7 @@ const EntityStixSightingRelationships: FunctionComponent<EntityStixSightingRelat
     orderAsc,
     openExports,
     filters,
+    searchTerm,
     numberOfElements,
   } = viewStorage;
 
@@ -195,6 +196,7 @@ const EntityStixSightingRelationships: FunctionComponent<EntityStixSightingRelat
           handleSwitchLocalMode={helpers.handleSwitchLocalMode}
           handleToggleExports={disableExport ? null : helpers.handleToggleExports}
           filters={filters}
+          keyword={searchTerm}
           availableFilterKeys={[
             'toTypes',
             'objectLabel',

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntities.jsx
@@ -31,6 +31,7 @@ const IndicatorEntities = ({ indicatorId, relationshipType, defaultStartTime, de
     sortBy,
     orderAsc,
     filters,
+    searchTerm,
   } = viewStorage;
   const paginationOptions = {
     ...rawPaginationOptions,
@@ -101,6 +102,7 @@ const IndicatorEntities = ({ indicatorId, relationshipType, defaultStartTime, de
         secondaryAction={true}
         noBottomPadding={true}
         filters={filters}
+        keyword={searchTerm}
         paginationOptions={paginationOptions}
         entityTypes={['stix-core-relationship']}
       >


### PR DESCRIPTION
### Proposed changes
Retain search keyword in UI for some screens:
- Indicator > Knowledge
- Indicator > Sightings

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7754