### PR TITLE
[backend] get all report's properties when using csv mapper (#6947)

### DIFF
--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
@@ -12,9 +12,9 @@ import { resolveUserByIdFromCache } from '../../domain/user';
 import { parseCsvMapper } from '../../modules/internal/csvMapper/csvMapper-utils';
 import type { ConnectorConfig } from '../connector';
 import { IMPORT_CSV_CONNECTOR } from './importCsv';
-import { internalLoadById } from '../../database/middleware-loader';
 import { DatabaseError, FunctionalError } from '../../config/errors';
 import { uploadToStorage } from '../../database/file-storage-helper';
+import { storeLoadByIdWithRefs } from '../../database/middleware';
 
 const RETRY_CONNECTION_PERIOD = 10000;
 
@@ -43,7 +43,7 @@ const initImportCsvConnector = () => {
     const fileId = messageParsed.event.file_id;
     const applicantUser = await resolveUserByIdFromCache(context, applicantId) as AuthUser;
     const entityId = messageParsed.event.entity_id;
-    const entity = entityId ? await internalLoadById(context, applicantUser, entityId) : undefined;
+    const entity = entityId ? await storeLoadByIdWithRefs(context, applicantUser, entityId) : undefined;
     let parsedConfiguration;
     try {
       parsedConfiguration = JSON.parse(messageParsed.configuration);

--- a/opencti-platform/opencti-graphql/src/database/stix-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-converter.ts
@@ -572,20 +572,8 @@ const convertAttackPatternToStix = (instance: StoreEntity, type: string): SDO.St
 const convertReportToStix = (instance: StoreEntity, type: string): SDO.StixReport => {
   assertType(ENTITY_TYPE_CONTAINER_REPORT, type);
   const report = buildStixDomain(instance);
-  const completeReport = {
-    ...report,
-    created_by_ref: report['created_by_ref'] ?? instance['created-by'],
-    object_marking_refs: report['object_marking_refs'].length ? report['object_marking_refs'] : instance['object-marking'],
-    extensions: {
-      [STIX_EXT_OCTI]: {
-        ...report['extensions'][STIX_EXT_OCTI],
-        assignee_ids_refs: report['extensions'][STIX_EXT_OCTI]['assignee_ids'] ?? instance['object-assignee'],
-        participant_ids_refs: report['extensions'][STIX_EXT_OCTI]['assignee_ids'] ?? instance['object-participant']
-      },
-    }
-  };
   return {
-    ...completeReport,
+    ...report,
     name: instance.name,
     description: instance.description,
     report_types: instance.report_types,
@@ -593,7 +581,7 @@ const convertReportToStix = (instance: StoreEntity, type: string): SDO.StixRepor
     object_refs: convertObjectReferences(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
-        ...completeReport.extensions[STIX_EXT_OCTI],
+        ...report.extensions[STIX_EXT_OCTI],
         extension_type: 'property-extension',
         content: instance.content,
         content_mapping: instance.content_mapping,

--- a/opencti-platform/opencti-graphql/src/database/stix-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-converter.ts
@@ -572,8 +572,20 @@ const convertAttackPatternToStix = (instance: StoreEntity, type: string): SDO.St
 const convertReportToStix = (instance: StoreEntity, type: string): SDO.StixReport => {
   assertType(ENTITY_TYPE_CONTAINER_REPORT, type);
   const report = buildStixDomain(instance);
-  return {
+  const completeReport = {
     ...report,
+    created_by_ref: report['created_by_ref'] ?? instance['created-by'],
+    object_marking_refs: report['object_marking_refs'].length ? report['object_marking_refs'] : instance['object-marking'],
+    extensions: {
+      [STIX_EXT_OCTI]: {
+        ...report['extensions'][STIX_EXT_OCTI],
+        assignee_ids_refs: report['extensions'][STIX_EXT_OCTI]['assignee_ids'] ?? instance['object-assignee'],
+        participant_ids_refs: report['extensions'][STIX_EXT_OCTI]['assignee_ids'] ?? instance['object-participant']
+      },
+    }
+  };
+  return {
+    ...completeReport,
     name: instance.name,
     description: instance.description,
     report_types: instance.report_types,
@@ -581,7 +593,7 @@ const convertReportToStix = (instance: StoreEntity, type: string): SDO.StixRepor
     object_refs: convertObjectReferences(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
-        ...report.extensions[STIX_EXT_OCTI],
+        ...completeReport.extensions[STIX_EXT_OCTI],
         extension_type: 'property-extension',
         content: instance.content,
         content_mapping: instance.content_mapping,


### PR DESCRIPTION
### Proposed changes

- use the right method to get all properties with ref

### Related issues

- close #6947 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- multi repository : client-python https://github.com/OpenCTI-Platform/client-python/pull/708