### PR TITLE
[backend/frontend] improve group and users display performance (#7533)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -70,22 +70,12 @@ const groupFragment = graphql`
     no_creators
     group_confidence_level {
       max_confidence
-      overrides{
+      overrides {
         max_confidence
         entity_type
       }
     }
     description
-    members {
-      edges {
-        node {
-          ...UserLine_node
-        }
-      }
-    }
-    group_confidence_level {
-      max_confidence
-    }
     default_dashboard {
       id
       name

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
@@ -17,7 +17,6 @@ const subscription = graphql`
     subscription RootGroupsSubscription($id: ID!) {
         group(id: $id) {
             ...Group_group
-            ...GroupEditionContainer_group
         }
     }
 `;
@@ -32,11 +31,6 @@ const groupQuery = graphql`
       id
       name
       ...Group_group
-      @arguments(
-        rolesOrderBy: $rolesOrderBy
-        rolesOrderMode: $rolesOrderMode
-      )
-      ...GroupEditionContainer_group
       @arguments(
         rolesOrderBy: $rolesOrderBy
         rolesOrderMode: $rolesOrderMode

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -226,10 +226,10 @@ export const groupEditDefaultMarking = async (context, user, groupId, defaultMar
 
 export const groupCleanContext = async (context, user, groupId) => {
   await delEditContext(user, groupId);
-  return storeLoadById(context, user, groupId, ENTITY_TYPE_GROUP).then((group) => notify(BUS_TOPICS.Group.EDIT_TOPIC, group, user));
+  return storeLoadById(context, user, groupId, ENTITY_TYPE_GROUP); // notify removed for performance issues with users cache
 };
 
 export const groupEditContext = async (context, user, groupId, input) => {
   await setEditContext(user, groupId, input);
-  return storeLoadById(context, user, groupId, ENTITY_TYPE_GROUP).then((group) => notify(BUS_TOPICS.Group.EDIT_TOPIC, group, user));
+  return storeLoadById(context, user, groupId, ENTITY_TYPE_GROUP); // notify removed for performance issues with users cache
 };

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -14,6 +14,7 @@ import {
   authenticateUser,
   batchCreator,
   batchRolesForUsers,
+  batchUserEffectiveConfidenceLevel,
   bookmarks,
   buildCompleteUser,
   deleteBookmark,
@@ -61,6 +62,7 @@ import { executionContext, REDACTED_USER } from '../utils/access';
 import { getNotifiers } from '../modules/notifier/notifier-domain';
 
 const rolesUsersLoader = batchLoader(batchRolesForUsers);
+const usersConfidenceLoader = batchLoader(batchUserEffectiveConfidenceLevel);
 const creatorLoader = batchLoader(batchCreator);
 
 const userResolvers = {
@@ -85,7 +87,7 @@ const userResolvers = {
     objectOrganization: (current, args, context) => userOrganizationsPaginated(context, context.user, current.id, args),
     editContext: (current) => fetchEditContext(current.id),
     sessions: (current) => findUserSessions(current.id),
-    effective_confidence_level: (current, args, context) => getUserEffectiveConfidenceLevel(current, context),
+    effective_confidence_level: (current, args, context) => usersConfidenceLoader.load(current, context, context.user),
     personal_notifiers: (current, _, context) => getNotifiers(context, context.user, current.personal_notifiers),
   },
   Member: {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Simplify group queries on group loading (no need for members since they are loaded in a separate query, ...)
* Remove notify on group edit context and group clean context => it was resetting the cache of users every time we were displaying a group.
* use batch loading for users effective confidence level
=> Overall performance improved by x10 locally 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7533

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
