### PR TITLE
[frontend/backend] Fix default value of variable "first" that cannot be null (#7905)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -3062,7 +3062,7 @@ const WorkbenchFileContentComponent = ({
                 filters: [{ key: 'definition', values: [object.name] }],
                 filterGroups: [],
               },
-              count: 1,
+              first: 1,
             }}
             render={({ props }) => {
               if (props && props.markingDefinitions) {

--- a/opencti-platform/opencti-front/src/private/components/settings/marking_definitions/MarkingDefinitionsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/marking_definitions/MarkingDefinitionsLines.jsx
@@ -8,8 +8,8 @@ import { MarkingDefinitionLine, MarkingDefinitionLineDummy } from './MarkingDefi
 const nbOfRowsToLoad = 50;
 
 export const markingDefinitionsLinesSearchQuery = graphql`
-  query MarkingDefinitionsLinesSearchQuery($search: String, $filters: FilterGroup, $count: Int) {
-    markingDefinitions(search: $search, filters: $filters, first: $count) {
+  query MarkingDefinitionsLinesSearchQuery($search: String, $filters: FilterGroup, $first: Int) {
+    markingDefinitions(search: $search, filters: $filters, first: $first) {
       edges {
         node {
           id

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -2550,7 +2550,8 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
 
 const elQueryBodyBuilder = async (context, user, options) => {
   // eslint-disable-next-line no-use-before-define
-  const { ids = [], first = ES_DEFAULT_PAGINATION, after, orderBy = null, orderMode = 'asc', noSize = false, noSort = false, intervalInclude = false } = options;
+  const { ids = [], after, orderBy = null, orderMode = 'asc', noSize = false, noSort = false, intervalInclude = false } = options;
+  const first = options.first ?? ES_DEFAULT_PAGINATION;
   const { types = null, search = null } = options;
   const filters = checkAndConvertFilters(options.filters, { noFiltersChecking: options.noFiltersChecking });
   const { startDate = null, endDate = null, dateAttribute = null } = options;
@@ -2947,7 +2948,8 @@ export const elAggregationsList = async (context, user, indexName, aggregations,
 
 export const elPaginate = async (context, user, indexName, options = {}) => {
   // eslint-disable-next-line no-use-before-define
-  const { baseData = false, baseFields = BASE_FIELDS, bypassSizeLimit = false, first = ES_DEFAULT_PAGINATION } = options;
+  const { baseData = false, baseFields = BASE_FIELDS, bypassSizeLimit = false } = options;
+  const first = options.first ?? ES_DEFAULT_PAGINATION;
   const { types = null, connectionFormat = true } = options;
   const body = await elQueryBodyBuilder(context, user, options);
   if (body.size > ES_MAX_PAGINATION && !bypassSizeLimit) {
@@ -2974,7 +2976,8 @@ export const elPaginate = async (context, user, indexName, options = {}) => {
     );
 };
 export const elList = async (context, user, indexName, opts = {}) => {
-  const { first = ES_DEFAULT_PAGINATION, maxSize = undefined } = opts;
+  const { maxSize = undefined } = opts;
+  const first = opts.first ?? ES_DEFAULT_PAGINATION;
   let emitSize = 0;
   let hasNextPage = true;
   let continueProcess = true;
@@ -2994,7 +2997,7 @@ export const elList = async (context, user, indexName, opts = {}) => {
     const paginateOpts = { ...opts, first, after: searchAfter, connectionFormat: false };
     const elements = await elPaginate(context, user, indexName, paginateOpts);
     emitSize += elements.length;
-    const noMoreElements = elements.length === 0 || elements.length < (first ?? ES_DEFAULT_PAGINATION);
+    const noMoreElements = elements.length === 0 || elements.length < first;
     const moreThanMax = maxSize ? emitSize >= maxSize : false;
     if (noMoreElements || moreThanMax) {
       if (elements.length > 0) {
@@ -3023,7 +3026,8 @@ export const elLoadBy = async (context, user, field, value, type = null, indices
   return R.head(hits);
 };
 export const elAttributeValues = async (context, user, field, opts = {}) => {
-  const { first, orderMode = 'asc', search } = opts;
+  const { orderMode = 'asc', search } = opts;
+  const first = opts.first ?? ES_DEFAULT_PAGINATION;
   const markingRestrictions = await buildDataRestrictions(context, user);
   const must = [];
   if (isNotEmptyField(search) && search.length > 0) {
@@ -3048,7 +3052,7 @@ export const elAttributeValues = async (context, user, field, opts = {}) => {
       values: {
         terms: {
           field: buildFieldForQuery(field),
-          size: first ?? ES_DEFAULT_PAGINATION,
+          size: first,
           order: { _key: orderMode },
         },
       },

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/markingDefinition-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/markingDefinition-test.js
@@ -89,6 +89,11 @@ describe('MarkingDefinition resolver standard behavior', () => {
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 20 } });
     expect(queryResult.data.markingDefinitions.edges.length).toEqual(12);
   });
+  it('should list markingDefinitions without option "first"', async () => {
+    // https://github.com/OpenCTI-Platform/opencti/issues/7905
+    const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: {} });
+    expect(queryResult.data.markingDefinitions.edges.length).toEqual(12);
+  });
   it('should update markingDefinition', async () => {
     const UPDATE_QUERY = gql`
       mutation MarkingDefinitionEdit($id: ID!, $input: [EditInput]!) {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/markingDefinition-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/markingDefinition-test.js
@@ -91,7 +91,7 @@ describe('MarkingDefinition resolver standard behavior', () => {
   });
   it('should list markingDefinitions without option "first"', async () => {
     // https://github.com/OpenCTI-Platform/opencti/issues/7905
-    const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: {} });
+    const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: null } });
     expect(queryResult.data.markingDefinitions.edges.length).toEqual(12);
   });
   it('should update markingDefinition', async () => {


### PR DESCRIPTION
### Proposed changes

* In front: change count variable of markings query to first to sync with backend name
* In back: avoid passing null to Elastic for pagination because not acceptable value

### Related issues

* #7905 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Elastic does not accept `null` value for its "size" parameter. Which correspond to the "first" option in our backend. We manage this option with a default value in case it was `undefined` but not when it was `null`. Now both cases fall back in default value.