### PR TITLE
[backend] Improve Attack Pattern knowledge matrix view performance (#6662)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrix.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrix.jsx
@@ -35,14 +35,6 @@ class AttackPatternsMatrix extends Component {
       <div className={classes.container}>
         <QueryRenderer
           query={attackPatternsMatrixColumnsQuery}
-          variables={{
-            count: 5000,
-            filters: {
-              mode: 'and',
-              filters: [{ key: 'revoked', values: ['false'] }],
-              filterGroups: [],
-            },
-          }}
           render={({ props }) => {
             if (props) {
               return (

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
@@ -233,7 +233,7 @@ class AttackPatternsMatrixColumnsComponent extends Component {
   level(attackPattern, maxNumberOfSameAttackPattern) {
     const { attackPatterns } = this.props;
     const numberOfCorrespondingAttackPatterns = R.filter(
-      (n) => n.id === attackPattern.id
+      (n) => n.id === attackPattern.attack_pattern_id
         || (attackPattern.subAttackPatternsIds
           && R.includes(n.id, attackPattern.subAttackPatternsIds)),
       attackPatterns,
@@ -306,8 +306,9 @@ class AttackPatternsMatrixColumnsComponent extends Component {
       .map((a) => {
         return {
           ...a,
+          id: a.kill_chain_id,
           attackPatterns: R.sortBy(R.prop('name'), a.attackPatterns.filter(filterByKeyword).map((ap) => {
-            return { ...ap, level: this.level(ap, maxNumberOfSameAttackPattern) };
+            return { ...ap, id: ap.attack_pattern_id, level: this.level(ap, maxNumberOfSameAttackPattern) };
           })).filter((o) => (modeOnlyActive ? o.level > 0 : o.level >= 0)),
         };
       });
@@ -500,12 +501,12 @@ const AttackPatternsMatrixColumns = createRefetchContainer(
       fragment AttackPatternsMatrixColumns_data on Query {
         attackPatternsMatrix {
           attackPatternsOfPhases {
-            id
+            kill_chain_id
             kill_chain_name
             phase_name
             x_opencti_order
             attackPatterns {
-              id
+              attack_pattern_id
               name
               description
               x_mitre_id

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
@@ -280,8 +280,6 @@ class AttackPatternsMatrixColumnsComponent extends Component {
     if (R.isNil(modeColorsReversed)) {
       modeColorsReversed = this.state.currentColorsReversed;
     }
-    const sortByOrder = R.sortBy(R.prop('x_opencti_order'));
-    const sortByName = R.sortBy(R.prop('name'));
     const filterByKeyword = (n) => searchTerm === ''
       || n.name.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1
       || n.description?.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1
@@ -302,63 +300,17 @@ class AttackPatternsMatrixColumnsComponent extends Component {
         R.values,
       )(selectedPatterns),
     );
-    const filterSubattackPattern = (n) => n.isSubAttackPattern === false;
-    const attackPatterns = R.pipe(
-      R.map((n) => ({
-        ...n.node,
-        subAttackPatternsIds: R.map(
-          (o) => o.node.id,
-          n.node.subAttackPatterns.edges,
-        ),
-      })),
-      R.map((n) => ({
-        ...n,
-        level: this.level(n, maxNumberOfSameAttackPattern),
-        subattackPatterns_text: R.pipe(
-          R.map(
-            (o) => `${o.node.x_mitre_id} ${o.node.name} ${o.node.description}`,
-          ),
-          R.join(' | '),
-        )(R.pathOr([], ['subAttackPatterns', 'edges'], n)),
-        subAttackPatterns: R.pipe(
-          R.map((o) => R.assoc(
-            'level',
-            this.level(o.node, maxNumberOfSameAttackPattern),
-            o.node,
-          )),
-          sortByName,
-        )(n.subAttackPatterns.edges),
-        killChainPhasesIds: R.map((o) => o.id, n.killChainPhases),
-      })),
-      R.filter(filterSubattackPattern),
-      R.filter(filterByKeyword),
-      R.filter((o) => (modeOnlyActive ? o.level > 0 : o.level >= 0)),
-    )(data.attackPatterns.edges);
-    const killChainPhases = R.pipe(
-      R.map((n) => n.node.killChainPhases),
-      R.flatten,
-      R.uniq,
-      R.filter((n) => n.kill_chain_name === this.state.currentKillChain),
-      sortByOrder,
-    )(data.attackPatterns.edges);
-    const killChains = R.uniq([
-      'mitre-attack',
-      ...R.pipe(
-        R.map((n) => n.node.killChainPhases),
-        R.flatten,
-        R.map((n) => n.kill_chain_name),
-      )(data.attackPatterns.edges),
-    ]);
-    const attackPatternsOfPhases = R.map(
-      (n) => ({
-        ...n,
-        attackPatterns: R.pipe(
-          R.filter((o) => R.includes(n.id, o.killChainPhasesIds)),
-          sortByName,
-        )(attackPatterns),
-      }),
-      killChainPhases,
-    );
+    const killChains = R.sortBy(R.prop('name'), R.uniq(data.attackPatternsMatrix.attackPatternsOfPhases.map((a) => a.kill_chain_name)));
+    const attackPatternsOfPhases = data.attackPatternsMatrix.attackPatternsOfPhases
+      .filter((a) => a.kill_chain_name === this.state.currentKillChain)
+      .map((a) => {
+        return {
+          ...a,
+          attackPatterns: R.sortBy(R.prop('name'), a.attackPatterns.filter(filterByKeyword).map((ap) => {
+            return { ...ap, level: this.level(ap, maxNumberOfSameAttackPattern) };
+          })).filter((o) => (modeOnlyActive ? o.level > 0 : o.level >= 0)),
+        };
+      });
     let heightCalc = 310;
     let className = navOpen ? classes.containerNavOpen : classes.container;
     if (marginRight) {
@@ -536,21 +488,8 @@ AttackPatternsMatrixColumnsComponent.propTypes = {
 };
 
 export const attackPatternsMatrixColumnsQuery = graphql`
-  query AttackPatternsMatrixColumnsQuery(
-    $orderBy: AttackPatternsOrdering
-    $orderMode: OrderingMode
-    $count: Int!
-    $cursor: ID
-    $filters: FilterGroup
-  ) {
+  query AttackPatternsMatrixColumnsQuery {
     ...AttackPatternsMatrixColumns_data
-      @arguments(
-        orderBy: $orderBy
-        orderMode: $orderMode
-        count: $count
-        cursor: $cursor
-        filters: $filters
-      )
   }
 `;
 
@@ -558,46 +497,21 @@ const AttackPatternsMatrixColumns = createRefetchContainer(
   AttackPatternsMatrixColumnsComponent,
   {
     data: graphql`
-      fragment AttackPatternsMatrixColumns_data on Query
-      @argumentDefinitions(
-        orderBy: { type: "AttackPatternsOrdering", defaultValue: x_mitre_id }
-        orderMode: { type: "OrderingMode", defaultValue: asc }
-        count: { type: "Int", defaultValue: 25 }
-        cursor: { type: "ID" }
-        filters: { type: "FilterGroup" }
-      ) {
-        attackPatterns(
-          orderBy: $orderBy
-          orderMode: $orderMode
-          first: $count
-          after: $cursor
-          filters: $filters
-        ) {
-          edges {
-            node {
+      fragment AttackPatternsMatrixColumns_data on Query {
+        attackPatternsMatrix {
+          attackPatternsOfPhases {
+            id
+            kill_chain_name
+            phase_name
+            x_opencti_order
+            attackPatterns {
               id
-              entity_type
-              parent_types
               name
               description
-              isSubAttackPattern
               x_mitre_id
-              subAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              killChainPhases {
-                id
-                kill_chain_name
-                phase_name
-                x_opencti_order
-              }
+              subAttackPatternsIds
+              subattackPatterns_text
+              killChainPhasesIds
             }
           }
         }

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrixColumns.jsx
@@ -286,7 +286,7 @@ class AttackPatternsMatrixColumnsComponent extends Component {
       || R.propOr('', 'x_mitre_id', n)
         .toLowerCase()
         .indexOf(searchTerm.toLowerCase()) !== -1
-      || R.propOr('', 'subattackPatterns_text', n)
+      || R.propOr('', 'subAttackPatternsSearchText', n)
         .toLowerCase()
         .indexOf(searchTerm.toLowerCase()) !== -1;
     const maxNumberOfSameAttackPattern = Math.max(
@@ -510,7 +510,7 @@ const AttackPatternsMatrixColumns = createRefetchContainer(
               description
               x_mitre_id
               subAttackPatternsIds
-              subattackPatterns_text
+              subAttackPatternsSearchText
               killChainPhasesIds
             }
           }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2533,7 +2533,7 @@ type AttackPatternForMatrix {
   description: String
   x_mitre_id: String
   subAttackPatternsIds: [String!]
-  subattackPatterns_text: String
+  subAttackPatternsSearchText: String
   killChainPhasesIds: [String!]
 }
 

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2483,9 +2483,9 @@ type AttackPattern implements BasicObject & StixObject & StixCoreObject & StixDo
   x_mitre_detection: String
   x_mitre_id: String
   killChainPhases: [KillChainPhase!]
-  coursesOfAction: CourseOfActionConnection
-  parentAttackPatterns: AttackPatternConnection
-  subAttackPatterns: AttackPatternConnection
+  coursesOfAction(first: Int, after: ID, orderBy: CoursesOfActionOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): CourseOfActionConnection
+  parentAttackPatterns(first: Int, after: ID, orderBy: AttackPatternsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): AttackPatternConnection
+  subAttackPatterns(first: Int, after: ID, orderBy: AttackPatternsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): AttackPatternConnection
   isSubAttackPattern: Boolean
   dataComponents: DataComponentConnection
   creators: [Creator!]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2527,6 +2527,28 @@ input AttackPatternAddInput {
   file: Upload
 }
 
+type AttackPatternForMatrix {
+  id: ID!
+  name: String!
+  description: String
+  x_mitre_id: String
+  subAttackPatternsIds: [String!]
+  subattackPatterns_text: String
+  killChainPhasesIds: [String!]
+}
+
+type AttackPatternsByKillChain {
+  id: ID!
+  kill_chain_name: String!
+  phase_name: String!
+  x_opencti_order: Int!
+  attackPatterns: [AttackPatternForMatrix!]
+}
+
+type AttackPatternsMatrix {
+  attackPatternsOfPhases: [AttackPatternsByKillChain!]
+}
+
 enum CampaignsOrdering {
   name
   first_seen
@@ -7591,6 +7613,7 @@ type Query {
   stixDomainObjectsDistribution(objectId: [String], relationship_type: [String], toTypes: [String], elementWithTargetTypes: [String], field: String!, dateAttribute: String, operation: StatsOperation!, limit: Int, order: String, types: [String], filters: FilterGroup, search: String): [Distribution]
   attackPattern(id: String): AttackPattern
   attackPatterns(first: Int, after: ID, orderBy: AttackPatternsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): AttackPatternConnection
+  attackPatternsMatrix: AttackPatternsMatrix
   campaign(id: String): Campaign
   campaigns(first: Int, after: ID, orderBy: CampaignsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): CampaignConnection
   campaignsTimeSeries(objectId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime!, interval: String!, relationship_type: [String]): [TimeSeries]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2528,7 +2528,7 @@ input AttackPatternAddInput {
 }
 
 type AttackPatternForMatrix {
-  id: ID!
+  attack_pattern_id: String!
   name: String!
   description: String
   x_mitre_id: String
@@ -2538,7 +2538,7 @@ type AttackPatternForMatrix {
 }
 
 type AttackPatternsByKillChain {
-  id: ID!
+  kill_chain_id: String!
   kill_chain_name: String!
   phase_name: String!
   x_opencti_order: Int!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2726,7 +2726,7 @@ input AttackPatternAddInput {
   file: Upload
 }
 type AttackPatternForMatrix {
-  id: ID! # Attack Pattern ID (internal id)
+  attack_pattern_id: String!
   name: String!
   description: String
   x_mitre_id: String
@@ -2735,7 +2735,7 @@ type AttackPatternForMatrix {
   killChainPhasesIds: [String!]
 }
 type AttackPatternsByKillChain {
-  id: ID! # Kill Chain ID (internal id)
+  kill_chain_id: String!
   kill_chain_name: String!
   phase_name: String!
   x_opencti_order: Int!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2731,7 +2731,7 @@ type AttackPatternForMatrix {
   description: String
   x_mitre_id: String
   subAttackPatternsIds: [String!]
-  subattackPatterns_text: String
+  subAttackPatternsSearchText: String
   killChainPhasesIds: [String!]
 }
 type AttackPatternsByKillChain {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2725,7 +2725,25 @@ input AttackPatternAddInput {
   update: Boolean
   file: Upload
 }
-
+type AttackPatternForMatrix {
+  id: ID! # Attack Pattern ID (internal id)
+  name: String!
+  description: String
+  x_mitre_id: String
+  subAttackPatternsIds: [String!]
+  subattackPatterns_text: String
+  killChainPhasesIds: [String!]
+}
+type AttackPatternsByKillChain {
+  id: ID! # Kill Chain ID (internal id)
+  kill_chain_name: String!
+  phase_name: String!
+  x_opencti_order: Int!
+  attackPatterns: [AttackPatternForMatrix!]
+}
+type AttackPatternsMatrix {
+  attackPatternsOfPhases: [AttackPatternsByKillChain!]
+}
 ############## Campaigns
 enum CampaignsOrdering {
   name
@@ -12699,6 +12717,7 @@ type Query {
     search: String
     toStix: Boolean
   ): AttackPatternConnection @auth(for: [KNOWLEDGE])
+  attackPatternsMatrix: AttackPatternsMatrix @auth(for: [KNOWLEDGE])
   campaign(id: String): Campaign @auth(for: [KNOWLEDGE])
   campaigns(
     first: Int

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2646,11 +2646,32 @@ type AttackPattern implements BasicObject & StixObject & StixCoreObject & StixDo
   x_mitre_detection: String
   x_mitre_id: String
   killChainPhases: [KillChainPhase!]
-  coursesOfAction: CourseOfActionConnection
-  parentAttackPatterns: AttackPatternConnection
-  subAttackPatterns: AttackPatternConnection
+  coursesOfAction(
+    first: Int
+    after: ID
+    orderBy: CoursesOfActionOrdering
+    orderMode: OrderingMode
+    filters: FilterGroup
+    search: String
+  ): CourseOfActionConnection
+  parentAttackPatterns(
+    first: Int
+    after: ID
+    orderBy: AttackPatternsOrdering
+    orderMode: OrderingMode
+    filters: FilterGroup
+    search: String
+  ): AttackPatternConnection
+  subAttackPatterns(
+    first: Int
+    after: ID
+    orderBy: AttackPatternsOrdering
+    orderMode: OrderingMode
+    filters: FilterGroup
+    search: String
+  ): AttackPatternConnection
   isSubAttackPattern: Boolean
-  dataComponents: DataComponentConnection
+  dataComponents: DataComponentConnection # TODO paginate ? is this API used ?
   # Technical
   creators: [Creator!]
   toStix: String

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -2991,7 +2991,7 @@ export const elAggregationRelationsCount = async (context, user, indexName, opti
 };
 
 export const elAggregationNestedTermsWithFilter = async (context, user, indexName, aggregation, opts = {}) => {
-  const { types = [], size = 500 } = opts;
+  const { types = [], size = ES_DEFAULT_PAGINATION } = opts;
   const { path, field, filter } = aggregation;
   const body = await elQueryBodyBuilder(context, user, { ...opts, noSize: true, noSort: true });
   body.size = 0;

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -1,6 +1,7 @@
 import * as R from 'ramda';
 import {
   buildPagination,
+  emptyPaginationResult,
   isEmptyField,
   isInferredIndex,
   isNotEmptyField,
@@ -10,7 +11,17 @@ import {
   READ_RELATIONSHIPS_INDICES,
   READ_RELATIONSHIPS_INDICES_WITHOUT_INFERRED
 } from './utils';
-import { elAggregationsList, elCount, elFindByIds, elList, elLoadById, elPaginate, ES_MINIMUM_FIXED_PAGINATION, UNIMPACTED_ENTITIES_ROLE } from './engine';
+import {
+  elAggregationNestedTerms,
+  elAggregationsList,
+  elCount,
+  elFindByIds,
+  elList,
+  elLoadById,
+  elPaginate,
+  ES_MINIMUM_FIXED_PAGINATION,
+  UNIMPACTED_ENTITIES_ROLE
+} from './engine';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_OBJECT, ABSTRACT_STIX_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
 import type { AuthContext, AuthUser } from '../types/user';
 import type {
@@ -31,6 +42,7 @@ import { ASSIGNEE_FILTER, CREATOR_FILTER, INSTANCE_REGARDING_OF, PARTICIPANT_FIL
 import { completeContextDataForEntity, publishUserAction } from '../listener/UserActionListener';
 import type { UserReadActionContextData } from '../listener/UserActionListener';
 import { extractEntityRepresentativeName } from './entity-representative';
+import { logApp } from '../config/conf';
 
 export interface FiltersWithNested extends Filter {
   nested?: Array<{
@@ -479,7 +491,11 @@ export const listEntitiesThroughRelationsPaginated = async <T extends BasicStore
     orderMode: args.orderMode ?? OrderingMode.Desc,
     filters: connectedFilters
   });
-  const entityPagination = await elPaginate(context, user, indices, paginateArgs) as StoreCommonConnection<T>;
+  const entityPagination = await elPaginate(context, user, indices, { ...paginateArgs }) as StoreCommonConnection<T>;
+  if (entityPagination.edges.length === 0) {
+    // no result, just return entityPagination, there is no relationships to find
+    return entityPagination;
+  }
   // As rel de-normalization are currently not directional, we need to post filters the result
   // Some entities could be found because of the none-directionality.
   const entityIds = entityPagination.edges.map((e) => e.node.internal_id);
@@ -506,6 +522,10 @@ export const listEntitiesThroughRelationsPaginated = async <T extends BasicStore
     filterGroups: [],
   };
   const connectedRelations = await listAllRelations<BasicStoreRelation>(context, user, relationType, { filters, connectionFormat: false });
+  if (connectedRelations.length === 0) {
+    // no connection found (because of relation direction), just return an empty result
+    return emptyPaginationResult();
+  }
   const relationsEntityMap = new Map();
   connectedRelations.forEach((relation) => {
     const id = reverse_relation ? relation.fromId : relation.toId;
@@ -528,6 +548,104 @@ export const listEntitiesThroughRelationsPaginated = async <T extends BasicStore
     edges: rebuildEdges,
     pageInfo: { ...entityPagination.pageInfo, globalCount: entityPagination.pageInfo.globalCount - (entityPagination.edges.length - rebuildEdges.length) },
   };
+};
+
+/* export const listEntitiesThroughRelationsPaginated2 = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, connectedEntityId: string,
+  relationType: string, entityType: string | string[], reverse_relation: boolean, args: EntityOptions<T> = {}): Promise<StoreCommonConnection<T>> => {
+  const entityTypes = Array.isArray(entityType) ? entityType : [entityType];
+  const { indices = READ_ENTITIES_INDICES, connectionFormat } = args;
+  if (connectionFormat === false) {
+    throw UnsupportedError('List connected entities paginated require connectionFormat option to true');
+  }
+  if (UNIMPACTED_ENTITIES_ROLE.includes(`${relationType}_to`)) {
+    throw UnsupportedError('List connected entities paginated cant be used', { type: entityType });
+  }
+  const connectedEntitiesIds = [connectedEntityId]; // TODO batch
+  const connectionsFilters: FilterGroupWithNested = {
+    mode: FilterMode.And,
+    filters: [
+      {
+        key: ['connections'],
+        values: [],
+        nested: [
+          { key: 'internal_id', values: connectedEntitiesIds },
+          ...(reverse_relation ? [] : [{ key: 'types', values: entityTypes }]),
+          { key: 'role', values: [reverse_relation ? '*_to' : '*_from'], operator: FilterOperator.Wildcard },
+        ],
+      }],
+    filterGroups: [],
+  };
+  const listArgs = { filters: connectionsFilters, connectionFormat: false, logQuery: true };
+  const connectedRelations = await listAllRelations<BasicStoreRelation>(context, user, relationType, listArgs);
+  // TODO refactor this code
+  const relationsEntityMap = new Map();
+  connectedRelations.forEach((relation) => {
+    const id = reverse_relation ? relation.fromId : relation.toId;
+    if (relationsEntityMap.has(id)) {
+      relationsEntityMap.set(id, [...relationsEntityMap.get(id), relation]);
+    } else {
+      relationsEntityMap.set(id, [relation]);
+    }
+  });
+  const rebuildEdges: BasicStoreCommonEdge<T>[] = [];
+  entityPagination.edges.forEach((edge) => {
+    const relatedRelations = relationsEntityMap.get(edge.node.id);
+    if (relatedRelations) {
+      const types = relatedRelations.map((relation: BasicStoreRelation) => (isInferredIndex(relation._index) ? 'inferred' : 'manual'));
+      const newEdge: BasicStoreCommonEdge<T> = { types, node: edge.node, cursor: edge.cursor };
+      rebuildEdges.push(newEdge);
+    }
+  });
+  return {
+    edges: rebuildEdges,
+    pageInfo: { ...entityPagination.pageInfo, globalCount: entityPagination.pageInfo.globalCount - (entityPagination.edges.length - rebuildEdges.length) },
+  };
+}; */
+export const findEntitiesIdsWithRelations = async (
+  context: AuthContext,
+  user: AuthUser,
+  connectedEntitiesIds: string[],
+  relationType: string,
+  entityType: string | string[],
+  reverse_relation: boolean
+) => {
+  const entityTypes = Array.isArray(entityType) ? entityType : [entityType];
+  const connectionsFilters: FilterGroupWithNested = {
+    mode: FilterMode.And,
+    filters: [
+      {
+        key: ['connections'],
+        values: [],
+        nested: [
+          { key: 'internal_id', values: connectedEntitiesIds },
+          ...(reverse_relation ? [] : [{ key: 'types', values: entityTypes }]),
+          { key: 'role', values: [reverse_relation ? `${relationType}_to` : `${relationType}_from`] },
+        ],
+      }],
+    filterGroups: [],
+  };
+  // TODO not working yet, need to find a way to filter the aggregation result with nested filter
+  // size: connectedEntitiesIds.length
+  const args = { filters: connectionsFilters, types: [relationType], resolveToRepresentative: false };
+  const aggregation = { field: 'connections.internal_id.keyword', path: 'connections' };
+  const aggregationResult = await elAggregationNestedTerms(context, user, READ_RELATIONSHIPS_INDICES, aggregation, args);
+  logApp.info('===== DEBUG ===== aggregationsList', { aggregationResult });
+  const resultEntityIds = aggregationResult.map((agg: { label: string; }) => agg.label)
+    .filter((id: string) => connectedEntitiesIds.includes(id)); // keep only ids we were looking for
+  return resultEntityIds;
+};
+export const batchListEntitiesThroughRelationsPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, connectedEntitiesIds: string[],
+  relationType: string, entityType: string | string[], reverse_relation: boolean, args: EntityOptions<T> = {}) => {
+  const resultMap = new Map();
+  for (let i = 0; i < connectedEntitiesIds.length; i += 1) {
+    const entityId = connectedEntitiesIds[i];
+    const result = await listEntitiesThroughRelationsPaginated(context, user, entityId, relationType, entityType, reverse_relation, args);
+    // logApp.info('result for entity', { entityId, result });
+    resultMap.set(entityId, result);
+  }
+  return connectedEntitiesIds.map((entityId) => {
+    return resultMap.get(entityId);
+  });
 };
 
 export const loadEntityThroughRelationsPaginated = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, connectedEntityId: string,

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -577,8 +577,8 @@ export const findEntitiesIdsWithRelations = async (
   const aggFilter = {
     bool: { filter: [{ term: { 'connections.role.keyword': connectionRole } }] }
   };
-  // TODO size: connectedEntitiesIds.length
-  const args = { filters: connectionsFilters, types: [relationType], resolveToRepresentative: false };
+  const aggSize = connectedEntitiesIds.length;
+  const args = { filters: connectionsFilters, types: [relationType], size: aggSize };
   const aggregation = { field: 'connections.internal_id.keyword', path: 'connections', filter: aggFilter };
   const aggregationResult = await elAggregationNestedTermsWithFilter(context, user, READ_RELATIONSHIPS_INDICES, aggregation, args);
   const resultEntityIds = aggregationResult.map((agg: { label: string; }) => agg.label)
@@ -591,7 +591,6 @@ export const batchListEntitiesThroughRelationsPaginated = async <T extends Basic
   for (let i = 0; i < connectedEntitiesIds.length; i += 1) {
     const entityId = connectedEntitiesIds[i];
     const result = await listEntitiesThroughRelationsPaginated(context, user, entityId, relationType, entityType, reverse_relation, args);
-    // logApp.info('result for entity', { entityId, result });
     resultMap.set(entityId, result);
   }
   return connectedEntitiesIds.map((entityId) => {

--- a/opencti-platform/opencti-graphql/src/database/utils.js
+++ b/opencti-platform/opencti-graphql/src/database/utils.js
@@ -220,6 +220,19 @@ export const fromBase64 = (base64String) => {
   return buff.toString('utf-8');
 };
 
+export const emptyPaginationResult = () => {
+  return {
+    edges: [],
+    pageInfo: {
+      startCursor: '',
+      endCursor: '',
+      hasNextPage: false,
+      hasPreviousPage: false,
+      globalCount: 0,
+    }
+  };
+};
+
 export const buildPagination = (limit, searchAfter, instances, globalCount) => {
   const edges = R.pipe(
     R.mapObjIndexed((record) => {

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -1,5 +1,5 @@
 import { createEntity } from '../database/middleware';
-import { BUS_TOPICS, logApp } from '../config/conf';
+import { BUS_TOPICS } from '../config/conf';
 import { notify } from '../database/redis';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION, ENTITY_TYPE_DATA_COMPONENT } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
@@ -49,7 +49,6 @@ export const isSubAttackPattern = async (context: AuthContext, user: AuthUser, a
 };
 export const batchIsSubAttackPattern = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
   const resultIds = await findEntitiesIdsWithRelations(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false);
-  logApp.info('===== DEBUG ===== batchIsSubAttackPattern', { resultIds });
   return attackPatternsIds.map((id) => {
     return resultIds.includes(id);
   });

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -90,7 +90,7 @@ export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUs
       })
       .map((attackPattern) => {
         const subAttackPatternsIds: string[] = [];
-        let subattackPatterns_text: string = '';
+        let subAttackPatternsSearchText: string = '';
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         if (attackPattern[RELATION_SUBTECHNIQUE_OF]) {
@@ -100,7 +100,7 @@ export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUs
               const subAttackPattern = allAttackPatternsById.get(s.fromId);
               if (subAttackPattern) {
                 subAttackPatternsIds.push(subAttackPattern.id);
-                subattackPatterns_text += `${subAttackPattern.x_mitre_id} ${subAttackPattern.name} ${subAttackPattern.description} | `;
+                subAttackPatternsSearchText += `${subAttackPattern.x_mitre_id} ${subAttackPattern.name} ${subAttackPattern.description} | `;
               }
             });
           }
@@ -111,7 +111,7 @@ export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUs
           description: attackPattern.description,
           x_mitre_id: attackPattern.x_mitre_id,
           subAttackPatternsIds,
-          subattackPatterns_text,
+          subAttackPatternsSearchText,
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           killChainPhasesIds: [...attackPattern[RELATION_KILL_CHAIN_PHASE]],

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -1,10 +1,17 @@
 import { createEntity } from '../database/middleware';
-import { BUS_TOPICS } from '../config/conf';
+import { BUS_TOPICS, logApp } from '../config/conf';
 import { notify } from '../database/redis';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION, ENTITY_TYPE_DATA_COMPONENT } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { RELATION_DETECTS, RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../schema/stixCoreRelationship';
-import { type EntityOptions, listEntities, listEntitiesThroughRelationsPaginated, storeLoadById } from '../database/middleware-loader';
+import {
+  batchListEntitiesThroughRelationsPaginated,
+  type EntityOptions,
+  findEntitiesIdsWithRelations,
+  listEntities,
+  listEntitiesThroughRelationsPaginated,
+  storeLoadById
+} from '../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../types/user';
 import type { BasicStoreCommon } from '../types/store';
 import type { AttackPatternAddInput } from '../generated/graphql';
@@ -25,14 +32,27 @@ export const addAttackPattern = async (context: AuthContext, user: AuthUser, att
 export const parentAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
   return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false, args);
 };
+export const batchParentAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[], args: EntityOptions<BasicStoreCommon>) => {
+  return batchListEntitiesThroughRelationsPaginated(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false, args);
+};
 
 export const childAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
   return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, args);
+};
+export const batchChildAttackPatternsPaginated = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[], args: EntityOptions<BasicStoreCommon>) => {
+  return batchListEntitiesThroughRelationsPaginated(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, args);
 };
 
 export const isSubAttackPattern = async (context: AuthContext, user: AuthUser, attackPatternId: string) => {
   const pagination = await parentAttackPatternsPaginated(context, user, attackPatternId, { first: 1 });
   return pagination.edges.length > 0;
+};
+export const batchIsSubAttackPattern = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
+  const resultIds = await findEntitiesIdsWithRelations(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, false);
+  logApp.info('===== DEBUG ===== batchIsSubAttackPattern', { resultIds });
+  return attackPatternsIds.map((id) => {
+    return resultIds.includes(id);
+  });
 };
 
 export const coursesOfActionPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -106,7 +106,7 @@ export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUs
           }
         }
         return {
-          id: attackPattern.id,
+          attack_pattern_id: attackPattern.id,
           name: attackPattern.name,
           description: attackPattern.description,
           x_mitre_id: attackPattern.x_mitre_id,
@@ -119,7 +119,7 @@ export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUs
       });
     if (phaseAttackPatterns.length > 0) {
       attackPatternsOfPhases.push({
-        id: killChainPhase.id,
+        kill_chain_id: killChainPhase.id,
         kill_chain_name: killChainPhase.kill_chain_name,
         phase_name: killChainPhase.phase_name,
         x_opencti_order: killChainPhase.x_opencti_order,

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -1,19 +1,24 @@
 import { createEntity } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
 import { notify } from '../database/redis';
+import { READ_INDEX_STIX_DOMAIN_OBJECTS, READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION, ENTITY_TYPE_DATA_COMPONENT } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { RELATION_DETECTS, RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../schema/stixCoreRelationship';
+import { ENTITY_TYPE_KILL_CHAIN_PHASE } from '../schema/stixMetaObject';
+import { RELATION_KILL_CHAIN_PHASE } from '../schema/stixRefRelationship';
 import {
   batchListEntitiesThroughRelationsPaginated,
   type EntityOptions,
   findEntitiesIdsWithRelations,
+  listAllEntities,
+  listAllRelations,
   listEntities,
   listEntitiesThroughRelationsPaginated,
   storeLoadById
 } from '../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../types/user';
-import type { BasicStoreCommon } from '../types/store';
+import type { BasicStoreCommon, BasicStoreRelation } from '../types/store';
 import type { AttackPatternAddInput } from '../generated/graphql';
 
 export const findById = (context: AuthContext, user: AuthUser, attackPatternId: string) => {
@@ -60,4 +65,58 @@ export const coursesOfActionPaginated = async (context: AuthContext, user: AuthU
 
 export const dataComponentsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
   return listEntitiesThroughRelationsPaginated(context, user, attackPatternId, RELATION_DETECTS, ENTITY_TYPE_DATA_COMPONENT, true, args);
+};
+
+export const getAttackPatternsMatrix = async (context: AuthContext, user: AuthUser) => {
+  const attackPatternsOfPhases = [];
+  const allAttackPatterns = await listAllEntities(context, user, [ENTITY_TYPE_ATTACK_PATTERN], { connectionFormat: false, indices: [READ_INDEX_STIX_DOMAIN_OBJECTS] });
+  const allAttackPatternsById = new Map(allAttackPatterns.map((a) => [a.id, a]));
+  const allKillChainPhases = await listAllEntities(context, user, [ENTITY_TYPE_KILL_CHAIN_PHASE], { connectionFormat: false, indices: [READ_INDEX_STIX_META_OBJECTS] });
+  const subTechniquesRelations = await listAllRelations<BasicStoreRelation>(context, user, RELATION_SUBTECHNIQUE_OF, { connectionFormat: false });
+  for (let index = 0; index < allKillChainPhases.length; index += 1) {
+    const killChainPhase = allKillChainPhases[index];
+    const phaseAttackPatterns = allAttackPatterns
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .filter((a) => a[RELATION_KILL_CHAIN_PHASE] && a[RELATION_KILL_CHAIN_PHASE].includes(killChainPhase.id))
+      .map((attackPattern) => {
+        const subAttackPatternsIds: string[] = [];
+        let subattackPatterns_text: string = '';
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        if (attackPattern[RELATION_SUBTECHNIQUE_OF]) {
+          const subAttackPatterns = subTechniquesRelations.filter((s) => s.toId === attackPattern.id);
+          if (subAttackPatterns.length > 0) {
+            subAttackPatterns.forEach((s) => {
+              const subAttackPattern = allAttackPatternsById.get(s.fromId);
+              if (subAttackPattern) {
+                subAttackPatternsIds.push(subAttackPattern.id);
+                subattackPatterns_text += `${subAttackPattern.x_mitre_id} ${subAttackPattern.name} ${subAttackPattern.description} | `;
+              }
+            });
+          }
+        }
+        return {
+          id: attackPattern.id,
+          name: attackPattern.name,
+          description: attackPattern.description,
+          x_mitre_id: attackPattern.x_mitre_id,
+          subAttackPatternsIds,
+          subattackPatterns_text,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          killChainPhasesIds: [...attackPattern[RELATION_KILL_CHAIN_PHASE]],
+        };
+      });
+    if (phaseAttackPatterns.length > 0) {
+      attackPatternsOfPhases.push({
+        id: killChainPhase.id,
+        kill_chain_name: killChainPhase.kill_chain_name,
+        phase_name: killChainPhase.phase_name,
+        x_opencti_order: killChainPhase.x_opencti_order,
+        attackPatterns: phaseAttackPatterns,
+      });
+    }
+  }
+  return { attackPatternsOfPhases };
 };

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -900,6 +900,31 @@ export type AttackPatternEditMutationsRelationDeleteArgs = {
   toId: Scalars['StixRef']['input'];
 };
 
+export type AttackPatternForMatrix = {
+  __typename?: 'AttackPatternForMatrix';
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  killChainPhasesIds?: Maybe<Array<Scalars['String']['output']>>;
+  name: Scalars['String']['output'];
+  subAttackPatternsIds?: Maybe<Array<Scalars['String']['output']>>;
+  subattackPatterns_text?: Maybe<Scalars['String']['output']>;
+  x_mitre_id?: Maybe<Scalars['String']['output']>;
+};
+
+export type AttackPatternsByKillChain = {
+  __typename?: 'AttackPatternsByKillChain';
+  attackPatterns?: Maybe<Array<AttackPatternForMatrix>>;
+  id: Scalars['ID']['output'];
+  kill_chain_name: Scalars['String']['output'];
+  phase_name: Scalars['String']['output'];
+  x_opencti_order: Scalars['Int']['output'];
+};
+
+export type AttackPatternsMatrix = {
+  __typename?: 'AttackPatternsMatrix';
+  attackPatternsOfPhases?: Maybe<Array<AttackPatternsByKillChain>>;
+};
+
 export enum AttackPatternsOrdering {
   Score = '_score',
   Created = 'created',
@@ -18703,6 +18728,7 @@ export type Query = {
   assignees?: Maybe<AssigneeConnection>;
   attackPattern?: Maybe<AttackPattern>;
   attackPatterns?: Maybe<AttackPatternConnection>;
+  attackPatternsMatrix?: Maybe<AttackPatternsMatrix>;
   audits?: Maybe<LogConnection>;
   auditsDistribution?: Maybe<Array<Maybe<Distribution>>>;
   auditsMultiTimeSeries?: Maybe<Array<Maybe<MultiTimeSeries>>>;
@@ -29917,6 +29943,9 @@ export type ResolversTypes = ResolversObject<{
   AttackPatternConnection: ResolverTypeWrapper<Omit<AttackPatternConnection, 'edges'> & { edges: Array<ResolversTypes['AttackPatternEdge']> }>;
   AttackPatternEdge: ResolverTypeWrapper<Omit<AttackPatternEdge, 'node'> & { node: ResolversTypes['AttackPattern'] }>;
   AttackPatternEditMutations: ResolverTypeWrapper<Omit<AttackPatternEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversTypes['AttackPattern']>, contextPatch?: Maybe<ResolversTypes['AttackPattern']>, fieldPatch?: Maybe<ResolversTypes['AttackPattern']>, relationAdd?: Maybe<ResolversTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversTypes['AttackPattern']> }>;
+  AttackPatternForMatrix: ResolverTypeWrapper<AttackPatternForMatrix>;
+  AttackPatternsByKillChain: ResolverTypeWrapper<AttackPatternsByKillChain>;
+  AttackPatternsMatrix: ResolverTypeWrapper<AttackPatternsMatrix>;
   AttackPatternsOrdering: AttackPatternsOrdering;
   Attribute: ResolverTypeWrapper<Attribute>;
   AttributeBasedOn: ResolverTypeWrapper<AttributeBasedOn>;
@@ -30741,6 +30770,9 @@ export type ResolversParentTypes = ResolversObject<{
   AttackPatternConnection: Omit<AttackPatternConnection, 'edges'> & { edges: Array<ResolversParentTypes['AttackPatternEdge']> };
   AttackPatternEdge: Omit<AttackPatternEdge, 'node'> & { node: ResolversParentTypes['AttackPattern'] };
   AttackPatternEditMutations: Omit<AttackPatternEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversParentTypes['AttackPattern']>, contextPatch?: Maybe<ResolversParentTypes['AttackPattern']>, fieldPatch?: Maybe<ResolversParentTypes['AttackPattern']>, relationAdd?: Maybe<ResolversParentTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversParentTypes['AttackPattern']> };
+  AttackPatternForMatrix: AttackPatternForMatrix;
+  AttackPatternsByKillChain: AttackPatternsByKillChain;
+  AttackPatternsMatrix: AttackPatternsMatrix;
   Attribute: Attribute;
   AttributeBasedOn: AttributeBasedOn;
   AttributeBasedOnInput: AttributeBasedOnInput;
@@ -31725,6 +31757,31 @@ export type AttackPatternEditMutationsResolvers<ContextType = any, ParentType ex
   fieldPatch?: Resolver<Maybe<ResolversTypes['AttackPattern']>, ParentType, ContextType, RequireFields<AttackPatternEditMutationsFieldPatchArgs, 'input'>>;
   relationAdd?: Resolver<Maybe<ResolversTypes['StixRefRelationship']>, ParentType, ContextType, RequireFields<AttackPatternEditMutationsRelationAddArgs, 'input'>>;
   relationDelete?: Resolver<Maybe<ResolversTypes['AttackPattern']>, ParentType, ContextType, RequireFields<AttackPatternEditMutationsRelationDeleteArgs, 'relationship_type' | 'toId'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AttackPatternForMatrixResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttackPatternForMatrix'] = ResolversParentTypes['AttackPatternForMatrix']> = ResolversObject<{
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  killChainPhasesIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  subAttackPatternsIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  subattackPatterns_text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  x_mitre_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AttackPatternsByKillChainResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttackPatternsByKillChain'] = ResolversParentTypes['AttackPatternsByKillChain']> = ResolversObject<{
+  attackPatterns?: Resolver<Maybe<Array<ResolversTypes['AttackPatternForMatrix']>>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  kill_chain_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  phase_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  x_opencti_order?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AttackPatternsMatrixResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttackPatternsMatrix'] = ResolversParentTypes['AttackPatternsMatrix']> = ResolversObject<{
+  attackPatternsOfPhases?: Resolver<Maybe<Array<ResolversTypes['AttackPatternsByKillChain']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -37139,6 +37196,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   assignees?: Resolver<Maybe<ResolversTypes['AssigneeConnection']>, ParentType, ContextType, Partial<QueryAssigneesArgs>>;
   attackPattern?: Resolver<Maybe<ResolversTypes['AttackPattern']>, ParentType, ContextType, Partial<QueryAttackPatternArgs>>;
   attackPatterns?: Resolver<Maybe<ResolversTypes['AttackPatternConnection']>, ParentType, ContextType, Partial<QueryAttackPatternsArgs>>;
+  attackPatternsMatrix?: Resolver<Maybe<ResolversTypes['AttackPatternsMatrix']>, ParentType, ContextType>;
   audits?: Resolver<Maybe<ResolversTypes['LogConnection']>, ParentType, ContextType, Partial<QueryAuditsArgs>>;
   auditsDistribution?: Resolver<Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, ParentType, ContextType, RequireFields<QueryAuditsDistributionArgs, 'field' | 'operation'>>;
   auditsMultiTimeSeries?: Resolver<Maybe<Array<Maybe<ResolversTypes['MultiTimeSeries']>>>, ParentType, ContextType, RequireFields<QueryAuditsMultiTimeSeriesArgs, 'interval' | 'operation' | 'startDate'>>;
@@ -40252,6 +40310,9 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   AttackPatternConnection?: AttackPatternConnectionResolvers<ContextType>;
   AttackPatternEdge?: AttackPatternEdgeResolvers<ContextType>;
   AttackPatternEditMutations?: AttackPatternEditMutationsResolvers<ContextType>;
+  AttackPatternForMatrix?: AttackPatternForMatrixResolvers<ContextType>;
+  AttackPatternsByKillChain?: AttackPatternsByKillChainResolvers<ContextType>;
+  AttackPatternsMatrix?: AttackPatternsMatrixResolvers<ContextType>;
   Attribute?: AttributeResolvers<ContextType>;
   AttributeBasedOn?: AttributeBasedOnResolvers<ContextType>;
   AttributeColumn?: AttributeColumnResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -675,6 +675,16 @@ export type AttackPatternContainersArgs = {
 };
 
 
+export type AttackPatternCoursesOfActionArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CoursesOfActionOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type AttackPatternExportFilesArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -718,6 +728,16 @@ export type AttackPatternObservedDataArgs = {
 
 export type AttackPatternOpinionsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type AttackPatternParentAttackPatternsArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AttackPatternsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -796,6 +816,16 @@ export type AttackPatternStixCoreRelationshipsDistributionArgs = {
   toId?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   toRole?: InputMaybe<Scalars['String']['input']>;
   toTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type AttackPatternSubAttackPatternsArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AttackPatternsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type AttackPatternAddInput = {
@@ -31621,7 +31651,7 @@ export type AttackPatternResolvers<ContextType = any, ParentType extends Resolve
   connectors?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType, Partial<AttackPatternConnectorsArgs>>;
   containers?: Resolver<Maybe<ResolversTypes['ContainerConnection']>, ParentType, ContextType, Partial<AttackPatternContainersArgs>>;
   containersNumber?: Resolver<Maybe<ResolversTypes['Number']>, ParentType, ContextType>;
-  coursesOfAction?: Resolver<Maybe<ResolversTypes['CourseOfActionConnection']>, ParentType, ContextType>;
+  coursesOfAction?: Resolver<Maybe<ResolversTypes['CourseOfActionConnection']>, ParentType, ContextType, Partial<AttackPatternCoursesOfActionArgs>>;
   created?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   createdBy?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType>;
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
@@ -31650,7 +31680,7 @@ export type AttackPatternResolvers<ContextType = any, ParentType extends Resolve
   objectOrganization?: Resolver<Maybe<Array<ResolversTypes['Organization']>>, ParentType, ContextType>;
   observedData?: Resolver<Maybe<ResolversTypes['ObservedDataConnection']>, ParentType, ContextType, Partial<AttackPatternObservedDataArgs>>;
   opinions?: Resolver<Maybe<ResolversTypes['OpinionConnection']>, ParentType, ContextType, Partial<AttackPatternOpinionsArgs>>;
-  parentAttackPatterns?: Resolver<Maybe<ResolversTypes['AttackPatternConnection']>, ParentType, ContextType>;
+  parentAttackPatterns?: Resolver<Maybe<ResolversTypes['AttackPatternConnection']>, ParentType, ContextType, Partial<AttackPatternParentAttackPatternsArgs>>;
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   pendingFiles?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<AttackPatternPendingFilesArgs>>;
   reports?: Resolver<Maybe<ResolversTypes['ReportConnection']>, ParentType, ContextType, Partial<AttackPatternReportsArgs>>;
@@ -31662,7 +31692,7 @@ export type AttackPatternResolvers<ContextType = any, ParentType extends Resolve
   stixCoreObjectsDistribution?: Resolver<Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, ParentType, ContextType, RequireFields<AttackPatternStixCoreObjectsDistributionArgs, 'field' | 'operation'>>;
   stixCoreRelationships?: Resolver<Maybe<ResolversTypes['StixCoreRelationshipConnection']>, ParentType, ContextType, Partial<AttackPatternStixCoreRelationshipsArgs>>;
   stixCoreRelationshipsDistribution?: Resolver<Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, ParentType, ContextType, RequireFields<AttackPatternStixCoreRelationshipsDistributionArgs, 'field' | 'operation'>>;
-  subAttackPatterns?: Resolver<Maybe<ResolversTypes['AttackPatternConnection']>, ParentType, ContextType>;
+  subAttackPatterns?: Resolver<Maybe<ResolversTypes['AttackPatternConnection']>, ParentType, ContextType, Partial<AttackPatternSubAttackPatternsArgs>>;
   toStix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   workflowEnabled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -902,8 +902,8 @@ export type AttackPatternEditMutationsRelationDeleteArgs = {
 
 export type AttackPatternForMatrix = {
   __typename?: 'AttackPatternForMatrix';
+  attack_pattern_id: Scalars['String']['output'];
   description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
   killChainPhasesIds?: Maybe<Array<Scalars['String']['output']>>;
   name: Scalars['String']['output'];
   subAttackPatternsIds?: Maybe<Array<Scalars['String']['output']>>;
@@ -914,7 +914,7 @@ export type AttackPatternForMatrix = {
 export type AttackPatternsByKillChain = {
   __typename?: 'AttackPatternsByKillChain';
   attackPatterns?: Maybe<Array<AttackPatternForMatrix>>;
-  id: Scalars['ID']['output'];
+  kill_chain_id: Scalars['String']['output'];
   kill_chain_name: Scalars['String']['output'];
   phase_name: Scalars['String']['output'];
   x_opencti_order: Scalars['Int']['output'];
@@ -31761,8 +31761,8 @@ export type AttackPatternEditMutationsResolvers<ContextType = any, ParentType ex
 }>;
 
 export type AttackPatternForMatrixResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttackPatternForMatrix'] = ResolversParentTypes['AttackPatternForMatrix']> = ResolversObject<{
+  attack_pattern_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   killChainPhasesIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   subAttackPatternsIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
@@ -31773,7 +31773,7 @@ export type AttackPatternForMatrixResolvers<ContextType = any, ParentType extend
 
 export type AttackPatternsByKillChainResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttackPatternsByKillChain'] = ResolversParentTypes['AttackPatternsByKillChain']> = ResolversObject<{
   attackPatterns?: Resolver<Maybe<Array<ResolversTypes['AttackPatternForMatrix']>>, ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  kill_chain_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   kill_chain_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   phase_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   x_opencti_order?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -907,7 +907,7 @@ export type AttackPatternForMatrix = {
   killChainPhasesIds?: Maybe<Array<Scalars['String']['output']>>;
   name: Scalars['String']['output'];
   subAttackPatternsIds?: Maybe<Array<Scalars['String']['output']>>;
-  subattackPatterns_text?: Maybe<Scalars['String']['output']>;
+  subAttackPatternsSearchText?: Maybe<Scalars['String']['output']>;
   x_mitre_id?: Maybe<Scalars['String']['output']>;
 };
 
@@ -31766,7 +31766,7 @@ export type AttackPatternForMatrixResolvers<ContextType = any, ParentType extend
   killChainPhasesIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   subAttackPatternsIds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  subattackPatterns_text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  subAttackPatternsSearchText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_mitre_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/resolvers/attackPattern.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/attackPattern.js
@@ -6,7 +6,8 @@ import {
   coursesOfActionPaginated,
   dataComponentsPaginated,
   findAll,
-  findById
+  findById,
+  getAttackPatternsMatrix,
 } from '../domain/attackPattern';
 import {
   stixDomainObjectAddRelation,
@@ -28,6 +29,7 @@ const attackPatternResolvers = {
   Query: {
     attackPattern: (_, { id }, context) => findById(context, context.user, id),
     attackPatterns: (_, args, context) => findAll(context, context.user, args),
+    attackPatternsMatrix: (_, __, context) => getAttackPatternsMatrix(context, context.user),
   },
   AttackPattern: {
     killChainPhases: (attackPattern, _, context) => loadThroughDenormalized(context, context.user, attackPattern, INPUT_KILLCHAIN, { sortBy: 'phase_name' }),

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/attackPattern-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/attackPattern-test.js
@@ -31,6 +31,28 @@ const LIST_QUERY = gql`
   }
 `;
 
+const MATRIX_QUERY = gql`
+  query attackPatternsMatrix {
+    attackPatternsMatrix {
+      attackPatternsOfPhases {
+        kill_chain_id
+        kill_chain_name
+        phase_name
+        x_opencti_order
+        attackPatterns {
+          attack_pattern_id
+          name
+          description
+          x_mitre_id
+          subAttackPatternsIds
+          subAttackPatternsSearchText
+          killChainPhasesIds
+        }
+      }
+    }
+  }
+`;
+
 const READ_QUERY = gql`
   query attackPattern($id: String!) {
     attackPattern(id: $id) {
@@ -121,6 +143,20 @@ describe('AttackPattern resolver standard behavior', () => {
   it('should list attackPatterns', async () => {
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
     expect(queryResult.data.attackPatterns.edges.length).toEqual(3);
+  });
+  it('should query attackPatterns matrix', async () => {
+    const queryResult = await queryAsAdmin({ query: MATRIX_QUERY });
+    expect(queryResult.data.attackPatternsMatrix).not.toBeNull();
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases).not.toBeNull();
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases.length).toEqual(2);
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[0].kill_chain_name).toEqual('mitre-pre-attack');
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[0].phase_name).toEqual('launch');
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[0].x_opencti_order).toEqual(0);
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[0].attackPatterns.length).toEqual(2);
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[1].kill_chain_name).toEqual('mitre-attack');
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[1].phase_name).toEqual('persistence');
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[1].x_opencti_order).toEqual(20);
+    expect(queryResult.data.attackPatternsMatrix.attackPatternsOfPhases[1].attackPatterns.length).toEqual(1);
   });
   it('should update attackPattern', async () => {
     const UPDATE_QUERY = gql`


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* optimize attackPatterns query (use aggregations for isSubAttackPattern), use batch loading for parentAttackPatterns and subAttackPatterns
* add pagination and filters for sub connections (coursesOfAction, parentAttackPatterns, subAttackPatterns), because we were only retrieving the first 20, without any way to retrieve more.
* create a dedicated and optimized query for attack pattern matrix view : attackPatternsMatrix
* TODO : code cleanup, renaming, frontend refactoring ?

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6662 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

After first 2 commits, perf test with +2k attack patterns (exported from testing)
- on master: query takes 20s
![Capture d'écran 2024-08-26 160150](https://github.com/user-attachments/assets/fc988395-baab-4a0d-a43a-d5f453029578)

- on branch: query takes 7s
![image](https://github.com/user-attachments/assets/66fd7cd6-5d66-46a1-80f4-49bf2296ba72)

- on branch - after replacing with attackPatternsMatrix query : query takes less than 1s
![Capture d'écran 2024-08-28 114752](https://github.com/user-attachments/assets/60c75542-3f78-4fcf-847d-79ccf965506e)
