### PR TITLE
[frontend] properly set light theme  primary color (#7934)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -35,7 +35,7 @@ const ThemeLight = (
       dark: '#c62828',
     },
     success: { main: '#03a847' },
-    primary: { main: primary || THEME_LIGHT_DEFAULT_PRIMARY  },
+    primary: { main: primary || THEME_LIGHT_DEFAULT_PRIMARY },
     secondary: { main: secondary || THEME_LIGHT_DEFAULT_SECONDARY },
     pagination: {
       main: '#000000',

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -35,7 +35,7 @@ const ThemeLight = (
       dark: '#c62828',
     },
     success: { main: '#03a847' },
-    primary: { main: THEME_LIGHT_DEFAULT_PRIMARY || '#0066ff' },
+    primary: { main: primary || THEME_LIGHT_DEFAULT_PRIMARY  },
     secondary: { main: secondary || THEME_LIGHT_DEFAULT_SECONDARY },
     pagination: {
       main: '#000000',


### PR DESCRIPTION
### Proposed changes

* Utilize the primary parameter in the light theme palette. 

### Related issues
* https://github.com/OpenCTI-Platform/opencti/issues/7934


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
