### PR TITLE
[frontend] Disable labels and in_platform sorting in Workbench content (#7798)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -150,6 +150,7 @@ const inlineStylesHeaders = {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     paddingRight: 10,
+    cursor: 'default',
   },
   markings: {
     float: 'left',
@@ -3172,7 +3173,7 @@ const WorkbenchFileContentComponent = ({
                 <div>
                   {sortHeader('ttype', 'Type', true)}
                   {sortHeader('default_value', 'Default value', true)}
-                  {sortHeader('labels', 'Labels', true)}
+                  {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
                   {sortHeader('in_platform', 'Already in plat.', true)}
                 </div>
@@ -3369,7 +3370,7 @@ const WorkbenchFileContentComponent = ({
                 <div>
                   {sortHeader('ttype', 'Type', true)}
                   {sortHeader('default_value', 'Default value', true)}
-                  {sortHeader('labels', 'Labels', true)}
+                  {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
                   {sortHeader('in_platform', 'Already in plat.', true)}
                 </div>
@@ -3609,7 +3610,7 @@ const WorkbenchFileContentComponent = ({
                 <div>
                   {sortHeader('ttype', 'Type', true)}
                   {sortHeader('default_value', 'Default value', true)}
-                  {sortHeader('labels', 'Labels', true)}
+                  {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
                 </div>
               }
@@ -3761,7 +3762,7 @@ const WorkbenchFileContentComponent = ({
                 <div>
                   {sortHeader('ttype', 'Type', true)}
                   {sortHeader('default_value', 'Default value', true)}
-                  {sortHeader('labels', 'Labels', true)}
+                  {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
                 </div>
               }
@@ -3927,7 +3928,7 @@ const WorkbenchFileContentComponent = ({
                 <div>
                   {sortHeader('ttype', 'Type', true)}
                   {sortHeader('default_value', 'Default value', true)}
-                  {sortHeader('labels', 'Labels', true)}
+                  {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
                   {sortHeader('in_platform', 'Already in plat.', true)}
                 </div>

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -171,6 +171,7 @@ const inlineStylesHeaders = {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     paddingRight: 10,
+    cursor: 'default',
   },
 };
 
@@ -3175,7 +3176,7 @@ const WorkbenchFileContentComponent = ({
                   {sortHeader('default_value', 'Default value', true)}
                   {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
-                  {sortHeader('in_platform', 'Already in plat.', true)}
+                  {sortHeader('in_platform', 'Already in plat.', false)}
                 </div>
               }
             />
@@ -3372,7 +3373,7 @@ const WorkbenchFileContentComponent = ({
                   {sortHeader('default_value', 'Default value', true)}
                   {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
-                  {sortHeader('in_platform', 'Already in plat.', true)}
+                  {sortHeader('in_platform', 'Already in plat.', false)}
                 </div>
               }
             />
@@ -3930,7 +3931,7 @@ const WorkbenchFileContentComponent = ({
                   {sortHeader('default_value', 'Default value', true)}
                   {sortHeader('labels', 'Labels', false)}
                   {sortHeader('markings', 'Marking definitions', true)}
-                  {sortHeader('in_platform', 'Already in plat.', true)}
+                  {sortHeader('in_platform', 'Already in plat.', false)}
                 </div>
               }
             />


### PR DESCRIPTION
### Proposed changes
In workbench content list, disable columns sorting by labels and by 'already in platforms'

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7798