### PR TITLE
[backend] Add two built-in retention rules on files and workbenches (#7482)

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1722867026940-add-builtin-retention-rules-on-files.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1722867026940-add-builtin-retention-rules-on-files.js
@@ -1,0 +1,49 @@
+import { logApp } from '../config/conf';
+import { elIndex } from '../database/engine';
+import { INDEX_INTERNAL_OBJECTS } from '../database/utils';
+import { generateInternalId, generateStandardId } from '../schema/identifier';
+import { ENTITY_TYPE_RETENTION_RULE } from '../schema/internalObject';
+import { RetentionRuleScope } from '../generated/graphql';
+import { emptyFilterGroup } from '../utils/filtering/filtering-utils';
+
+const message = '[MIGRATION] Add two built-in retention rules (on files and workbenches)';
+
+export const up = async (next) => {
+  logApp.info(`${message} > started`);
+  const addRetentionRule = async (input) => {
+    const retentionRuleId = generateInternalId();
+    const retentionRule = {
+      id: retentionRuleId,
+      internal_id: retentionRuleId,
+      standard_id: generateStandardId(ENTITY_TYPE_RETENTION_RULE, input),
+      entity_type: ENTITY_TYPE_RETENTION_RULE,
+      last_execution_date: null,
+      last_deleted_count: null,
+      remaining_count: null,
+      ...input,
+    };
+    await elIndex(INDEX_INTERNAL_OBJECTS, retentionRule);
+  };
+
+  const fileInput = {
+    name: 'Default retention rule on files',
+    scope: RetentionRuleScope.File,
+    max_retention: 133,
+    filters: JSON.stringify(emptyFilterGroup),
+  };
+  const workbenchInput = {
+    name: 'Default retention rule on workbenches',
+    scope: RetentionRuleScope.Workbench,
+    max_retention: 60,
+    filters: JSON.stringify(emptyFilterGroup),
+  };
+  await addRetentionRule(fileInput);
+  await addRetentionRule(workbenchInput);
+
+  logApp.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -22,6 +22,12 @@ import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationshi
 import { STIX_CORE_RELATIONSHIPS } from '../../schema/stixCoreRelationship';
 import { UnsupportedError } from '../../config/errors';
 
+export const emptyFilterGroup = {
+  mode: 'and',
+  filters: [],
+  filterGroups: [],
+};
+
 //----------------------------------------------------------------------------------------------------------------------
 // Basic utility functions
 


### PR DESCRIPTION
Chunk 2 of 7482

### Proposed changes
- Add two built-in retention rules (on for files and one for worbenches) at platform initialization for new platforms
- Add these two buit-in retention rules for existing platforms via a migration

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7482


### Warning
PR to be merged just before the 6.3 release, when feature flag FILE_RETENTION_RULES is removed