### PR TITLE
[backend] display created field for csv mapper (#7226)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
@@ -1,7 +1,6 @@
 import {
   aliases,
   baseType,
-  created,
   createdAt,
   creators,
   entityLocationType,
@@ -35,7 +34,6 @@ export const INTERNAL_ATTRIBUTES = [
   updatedAt.name,
   modified.name,
   // Technical
-  created.name,
   entityType.name,
   parentTypes.name,
   entityLocationType.name,

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -100,7 +100,7 @@ export const csvMapperSchemaAttributes = async (context: AuthContext, user: Auth
   types.forEach((type) => {
     const attributesDef = schemaAttributesDefinition.getAttributes(type);
     const attributes: CsvMapperSchemaAttribute[] = Array.from(attributesDef.values()).flatMap((attribute) => {
-      if (INTERNAL_ATTRIBUTES.includes(attribute.name)) return [];
+      if (INTERNAL_ATTRIBUTES.includes(attribute.name) || attribute.label === 'Original creation date') return [];
       return [{
         name: attribute.name,
         label: attribute.label,

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -17,6 +17,7 @@ import { schemaTypesDefinition } from '../../../schema/schema-types';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT, ABSTRACT_STIX_META_OBJECT } from '../../../schema/general';
 import { type BasicStoreEntityIngestionCsv, ENTITY_TYPE_INGESTION_CSV } from '../../ingestion/ingestion-types';
 import { FunctionalError } from '../../../config/errors';
+import { created } from '../../../schema/attribute-definition';
 
 // -- UTILS --
 
@@ -100,7 +101,7 @@ export const csvMapperSchemaAttributes = async (context: AuthContext, user: Auth
   types.forEach((type) => {
     const attributesDef = schemaAttributesDefinition.getAttributes(type);
     const attributes: CsvMapperSchemaAttribute[] = Array.from(attributesDef.values()).flatMap((attribute) => {
-      if (INTERNAL_ATTRIBUTES.includes(attribute.name) || attribute.label === 'Original creation date') return [];
+      if (INTERNAL_ATTRIBUTES.includes(attribute.name) || attribute === created) return [];
       return [{
         name: attribute.name,
         label: attribute.label,

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -17,7 +17,6 @@ import { schemaTypesDefinition } from '../../../schema/schema-types';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT, ABSTRACT_STIX_META_OBJECT } from '../../../schema/general';
 import { type BasicStoreEntityIngestionCsv, ENTITY_TYPE_INGESTION_CSV } from '../../ingestion/ingestion-types';
 import { FunctionalError } from '../../../config/errors';
-import { created } from '../../../schema/attribute-definition';
 
 // -- UTILS --
 
@@ -101,7 +100,7 @@ export const csvMapperSchemaAttributes = async (context: AuthContext, user: Auth
   types.forEach((type) => {
     const attributesDef = schemaAttributesDefinition.getAttributes(type);
     const attributes: CsvMapperSchemaAttribute[] = Array.from(attributesDef.values()).flatMap((attribute) => {
-      if (INTERNAL_ATTRIBUTES.includes(attribute.name) || attribute === created) return [];
+      if (INTERNAL_ATTRIBUTES.includes(attribute.name)) return [];
       return [{
         name: attribute.name,
         label: attribute.label,


### PR DESCRIPTION
### Proposed changes

- Remove `created` from INTERNAL_ATTRIBUTES list
- Display `created` field into csv mapper creation form

### Related issues

- close #7226 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality