### PR TITLE
[backend] Kill session on synchro when an HTTP error is send to client. (#7842)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -60,6 +60,16 @@ const MAX_CACHE_TIME = (conf.get('app:live_stream:cache_max_time') ?? 1) * ONE_H
 const MAX_CACHE_SIZE = conf.get('app:live_stream:cache_max_size') ?? 5000;
 const HEARTBEAT_PERIOD = conf.get('app:live_stream:heartbeat_period') ?? 5000;
 
+const sendErrorStatusAndKillSession = (req, res, httpStatus) => {
+  try {
+    res.status(httpStatus).end();
+    req.session.destroy();
+  } catch (error) {
+    // We don't care but can be interesting for debug.
+    logApp.info('Error when trying to kill a session', { error });
+  }
+};
+
 const createBroadcastClient = (channel) => {
   return {
     id: channel.id,
@@ -90,20 +100,20 @@ const authenticate = async (req, res, next) => {
       next();
     } else {
       res.statusMessage = 'You are not authenticated, please check your credentials';
-      res.status(401).end();
+      sendErrorStatusAndKillSession(req, res, 401);
     }
   } catch (err) {
     res.statusMessage = `Error in stream: ${err.message}`;
-    res.status(500).end();
+    sendErrorStatusAndKillSession(req, res, 500);
   }
 };
 
-const computeUserAndCollection = async (res, { context, user, id }) => {
+const computeUserAndCollection = async (req, res, { context, user, id }) => {
   // Global live stream only available for bypass
   if (id === DEFAULT_LIVE_STREAM) {
     if (!isUserHasCapability(user, BYPASS)) {
       res.statusMessage = 'You are not authorized, please check your credentials';
-      res.status(401).end();
+      sendErrorStatusAndKillSession(req, res, 401);
       return { error: res.statusMessage };
     }
     return { streamFilters: null, collection: null };
@@ -113,14 +123,14 @@ const computeUserAndCollection = async (res, { context, user, id }) => {
   // If collection not found
   if (!collection) {
     res.statusMessage = 'You are not authorized, please check your credentials';
-    res.status(401).end();
+    sendErrorStatusAndKillSession(req, res, 401);
     return { error: res.statusMessage };
   }
   // Check if collection exist and started
   if (!collection.stream_live) {
     res.statusMessage = 'This live stream is stopped';
-    res.status(410).end();
-    logApp.warn('This live stream is stopped', { streamCollectionId: id });
+    sendErrorStatusAndKillSession(req, res, 410);
+    logApp.warn('This live stream is stopped but still requested', { streamCollectionId: id });
     return { error: 'This live stream is stopped' };
   }
   const streamFilters = JSON.parse(collection.filters);
@@ -131,7 +141,7 @@ const computeUserAndCollection = async (res, { context, user, id }) => {
   // Access is restricted, user must be authenticated
   if (!user || !isUserHasCapability(user, TAXIIAPI)) {
     res.statusMessage = 'You are not authorized, please check your credentials';
-    res.status(401).end();
+    sendErrorStatusAndKillSession(req, res, 401);
     return { error: res.statusMessage };
   }
   // Access is restricted, check the current user
@@ -140,7 +150,7 @@ const computeUserAndCollection = async (res, { context, user, id }) => {
   if (collectionAccessIds.length > 0) { // If restrictions have been setup
     if (!isUserHasCapability(user, BYPASS) && !collectionAccessIds.some((accessId) => userAccessIds.includes(accessId))) {
       res.statusMessage = 'You are not authorized, please check your credentials';
-      res.status(401).end();
+      sendErrorStatusAndKillSession(req, res, 401);
       return { error: res.statusMessage };
     }
   }
@@ -154,7 +164,7 @@ const computeUserAndCollection = async (res, { context, user, id }) => {
     const isUserHaveAccess = filterMarkings.some((m) => userMarkings.includes(m));
     if (!isUserHaveAccess) {
       res.statusMessage = 'You need to have access to specific markings for this live stream';
-      res.status(401).end();
+      sendErrorStatusAndKillSession(req, res, 401);
       return { error: res.statusMessage };
     }
   }
@@ -170,14 +180,14 @@ const authenticateForPublic = async (req, res, next) => {
   req.capabilities = user.capabilities;
   req.allowed_marking = user.allowed_marking;
   req.expirationTime = utcDate().add(1, 'days').toDate();
-  const { error, collection, streamFilters } = await computeUserAndCollection(res, {
+  const { error, collection, streamFilters } = await computeUserAndCollection(req, res, {
     context,
     user: req.user,
     id: req.params.id
   });
   if (error || (!collection?.stream_public && !auth)) {
     res.statusMessage = 'You are not authenticated, please check your credentials';
-    res.status(401).end();
+    sendErrorStatusAndKillSession(req, res, 401);
   } else {
     req.collection = collection;
     req.streamFilters = streamFilters;
@@ -281,6 +291,7 @@ const createSseMiddleware = () => {
         if (!req.finished) {
           try {
             res.end();
+            req.session.destroy();
           } catch (e) {
             logApp.error(e, { action: 'close', clientId: channel.userId });
           }
@@ -306,7 +317,8 @@ const createSseMiddleware = () => {
       // Generic stream only available for bypass users
       if (!isUserHasCapability(sessionUser, BYPASS)) {
         res.statusMessage = 'Consume generic stream is only authorized for bypass user';
-        res.status(401).end();
+        sendErrorStatusAndKillSession(req, res, 401);
+        logApp.info('[ANGIE] genericStreamHandler 401 - Error, we need to kill session');
         return;
       }
       const { client } = createSseChannel(req, res, startStreamId);
@@ -326,7 +338,8 @@ const createSseMiddleware = () => {
       await processor.start(startStreamId);
     } catch (err) {
       res.statusMessage = `Error in stream: ${err.message}`;
-      res.status(500).end();
+      sendErrorStatusAndKillSession(req, res, 500);
+      logApp.info('[ANGIE] genericStreamHandler 500 - Error, we need to kill session');
     }
   };
   const manageStreamConnectionHandler = async (req, res) => {
@@ -336,7 +349,7 @@ const createSseMiddleware = () => {
       if (client) {
         if (client.userId !== req.userId) {
           res.statusMessage = 'You cant access this resource';
-          res.status(401).end();
+          sendErrorStatusAndKillSession(req, res, 401);
         } else {
           const { delay = 0 } = req.body;
           client.setChannelDelay(delay);
@@ -344,11 +357,11 @@ const createSseMiddleware = () => {
         }
       } else {
         res.statusMessage = 'This is not your connection';
-        res.status(401).end();
+        sendErrorStatusAndKillSession(req, res, 401);
       }
     } catch (err) {
       res.statusMessage = `Error in connection management: ${err.message}`;
-      res.status(500).end();
+      sendErrorStatusAndKillSession(req, res, 500);
     }
   };
   const resolveAndPublishMissingRefs = async (context, cache, channel, req, eventId, stixData) => {
@@ -636,7 +649,7 @@ const createSseMiddleware = () => {
         // Wait to prevent flooding
         channel.setLastEventId(lastEventId);
         await wait(channel.delay);
-        const newComputed = await computeUserAndCollection(res, { id, user, context });
+        const newComputed = await computeUserAndCollection(req, res, { id, user, context });
         streamFilters = newComputed.streamFilters;
         collection = newComputed.collection;
         error = newComputed.error;
@@ -688,7 +701,7 @@ const createSseMiddleware = () => {
     } catch (e) {
       logApp.error(e, { id, type: 'live' });
       res.statusMessage = `Error in stream ${id}: ${e.message}`;
-      res.status(500).end();
+      sendErrorStatusAndKillSession(req, res, 500);
     }
   };
   return {

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -63,7 +63,9 @@ const HEARTBEAT_PERIOD = conf.get('app:live_stream:heartbeat_period') ?? 5000;
 const sendErrorStatusAndKillSession = (req, res, httpStatus) => {
   try {
     res.status(httpStatus).end();
-    req.session.destroy();
+    if (req.session) {
+      req.session.destroy();
+    }
   } catch (error) {
     // We don't care but can be interesting for debug.
     logApp.info('Error when trying to kill a session', { error });

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -339,7 +339,6 @@ const createSseMiddleware = () => {
     } catch (err) {
       res.statusMessage = `Error in stream: ${err.message}`;
       sendErrorStatusAndKillSession(req, res, 500);
-      logApp.info('[ANGIE] genericStreamHandler 500 - Error, we need to kill session');
     }
   };
   const manageStreamConnectionHandler = async (req, res) => {

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -318,7 +318,6 @@ const createSseMiddleware = () => {
       if (!isUserHasCapability(sessionUser, BYPASS)) {
         res.statusMessage = 'Consume generic stream is only authorized for bypass user';
         sendErrorStatusAndKillSession(req, res, 401);
-        logApp.info('[ANGIE] genericStreamHandler 401 - Error, we need to kill session');
         return;
       }
       const { client } = createSseChannel(req, res, startStreamId);

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -17,7 +17,7 @@ import { getHttpClient } from '../utils/http-client';
 import { createSyncHttpUri, httpBase } from '../domain/connector-utils';
 
 const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock';
-const SCHEDULE_TIME = 10000;
+const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
 
 const syncManagerInstance = (syncId) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Kill session when an HTTP error is send back because EventSource that is used on syncManager closes the stream automatically on HTTP code that are different from 200 or 300 (redirects).

From my test locally, session flood can happen:
- When remote OCTI stream sever is "running = false"
- When user has not enough rights (marking, capacity or other checks on data)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #7842 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
