### PR TITLE
[ci] Improve e2e experience by having a sandbox space on drone. (#7378)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -115,7 +115,7 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional
-      - cp -a opencti-platform/opencti-front/* e2e-front-sandbox
+      - cp -R opencti-platform/opencti-front/* e2e-front-sandbox
       - ls -lart
       - cd e2e-front-sandbox
       - yarn install
@@ -179,8 +179,9 @@ steps:
       - frontend-tests
       - frontend-e2e-tests
 
-  - name: upload-tests-artefacts
+  - name: upload-frontend-artefacts
     image: plugins/s3
+    failure: ignore
     settings:
       bucket: octi-drone-artefact
       access_key:
@@ -188,10 +189,10 @@ steps:
       secret_key:
         from_secret: octi-s3-secret-key
       source: opencti-platform/opencti-front/test-results/**/*
-      target: /octi/$DRONE_BUILD_NUMBER/front
+      target: /octi/$DRONE_BUILD_NUMBER/opencti-front
     depends_on:
+      - frontend-tests
       - frontend-e2e-tests
-      - frontend-e2e-tests-sandbox
 
 services:
   - name: redis

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,8 +106,8 @@ steps:
     image: node:20.16.0
     failure: ignore
     volumes:
-      - name: cache-node-frontend-e2e-deflake
-        path: /drone/src/opencti-platform/opencti-front/node_modules
+      - name: cache-node-frontend-e2e-sandbox
+        path: /drone/src/e2e-front-sandbox/node_modules
     environment:
       BACK_END_URL: http://opencti-e2e-start:4500
       E2E_TEST: true
@@ -115,9 +115,10 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional
+      - mkdir e2e-front-sandbox
       - cp -R opencti-platform/opencti-front/* e2e-front-sandbox
-      - ls -lart
       - cd e2e-front-sandbox
+      - ls -lart
       - yarn install
       - npx playwright install --with-deps chromium
       - yarn build
@@ -183,6 +184,7 @@ steps:
     image: plugins/s3
     failure: ignore
     settings:
+      endpoint: https://s3.testing.octi.staging.filigran.io/
       bucket: octi-drone-artefact
       access_key:
         from_secret: octi-s3-access-key

--- a/.drone.yml
+++ b/.drone.yml
@@ -112,6 +112,10 @@ steps:
       BACK_END_URL: http://opencti-e2e-start:4500
       E2E_TEST: true
       TEAMS_WEBHOOK: teams-webhook-url
+    when:
+      event:
+        include:
+        - pull_request
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional
@@ -124,7 +128,7 @@ steps:
       - yarn build
       - yarn test:e2e:sandbox
     depends_on:
-      - frontend-tests
+      - frontend-e2e-tests
 
   - name: frontend-verify-translation
     image: node:20.16.0
@@ -180,9 +184,13 @@ steps:
       - frontend-tests
       - frontend-e2e-tests
 
-  - name: upload-frontend-artefacts
+  - name: upload-frontend-test-results
     image: plugins/s3
     failure: ignore
+    when:
+      event:
+        include:
+        - pull_request
     settings:
       endpoint: https://s3.testing.octi.staging.filigran.io
       bucket: octi-drone-artefact
@@ -191,11 +199,11 @@ steps:
         from_secret: octi-s3-access-key
       secret_key:
         from_secret: octi-s3-secret-key
-      source: /drone/src/opencti-platform/opencti-front/src/**/*
+      source: /drone/src/opencti-platform/opencti-front/test-results/**/*
       target: /octi/opencti-front
-#    depends_on:
-#      - frontend-tests
-#      - frontend-e2e-tests
+    depends_on:
+      - frontend-tests
+      - frontend-e2e-tests
 
 services:
   - name: redis

--- a/.drone.yml
+++ b/.drone.yml
@@ -115,7 +115,9 @@ steps:
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional
-      - cd opencti-platform/opencti-front
+      - cp -a opencti-platform/opencti-front/* e2e-front-sandbox
+      - ls -lart
+      - cd e2e-front-sandbox
       - yarn install
       - npx playwright install --with-deps chromium
       - yarn build

--- a/.drone.yml
+++ b/.drone.yml
@@ -177,6 +177,20 @@ steps:
       - frontend-tests
       - frontend-e2e-tests
 
+  - name: upload-tests-artefacts
+    image: plugins/s3
+    settings:
+      bucket: octi-drone-artefact
+      access_key:
+        from_secret: octi-s3-access-key
+      secret_key:
+        from_secret: octi-s3-secret-key
+      source: opencti-platform/opencti-front/test-results/**/*
+      target: /octi/$DRONE_BUILD_NUMBER/front
+    depends_on:
+      - frontend-e2e-tests
+      - frontend-e2e-tests-sandbox
+
 services:
   - name: redis
     image: redis:7.4.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -191,7 +191,7 @@ steps:
         from_secret: octi-s3-access-key
       secret_key:
         from_secret: octi-s3-secret-key
-      source: opencti-platform/opencti-front/static/**/*
+      source: /drone/src/opencti-platform/opencti-front/src/**/*
       target: /octi/opencti-front
 #    depends_on:
 #      - frontend-tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,27 @@ steps:
     depends_on:
       - frontend-tests
 
+  - name: frontend-e2e-tests-sandbox
+    image: node:20.16.0
+    failure: ignore
+    volumes:
+      - name: cache-node-frontend-e2e-deflake
+        path: /drone/src/opencti-platform/opencti-front/node_modules
+    environment:
+      BACK_END_URL: http://opencti-e2e-start:4500
+      E2E_TEST: true
+      TEAMS_WEBHOOK: teams-webhook-url
+    commands:
+      - apt-get update
+      - apt-get -y install netcat-traditional
+      - cd opencti-platform/opencti-front
+      - yarn install
+      - npx playwright install --with-deps chromium
+      - yarn build
+      - yarn test:e2e:sandbox
+    depends_on:
+      - frontend-tests
+
   - name: frontend-verify-translation
     image: node:20.16.0
     commands:
@@ -379,3 +400,6 @@ volumes:
   - name: cache-node-frontend-e2e
     host:
       path: /tmp/cache-node-frontend-e2e
+  - name: cache-node-frontend-e2e-flake
+    host:
+      path: /tmp/cache-node-frontend-e2e-flake

--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,7 @@ steps:
     failure: ignore
     volumes:
       - name: cache-node-frontend-e2e-sandbox
-        path: /drone/src/e2e-front-sandbox/node_modules
+        path: /drone/src/opencti-platform/e2e-front-sandbox/node_modules
     environment:
       BACK_END_URL: http://opencti-e2e-start:4500
       E2E_TEST: true
@@ -184,17 +184,18 @@ steps:
     image: plugins/s3
     failure: ignore
     settings:
-      endpoint: https://s3.testing.octi.staging.filigran.io/
+      endpoint: https://s3.testing.octi.staging.filigran.io
       bucket: octi-drone-artefact
+      path_style: true
       access_key:
         from_secret: octi-s3-access-key
       secret_key:
         from_secret: octi-s3-secret-key
-      source: opencti-platform/opencti-front/test-results/**/*
-      target: /octi/$DRONE_BUILD_NUMBER/opencti-front
-    depends_on:
-      - frontend-tests
-      - frontend-e2e-tests
+      source: opencti-platform/opencti-front/static/**/*
+      target: /octi/opencti-front
+#    depends_on:
+#      - frontend-tests
+#      - frontend-e2e-tests
 
 services:
   - name: redis

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -176,8 +176,9 @@
     "auto-translation:ja-back": "i18n-auto-translation -a deepl-free -p ./lang/back/en.json -t ja -k",
     "auto-translation:es-back": "i18n-auto-translation -a deepl-free -p ./lang/back/en.json -t es -k",
     "auto-translation:de-back": "i18n-auto-translation -a deepl-free -p ./lang/back/en.json -t de -k",
-    "test:e2e": "E2E_TEST=true yarn playwright test",
-    "test:e2e:ui": "E2E_TEST=true yarn playwright test --ui",
+    "test:e2e": "E2E_TEST=true yarn playwright test --workers=1 --retries=1 --grep-invert @sandbox",
+    "test:e2e:sandbox": "E2E_TEST=true yarn playwright test --workers=1 --grep @sandbox",
+    "test:e2e:ui": "E2E_TEST=true yarn playwright test --ui --workers=1",
     "generate-test-e2e": "npx playwright codegen http://localhost:3000/",
     "test:e2e:coverage": "E2E_TEST=true E2E_COVERAGE=true yarn playwright test && yarn show-report-e2e",
     "show-report-e2e": "start \"\" test-results/report.html && start \"\" test-results/coverage/index.html"

--- a/opencti-platform/opencti-front/tests_e2e/Export file/exportReport.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/Export file/exportReport.spec.ts
@@ -4,7 +4,7 @@ import FormExportPageModel from '../model/form/formExport.pageModel';
 import ReportPage from '../model/report.pageModel';
 import ReportFormPage from '../model/form/reportForm.pageModel';
 
-test.skip('Add an Export in a report and check the export is present in content', async ({ page }) => {
+test('Add an Export in a report and check the export is present in content', { tag: ['@sandbox'] }, async ({ page }) => {
   const reportPage = new ReportPage(page);
   const reportForm = new ReportFormPage(page);
   const reportDetailsPage = new ReportDetailsPage(page);

--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -21,7 +21,7 @@ import TaskPopup from '../model/taskPopup.pageModel';
  * Verify entity count for both labels 'background-task-filter-add-label' and 'background-task-search-add-label'
  * @param page
  */
-test.skip('Verify background tasks execution', { tag: ['@mutation', '@incident', '@task', '@filter'] }, async ({ page }) => {
+test('Verify background tasks execution', { tag: ['@sandbox', '@mutation', '@incident', '@task', '@filter'] }, async ({ page }) => {
   const incidentPage = new EventsIncidentPage(page);
   const filter = new FiltersPageModel(page);
   const search = new SearchPageModel(page);

--- a/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
@@ -160,5 +160,8 @@ const navigateAllMenu = async (page: Page) => {
 
 test('Check navigation on all pages', { tag: ['@navigation'] }, async ({ page }) => {
   await navigateAllMenu(page);
+});
+
+test('Check navigation on all pages - wip part', { tag: ['@sandbox'] }, async ({ page }) => {
   await navigateReports(page);
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Run e2e flaky test in drone in a dedicated step that does not fail the build until it's stable enough to be a blocker.
* Upload frontend test artefact to an S3 bucket (not failing build in case of error too)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* e2e daily flaky pain

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
