### PR TITLE
[frontend] change chart's background color (#7737)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Charts.js
+++ b/opencti-platform/opencti-front/src/utils/Charts.js
@@ -73,7 +73,7 @@ export const lineChartOptions = (
 ) => ({
   chart: {
     type: 'line',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     width: '100%',
@@ -167,7 +167,7 @@ export const areaChartOptions = (
 ) => ({
   chart: {
     type: 'area',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     stacked: isStacked,
@@ -277,7 +277,7 @@ export const verticalBarsChartOptions = (
 ) => ({
   chart: {
     type: 'bar',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     stacked: isStacked,
@@ -388,7 +388,7 @@ export const horizontalBarsChartOptions = (
   events: ['xAxisLabelClick'],
   chart: {
     type: 'bar',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     stacked,
@@ -574,7 +574,7 @@ export const radarChartOptions = (
 ) => ({
   chart: {
     type: 'radar',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     offsetY: offset ? -20 : 0,
     parentHeightOffset: 0,
@@ -687,7 +687,7 @@ export const polarAreaChartOptions = (
   return {
     chart: {
       type: 'polarArea',
-      background: 'transparent',
+      background: theme.palette.background.paper,
       toolbar: toolbarOptions,
       foreColor: theme.palette.text.secondary,
       width: '100%',
@@ -800,7 +800,7 @@ export const donutChartOptions = (
   return {
     chart: {
       type: 'donut',
-      background: 'transparent',
+      background: theme.palette.background.paper,
       toolbar: toolbarOptions,
       foreColor: theme.palette.text.secondary,
       width: '100%',
@@ -858,7 +858,7 @@ export const donutChartOptions = (
           value: {
             show: displayValue,
           },
-          background: 'transparent',
+          background: theme.palette.background.paper,
           size: `${size}%`,
         },
       },
@@ -882,7 +882,7 @@ export const treeMapOptions = (
   return {
     chart: {
       type: 'treemap',
-      background: 'transparent',
+      background: theme.palette.background.paper,
       toolbar: toolbarOptions,
       foreColor: theme.palette.text.secondary,
       width: '100%',
@@ -965,7 +965,7 @@ export const heatMapOptions = (
 ) => ({
   chart: {
     type: 'heatmap',
-    background: 'transparent',
+    background: theme.palette.background.paper,
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     stacked: isStacked,


### PR DESCRIPTION
### Proposed changes

- Use theme to replace the chart's background color

### Related issues

* close #7737 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- Previously, the background was `transparent`
- In the plateform, nothing change
- When you export to PNG, with `tranparent` option, you had a white background
- With the dark mode in opencti, the font color is white
- The export create a image with white background and white font.
- Now, the background has the same color of the component's background, you can't see the difference but in the PNG, you get a result that looks like the one on the platform, with a distinct background and font.