### PR TITLE
[frontend] start and stop time edition for nested ref (#7968)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipEditionOverview.jsx
@@ -96,12 +96,14 @@ export const stixRefRelationshipEditionFocus = graphql`
 `;
 
 const stixNestedRefRelationshipValidation = (t) => Yup.object().shape({
-  start_time: Yup.date()
+  start_time: Yup.date().nullable()
+    .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+  stop_time: Yup.date().nullable()
     .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
-    .required(t('This field is required')),
-  stop_time: Yup.date()
-    .typeError(t('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
-    .required(t('This field is required')),
+    .min(
+      Yup.ref('start_time'),
+      "The end date can't be before the start date",
+    ),
 });
 
 class StixNestedRefRelationshipEditionOverview extends Component {


### PR DESCRIPTION
### Proposed changes
fix error message at start_time and stop_time edition of a nested relationship in an entity Knowledge tab

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7968