### PR TITLE
[backend] lower verbosity of feature flag logs

### DIFF
--- a/opencti-platform/opencti-graphql/src/boot.js
+++ b/opencti-platform/opencti-graphql/src/boot.js
@@ -1,5 +1,5 @@
 import { environment, getStoppingState, logApp, setStoppingState } from './config/conf';
-import platformInit, { checkSystemDependencies } from './initialization';
+import platformInit, { checkDeactivatedFeatureFlags, checkSystemDependencies } from './initialization';
 import cacheManager from './manager/cacheManager';
 import { shutdownRedisClients } from './database/redis';
 import { UnknownError } from './config/errors';
@@ -9,6 +9,7 @@ import { shutdownModules, startModules } from './managers';
 export const platformStart = async () => {
   logApp.info('[OPENCTI] Starting platform', { environment });
   try {
+    checkDeactivatedFeatureFlags();
     // Check all dependencies access
     try {
       await checkSystemDependencies();

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -467,11 +467,7 @@ export const setStoppingState = (state) => {
 
 export const DISABLED_FEATURE_FLAGS = nconf.get('app:disabled_dev_features') ?? [];
 export const isFeatureEnabled = (feature) => {
-  const isActivated = DISABLED_FEATURE_FLAGS.length === 0 || !DISABLED_FEATURE_FLAGS.includes(feature);
-  if (!isActivated) {
-    logApp.info('[FEATURE-FLAG] Deactivated feature still in development', { feature });
-  }
-  return isActivated;
+  return DISABLED_FEATURE_FLAGS.length === 0 || !DISABLED_FEATURE_FLAGS.includes(feature);
 };
 
 export const REDIS_PREFIX = nconf.get('redis:namespace') ? `${nconf.get('redis:namespace')}:` : '';

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -1,7 +1,7 @@
 // Admin user initialization
 import { v4 as uuidv4 } from 'uuid';
 import semver from 'semver';
-import { logApp, PLATFORM_VERSION } from './config/conf';
+import { DISABLED_FEATURE_FLAGS, logApp, PLATFORM_VERSION } from './config/conf';
 import { elUpdateIndicesMappings, initializeSchema, searchEngineInit } from './database/engine';
 import { initializeAdminUser } from './config/providers';
 import { initializeBucket, storageInit } from './database/file-storage';
@@ -23,6 +23,12 @@ import { initializeData } from './database/data-initialization';
 // region Platform constants
 const PLATFORM_LOCK_ID = 'platform_init_lock';
 // endregion
+
+export const checkDeactivatedFeatureFlags = () => {
+  if (DISABLED_FEATURE_FLAGS.length > 0) {
+    logApp.info(`[FEATURE-FLAG] Deactivated features still in development: ${DISABLED_FEATURE_FLAGS}`);
+  }
+};
 
 // Check every dependency
 export const checkSystemDependencies = async () => {


### PR DESCRIPTION
Only log feature flags config at platform initialization once, not on every call to `isFeatureEnabled` which can clog the log files.