### PR TITLE
Popover removal analyses

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
@@ -8,6 +8,7 @@ import ExternalReferenceDetails from './ExternalReferenceDetails';
 import ExternalReferenceEdition from './ExternalReferenceEdition';
 import Security from '../../../../utils/Security';
 import ExternalReferencePopover from './ExternalReferencePopover';
+import ExternalReferencePopoverDeletion from './ExternalReferencePopoverDeletion';
 import ExternalReferenceHeader from './ExternalReferenceHeader';
 import ExternalReferenceFileImportViewer from './ExternalReferenceFileImportViewer';
 import ExternalReferenceStixCoreObjects from './ExternalReferenceStixCoreObjects';
@@ -44,7 +45,7 @@ ExternalReferenceComponentProps
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   return (
     <div className={classes.container}>
-      <ExternalReferenceHeader
+      {!isFABReplaced && (<ExternalReferenceHeader
         externalReference={externalReference}
         PopoverComponent={
           <ExternalReferencePopover id={''} handleRemove={undefined} />
@@ -54,7 +55,18 @@ ExternalReferenceComponentProps
             <ExternalReferenceEdition externalReferenceId={externalReference.id} />
           </Security>
         )}
-      />
+                          />)}
+      {isFABReplaced && (<ExternalReferenceHeader
+        externalReference={externalReference}
+        PopoverComponent={
+          <ExternalReferencePopoverDeletion id={'externalReference.id'} handleRemove={undefined} />
+        }
+        EditComponent={(
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <ExternalReferenceEdition externalReferenceId={externalReference.id} />
+          </Security>
+        )}
+                         />)}
       <Grid
         container={true}
         spacing={3}

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionContainer.tsx
@@ -5,6 +5,7 @@ import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import { ExternalReferenceEditionContainer_externalReference$data } from './__generated__/ExternalReferenceEditionContainer_externalReference.graphql';
 import ExternalReferenceEditionOverview from './ExternalReferenceEditionOverview';
+import ExternalReferencePopoverDeletion from './ExternalReferencePopoverDeletion';
 
 interface ExternalReferenceEditionContainerProps {
   handleClose: () => void
@@ -22,7 +23,6 @@ const ExternalReferenceEditionContainer: FunctionComponent<ExternalReferenceEdit
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { editContext } = externalReference;
 
   return (
@@ -34,10 +34,18 @@ const ExternalReferenceEditionContainer: FunctionComponent<ExternalReferenceEdit
       open={open}
       controlledDial={isFABReplaced ? controlledDial : undefined}
     >
-      <ExternalReferenceEditionOverview
-        externalReference={externalReference}
-        context={editContext}
-      />
+      <>
+        <ExternalReferenceEditionOverview
+          externalReference={externalReference}
+          context={editContext}
+        />
+        {isFABReplaced && (
+          <ExternalReferencePopoverDeletion
+            id={externalReference.id}
+            handleRemove={undefined}
+          />
+        )}
+      </>
     </Drawer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionOverview.tsx
@@ -59,7 +59,6 @@ const ExternalReferenceEditionOverviewComponent: FunctionComponent<
 ExternalReferenceEditionOverviewComponentProps
 > = ({ externalReference, context }) => {
   const { t_i18n } = useFormatter();
-
   const [commitMutationExternalReferenceEditionOverviewFocus] = useApiMutation(
     externalReferenceEditionOverviewFocus,
   );
@@ -71,7 +70,6 @@ ExternalReferenceEditionOverviewComponentProps
     ['source_name', 'external_id', 'url', 'description'],
     externalReference,
   );
-
   const handleChangeFocus = (name: string) => {
     commitMutationExternalReferenceEditionOverviewFocus({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceHeader.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, ReactElement } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
+import useHelper from 'src/utils/hooks/useHelper';
 import { truncate } from '../../../../utils/String';
 import Security from '../../../../utils/Security';
 import { ExternalReferenceHeader_externalReference$data } from './__generated__/ExternalReferenceHeader_externalReference.graphql';
@@ -27,6 +28,8 @@ interface ExternalReferenceHeaderComponentProps {
 
 const ExternalReferenceHeaderComponent: FunctionComponent<ExternalReferenceHeaderComponentProps> = ({ externalReference, PopoverComponent, EditComponent }) => {
   const classes = useStyles();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <div
@@ -44,11 +47,11 @@ const ExternalReferenceHeaderComponent: FunctionComponent<ExternalReferenceHeade
         >
           {truncate(externalReference.source_name, 80)}
         </Typography>
-        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+        {!isFABReplaced && <Security needs={[KNOWLEDGE_KNUPDATE]}>
           <div className={classes.popover}>
             {React.cloneElement(PopoverComponent, { id: externalReference.id })}
           </div>
-        </Security>
+        </Security>}
         <div className="clearfix" />
       </div>
       {EditComponent}

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencePopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencePopoverDeletion.tsx
@@ -1,0 +1,153 @@
+import React, { FunctionComponent, useState } from 'react';
+import { graphql } from 'react-relay';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { useNavigate } from 'react-router-dom';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import { useFormatter } from '../../../../components/i18n';
+import { deleteNodeFromId } from '../../../../utils/store';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+export const externalReferencePopoverDeletionDeleteMutation = graphql`
+  mutation ExternalReferencePopoverDeletionDeleteMutation($id: ID!) {
+    externalReferenceEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+interface ExternalReferencePopoverDeletionProps {
+  id: string;
+  objectId?: string;
+  handleRemove: (() => void) | undefined;
+  isExternalReferenceAttachment?: boolean;
+}
+
+const ExternalReferencePopoverDeletion: FunctionComponent<
+ExternalReferencePopoverDeletionProps
+> = ({ id, objectId, handleRemove, isExternalReferenceAttachment }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [commit] = useApiMutation(externalReferencePopoverDeletionDeleteMutation);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+  };
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      updater: (store) => {
+        if (handleRemove && objectId) {
+          deleteNodeFromId(
+            store,
+            objectId,
+            'Pagination_externalReferences',
+            undefined,
+            id,
+          );
+        }
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        if (handleRemove) {
+          handleCloseDelete();
+        } else {
+          navigate('/dashboard/analyses/external_references');
+        }
+      },
+    });
+  };
+  return (
+    <React.Fragment>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        PaperProps={{ elevation: 1 }}
+        open={displayDelete}
+        keepMounted={true}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this external reference?')}
+            {isExternalReferenceAttachment && (
+              <Alert
+                severity="warning"
+                variant="outlined"
+                style={{ position: 'relative', marginTop: 20 }}
+              >
+                {t_i18n(
+                  'This external reference is linked to a file. If you delete it, the file will be deleted as well.',
+                )}
+              </Alert>
+            )}
+          </DialogContentText>
+          {/* <QueryRenderer
+            query={externalReferenceDeletionEditionQuery}
+            variables={{ id }}
+            render={({
+              props,
+            }: {
+              props: ExternalReferencePopoverEditionQuery$data;
+            }) => {
+              if (props && props.externalReference) {
+                return (
+                  <ExternalReferenceEditionContainer
+                    externalReference={props.externalReference}
+                    handleClose={handleCloseUpdate}
+                    open={displayEdit}
+                  />
+                );
+              }
+              return <div />;
+            }}
+          /> */}
+          {isExternalReferenceAttachment && (
+            <Alert
+              severity="warning"
+              variant="outlined"
+              style={{ position: 'relative', marginTop: 20 }}
+            >
+              {t_i18n(
+                'This external reference is linked to a file. If you delete it, the file will be deleted as well.',
+              )}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};
+
+export default ExternalReferencePopoverDeletion;

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
@@ -25,6 +25,7 @@ import { FormikConfig } from 'formik/dist/types';
 import { Link } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+import useHelper from 'src/utils/hooks/useHelper';
 import { FileLine_file$data } from '@components/common/files/__generated__/FileLine_file.graphql';
 import ManageImportConnectorMessage from '@components/data/import/ManageImportConnectorMessage';
 import ObjectMarkingField from '@components/common/form/ObjectMarkingField';
@@ -49,6 +50,7 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
+import ExternalReferencePopoverDeletion from './ExternalReferencePopoverDeletion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -235,6 +237,8 @@ StixCoreObjectExternalReferencesLinesContainerProps
     });
   };
   const [hasUserChoiceCsvMapper, setHasUserChoiceCsvMapper] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const onCsvMapperSelection = (option: CsvMapperFieldOption | string) => {
     const parsedOption = typeof option === 'string' ? JSON.parse(option) : option;
     const parsedRepresentations = JSON.parse(parsedOption.representations);
@@ -336,14 +340,25 @@ StixCoreObjectExternalReferencesLinesContainerProps
                               externalReferenceId={externalReference.id}
                             />
                           </Security>
-                          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                            <ExternalReferencePopover
+                          {!isFABReplaced
+                            && <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                              <ExternalReferencePopover
+                                id={externalReference.id}
+                                handleRemove={() => handleOpenDialog(externalReferenceEdge)
+                                }
+                                objectId={stixCoreObjectId}
+                              />
+                            </Security>
+                          }
+                          {isFABReplaced && <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                            <ExternalReferencePopoverDeletion
                               id={externalReference.id}
                               handleRemove={() => handleOpenDialog(externalReferenceEdge)
                               }
                               objectId={stixCoreObjectId}
                             />
                           </Security>
+                          }
                         </ListItemSecondaryAction>
                       </ListItem>
                       {externalReference.importFiles?.edges
@@ -400,8 +415,18 @@ StixCoreObjectExternalReferencesLinesContainerProps
                             />
                           </Security>
                         )}
-                        <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                          <ExternalReferencePopover
+                        {!isFABReplaced
+                          && <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                            <ExternalReferencePopover
+                              id={externalReference.id}
+                              isExternalReferenceAttachment={isFileAttached}
+                              handleRemove={() => handleOpenDialog(externalReferenceEdge)
+                              }
+                              objectId={stixCoreObjectId}
+                            />
+                          </Security>}
+                        {isFABReplaced && <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                          <ExternalReferencePopoverDeletion
                             id={externalReference.id}
                             isExternalReferenceAttachment={isFileAttached}
                             handleRemove={() => handleOpenDialog(externalReferenceEdge)
@@ -409,6 +434,7 @@ StixCoreObjectExternalReferencesLinesContainerProps
                             objectId={stixCoreObjectId}
                           />
                         </Security>
+                        }
                       </ListItemSecondaryAction>
                     </ListItem>
                     {externalReference.importFiles?.edges

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
@@ -22,6 +22,7 @@ import { interval } from 'rxjs';
 import { Link } from 'react-router-dom';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
+import useHelper from '../../../../utils/hooks/useHelper';
 import inject18n from '../../../../components/i18n';
 import { truncate } from '../../../../utils/String';
 import { commitMutation } from '../../../../relay/environment';
@@ -36,6 +37,7 @@ import { FIVE_SECONDS } from '../../../../utils/Time';
 import ExternalReferencePopover from './ExternalReferencePopover';
 import { isNotEmptyField } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
+import ExternalReferencePopoverDeletion from './ExternalReferencePopoverDeletion';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -176,6 +178,8 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
     const { expanded } = this.state;
     const externalReferencesEdges = data.stixCoreRelationship.externalReferences.edges;
     const expandable = externalReferencesEdges.length > 7;
+    const { isFeatureEnable } = useHelper();
+    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
     return (
       <div style={{ height: '100%' }}>
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
@@ -266,7 +270,7 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                               </Security>
                             )}
                             <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                              <ExternalReferencePopover
+                              {!isFABReplaced && <ExternalReferencePopover
                                 id={externalReference.id}
                                 isExternalReferenceAttachment={isFileAttached}
                                 objectId={stixCoreRelationshipId}
@@ -274,7 +278,16 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                                   this,
                                   externalReferenceEdge,
                                 )}
-                              />
+                                                 />}
+                              {isFABReplaced && <ExternalReferencePopoverDeletion
+                                id={externalReference.id}
+                                isExternalReferenceAttachment={isFileAttached}
+                                objectId={stixCoreRelationshipId}
+                                handleRemove={this.handleOpenDialog.bind(
+                                  this,
+                                  externalReferenceEdge,
+                                )}
+                                                />}
                             </Security>
                           </ListItemSecondaryAction>
                         </ListItem>
@@ -323,13 +336,20 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                             />
                           </Security>
                           <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                            <ExternalReferencePopover
+                            {!isFABReplaced && <ExternalReferencePopover
                               id={externalReference.id}
                               handleRemove={this.handleOpenDialog.bind(
                                 this,
                                 externalReferenceEdge,
                               )}
-                            />
+                                               />}
+                            {isFABReplaced && <ExternalReferencePopoverDeletion
+                              id={externalReference.id}
+                              handleRemove={this.handleOpenDialog.bind(
+                                this,
+                                externalReferenceEdge,
+                              )}
+                                              />}
                           </Security>
                         </ListItemSecondaryAction>
                       </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -22,6 +22,7 @@ import { interval } from 'rxjs';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import { Link } from 'react-router-dom';
+import useHelper from '../../../../utils/hooks/useHelper';
 import inject18n from '../../../../components/i18n';
 import { truncate } from '../../../../utils/String';
 import { commitMutation } from '../../../../relay/environment';
@@ -36,6 +37,7 @@ import ExternalReferencePopover from './ExternalReferencePopover';
 import ExternalReferenceEnrichment from './ExternalReferenceEnrichment';
 import { isNotEmptyField } from '../../../../utils/utils';
 import ItemIcon from '../../../../components/ItemIcon';
+import ExternalReferencePopoverDeletion from './ExternalReferencePopoverDeletion';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -176,6 +178,8 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
     const { expanded } = this.state;
     const externalReferencesEdges = data.stixSightingRelationship.externalReferences.edges;
     const expandable = externalReferencesEdges.length > 7;
+    const { isFeatureEnable } = useHelper();
+    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
     return (
       <div style={{ height: '100%' }}>
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
@@ -263,7 +267,7 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
                               </Security>
                             )}
                             <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                              <ExternalReferencePopover
+                              {!isFABReplaced && <ExternalReferencePopover
                                 id={externalReference.id}
                                 objectId={stixSightingRelationshipId}
                                 isExternalReferenceAttachment={isFileAttached}
@@ -271,7 +275,16 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
                                   this,
                                   externalReferenceEdge,
                                 )}
-                              />
+                                                 />}
+                              {isFABReplaced && <ExternalReferencePopoverDeletion
+                                id={externalReference.id}
+                                objectId={stixSightingRelationshipId}
+                                isExternalReferenceAttachment={isFileAttached}
+                                handleRemove={this.handleOpenDialog.bind(
+                                  this,
+                                  externalReferenceEdge,
+                                )}
+                                                />}
                             </Security>
                           </ListItemSecondaryAction>
                         </ListItem>
@@ -319,14 +332,22 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
                             />
                           </Security>
                           <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                            <ExternalReferencePopover
+                            {!isFABReplaced && <ExternalReferencePopover
                               id={externalReference.id}
                               isExternalReferenceAttachment={isFileAttached}
                               handleRemove={this.handleOpenDialog.bind(
                                 this,
                                 externalReferenceEdge,
                               )}
-                            />
+                                               />}
+                            {isFABReplaced && <ExternalReferencePopoverDeletion
+                              id={externalReference.id}
+                              isExternalReferenceAttachment={isFileAttached}
+                              handleRemove={this.handleOpenDialog.bind(
+                                this,
+                                externalReferenceEdge,
+                              )}
+                                              />}
                           </Security>
                         </ListItemSecondaryAction>
                       </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionContainer.jsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
 import GroupingEditionOverview from './GroupingEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useHelper from '../../../../utils/hooks/useHelper';
+import GroupingPopoverDeletion from './GroupingPopoverDeletion';
 
 const GroupingEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { handleClose, grouping, open, controlledDial } = props;
   const { editContext } = grouping;
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+  };
 
   return (
     <Drawer
@@ -23,12 +30,22 @@ const GroupingEditionContainer = (props) => {
       context={editContext}
       controlledDial={isFABReplaced ? controlledDial : undefined}
     >
-      <GroupingEditionOverview
-        grouping={grouping}
-        enableReferences={useIsEnforceReference('Grouping')}
-        context={editContext}
-        handleClose={handleClose}
-      />
+      <>
+        <GroupingEditionOverview
+          grouping={grouping}
+          enableReferences={useIsEnforceReference('Grouping')}
+          context={editContext}
+          handleClose={handleClose}
+        />
+        {isFABReplaced
+          && <GroupingPopoverDeletion
+            groupingId={grouping.id}
+            displayDelete={displayDelete}
+            handleClose={handleClose}
+            handleCloseDelete={handleCloseDelete}
+            handleOpenDelete={handleOpenDelete}
+             />}
+      </>
     </Drawer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -16,6 +16,7 @@ import AttackPatternsMatrix from '../../techniques/attack_patterns/AttackPattern
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../../utils/ListParameters';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat-router/withRouter';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const styles = () => ({
   container: {
@@ -147,15 +148,29 @@ class GroupingKnowledgeComponent extends Component {
       enableReferences,
     } = this.props;
     const { currentModeOnlyActive, currentColorsReversed, currentKillChain } = this.state;
+    const { isFeatureEnable } = useHelper();
+    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
     return (
       <div
         className={classes.container}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
       >
-        {mode !== 'graph' && (
+        {!isFABReplaced && mode !== 'graph' && (
           <ContainerHeader
             container={grouping}
             PopoverComponent={<GroupingPopover />}
+            link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
+            modes={['graph', 'correlation', 'matrix']}
+            currentMode={mode}
+            knowledge={true}
+            enableSuggestions={true}
+            investigationAddFromContainer={investigationAddFromContainer}
+          />
+        )}
+        {isFABReplaced && mode !== 'graph' && (
+          <ContainerHeader
+            container={grouping}
+            PopoverComponent={null}
             link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
             modes={['graph', 'correlation', 'matrix']}
             currentMode={mode}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -16,7 +16,6 @@ import AttackPatternsMatrix from '../../techniques/attack_patterns/AttackPattern
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../../utils/ListParameters';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat-router/withRouter';
-import useHelper from '../../../../utils/hooks/useHelper';
 
 const styles = () => ({
   container: {
@@ -148,29 +147,15 @@ class GroupingKnowledgeComponent extends Component {
       enableReferences,
     } = this.props;
     const { currentModeOnlyActive, currentColorsReversed, currentKillChain } = this.state;
-    const { isFeatureEnable } = useHelper();
-    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
     return (
       <div
         className={classes.container}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
       >
-        {!isFABReplaced && mode !== 'graph' && (
+        {mode !== 'graph' && (
           <ContainerHeader
             container={grouping}
             PopoverComponent={<GroupingPopover />}
-            link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
-            modes={['graph', 'correlation', 'matrix']}
-            currentMode={mode}
-            knowledge={true}
-            enableSuggestions={true}
-            investigationAddFromContainer={investigationAddFromContainer}
-          />
-        )}
-        {isFABReplaced && mode !== 'graph' && (
-          <ContainerHeader
-            container={grouping}
-            PopoverComponent={null}
             link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
             modes={['graph', 'correlation', 'matrix']}
             currentMode={mode}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
@@ -46,6 +46,7 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import RelationSelection from '../../../../utils/graph/RelationSelection';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { containerTypes } from '../../../../utils/hooks/useAttributes';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ignoredStixCoreObjectsTypes = ['Note', 'Opinion'];
 
@@ -1013,6 +1014,8 @@ class GroupingKnowledgeGraphComponent extends Component {
       timeRangeInterval,
       this.graphObjects,
     );
+    const { isFeatureEnable } = useHelper();
+    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
     return (
       <UserContext.Consumer>
@@ -1022,7 +1025,7 @@ class GroupingKnowledgeGraphComponent extends Component {
             || window.innerHeight - 235 - bannerSettings.bannerHeightNumber * 2;
           return (
             <>
-              <ContainerHeader
+              {!isFABReplaced && <ContainerHeader
                 container={grouping}
                 PopoverComponent={<GroupingPopover />}
                 link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
@@ -1033,7 +1036,19 @@ class GroupingKnowledgeGraphComponent extends Component {
                 enableSuggestions={true}
                 onApplied={this.handleApplySuggestion.bind(this)}
                 investigationAddFromContainer={investigationAddFromContainer}
-              />
+                                 />}
+              {isFABReplaced && <ContainerHeader
+                container={grouping}
+                PopoverComponent={null}
+                link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
+                modes={['graph', 'content', 'correlation', 'matrix']}
+                currentMode={mode}
+                adjust={this.handleZoomToFit.bind(this)}
+                knowledge={true}
+                enableSuggestions={true}
+                onApplied={this.handleApplySuggestion.bind(this)}
+                investigationAddFromContainer={investigationAddFromContainer}
+                                />}
               <GroupingKnowledgeGraphBar
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
@@ -46,7 +46,6 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import RelationSelection from '../../../../utils/graph/RelationSelection';
 import withRouter from '../../../../utils/compat-router/withRouter';
 import { containerTypes } from '../../../../utils/hooks/useAttributes';
-import useHelper from '../../../../utils/hooks/useHelper';
 
 const ignoredStixCoreObjectsTypes = ['Note', 'Opinion'];
 
@@ -91,8 +90,7 @@ class GroupingKnowledgeGraphComponent extends Component {
       R.map((n) => R.assoc(
         'tlabel',
         props.t(
-          `${n.relationship_type ? 'relationship_' : 'entity_'}${
-            n.entity_type
+          `${n.relationship_type ? 'relationship_' : 'entity_'}${n.entity_type
           }`,
         ),
         n,
@@ -392,8 +390,7 @@ class GroupingKnowledgeGraphComponent extends Component {
         R.map((n) => ({
           label: n,
           tlabel: this.props.t(
-            `${n.relationship_type ? 'relationship_' : 'entity_'}${
-              n.entity_type
+            `${n.relationship_type ? 'relationship_' : 'entity_'}${n.entity_type
             }`,
           ),
         })),
@@ -969,12 +966,12 @@ class GroupingKnowledgeGraphComponent extends Component {
     if (isNotEmptyField(keyword)) {
       const filterByKeyword = (n) => keyword === ''
         || (getMainRepresentative(n) || '').toLowerCase().indexOf(keyword.toLowerCase())
-          !== -1
+        !== -1
         || (getSecondaryRepresentative(n) || '')
           .toLowerCase()
           .indexOf(keyword.toLowerCase()) !== -1
         || (n.entity_type || '').toLowerCase().indexOf(keyword.toLowerCase())
-          !== -1;
+        !== -1;
       R.map(
         (n) => filterByKeyword(n) && this.selectedNodes.add(n),
         this.state.graphData.nodes,
@@ -1014,8 +1011,6 @@ class GroupingKnowledgeGraphComponent extends Component {
       timeRangeInterval,
       this.graphObjects,
     );
-    const { isFeatureEnable } = useHelper();
-    const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
     return (
       <UserContext.Consumer>
@@ -1025,7 +1020,7 @@ class GroupingKnowledgeGraphComponent extends Component {
             || window.innerHeight - 235 - bannerSettings.bannerHeightNumber * 2;
           return (
             <>
-              {!isFABReplaced && <ContainerHeader
+              <ContainerHeader
                 container={grouping}
                 PopoverComponent={<GroupingPopover />}
                 link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
@@ -1036,19 +1031,7 @@ class GroupingKnowledgeGraphComponent extends Component {
                 enableSuggestions={true}
                 onApplied={this.handleApplySuggestion.bind(this)}
                 investigationAddFromContainer={investigationAddFromContainer}
-                                 />}
-              {isFABReplaced && <ContainerHeader
-                container={grouping}
-                PopoverComponent={null}
-                link={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
-                modes={['graph', 'content', 'correlation', 'matrix']}
-                currentMode={mode}
-                adjust={this.handleZoomToFit.bind(this)}
-                knowledge={true}
-                enableSuggestions={true}
-                onApplied={this.handleApplySuggestion.bind(this)}
-                investigationAddFromContainer={investigationAddFromContainer}
-                                />}
+              />
               <GroupingKnowledgeGraphBar
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingPopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingPopoverDeletion.tsx
@@ -1,0 +1,88 @@
+import React, { FunctionComponent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const groupingPopoverDeletionDeleteMutation = graphql`
+  mutation GroupingPopoverDeletionDeleteMutation($id: ID!) {
+    groupingDelete(id: $id)
+  }
+`;
+
+interface GroupingPopoverDeletionProps {
+  groupingId: string;
+  displayDelete: boolean;
+  handleClose: () => void;
+  handleCloseDelete: () => void;
+  handleOpenDelete: () => void;
+}
+
+const GroupingPopoverDeletion: FunctionComponent<GroupingPopoverDeletionProps> = ({
+  groupingId,
+  displayDelete,
+  handleClose,
+  handleCloseDelete,
+  handleOpenDelete,
+}) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [deleting, setDeleting] = useState(false);
+  const [commitMutation] = useApiMutation(groupingPopoverDeletionDeleteMutation);
+  const submitDelete = () => {
+    setDeleting(true);
+    commitMutation({
+      variables: { id: groupingId },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/analyses/groupings');
+      },
+    });
+  };
+  return (
+    <React.Fragment>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this grouping?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};
+
+export default GroupingPopoverDeletion;

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -29,6 +29,7 @@ import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
 import GroupingEdition from './GroupingEdition';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const subscription = graphql`
   subscription RootGroupingSubscription($id: ID!) {
@@ -89,6 +90,8 @@ const RootGrouping = () => {
   const location = useLocation();
   const enableReferences = useIsEnforceReference('Grouping') && !useGranted([KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE]);
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   useSubscription(subConfig);
 
   return (
@@ -110,7 +113,7 @@ const RootGrouping = () => {
                     { label: grouping.name, current: true },
                   ]}
                   />
-                  <ContainerHeader
+                  {!isFABReplaced && <ContainerHeader
                     container={grouping}
                     PopoverComponent={<GroupingPopover />}
                     EditComponent={(
@@ -122,7 +125,20 @@ const RootGrouping = () => {
                     enableQuickExport={true}
                     enableAskAi={true}
                     redirectToContent={true}
-                  />
+                                     />}
+                  {isFABReplaced && <ContainerHeader
+                    container={grouping}
+                    PopoverComponent={null}
+                    EditComponent={(
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <GroupingEdition groupingId={grouping.id} />
+                      </Security>
+                    )}
+                    enableQuickSubscription={true}
+                    enableQuickExport={true}
+                    enableAskAi={true}
+                    redirectToContent={true}
+                                    />}
                   <Box
                     sx={{
                       borderBottom: 1,

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionContainer.tsx
@@ -9,12 +9,14 @@ import {
 } from '@components/analyses/malware_analyses/__generated__/MalwareAnalysisEditionOverview_malwareAnalysis.graphql';
 import { MalwareAnalysisEditionDetails_malwareAnalysis$key } from '@components/analyses/malware_analyses/__generated__/MalwareAnalysisEditionDetails_malwareAnalysis.graphql';
 import useHelper from 'src/utils/hooks/useHelper';
+import { useParams } from 'react-router-dom';
 import { useFormatter } from '../../../../components/i18n';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import MalwareAnalysisEditionOverview from './MalwareAnalysisEditionOverview';
 import { MalwareAnalysisEditionContainerQuery } from './__generated__/MalwareAnalysisEditionContainerQuery.graphql';
 import MalwareAnalysisEditionDetails from './MalwareAnalysisEditionDetails';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
+import MalwareAnalysisPopoverDeletion from './MalwareAnalysisPopoverDeletion';
 
 interface MalwareAnalysisEditionContainerProps {
   queryRef: PreloadedQuery<MalwareAnalysisEditionContainerQuery>
@@ -44,7 +46,7 @@ const MalwareAnalysisEditionContainer: FunctionComponent<MalwareAnalysisEditionC
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
+  const { malwareAnalysisId } = useParams() as { malwareAnalysisId: string };
   const { malwareAnalysis } = usePreloadedQuery(malwareAnalysisEditionQuery, queryRef);
 
   const [currentTab, setCurrentTab] = useState(0);
@@ -88,6 +90,9 @@ const MalwareAnalysisEditionContainer: FunctionComponent<MalwareAnalysisEditionC
               enableReferences={useIsEnforceReference('Malware-Analysis')}
               handleClose={onClose}
             />
+          )}
+          {isFABReplaced && (
+            <MalwareAnalysisPopoverDeletion id={malwareAnalysisId} />
           )}
         </>
       )}

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisPopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisPopoverDeletion.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { RelayError } from '../../../../relay/relayTypes';
+import { MESSAGING$ } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const MalwareAnalysisPopoverDeletionDeleteMutation = graphql`
+  mutation MalwareAnalysisPopoverDeletionDeleteMutation($id: ID!) {
+    malwareAnalysisDelete(id: $id)
+  }
+`;
+
+const MalwareAnalysisPopoverDeletion = ({ id }: { id: string }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const [commit] = useApiMutation(MalwareAnalysisPopoverDeletionDeleteMutation);
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/analyses/malware_analyses');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.data.reason);
+      },
+    });
+  };
+  return (
+    <React.Fragment>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        PaperProps={{ elevation: 1 }}
+        open={displayDelete}
+        keepMounted={true}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this malware analysis?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};
+
+export default MalwareAnalysisPopoverDeletion;

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -12,6 +12,7 @@ import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import Security from 'src/utils/Security';
 import { KNOWLEDGE_KNUPDATE } from 'src/utils/hooks/useGranted';
+import useHelper from 'src/utils/hooks/useHelper';
 import { QueryRenderer } from '../../../../relay/environment';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Loader from '../../../../components/Loader';
@@ -29,6 +30,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
 import MalwareAnalysisEdition from './MalwareAnalysisEdition';
+import MalwareAnalysisPopoverDeletion from './MalwareAnalysisPopoverDeletion';
 
 const subscription = graphql`
   subscription RootMalwareAnalysisSubscription($id: ID!) {
@@ -80,6 +82,8 @@ const RootMalwareAnalysis = () => {
   );
   const location = useLocation();
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   useSubscription(subConfig);
   const link = `/dashboard/analyses/malware_analyses/${malwareAnalysisId}/knowledge`;
   return (
@@ -100,7 +104,7 @@ const RootMalwareAnalysis = () => {
                     { label: getMainRepresentative(malwareAnalysis), current: true },
                   ]}
                   />
-                  <StixDomainObjectHeader
+                  {!isFABReplaced && <StixDomainObjectHeader
                     entityType={'Malware-Analysis'}
                     stixDomainObject={malwareAnalysis}
                     PopoverComponent={
@@ -112,7 +116,20 @@ const RootMalwareAnalysis = () => {
                       </Security>
                     )}
                     noAliases={true}
-                  />
+                                     />}
+                  {isFABReplaced && <StixDomainObjectHeader
+                    entityType={'Malware-Analysis'}
+                    stixDomainObject={malwareAnalysis}
+                    PopoverComponent={
+                      <MalwareAnalysisPopoverDeletion id={malwareAnalysisId} />
+                    }
+                    EditComponent={(
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <MalwareAnalysisEdition malwareAnalysisId={malwareAnalysis.id} />
+                      </Security>
+                    )}
+                    noAliases={true}
+                                    />}
                   <Box
                     sx={{
                       borderBottom: 1,

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionContainer.tsx
@@ -35,11 +35,13 @@ const NoteEditionContainer: FunctionComponent<NoteEditionContainerProps> = ({
       controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       {({ onClose }) => (
-        <NoteEditionOverview
-          note={note}
-          context={editContext}
-          handleClose={onClose}
-        />
+        <>
+          <NoteEditionOverview
+            note={note}
+            context={editContext}
+            handleClose={onClose}
+          />
+        </>
       )}
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
+import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -23,6 +24,7 @@ import SliderField from '../../../../components/fields/SliderField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import NotePopoverDeletion from './NotePopoverDeletion';
 
 export const noteMutationFieldPatch = graphql`
   mutation NoteEditionOverviewFieldPatchMutation(
@@ -146,6 +148,8 @@ NoteEditionOverviewProps
     objectMarking: convertMarkings(note),
     x_opencti_workflow_id: convertStatus(t_i18n, note) as Option,
   };
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   return (
     <Formik
@@ -271,6 +275,10 @@ NoteEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
+          {isFABReplaced
+            && <NotePopoverDeletion
+              id={note.id}
+               />}
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NotePopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NotePopoverDeletion.tsx
@@ -1,0 +1,101 @@
+import React, { FunctionComponent, useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import { StixCoreObjectOrStixCoreRelationshipNoteCard_node$data } from './__generated__/StixCoreObjectOrStixCoreRelationshipNoteCard_node.graphql';
+import Transition from '../../../../components/Transition';
+import { deleteNode } from '../../../../utils/store';
+import { StixCoreObjectOrStixCoreRelationshipNotesCardsQuery$variables } from './__generated__/StixCoreObjectOrStixCoreRelationshipNotesCardsQuery.graphql';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const NotePopoverDeletionDeleteMutation = graphql`
+  mutation NotePopoverDeletionDeleteMutation($id: ID!) {
+    noteEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+interface NotePopoverProps {
+  id?: string;
+  handleOpenRemoveExternal?: () => void;
+  note?: StixCoreObjectOrStixCoreRelationshipNoteCard_node$data;
+  paginationOptions?: StixCoreObjectOrStixCoreRelationshipNotesCardsQuery$variables;
+}
+
+const NotePopoverDeletion: FunctionComponent<NotePopoverProps> = ({
+  id,
+  handleOpenRemoveExternal,
+  paginationOptions,
+}) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const [displayDelete, setDisplayDelete] = useState<boolean>(false);
+  const [deleting, setDeleting] = useState<boolean>(false);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const [commit] = useApiMutation(NotePopoverDeletionDeleteMutation);
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      updater: (store) => {
+        if (paginationOptions) {
+          deleteNode(store, 'Pagination_notes', paginationOptions, id);
+        }
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        if (handleOpenRemoveExternal) {
+          handleCloseDelete();
+        } else {
+          navigate('/dashboard/analyses/notes');
+        }
+      },
+    });
+  };
+  return (
+    <React.Fragment>
+      <Button
+        color="error"
+        variant="contained"
+        onClick={handleOpenDelete}
+        disabled={deleting}
+        sx={{ marginTop: 2 }}
+      >
+        {t_i18n('Delete')}
+      </Button>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this note?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};
+
+export default NotePopoverDeletion;

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import useHelper from '../../../../utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import ReportEditionOverview from './ReportEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
+import ReportPopoverDeletion from './ReportPopoverDeletion';
 
 const ReportEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { handleClose, report, open, controlledDial } = props;
   const { editContext } = report;
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+  };
 
   return (
     <Drawer
@@ -23,12 +30,23 @@ const ReportEditionContainer = (props) => {
       context={editContext}
       controlledDial={isFABReplaced ? controlledDial : undefined}
     >
-      <ReportEditionOverview
-        report={report}
-        enableReferences={useIsEnforceReference('Report')}
-        context={editContext}
-        handleClose={handleClose}
-      />
+      <>
+        <ReportEditionOverview
+          report={report}
+          enableReferences={useIsEnforceReference('Report')}
+          context={editContext}
+          handleClose={handleClose}
+        />
+        {isFABReplaced
+          && <ReportPopoverDeletion
+            reportId={report.id}
+            displayDelete={displayDelete}
+            handleClose={handleClose}
+            handleCloseDelete={handleCloseDelete}
+            handleOpenDelete={handleOpenDelete}
+             />
+        }
+      </>
     </Drawer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
@@ -38,14 +38,10 @@ const ReportEditionContainer = (props) => {
           handleClose={handleClose}
         />
         {isFABReplaced
-          && <ReportPopoverDeletion
+          && (<ReportPopoverDeletion
             reportId={report.id}
-            displayDelete={displayDelete}
-            handleClose={handleClose}
-            handleCloseDelete={handleCloseDelete}
-            handleOpenDelete={handleOpenDelete}
-             />
-        }
+          />
+        )}
       </>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -251,6 +251,8 @@ class ReportKnowledgeComponent extends Component {
       orderBy,
       orderMode: 'desc',
     };
+    // const { isFeatureEnable } = useHelper();
+    // const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
     return (
       <div
         className={classes.container}
@@ -258,17 +260,30 @@ class ReportKnowledgeComponent extends Component {
         data-testid='report-knowledge'
       >
         {mode !== 'graph' && (
-        <ContainerHeader
-          container={report}
-          PopoverComponent={<ReportPopover />}
-          link={`/dashboard/analyses/reports/${report.id}/knowledge`}
-          modes={['graph', 'timeline', 'correlation', 'matrix']}
-          currentMode={mode}
-          knowledge={true}
-          enableSuggestions={true}
-          investigationAddFromContainer={investigationAddFromContainer}
-        />
-        )}
+          <ContainerHeader
+            container={report}
+            PopoverComponent={<ReportPopover />}
+            link={`/dashboard/analyses/reports/${report.id}/knowledge`}
+            modes={['graph', 'timeline', 'correlation', 'matrix']}
+            currentMode={mode}
+            knowledge={true}
+            enableSuggestions={true}
+            investigationAddFromContainer={investigationAddFromContainer}
+          />
+        )
+        }
+        {/* {isFABReplaced && mode !== 'graph' && (
+          <ContainerHeader
+            container={report}
+            PopoverComponent={null}
+            link={`/dashboard/analyses/reports/${report.id}/knowledge`}
+            modes={['graph', 'timeline', 'correlation', 'matrix']}
+            currentMode={mode}
+            knowledge={true}
+            enableSuggestions={true}
+            investigationAddFromContainer={investigationAddFromContainer}
+          />
+        )} */}
         <Routes>
           <Route
             path="/graph"
@@ -279,7 +294,7 @@ class ReportKnowledgeComponent extends Component {
                 render={({ props }) => {
                   if (props && props.report) {
                     return (
-                      <ReportKnowledgeGraph report={props.report} mode={mode} enableReferences={enableReferences}/>
+                      <ReportKnowledgeGraph report={props.report} mode={mode} enableReferences={enableReferences} />
                     );
                   }
                   return (

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
@@ -93,8 +93,7 @@ class ReportKnowledgeGraphComponent extends Component {
       R.map((n) => R.assoc(
         'tlabel',
         props.t(
-          `${n.relationship_type ? 'relationship_' : 'entity_'}${
-            n.entity_type
+          `${n.relationship_type ? 'relationship_' : 'entity_'}${n.entity_type
           }`,
         ),
         n,
@@ -395,8 +394,7 @@ class ReportKnowledgeGraphComponent extends Component {
         R.map((n) => ({
           label: n,
           tlabel: this.props.t(
-            `${n.relationship_type ? 'relationship_' : 'entity_'}${
-              n.entity_type
+            `${n.relationship_type ? 'relationship_' : 'entity_'}${n.entity_type
             }`,
           ),
         })),
@@ -970,12 +968,12 @@ class ReportKnowledgeGraphComponent extends Component {
     if (isNotEmptyField(keyword)) {
       const filterByKeyword = (n) => keyword === ''
         || (getMainRepresentative(n) || '').toLowerCase().indexOf(keyword.toLowerCase())
-          !== -1
+        !== -1
         || (getSecondaryRepresentative(n) || '')
           .toLowerCase()
           .indexOf(keyword.toLowerCase()) !== -1
         || (n.entity_type || '').toLowerCase().indexOf(keyword.toLowerCase())
-          !== -1;
+        !== -1;
       R.map(
         (n) => filterByKeyword(n) && this.selectedNodes.add(n),
         this.state.graphData.nodes,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
@@ -10,12 +10,15 @@ import ReportEditionContainer from './ReportEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { QueryRenderer } from '../../../../relay/environment';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ReportPopover = ({ id }) => {
   const { t_i18n } = useFormatter();
   const [anchorEl, setAnchorEl] = useState(null);
   const [displayEdit, setDisplayEdit] = useState(false);
   const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACED');
   const handleOpen = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
   const handleOpenDelete = () => {
@@ -33,44 +36,52 @@ const ReportPopover = ({ id }) => {
   const handleCloseEnrichment = () => {
     setDisplayEnrichment(false);
   };
-  return (
+  return isFABReplaced 
+  ? (<></>)
+  : (
     <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-        title={t_i18n('Report actions')}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-          <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
-        </Security>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
-      <QueryRenderer
-        query={reportEditionQuery}
-        variables={{ id }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <ReportEditionContainer
-                report={props.report}
-                handleClose={handleCloseEdit}
-                open={displayEdit}
-              />
-            );
-          }
-          return <div />;
-        }}
-      />
-    </>
-  );
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+          title={t_i18n('Report actions')}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
+          </Security>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
+        <ReportPopoverDeletion
+          reportId={id}
+          displayDelete={displayDelete}
+          handleClose={handleClose}
+          handleCloseDelete={handleCloseDelete}
+        />
+        <QueryRenderer
+          query={reportEditionQuery}
+          variables={{ id }}
+          render={({ props }) => {
+            if (props) {
+              return (
+                <ReportEditionContainer
+                  report={props.report}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
+      </>
+    );
 };
 
 export default ReportPopover;

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
@@ -10,22 +10,16 @@ import ReportEditionContainer from './ReportEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { QueryRenderer } from '../../../../relay/environment';
-import ReportPopoverDeletion from './ReportPopoverDeletion';
 
 const ReportPopover = ({ id }) => {
   const { t_i18n } = useFormatter();
   const [anchorEl, setAnchorEl] = useState(null);
-  const [displayDelete, setDisplayDelete] = useState(false);
   const [displayEdit, setDisplayEdit] = useState(false);
   const [displayEnrichment, setDisplayEnrichment] = useState(false);
   const handleOpen = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
   const handleOpenDelete = () => {
-    setDisplayDelete(true);
     handleClose();
-  };
-  const handleCloseDelete = () => {
-    setDisplayDelete(false);
   };
   const handleOpenEdit = () => {
     setDisplayEdit(true);
@@ -59,12 +53,6 @@ const ReportPopover = ({ id }) => {
         </Security>
       </Menu>
       <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
-      <ReportPopoverDeletion
-        reportId={id}
-        displayDelete={displayDelete}
-        handleClose={handleClose}
-        handleCloseDelete={handleCloseDelete}
-      />
       <QueryRenderer
         query={reportEditionQuery}
         variables={{ id }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopoverDeletion.tsx
@@ -40,6 +40,7 @@ interface ReportPopoverDeletionProps {
   displayDelete: boolean;
   handleClose: () => void;
   handleCloseDelete: () => void;
+  handleOpenDelete: () => void;
 }
 
 const ReportPopoverDeletion: FunctionComponent<ReportPopoverDeletionProps> = ({
@@ -47,6 +48,7 @@ const ReportPopoverDeletion: FunctionComponent<ReportPopoverDeletionProps> = ({
   displayDelete,
   handleClose,
   handleCloseDelete,
+  handleOpenDelete,
 }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
@@ -66,63 +68,75 @@ const ReportPopoverDeletion: FunctionComponent<ReportPopoverDeletionProps> = ({
     });
   };
   return (
-    <Dialog
-      open={displayDelete}
-      TransitionComponent={Transition}
-      PaperProps={{ elevation: 1 }}
-      onClose={handleCloseDelete}
-    >
-      <DialogContent>
-        <DialogContentText>
-          {t_i18n('Do you want to delete this report?')}
-        </DialogContentText>
-        <QueryRenderer
-          query={reportPopoverDeletionQuery}
-          variables={{ id: reportId }}
-          render={(result: { props: ReportPopoverDeletionQuery$data }) => {
-            const numberOfDeletions = result.props?.report?.deleteWithElementsCount ?? 0;
-            if (numberOfDeletions === 0) return <div />;
-            return (
-              <Alert
-                severity="warning"
-                variant="outlined"
-                style={{ marginTop: 20 }}
-              >
-                <AlertTitle>{t_i18n('Cascade delete')}</AlertTitle>
-                {t_i18n('In this report, ')}&nbsp;
-                <strong style={{ color: theme.palette.error.main }}>
-                  {numberOfDeletions}
-                </strong>
-                &nbsp;
-                {t_i18n(
-                  'element(s) are not linked to any other reports and will be orphan after the deletion.',
-                )}
-                <FormGroup>
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        disableRipple={true}
-                        checked={purgeElements}
-                        onChange={() => setPurgeElements(!purgeElements)}
-                      />
-                    }
-                    label={t_i18n('Also delete these elements')}
-                  />
-                </FormGroup>
-              </Alert>
-            );
-          }}
-        ></QueryRenderer>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleCloseDelete} disabled={deleting}>
-          {t_i18n('Cancel')}
-        </Button>
-        <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-          {t_i18n('Delete')}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <React.Fragment>
+      <Button
+        color="error"
+        variant="contained"
+        onClick={handleOpenDelete}
+        disabled={deleting}
+        sx={{ marginTop: 2 }}
+      >
+        {t_i18n('Delete')}
+      </Button>
+      <Dialog
+        open={displayDelete}
+        TransitionComponent={Transition}
+        PaperProps={{ elevation: 1 }}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this report?')}
+          </DialogContentText>
+          <QueryRenderer
+            query={reportPopoverDeletionQuery}
+            variables={{ id: reportId }}
+            render={(result: { props: ReportPopoverDeletionQuery$data }) => {
+              const numberOfDeletions = result.props?.report?.deleteWithElementsCount ?? 0;
+              if (numberOfDeletions === 0) return <div />;
+              return (
+                <Alert
+                  severity="warning"
+                  variant="outlined"
+                  style={{ marginTop: 20 }}
+                >
+                  <AlertTitle>{t_i18n('Cascade delete')}</AlertTitle>
+                  {t_i18n('In this report, ')}&nbsp;
+                  <strong style={{ color: theme.palette.error.main }}>
+                    {numberOfDeletions}
+                  </strong>
+                  &nbsp;
+                  {t_i18n(
+                    'element(s) are not linked to any other reports and will be orphan after the deletion.',
+                  )}
+                  <FormGroup>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          disableRipple={true}
+                          checked={purgeElements}
+                          onChange={() => setPurgeElements(!purgeElements)}
+                        />
+                      }
+                      label={t_i18n('Also delete these elements')}
+                    />
+                  </FormGroup>
+                </Alert>
+              );
+            }}
+          >
+          </QueryRenderer>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -112,12 +112,21 @@ const RootReport = () => {
                     { label: report.name, current: true },
                   ]}
                   />
-                  <ContainerHeader
+                  {!isFABReplaced && <ContainerHeader
                     container={report}
                     PopoverComponent={
                       <ReportPopover id={reportId} />
                     }
-                    EditComponent={isFABReplaced && (
+                    enableQuickSubscription={true}
+                    enableQuickExport={true}
+                    enableAskAi={true}
+                    overview={isOverview}
+                    redirectToContent={true}
+                                     />}
+                  {isFABReplaced && <ContainerHeader
+                    container={report}
+                    PopoverComponent={null}
+                    EditComponent={(
                       <Security needs={[KNOWLEDGE_KNUPDATE]}>
                         <ReportEdition reportId={report.id} />
                       </Security>
@@ -127,7 +136,7 @@ const RootReport = () => {
                     enableAskAi={true}
                     overview={isOverview}
                     redirectToContent={true}
-                  />
+                                    />}
                   <Box
                     sx={{
                       borderBottom: 1,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -23,8 +23,10 @@ import MenuItem from '@mui/material/MenuItem';
 import CircularProgress from '@mui/material/CircularProgress';
 import { makeStyles } from '@mui/styles';
 import Box from '@mui/material/Box';
+import useHelper from '../../../../utils/hooks/useHelper';
 import { stixCoreObjectQuickSubscriptionContentQuery } from '../stix_core_objects/stixCoreObjectTriggersUtils';
 import StixCoreObjectAskAI from '../stix_core_objects/StixCoreObjectAskAI';
+import StixCoreObjectEnrichment from '../stix_core_objects/StixCoreObjectEnrichment';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 import StixCoreObjectSubscribers from '../stix_core_objects/StixCoreObjectSubscribers';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
@@ -469,6 +471,10 @@ const ContainerHeader = (props) => {
   const [selectedEntity, setSelectedEntity] = useState({});
   const [applying, setApplying] = useState([]);
   const [applied, setApplied] = useState([]);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+
   // Suggestions
   const resolveThreats = (objects) => objects.filter(
     (o) => [
@@ -515,7 +521,12 @@ const ContainerHeader = (props) => {
       localStorage.getItem(`suggestions-rules-${container.id}`) || '[]',
     );
   };
-
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+  };
   const generateSuggestions = (objects) => {
     const suggestions = [];
     const resolvedThreats = resolveThreats(objects);
@@ -1063,9 +1074,19 @@ const ContainerHeader = (props) => {
                 type="container"
               />
             )}
-            {!knowledge && (
+            {!isFABReplaced && !knowledge && (
               <Security needs={popoverSecurity || [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNENRICHMENT]}>
                 {React.cloneElement(PopoverComponent, { id: container.id })}
+              </Security>
+            )}
+            {isFABReplaced && (
+              <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
+                <StixCoreObjectEnrichment
+                  stixCoreObjectId={container.id}
+                  displayEnrichment={displayEnrichment}
+                  handleOpenEnrichment={handleOpenEnrichment}
+                  handleClose={handleCloseEnrichment}
+                />
               </Security>
             )}
             {EditComponent}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -1074,7 +1074,7 @@ const ContainerHeader = (props) => {
                 type="container"
               />
             )}
-            {!isFABReplaced && !knowledge && (
+            {!knowledge && (
               <Security needs={popoverSecurity || [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNENRICHMENT]}>
                 {React.cloneElement(PopoverComponent, { id: container.id })}
               </Security>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichment.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichment.jsx
@@ -1,38 +1,75 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as R from 'ramda';
 import { CloudRefreshOutline } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
 import ToggleButton from '@mui/material/ToggleButton';
+import useHelper from '../../../../utils/hooks/useHelper';
 import Drawer from '../drawer/Drawer';
 import { QueryRenderer } from '../../../../relay/environment';
 import inject18n from '../../../../components/i18n';
 import StixCoreObjectEnrichmentLines, { stixCoreObjectEnrichmentLinesQuery } from './StixCoreObjectEnrichmentLines';
 
-class StixCoreObjectEnrichment extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const StixCoreObjectEnrichment = (props) => {
+  const { t, stixCoreObjectId, handleClose, open } = props;
+  const [openDrawer, setOpenDrawer] = useState(false);
+  const [search, setSearch] = useState('');
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
-  handleOpen() {
-    if (this.props.closeMenu) {
-      this.props.closeMenu();
+  const handleOpenEnrichment = () => {
+    if (props.closeMenu) {
+      props.closeMenu();
     }
-    this.setState({ open: true });
-  }
+    setOpenDrawer(true);
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleCloseEnrichment = () => {
+    setOpenDrawer(false);
+    setSearch('');
+  };
 
-  render() {
-    const { t, stixCoreObjectId, handleClose, open } = this.props;
-    return (
-      <>
-        {!handleClose
+  return (
+    <>
+      {isFABReplaced && <Tooltip title={t('Enrichment')}>
+        <ToggleButton
+          onClick={handleOpenEnrichment}
+          value="enrich"
+          size="small"
+          style={{ marginRight: 3 }}
+        >
+          <CloudRefreshOutline fontSize="small" color="primary" />
+        </ToggleButton>
+      </Tooltip>}
+      {isFABReplaced && <Drawer
+        open={openDrawer || open}
+        onClose={handleCloseEnrichment || handleClose}
+        title={t('Enrichment connectors')}
+                        >
+        <QueryRenderer
+          query={stixCoreObjectEnrichmentLinesQuery}
+          variables={{ id: stixCoreObjectId }}
+          render={({ props: queryProps }) => {
+            if (
+              queryProps
+              && queryProps.stixCoreObject
+              && queryProps.connectorsForImport
+            ) {
+              return (
+                <StixCoreObjectEnrichmentLines
+                  stixCoreObject={queryProps.stixCoreObject}
+                  connectorsForImport={queryProps.connectorsForImport}
+                  search={search}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
+      </Drawer>}
+      {!isFABReplaced && !handleClose
           && <Tooltip title={t('Enrichment')}>
             <ToggleButton
-              onClick={this.handleOpen.bind(this)}
+              onClick={handleOpenEnrichment}
               value="enrich"
               size="small"
               style={{ marginRight: 3 }}
@@ -41,34 +78,33 @@ class StixCoreObjectEnrichment extends Component {
             </ToggleButton>
           </Tooltip>
         }
-        <Drawer
-          open={open || this.state.open}
-          onClose={handleClose || this.handleClose.bind(this)}
-          title={t('Enrichment connectors')}
-        >
-          <QueryRenderer
-            query={stixCoreObjectEnrichmentLinesQuery}
-            variables={{ id: stixCoreObjectId }}
-            render={({ props: queryProps }) => {
-              if (
-                queryProps
+      {!isFABReplaced && <Drawer
+        open={open || handleOpenEnrichment}
+        onClose={handleClose || handleCloseEnrichment}
+        title={t('Enrichment connectors')}
+                         >
+        <QueryRenderer
+          query={stixCoreObjectEnrichmentLinesQuery}
+          variables={{ id: stixCoreObjectId }}
+          render={({ props: queryProps }) => {
+            if (
+              queryProps
                 && queryProps.stixCoreObject
                 && queryProps.connectorsForImport
-              ) {
-                return (
-                  <StixCoreObjectEnrichmentLines
-                    stixCoreObject={queryProps.stixCoreObject}
-                    connectorsForImport={queryProps.connectorsForImport}
-                  />
-                );
-              }
-              return <div />;
-            }}
-          />
-        </Drawer>
-      </>
-    );
-  }
-}
+            ) {
+              return (
+                <StixCoreObjectEnrichmentLines
+                  stixCoreObject={queryProps.stixCoreObject}
+                  connectorsForImport={queryProps.connectorsForImport}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
+        </Drawer>}
+    </>
+  );
+};
 
 export default R.compose(inject18n)(StixCoreObjectEnrichment);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -24,6 +24,7 @@ import MenuItem from '@mui/material/MenuItem';
 import * as R from 'ramda';
 import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
+import useHelper from '../../../../utils/hooks/useHelper';
 import { stixCoreObjectQuickSubscriptionContentQuery } from '../stix_core_objects/stixCoreObjectTriggersUtils';
 import StixCoreObjectAskAI from '../stix_core_objects/StixCoreObjectAskAI';
 import StixCoreObjectSubscribers from '../stix_core_objects/StixCoreObjectSubscribers';
@@ -178,7 +179,6 @@ export const stixDomainObjectMutation = graphql`
 const aliasValidation = (t) => Yup.object().shape({
   references: Yup.array().required(t('This field is required')),
 });
-
 const StixDomainObjectHeader = (props) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
@@ -205,6 +205,8 @@ const StixDomainObjectHeader = (props) => {
   const [aliasToDelete, setAliasToDelete] = useState(null);
   const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
   const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   let type = 'unsupported';
   const isThreat = ['Threat-Actor-Group', 'Threat-Actor-Individual', 'Intrusion-Set', 'Campaign', 'Incident', 'Malware', 'Tool'].includes(stixDomainObject.entity_type);
   const isVictim = ['Sector', 'Organization', 'System', 'Individual', 'Region', 'Country', 'Administrative-Area', 'City', 'Position'].includes(stixDomainObject.entity_type);
@@ -531,7 +533,7 @@ const StixDomainObjectHeader = (props) => {
               type={type}
             />
           )}
-          {(isKnowledgeUpdater || isKnowledgeEnricher) && (
+          {!isFABReplaced && (isKnowledgeUpdater || isKnowledgeEnricher) && (
           <div className={classes.popover}>
             {/* TODO remove this when all components are pure function without compose() */}
             {!React.isValidElement(PopoverComponent) ? (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -533,7 +533,7 @@ const StixDomainObjectHeader = (props) => {
               type={type}
             />
           )}
-          {!isFABReplaced && (isKnowledgeUpdater || isKnowledgeEnricher) && (
+          {(isKnowledgeUpdater || isKnowledgeEnricher) && (
           <div className={classes.popover}>
             {/* TODO remove this when all components are pure function without compose() */}
             {!React.isValidElement(PopoverComponent) ? (


### PR DESCRIPTION
### Proposed changes

* Remove the ... popover icon.
* Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
* Float the Enrich option to the top row and use the default cloud enrichment icon
* Only applies to analyses

This work is complemenatry to the FAB replacement PRs that have been being submiited.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
