### PR TITLE
[frontend/backend] authorized members bypass organization sharing for case IR (#4538)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -47,6 +47,9 @@ const rootSettingsFragment = graphql`
     platform_openmtd_url
     platform_theme
     platform_whitemark
+    platform_organization {
+      id
+    }
     platform_session_idle_timeout
     platform_session_timeout
     platform_feature_flags {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncident.tsx
@@ -27,7 +27,7 @@ import ListLines from '../../../../components/list_lines/ListLines';
 import { CaseTasksLineDummy } from '../tasks/CaseTasksLine';
 import { isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import { FilterGroup } from '../../../../utils/filters/filtersHelpers-types';
-import { getCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -52,7 +52,7 @@ const CaseIncident: React.FC<CaseIncidentProps> = ({ caseIncidentData, enableRef
   const caseIncident = useFragment(caseFragment, caseIncidentData);
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const { canEdit } = getCurrentUserAccessRight(caseIncident.currentUserAccessRight);
+  const { canEdit } = useGetCurrentUserAccessRight(caseIncident.currentUserAccessRight);
 
   const LOCAL_STORAGE_KEY_CASE_TASKS = `cases-${caseIncident.id}-caseTask`;
 

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -143,7 +143,7 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
         container={caseData}
         PopoverComponent={<CaseIncidentPopover id={caseData.id} />}
         EditComponent={
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <Security needs={[KNOWLEDGE_KNUPDATE]} hasAccess={currentAccessRight.canEdit}>
             <CaseIncidentEdition caseId={caseData.id} />
           </Security>
         }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -32,6 +32,7 @@ import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE } 
 import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
 import CaseIncidentEdition from './CaseIncidentEdition';
 import useHelper from '../../../../utils/hooks/useHelper';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
 const subscription = graphql`
   subscription RootIncidentCaseSubscription($id: ID!) {
@@ -104,9 +105,7 @@ const caseIncidentAuthorizedMembersMutation = graphql`
 `;
 
 const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
-  const subConfig = useMemo<
-  GraphQLSubscriptionConfig<RootIncidentSubscription>
-  >(
+  const subConfig = useMemo<GraphQLSubscriptionConfig<RootIncidentSubscription>>(
     () => ({
       subscription,
       variables: { id: caseId },
@@ -123,151 +122,150 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
     connectorsForExport,
     connectorsForImport,
   } = usePreloadedQuery<RootIncidentCaseQuery>(caseIncidentQuery, queryRef);
-  const isOverview = location.pathname === `/dashboard/cases/incidents/${caseData?.id}`;
-  const paddingRight = getPaddingRight(location.pathname, caseData?.id, '/dashboard/cases/incidents', false);
+  if (!caseData) {
+    return <ErrorNotFound />;
+  }
+  const isOverview = location.pathname === `/dashboard/cases/incidents/${caseData.id}`;
+  const paddingRight = getPaddingRight(location.pathname, caseData.id, '/dashboard/cases/incidents', false);
   const { isFeatureEnable } = useHelper();
-  const canManageAuthorizedMembers = caseData?.currentUserAccessRight === 'admin' && isFeatureEnable('CONTAINERS_AUTHORIZED_MEMBERS');
+
+  const currentAccessRight = useGetCurrentUserAccessRight(caseData.currentUserAccessRight);
+  const canManageAuthorizedMembers = currentAccessRight.canManage && isFeatureEnable('CONTAINERS_AUTHORIZED_MEMBERS');
   return (
-    <>
-      {caseData ? (
-        <div style={{ paddingRight }} data-testid="incident-details-page">
-          <Breadcrumbs variant="object" elements={[
-            { label: t_i18n('Cases') },
-            { label: t_i18n('Incident responses'), link: '/dashboard/cases/incidents' },
-            { label: caseData.name, current: true },
-          ]}
+    <div style={{ paddingRight }} data-testid="incident-details-page">
+      <Breadcrumbs variant="object" elements={[
+        { label: t_i18n('Cases') },
+        { label: t_i18n('Incident responses'), link: '/dashboard/cases/incidents' },
+        { label: caseData.name, current: true },
+      ]}
+      />
+      <ContainerHeader
+        container={caseData}
+        PopoverComponent={<CaseIncidentPopover id={caseData.id} />}
+        EditComponent={
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <CaseIncidentEdition caseId={caseData.id} />
+          </Security>
+        }
+        enableQuickSubscription={true}
+        enableAskAi={true}
+        redirectToContent={true}
+        enableManageAuthorizedMembers={canManageAuthorizedMembers}
+        authorizedMembersMutation={caseIncidentAuthorizedMembersMutation}
+      />
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          marginBottom: 3,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItem: 'center',
+        }}
+      >
+        <Tabs
+          value={getCurrentTab(location.pathname, caseData.id, '/dashboard/cases/incidents')}
+        >
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}`}
+            value={`/dashboard/cases/incidents/${caseData.id}`}
+            label={t_i18n('Overview')}
           />
-          <ContainerHeader
-            container={caseData}
-            PopoverComponent={<CaseIncidentPopover id={caseData.id} />}
-            EditComponent={
-              <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                <CaseIncidentEdition caseId={caseData.id} />
-              </Security>
-            }
-            enableQuickSubscription={true}
-            enableAskAi={true}
-            redirectToContent={true}
-            enableManageAuthorizedMembers={canManageAuthorizedMembers}
-            authorizedMembersMutation={caseIncidentAuthorizedMembersMutation}
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}/knowledge/graph`}
+            value={`/dashboard/cases/incidents/${caseData.id}/knowledge`}
+            label={t_i18n('Knowledge')}
           />
-          <Box
-            sx={{
-              borderBottom: 1,
-              borderColor: 'divider',
-              marginBottom: 3,
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItem: 'center',
-            }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, caseData.id, '/dashboard/cases/incidents')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}`}
-                value={`/dashboard/cases/incidents/${caseData.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}/knowledge/graph`}
-                value={`/dashboard/cases/incidents/${caseData.id}/knowledge`}
-                label={t_i18n('Knowledge')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}/content`}
-                value={`/dashboard/cases/incidents/${caseData.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}/entities`}
-                value={`/dashboard/cases/incidents/${caseData.id}/entities`}
-                label={t_i18n('Entities')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}/observables`}
-                value={`/dashboard/cases/incidents/${caseData.id}/observables`}
-                label={t_i18n('Observables')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/incidents/${caseData.id}/files`}
-                value={`/dashboard/cases/incidents/${caseData.id}/files`}
-                label={t_i18n('Data')}
-              />
-            </Tabs>
-            {isOverview && (
-            <StixCoreObjectSimulationResult id={caseData.id} type="container" />
-            )}
-          </Box>
-          <Routes>
-            <Route
-              path="/"
-              element={<CaseIncident caseIncidentData={caseData} enableReferences={enableReferences} />}
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}/content`}
+            value={`/dashboard/cases/incidents/${caseData.id}/content`}
+            label={t_i18n('Content')}
+          />
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}/entities`}
+            value={`/dashboard/cases/incidents/${caseData.id}/entities`}
+            label={t_i18n('Entities')}
+          />
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}/observables`}
+            value={`/dashboard/cases/incidents/${caseData.id}/observables`}
+            label={t_i18n('Observables')}
+          />
+          <Tab
+            component={Link}
+            to={`/dashboard/cases/incidents/${caseData.id}/files`}
+            value={`/dashboard/cases/incidents/${caseData.id}/files`}
+            label={t_i18n('Data')}
+          />
+        </Tabs>
+        {isOverview && (
+          <StixCoreObjectSimulationResult id={caseData.id} type="container" />
+        )}
+      </Box>
+      <Routes>
+        <Route
+          path="/"
+          element={<CaseIncident caseIncidentData={caseData} enableReferences={enableReferences} />}
+        />
+        <Route
+          path="/entities"
+          element={
+            <ContainerStixDomainObjects
+              container={caseData}
+              enableReferences={enableReferences}
+            />}
+        />
+        <Route
+          path="/observables"
+          element={
+            <ContainerStixCyberObservables
+              container={caseData}
+              enableReferences={enableReferences}
+            />}
+        />
+        <Route
+          path="/knowledge"
+          element={
+            <Navigate
+              replace={true}
+              to={`/dashboard/cases/incidents/${caseId}/knowledge/graph`}
+            />}
+        />
+        <Route
+          path="/content/*"
+          element={
+            <StixCoreObjectContentRoot
+              stixCoreObject={caseData}
+              isContainer={true}
             />
-            <Route
-              path="/entities"
-              element={
-                <ContainerStixDomainObjects
-                  container={caseData}
-                  enableReferences={enableReferences}
-                />}
-            />
-            <Route
-              path="/observables"
-              element={
-                <ContainerStixCyberObservables
-                  container={caseData}
-                  enableReferences={enableReferences}
-                />}
-            />
-            <Route
-              path="/knowledge"
-              element={
-                <Navigate
-                  replace={true}
-                  to={`/dashboard/cases/incidents/${caseId}/knowledge/graph`}
-                />}
-            />
-            <Route
-              path="/content/*"
-              element={
-                <StixCoreObjectContentRoot
-                  stixCoreObject={caseData}
-                  isContainer={true}
-                />
-              }
-            />
-            <Route
-              path="/knowledge/*"
-              element={
-                <IncidentKnowledge caseData={caseData}
-                  enableReferences={enableReferences}
-                />}
-            />
-            <Route
-              path="/files"
-              element={
-                <StixCoreObjectFilesAndHistory
-                  id={caseId}
-                  connectorsExport={connectorsForExport}
-                  connectorsImport={connectorsForImport}
-                  entity={caseData}
-                  withoutRelations={true}
-                  bypassEntityId={true}
-                />}
-            />
-          </Routes>
-        </div>
-      ) : (
-        <ErrorNotFound />
-      )}
-    </>
+          }
+        />
+        <Route
+          path="/knowledge/*"
+          element={
+            <IncidentKnowledge caseData={caseData}
+              enableReferences={enableReferences}
+            />}
+        />
+        <Route
+          path="/files"
+          element={
+            <StixCoreObjectFilesAndHistory
+              id={caseId}
+              connectorsExport={connectorsForExport}
+              connectorsImport={connectorsForImport}
+              entity={caseData}
+              withoutRelations={true}
+              bypassEntityId={true}
+            />}
+        />
+      </Routes>
+    </div>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Feedback.tsx
@@ -11,7 +11,7 @@ import FeedbackEdition from './FeedbackEdition';
 import StixCoreObjectExternalReferences from '../../analyses/external_references/StixCoreObjectExternalReferences';
 import StixCoreObjectLatestHistory from '../../common/stix_core_objects/StixCoreObjectLatestHistory';
 import { Feedback_case$key } from './__generated__/Feedback_case.graphql';
-import { getCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import useOverviewLayoutCustomization from '../../../../utils/hooks/useOverviewLayoutCustomization';
 
 const feedbackFragment = graphql`
@@ -84,7 +84,7 @@ const Feedback: React.FC<FeedbackProps> = ({ feedbackData, enableReferences }) =
   const { isFeatureEnable } = useHelper();
   const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const overviewLayoutCustomization = useOverviewLayoutCustomization('Feedback');
-  const { canEdit } = getCurrentUserAccessRight(feedback.currentUserAccessRight);
+  const { canEdit } = useGetCurrentUserAccessRight(feedback.currentUserAccessRight);
 
   return (
     <>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -42,7 +42,7 @@ import StixCoreObjectQuickSubscription from '../stix_core_objects/StixCoreObject
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import StixCoreObjectFileExport from '../stix_core_objects/StixCoreObjectFileExport';
 import Transition from '../../../../components/Transition';
-import { authorizedMembersToOptions } from '../../../../utils/authorizedMembers';
+import { authorizedMembersToOptions, useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -753,6 +753,7 @@ const ContainerHeader = (props) => {
       ],
     },
   };
+  const { canEdit } = useGetCurrentUserAccessRight(container.currentUserAccessRight);
   const triggerData = useLazyLoadQuery(stixCoreObjectQuickSubscriptionContentQuery, { first: 20, ...triggersPaginationOptions });
   return (
     <Box sx={containerStyle}>
@@ -1064,7 +1065,7 @@ const ContainerHeader = (props) => {
               />
             )}
             {!knowledge && (
-              <Security needs={popoverSecurity || [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNENRICHMENT]}>
+              <Security needs={popoverSecurity || [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNENRICHMENT]} hasAccess={canEdit}>
                 {React.cloneElement(PopoverComponent, { id: container.id })}
               </Security>
             )}
@@ -1098,9 +1099,11 @@ export default createFragmentContainer(ContainerHeader, {
       }
       ... on Case {
         name
+        currentUserAccessRight
       }
       ... on Feedback {
         name
+        currentUserAccessRight
       }
       ... on Task {
         name

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -29,6 +29,7 @@ import { useSettingsMessagesBannerHeight } from '../../settings/settings_message
 import StixCoreObjectSubscribers from '../stix_core_objects/StixCoreObjectSubscribers';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
 import ExportButtons from '../../../../components/ExportButtons';
+import useHelper from '../../../../utils/hooks/useHelper';
 import Security from '../../../../utils/Security';
 import { useFormatter } from '../../../../components/i18n';
 import { truncate } from '../../../../utils/String';
@@ -464,6 +465,7 @@ const ContainerHeader = (props) => {
   } = props;
   const classes = useStyles();
   const { t_i18n, fd } = useFormatter();
+  const { isFeatureEnable } = useHelper();
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
   const [displaySuggestions, setDisplaySuggestions] = useState(false);
   const [selectedEntity, setSelectedEntity] = useState({});
@@ -753,7 +755,8 @@ const ContainerHeader = (props) => {
       ],
     },
   };
-  const { canEdit } = useGetCurrentUserAccessRight(container.currentUserAccessRight);
+  const currentAccessRight = useGetCurrentUserAccessRight(container.currentUserAccessRight);
+  const canEdit = currentAccessRight.canEdit || container.entity_type !== 'Case-Incident' || !isFeatureEnable('CONTAINERS_AUTHORIZED_MEMBERS');
   const triggerData = useLazyLoadQuery(stixCoreObjectQuickSubscriptionContentQuery, { first: 20, ...triggersPaginationOptions });
   return (
     <Box sx={containerStyle}>
@@ -1099,7 +1102,6 @@ export default createFragmentContainer(ContainerHeader, {
       }
       ... on Case {
         name
-        currentUserAccessRight
       }
       ... on Feedback {
         name
@@ -1110,6 +1112,7 @@ export default createFragmentContainer(ContainerHeader, {
       }
       ... on CaseIncident {
         name
+        currentUserAccessRight
         authorized_members {
           id
           name

--- a/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembers.tsx
@@ -25,6 +25,7 @@ interface FormAuthorizedMembersProps {
   ) => void;
   owner?: Creator;
   canDeactivate?: boolean;
+  showAllMembersLine?: boolean;
 }
 
 const FormAuthorizedMembers = ({
@@ -34,6 +35,7 @@ const FormAuthorizedMembers = ({
   onSubmit,
   owner,
   canDeactivate,
+  showAllMembersLine,
 }: FormAuthorizedMembersProps) => {
   const { t_i18n } = useFormatter();
 
@@ -66,7 +68,7 @@ const FormAuthorizedMembers = ({
                   name="authorizedMembers"
                   component={AuthorizedMembersField}
                   owner={owner}
-                  showAllMembersLine
+                  showAllMembersLine={showAllMembersLine}
                   canDeactivate={canDeactivate}
                 />
               )}

--- a/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembersDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembersDialog.tsx
@@ -10,6 +10,7 @@ import { AuthorizedMemberOption, Creator } from '../../../../utils/authorizedMem
 import { handleErrorInForm } from '../../../../relay/environment';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useAuth from '../../../../utils/hooks/useAuth';
 
 interface FormAuthorizedMembersDialogProps {
   id: string;
@@ -27,6 +28,8 @@ const FormAuthorizedMembersDialog = ({
   const { t_i18n } = useFormatter();
   const [open, setOpen] = useState(false);
   const isEnterpriseEdition = useEnterpriseEdition();
+  const { settings } = useAuth();
+  const showAllMembersLine = !settings.platform_organization?.id;
   const [commit] = useApiMutation(mutation);
   const onSubmit = (
     values: FormAuthorizedMembersInputs,
@@ -81,6 +84,7 @@ const FormAuthorizedMembersDialog = ({
         onSubmit={onSubmit}
         owner={owner}
         canDeactivate
+        showAllMembersLine={showAllMembersLine}
       />
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
@@ -43,7 +43,7 @@ import { useFormatter } from '../../../components/i18n';
 import WorkspaceManageAccessDialog from './WorkspaceManageAccessDialog';
 import Transition from '../../../components/Transition';
 import useHelper from '../../../utils/hooks/useHelper';
-import { getCurrentUserAccessRight } from '../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -117,7 +117,7 @@ const WorkspaceHeader = ({
   const [openTag, setOpenTag] = useState(false);
   const [newTag, setNewTag] = useState('');
   const [openTags, setOpenTags] = useState(false);
-  const { canManage, canEdit } = getCurrentUserAccessRight(workspace.currentUserAccessRight);
+  const { canManage, canEdit } = useGetCurrentUserAccessRight(workspace.currentUserAccessRight);
   const [displayDuplicate, setDisplayDuplicate] = useState(false);
   const handleCloseDuplicate = () => setDisplayDuplicate(false);
   const [duplicating, setDuplicating] = useState(false);

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceManageAccessDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceManageAccessDialog.tsx
@@ -109,6 +109,7 @@ WorkspaceManageAccessDialogProps
       handleClose={handleClose}
       onSubmit={onSubmitForm}
       owner={owner ?? undefined}
+      showAllMembersLine={true}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
@@ -25,7 +25,7 @@ import { deleteNode, insertNode } from '../../../utils/store';
 import handleExportJson from './workspaceExportHandler';
 import WorkspaceDuplicationDialog from './WorkspaceDuplicationDialog';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
-import { getCurrentUserAccessRight } from '../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
 import useHelper from '../../../utils/hooks/useHelper';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -110,7 +110,7 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
   };
 
   const handleCloseEdit = () => setDisplayEdit(false);
-  const { canManage, canEdit } = getCurrentUserAccessRight(workspace.currentUserAccessRight);
+  const { canManage, canEdit } = useGetCurrentUserAccessRight(workspace.currentUserAccessRight);
   if (!canEdit && workspace.type !== 'dashboard') {
     return <></>;
   }

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
@@ -12,7 +12,7 @@ import useDeletion from '../../../../../utils/hooks/useDeletion';
 import DeleteDialog from '../../../../../components/DeleteDialog';
 import { EXPLORE_EXUPDATE_PUBLISH } from '../../../../../utils/hooks/useGranted';
 import Security from '../../../../../utils/Security';
-import { getCurrentUserAccessRight } from '../../../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../../../utils/authorizedMembers';
 import { deleteNode } from '../../../../../utils/store';
 
 interface PublicDashboardLineActionsProps {
@@ -44,7 +44,7 @@ const PublicDashboardLineActions = ({ publicDashboard, paginationOptions }: Publ
   const deletion = useDeletion({});
   const { handleOpenDelete } = deletion;
 
-  const { canManage } = getCurrentUserAccessRight(publicDashboard.dashboard.currentUserAccessRight);
+  const { canManage } = useGetCurrentUserAccessRight(publicDashboard.dashboard.currentUserAccessRight);
 
   const copyLinkUrl = () => {
     copyToClipboard(

--- a/opencti-platform/opencti-front/src/utils/authorizedMembers.ts
+++ b/opencti-platform/opencti-front/src/utils/authorizedMembers.ts
@@ -54,7 +54,7 @@ export const authorizedMembersToOptions = (
     });
 };
 
-export const getCurrentUserAccessRight = (userAccessRight: string | null | undefined) => {
+export const useGetCurrentUserAccessRight = (userAccessRight: string | null | undefined) => {
   const canManage = userAccessRight === 'admin';
   const canEdit = canManage || userAccessRight === 'edit';
   const canView = canManage || canEdit || userAccessRight === 'view';

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -224,7 +224,7 @@ describe('Elasticsearch computation', () => {
     // noinspection JSUnresolvedVariable
     const storedFormat = moment(R.head(data).date)._f;
     expect(storedFormat).toEqual('YYYY-MM-DD');
-    expect(R.head(data).value).toEqual(35);
+    expect(R.head(data).value).toEqual(36);
   });
   it('should month histogram accurate', async () => {
     const data = await elHistogramCount(
@@ -396,7 +396,7 @@ describe('Elasticsearch pagination', () => {
   it('should entity paginate everything', async () => {
     const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { first: ES_MAX_PAGINATION });
     expect(data).not.toBeNull();
-    expect(data.edges.length).toEqual(536);
+    expect(data.edges.length).toEqual(537);
     const filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('ENTITY');
@@ -492,7 +492,7 @@ describe('Elasticsearch pagination', () => {
       filterGroups: [],
     };
     const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { filters, first: ES_MAX_PAGINATION });
-    expect(data.edges.length).toEqual(525);
+    expect(data.edges.length).toEqual(526);
   });
   it('should entity paginate with field exist filter', async () => {
     const filters = {
@@ -555,7 +555,7 @@ describe('Elasticsearch pagination', () => {
       filterGroups: [],
     };
     data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { filters, first: ES_MAX_PAGINATION });
-    expect(data.edges.length).toEqual(367);
+    expect(data.edges.length).toEqual(368);
     filters = {
       mode: 'and',
       filters: [
@@ -573,7 +573,7 @@ describe('Elasticsearch pagination', () => {
       orderMode: 'asc',
       first: ES_MAX_PAGINATION
     });
-    expect(data.edges.length).toEqual(518 + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
+    expect(data.edges.length).toEqual(519 + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
     const createdDates = R.map((e) => e.node.created, data.edges);
     let previousCreatedDate = null;
     for (let index = 0; index < createdDates.length; index += 1) {
@@ -671,7 +671,7 @@ describe('Elasticsearch pagination', () => {
     let data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { includeAuthorities: true });
     expect(data).not.toBeNull();
     const groupByIndices = R.groupBy((e) => e.node._index, data.edges);
-    expect(groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].length).toEqual(92);
+    expect(groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].length).toEqual(93);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_core_relationships-000001`].length).toEqual(24);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_meta_relationships-000001`].length).toEqual(129);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_sighting_relationships-000001`].length).toEqual(2);
@@ -683,14 +683,14 @@ describe('Elasticsearch pagination', () => {
     expect(metaByEntityType['external-reference'].length).toEqual(7);
     expect(metaByEntityType['object-marking'].length).toEqual(28);
     expect(metaByEntityType['kill-chain-phase'].length).toEqual(3);
-    expect(data.edges.length).toEqual(247);
+    expect(data.edges.length).toEqual(248);
     let filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');
     // Same query with no pagination
     data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { connectionFormat: false });
     expect(data).not.toBeNull();
-    expect(data.length).toEqual(247);
+    expect(data.length).toEqual(248);
     filterBaseTypes = R.uniq(R.map((e) => e.base_type, data));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -1237,7 +1237,7 @@ describe('Complex filters combinations for elastic queries', () => {
         filters: undefined,
       }
     });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(43);
+    expect(queryResult.data.globalSearch.edges.length).toEqual(44);
     // (source_reliability is empty)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,
@@ -1257,7 +1257,7 @@ describe('Complex filters combinations for elastic queries', () => {
         },
       }
     });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(32); // 41 entities - 9 entities with a source reliability = 32
+    expect(queryResult.data.globalSearch.edges.length).toEqual(33); // 44 entities - 11 entities with a source reliability = 33
     // (source_reliability is not empty)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,
@@ -1317,7 +1317,7 @@ describe('Complex filters combinations for elastic queries', () => {
         },
       }
     });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(37); // 43 entities - 6 entities with source reliability equals to A = 37
+    expect(queryResult.data.globalSearch.edges.length).toEqual(38); // 44 entities - 6 entities with source reliability equals to A = 38
     // (source_reliability = A - Completely reliable OR B - Usually reliable)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,
@@ -1420,7 +1420,7 @@ describe('Complex filters combinations for elastic queries', () => {
         },
       }
     });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(30); // 41 - 9 with a source reliability - 2 with a reliability (and no source reliability) = 30
+    expect(queryResult.data.globalSearch.edges.length).toEqual(31); // 44 - 11 with a source reliability - 2 with a reliability (and no source reliability) = 31
     // (computed_reliability is not empty)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,
@@ -1440,7 +1440,7 @@ describe('Complex filters combinations for elastic queries', () => {
         },
       }
     });
-    expect(queryResult.data.globalSearch.edges.length).toEqual(13); // 9 entities with a source reliability + 2 entities with a reliability = 11
+    expect(queryResult.data.globalSearch.edges.length).toEqual(13); // 11 entities with a source reliability + 2 entities with a reliability = 13
     // (computed_reliability = A - Completely reliable)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -184,7 +184,7 @@ describe('Entities listing', () => {
   it('should list multiple entities', async () => {
     const entities = await listEntities(testContext, ADMIN_USER, ['Malware', 'Organization']);
     expect(entities).not.toBeNull();
-    expect(entities.edges.length).toEqual(9); // 2 malwares + 7 organizations
+    expect(entities.edges.length).toEqual(10); // 2 malwares + 8 organizations
     const aggregationMap = new Map(entities.edges.map((i) => [i.node.name, i.node]));
     expect(aggregationMap.get('Paradise Ransomware')).not.toBeUndefined();
     expect(aggregationMap.get('Allied Universal')).not.toBeUndefined();

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/case-incident-response-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/case-incident-response-test.ts
@@ -1,13 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, getUserIdByEmail, queryAsAdmin, USER_EDITOR } from '../../utils/testQuery';
+import {
+  ADMIN_USER,
+  adminQuery,
+  editorQuery,
+  getOrganizationIdByName,
+  getUserIdByEmail,
+  PLATFORM_ORGANIZATION,
+  queryAsAdmin,
+  securityQuery,
+  TEST_ORGANIZATION,
+  USER_EDITOR,
+  USER_SECURITY
+} from '../../utils/testQuery';
 import type { CaseIncident, EntitySettingEdge } from '../../../src/generated/graphql';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../../../src/modules/case/case-incident/case-incident-types';
 import { queryAsUserWithSuccess } from '../../utils/testQueryHelper';
 import { executionContext, SYSTEM_USER } from '../../../src/utils/access';
 import { initCreateEntitySettings } from '../../../src/modules/entitySetting/entitySetting-domain';
-import { resetCacheForEntity } from '../../../src/database/cache';
-import { ENTITY_TYPE_ENTITY_SETTING } from '../../../src/modules/entitySetting/entitySetting-types';
 
 const CREATE_QUERY = gql`
   mutation CaseIncidentAdd($input: CaseIncidentAddInput!) {
@@ -41,9 +51,55 @@ const READ_QUERY = gql`
   }
 `;
 
+const LIST_QUERY = gql`
+  query caseIncidents(
+    $first: Int
+    $after: ID
+    $orderBy: CaseIncidentsOrdering
+    $orderMode: OrderingMode
+    $filters: FilterGroup
+    $search: String
+    $toStix: Boolean
+  ) {
+    caseIncidents(
+      first: $first
+      after: $after
+      orderBy: $orderBy
+      orderMode: $orderMode
+      filters: $filters
+      search: $search
+      toStix: $toStix
+    ) {
+      edges {
+        node {
+          id
+          standard_id
+        }
+      }
+    }
+  }
+`;
+
 const DELETE_QUERY = gql`
   mutation CaseIncidentDelete($id: ID!) {
     caseIncidentDelete(id: $id)
+  }
+`;
+
+const EDIT_AUTHORIZED_MEMBERS_QUERY = gql`
+  mutation CaseIncidentEditAuthorizedMembers(
+    $id: ID!
+    $input: [MemberAccessInput!]!
+  ) {
+    caseIncidentEditAuthorizedMembers(id: $id, input: $input){
+      authorized_members {
+        id
+        name
+        entity_type
+        access_right
+      }
+      id
+    }
   }
 `;
 
@@ -75,34 +131,6 @@ describe('Case Incident Response resolver standard behavior', () => {
     expect(queryResult?.data?.caseIncident.id).toEqual(caseIncidentResponse.id);
   });
   it('should list Case Incident Response', async () => {
-    const LIST_QUERY = gql`
-      query caseIncidents(
-        $first: Int
-        $after: ID
-        $orderBy: CaseIncidentsOrdering
-        $orderMode: OrderingMode
-        $filters: FilterGroup
-        $search: String
-        $toStix: Boolean
-      ) {
-        caseIncidents(
-          first: $first
-          after: $after
-          orderBy: $orderBy
-          orderMode: $orderMode
-          filters: $filters
-          search: $search
-          toStix: $toStix
-        ) {
-          edges {
-            node {
-              id
-              standard_id
-            }
-          }
-        }
-      }
-    `;
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
     expect(queryResult?.data?.caseIncidents.edges.length).toEqual(1);
   });
@@ -140,22 +168,6 @@ describe('Case Incident Response resolver standard behavior', () => {
 
 describe('Case Incident Response standard behavior with authorized_members activation from entity', () => {
   let caseIncidentResponseAuthorizedMembersFromEntity: CaseIncident;
-  const EDIT_AUTHORIZED_MEMBERS_QUERY = gql`
-    mutation CaseIncidentEditAuthorizedMembers(
-      $id: ID!
-      $input: [MemberAccessInput!]!
-    ) {
-      caseIncidentEditAuthorizedMembers(id: $id, input: $input){
-        authorized_members {
-          id
-          name
-          entity_type
-          access_right
-        }
-        id
-      }
-    }
-  `;
   it('should Case Incident Response created', async () => {
     // Create Case Incident Response
     const caseIncidentResponseCreateQueryResult = await queryAsAdmin({
@@ -220,9 +232,10 @@ describe('Case Incident Response standard behavior with authorized_members activ
       }
     });
     // Get current User access right
-    const currentUserAccessRightQueryResult = await queryAsUserWithSuccess(USER_EDITOR.client, { query: READ_QUERY,
-      variables: { id: caseIncidentResponseAuthorizedMembersFromEntity.id }, });
-    // console.log(currentUserAccessRightQueryResult?.data?.caseIncident.currentUserAccessRight);
+    const currentUserAccessRightQueryResult = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: READ_QUERY,
+      variables: { id: caseIncidentResponseAuthorizedMembersFromEntity.id },
+    });
     expect(currentUserAccessRightQueryResult).not.toBeNull();
     expect(currentUserAccessRightQueryResult?.data?.caseIncident.currentUserAccessRight).toEqual('view');
   });
@@ -255,24 +268,24 @@ describe('Case Incident Response standard behavior with authorized_members activ
     }
   `;
   it('should init entity settings', async () => {
-    const LIST_QUERY = gql`
-          query entitySettings {
-              entitySettings {
-                  edges {
-                      node {
-                          id
-                          target_type
-                          platform_entity_files_ref
-                          platform_hidden_type
-                          enforce_reference
-                      }
-                  }
-              }
+    const ENTITY_SETTINGS_QUERY = gql`
+      query entitySettings {
+        entitySettings {
+          edges {
+            node {
+              id
+              target_type
+              platform_entity_files_ref
+              platform_hidden_type
+              enforce_reference
+            }
           }
-      `;
+        }
+      }
+    `;
     const context = executionContext('test');
     await initCreateEntitySettings(context, SYSTEM_USER);
-    const queryResult = await queryAsAdmin({ query: LIST_QUERY });
+    const queryResult = await adminQuery({ query: ENTITY_SETTINGS_QUERY });
 
     const entitySettingCaseIncidentResponse = queryResult.data?.entitySettings.edges
       .filter((entitySetting: EntitySettingEdge) => entitySetting.node.target_type === ENTITY_TYPE_CONTAINER_CASE_INCIDENT)[0];
@@ -292,13 +305,12 @@ describe('Case Incident Response standard behavior with authorized_members activ
         ]
       }
     ]);
-    const updateEntitySettingsResult = await queryAsAdmin({
+    const updateEntitySettingsResult = await adminQuery({
       query: ENTITY_SETTINGS_UPDATE_QUERY,
       variables: { ids: [entitySettingIdCaseIncidentResponse], input: { key: 'attributes_configuration', value: [authorizedMembersConfiguration] } },
     });
     expect(updateEntitySettingsResult.data?.entitySettingsFieldPatch?.[0]?.attributes_configuration).toEqual(authorizedMembersConfiguration);
-    resetCacheForEntity(ENTITY_TYPE_ENTITY_SETTING);
-    const caseIncidentResponseAuthorizedMembersData = await queryAsAdmin({
+    const caseIncidentResponseAuthorizedMembersData = await adminQuery({
       query: CREATE_QUERY,
       variables: {
         input: {
@@ -317,7 +329,7 @@ describe('Case Incident Response standard behavior with authorized_members activ
     caseIncidentResponseAuthorizedMembersFromSettings = caseIncidentResponseAuthorizedMembersData?.data?.caseIncidentAdd;
     // Clean
     const cleanAuthorizedMembersConfiguration = JSON.stringify([{ name: 'authorized_members', default_values: null }]);
-    const cleanEntitySettingsResult = await queryAsAdmin({
+    const cleanEntitySettingsResult = await adminQuery({
       query: ENTITY_SETTINGS_UPDATE_QUERY,
       variables: { ids: [entitySettingIdCaseIncidentResponse], input: { key: 'attributes_configuration', value: [cleanAuthorizedMembersConfiguration] } },
     });
@@ -325,12 +337,342 @@ describe('Case Incident Response standard behavior with authorized_members activ
   });
   it('should Case Incident Response deleted', async () => {
     // Delete the case
-    await queryAsAdmin({
+    await adminQuery({
       query: DELETE_QUERY,
       variables: { id: caseIncidentResponseAuthorizedMembersFromSettings.id },
     });
     // Verify is no longer found
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: caseIncidentResponseAuthorizedMembersFromSettings.id } });
+    const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: caseIncidentResponseAuthorizedMembersFromSettings.id } });
+    expect(queryResult).not.toBeNull();
+    expect(queryResult?.data?.caseIncident).toBeNull();
+  });
+});
+
+describe('Case Incident Response and organization sharing standard behavior without platform organization', () => {
+  let testOrganizationId: string;
+  let caseIrId: string;
+  let userSecurityId: string;
+  let settingsInternalId: string;
+  const EE_QUERY = gql`
+    mutation PoliciesFieldPatchMutation($id: ID!, $input: [EditInput]!) {
+      settingsEdit(id: $id) {
+        fieldPatch(input: $input) {
+          enterprise_edition
+          id
+        }
+      }
+    }
+  `;
+  it('should Case Incident Response created', async () => {
+    // Create Case Incident Response
+    const caseIRCreateQueryResult = await adminQuery({
+      query: CREATE_QUERY,
+      variables: {
+        input: {
+          name: 'Case IR without platform Orga'
+        }
+      }
+    });
+
+    expect(caseIRCreateQueryResult).not.toBeNull();
+    expect(caseIRCreateQueryResult?.data?.caseIncidentAdd.authorized_members).not.toBeUndefined();
+    expect(caseIRCreateQueryResult?.data?.caseIncidentAdd.authorized_members).toEqual([]); // authorized members not activated
+    caseIrId = caseIRCreateQueryResult?.data?.caseIncidentAdd.id;
+  });
+  it('should EE activated', async () => {
+    // Get settings ID
+    const SETTINGS_READ_QUERY = gql`
+      query settings {
+        settings {
+          id
+        }
+      }
+    `;
+    const queryResult = await adminQuery({ query: SETTINGS_READ_QUERY, variables: {} });
+    settingsInternalId = queryResult.data?.settings?.id;
+
+    // Set plateform organization
+    const eeActivationQuery = await adminQuery({
+      query: EE_QUERY,
+      variables: {
+        id: settingsInternalId,
+        input: [
+          { key: 'enterprise_edition', value: new Date().getTime() },
+        ]
+      }
+    });
+
+    expect(eeActivationQuery).not.toBeNull();
+    expect(eeActivationQuery?.data?.settingsEdit.fieldPatch.enterprise_edition).not.toBeUndefined();
+  });
+  it('should share Case Incident Response with Organization', async () => {
+    // Get organization id
+    testOrganizationId = await getOrganizationIdByName(TEST_ORGANIZATION.name);
+    const ORGANIZATION_SHARING_QUERY = gql`
+      mutation StixCoreObjectSharingGroupAddMutation(
+        $id: ID!
+        $organizationId: ID!
+      ) {
+        stixCoreObjectEdit(id: $id) {
+          restrictionOrganizationAdd(organizationId: $organizationId) {
+            id
+            objectOrganization {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+
+    const organizationSharingQueryResult = await adminQuery({
+      query: ORGANIZATION_SHARING_QUERY,
+      variables: { id: caseIrId, organizationId: testOrganizationId }
+    });
+    expect(organizationSharingQueryResult).not.toBeNull();
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd).not.toBeNull();
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd.objectOrganization[0].name).toEqual(TEST_ORGANIZATION.name);
+  });
+  it('should not access Case Incident Response', async () => {
+    const caseIRQueryResult = await securityQuery({ query: READ_QUERY, variables: { id: caseIrId } }); // USER_SECURITY is not part of TEST_ORGANIZATION
+    expect(caseIRQueryResult).not.toBeNull();
+    expect(caseIRQueryResult.data?.caseIncident).toBeNull();
+  });
+  it('should Authorized Members activated', async () => {
+    userSecurityId = await getUserIdByEmail(USER_SECURITY.email);
+    await queryAsAdmin({
+      query: EDIT_AUTHORIZED_MEMBERS_QUERY,
+      variables: {
+        id: caseIrId,
+        input: [
+          {
+            id: ADMIN_USER.id,
+            access_right: 'admin'
+          },
+          {
+            id: userSecurityId,
+            access_right: 'view'
+          }
+        ]
+      }
+    });
+    // Verify if authorized members have been edited
+    const caseIRUpdatedQueryResult = await adminQuery({
+      query: READ_QUERY,
+      variables: { id: caseIrId }
+    });
+    expect(caseIRUpdatedQueryResult).not.toBeNull();
+    expect(caseIRUpdatedQueryResult?.data?.caseIncident.authorized_members).not.toBeUndefined();
+    expect(caseIRUpdatedQueryResult?.data?.caseIncident.authorized_members).toEqual([
+      {
+        id: ADMIN_USER.id,
+        access_right: 'admin'
+      },
+      {
+        id: userSecurityId,
+        access_right: 'view'
+      }
+    ]);
+  });
+  it('should access Case Incident Response out of her organization if authorized members activated', async () => {
+    const caseIRQueryResult = await securityQuery({ query: READ_QUERY, variables: { id: caseIrId } });
+    expect(caseIRQueryResult).not.toBeNull();
+    expect(caseIRQueryResult?.data?.caseIncident).not.toBeUndefined();
+    expect(caseIRQueryResult?.data?.caseIncident.id).toEqual(caseIrId);
+  });
+  it('should Case Incident Response deleted', async () => {
+    // Delete the case
+    await adminQuery({
+      query: DELETE_QUERY,
+      variables: { id: caseIrId },
+    });
+    // Verify is no longer found
+    const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: caseIrId } });
+    expect(queryResult).not.toBeNull();
+    expect(queryResult?.data?.caseIncident).toBeNull();
+  });
+  it('should EE deactivated', async () => {
+    // Remove EE
+    const eeDeactivationQuery = await adminQuery({
+      query: EE_QUERY,
+      variables: { id: settingsInternalId,
+        input: [
+          { key: 'enterprise_edition', value: [] },
+        ] }
+    });
+    expect(eeDeactivationQuery).not.toBeNull();
+    expect(eeDeactivationQuery?.data?.settingsEdit.fieldPatch.enterprise_edition).toBeNull();
+  });
+});
+
+describe('Case Incident Response and organization sharing standard behavior with platform organization', () => {
+  let testOrganizationId: string;
+  let caseIrId: string;
+  let userEditorId: string;
+  let settingsInternalId: string;
+  const PLATFORM_ORGANIZATION_QUERY = gql`
+    mutation PoliciesFieldPatchMutation($id: ID!, $input: [EditInput]!) {
+      settingsEdit(id: $id) {
+        fieldPatch(input: $input) {
+          platform_organization {
+            id
+            name
+          }
+          enterprise_edition
+          id
+        }
+      }
+    }
+  `;
+  it('should plateform organization sharing and EE activated', async () => {
+    // Get organization id
+    testOrganizationId = await getOrganizationIdByName(PLATFORM_ORGANIZATION.name);
+
+    // Get settings ID
+    const SETTINGS_READ_QUERY = gql`
+      query settings {
+        settings {
+          id
+          platform_organization {
+            id
+            name
+          }
+        }
+      }
+    `;
+    const queryResult = await adminQuery({ query: SETTINGS_READ_QUERY, variables: {} });
+    settingsInternalId = queryResult.data?.settings?.id;
+
+    // Set plateform organization
+    const platformOrganization = await adminQuery({
+      query: PLATFORM_ORGANIZATION_QUERY,
+      variables: {
+        id: settingsInternalId,
+        input: [
+          { key: 'platform_organization', value: testOrganizationId },
+          { key: 'enterprise_edition', value: new Date().getTime() },
+        ]
+      }
+    });
+
+    expect(platformOrganization).not.toBeNull();
+    expect(platformOrganization?.data?.settingsEdit.fieldPatch.platform_organization).not.toBeUndefined();
+    expect(platformOrganization?.data?.settingsEdit.fieldPatch.enterprise_edition).not.toBeUndefined();
+    expect(platformOrganization?.data?.settingsEdit.fieldPatch.platform_organization.name).toEqual(PLATFORM_ORGANIZATION.name);
+  });
+  it('should Case Incident Response created', async () => {
+    // Create Case Incident Response
+    const caseIRCreateQueryResult = await adminQuery({
+      query: CREATE_QUERY,
+      variables: {
+        input: {
+          name: 'Case IR with platform orga'
+        }
+      }
+    });
+
+    expect(caseIRCreateQueryResult).not.toBeNull();
+    expect(caseIRCreateQueryResult?.data?.caseIncidentAdd.authorized_members).not.toBeUndefined();
+    expect(caseIRCreateQueryResult?.data?.caseIncidentAdd.authorized_members).toEqual([]); // authorized members not activated
+    caseIrId = caseIRCreateQueryResult?.data?.caseIncidentAdd.id;
+  });
+  it('should share Case Incident Response with Organization', async () => {
+    // Get organization id
+    testOrganizationId = await getOrganizationIdByName(PLATFORM_ORGANIZATION.name);
+
+    const ORGANIZATION_SHARING_QUERY = gql`
+      mutation StixCoreObjectSharingGroupAddMutation(
+        $id: ID!
+        $organizationId: ID!
+      ) {
+        stixCoreObjectEdit(id: $id) {
+          restrictionOrganizationAdd(organizationId: $organizationId) {
+            id
+            objectOrganization {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+
+    const organizationSharingQueryResult = await adminQuery({
+      query: ORGANIZATION_SHARING_QUERY,
+      variables: { id: caseIrId, organizationId: testOrganizationId }
+    });
+    expect(organizationSharingQueryResult).not.toBeNull();
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd).not.toBeNull();
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd.objectOrganization[0].name).toEqual(PLATFORM_ORGANIZATION.name);
+  });
+  it('should not access Case Incident Response out of his organization', async () => {
+    const caseIRQueryResult = await editorQuery({ query: READ_QUERY, variables: { id: caseIrId } });
+    expect(caseIRQueryResult).not.toBeNull();
+    expect(caseIRQueryResult.data?.caseIncident).toBeNull();
+  });
+  it('should Authorized Members activated', async () => {
+    userEditorId = await getUserIdByEmail(USER_EDITOR.email);
+    await queryAsAdmin({
+      query: EDIT_AUTHORIZED_MEMBERS_QUERY,
+      variables: {
+        id: caseIrId,
+        input: [
+          {
+            id: ADMIN_USER.id,
+            access_right: 'admin'
+          },
+          {
+            id: userEditorId,
+            access_right: 'view'
+          }
+        ]
+      }
+    });
+    // Verify if authorized members have been edited
+    const caseIRUpdatedQueryResult = await adminQuery({
+      query: READ_QUERY,
+      variables: { id: caseIrId }
+    });
+    expect(caseIRUpdatedQueryResult).not.toBeNull();
+    expect(caseIRUpdatedQueryResult?.data?.caseIncident.authorized_members).not.toBeUndefined();
+    expect(caseIRUpdatedQueryResult?.data?.caseIncident.authorized_members).toEqual([
+      {
+        id: ADMIN_USER.id,
+        access_right: 'admin'
+      },
+      {
+        id: userEditorId,
+        access_right: 'view'
+      }
+    ]);
+  });
+  it('should access Case Incident Response out of her organization if authorized members activated', async () => {
+    const caseIRQueryResult = await editorQuery({ query: READ_QUERY, variables: { id: caseIrId } });
+    expect(caseIRQueryResult).not.toBeNull();
+    expect(caseIRQueryResult?.data?.caseIncident).not.toBeUndefined();
+    expect(caseIRQueryResult?.data?.caseIncident.id).toEqual(caseIrId);
+  });
+  it('should plateform organization sharing and EE deactivated', async () => {
+    // Remove plateform organization
+    const platformOrganization = await adminQuery({
+      query: PLATFORM_ORGANIZATION_QUERY,
+      variables: { id: settingsInternalId,
+        input: [
+          { key: 'platform_organization', value: [] },
+          { key: 'enterprise_edition', value: [] },
+        ] }
+    });
+    expect(platformOrganization).not.toBeNull();
+    expect(platformOrganization?.data?.settingsEdit.fieldPatch.platform_organization).toBeNull();
+  });
+  it('should Case Incident Response deleted', async () => {
+    // Delete the case
+    await adminQuery({
+      query: DELETE_QUERY,
+      variables: { id: caseIrId },
+    });
+    // Verify is no longer found
+    const queryResult = await adminQuery({ query: READ_QUERY, variables: { id: caseIrId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult?.data?.caseIncident).toBeNull();
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
@@ -132,7 +132,7 @@ describe('Organization resolver standard behavior', () => {
   });
   it('should list organizations', async () => {
     const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
-    expect(queryResult.data.organizations.edges.length).toEqual(8);
+    expect(queryResult.data.organizations.edges.length).toEqual(9);
   });
   it('should update organization', async () => {
     const UPDATE_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixDomainObject-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixDomainObject-test.js
@@ -154,7 +154,7 @@ describe('StixDomainObject resolver standard behavior', () => {
       }
     `;
     const queryResult = await queryAsAdmin({ query: NUMBER_QUERY });
-    expect(queryResult.data.stixDomainObjectsNumber.total).toEqual(38);
+    expect(queryResult.data.stixDomainObjectsNumber.total).toEqual(39);
   });
   it('should timeseries stixDomainObjects to be accurate', async () => {
     const TIMESERIES_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.js
@@ -613,10 +613,10 @@ describe('User resolver standard behavior', () => {
 describe('User list members query behavior', () => {
   it('Should user lists all members', async () => {
     const queryResult = await editorQuery({ query: LIST_MEMBERS_QUERY });
-    expect(queryResult.data.members.edges.length).toEqual(22);
+    expect(queryResult.data.members.edges.length).toEqual(23);
     expect(queryResult.data.members.edges.filter(({ node: { entity_type } }) => entity_type === ENTITY_TYPE_USER).length).toEqual(TESTING_USERS.length + 1); // +1 = Plus admin user
     expect(queryResult.data.members.edges.filter(({ node: { entity_type } }) => entity_type === ENTITY_TYPE_GROUP).length).toEqual(TESTING_GROUPS.length + 2); // 2 built-in groups
-    expect(queryResult.data.members.edges.filter(({ node: { entity_type } }) => entity_type === ENTITY_TYPE_IDENTITY_ORGANIZATION).length).toEqual(7);
+    expect(queryResult.data.members.edges.filter(({ node: { entity_type } }) => entity_type === ENTITY_TYPE_IDENTITY_ORGANIZATION).length).toEqual(8);
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -23,7 +23,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes['kill-chain-phase'].length).toBe(3);
       expect(createEventsByTypes['course-of-action'].length).toBe(3);
       expect(createEventsByTypes.label.length).toBe(15);
-      expect(createEventsByTypes.identity.length).toBe(31);
+      expect(createEventsByTypes.identity.length).toBe(32);
       expect(createEventsByTypes.location.length).toBe(15);
       expect(createEventsByTypes.relationship.length).toBe(136);
       expect(createEventsByTypes.sighting.length).toBe(4);
@@ -46,7 +46,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(342); // 328 created at init + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(780);
+      expect(createEvents.length).toBe(785);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -82,7 +82,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(154);
+      expect(updateEvents.length).toBe(158);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;
@@ -95,7 +95,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(133);
+      expect(deleteEvents.length).toBe(135);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -46,7 +46,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(342); // 328 created at init + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(785);
+      expect(createEvents.length).toBe(784);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,8 +22,8 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1075;
-export const SYNC_LIVE_EVENTS_SIZE = 607;
+export const RAW_EVENTS_SIZE = 1086;
+export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';
 export const API_URI = `http://localhost:${conf.get('app:port')}`;
@@ -274,6 +274,11 @@ export const TEST_ORGANIZATION: Organization = {
   id: generateStandardId(ENTITY_TYPE_IDENTITY_ORGANIZATION, { name: 'TestOrganization', identity_class: 'organization' }),
 };
 
+export const PLATFORM_ORGANIZATION: Organization = {
+  name: 'PlatformOrganization',
+  id: generateStandardId(ENTITY_TYPE_IDENTITY_ORGANIZATION, { name: 'PlatformOrganization', identity_class: 'organization' }),
+};
+
 // Users
 interface User {
   id: string,
@@ -341,6 +346,7 @@ export const USER_SECURITY: User = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'security@opencti.io' }),
   email: 'security@opencti.io',
   password: 'security',
+  organizations: [PLATFORM_ORGANIZATION],
   groups: [AMBER_STRICT_GROUP],
   client: createHttpClient('security@opencti.io', 'security')
 };

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1086;
+export const RAW_EVENTS_SIZE = 1085;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Add filter in elastic query to let user access entity if they is in authorized_members (even if user is member of the organization)
* backend tests
* Add refresh session if plateform organization is updated
* Ensure session is updated in the cache
*  add 1 identity => +1 live event
*  5 create / 4 updates / 2 delete => +9 raw events


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/4538
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
