### PR TITLE
[frontend] Group members are inconsistent and can lead to mistakes on managing RBAC (#8050)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -39,7 +39,7 @@ const GroupEditionContainerFragment = graphql`
     rolesOrderMode: { type: "OrderingMode", defaultValue: asc }
   ) {
     id
-    members {
+    members(first: 500) {
       edges {
         node {
           id


### PR DESCRIPTION
### Proposed changes

* Change default pagination of group's member query from 20 (by default) to 500

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/8050