### PR TITLE
[frontend] roll back apexcharts to 3.51.0 (#8124)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -23,7 +23,7 @@
     "@rjsf/mui": "5.18.1",
     "@rjsf/utils": "5.18.1",
     "analytics": "0.8.14",
-    "apexcharts": "3.52.0",
+    "apexcharts": "3.51.0",
     "axios": "1.7.4",
     "ckeditor5-custom-build": "0.0.1",
     "classnames": "2.5.1",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -7054,9 +7054,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apexcharts@npm:3.52.0":
-  version: 3.52.0
-  resolution: "apexcharts@npm:3.52.0"
+"apexcharts@npm:3.51.0":
+  version: 3.51.0
+  resolution: "apexcharts@npm:3.51.0"
   dependencies:
     "@yr/monotone-cubic-spline": "npm:^1.0.3"
     svg.draggable.js: "npm:^2.2.2"
@@ -7065,7 +7065,7 @@ __metadata:
     svg.pathmorphing.js: "npm:^0.1.3"
     svg.resize.js: "npm:^1.4.3"
     svg.select.js: "npm:^3.0.1"
-  checksum: 10/a9d050dcbcfbc5d1828fc449a4b6a085663f54f0d358eddb9bf3f93183b6f13f7644662f6cf196bc2e1d288375a80e7569cf7a99bc64eb0b6d6a94c877588b4c
+  checksum: 10/c66dc251643e4a4f1e05bf17206becf0a9dd9e67983723aad801ce4681d0cbcfb7f16e15b6a83974d88d69bf4ece9598e712bb7e300d0f36da4aa2a87c9ba467
   languageName: node
   linkType: hard
 
@@ -15807,7 +15807,7 @@ __metadata:
     "@types/uuid": "npm:10.0.0"
     "@vitejs/plugin-react": "npm:4.3.1"
     analytics: "npm:0.8.14"
-    apexcharts: "npm:3.52.0"
+    apexcharts: "npm:3.51.0"
     axios: "npm:1.7.4"
     babel-plugin-relay: "npm:17.0.0"
     chokidar: "npm:3.6.0"


### PR DESCRIPTION
Rolling back apexcharts to prevent out-of-memory error in the chart displayed in Rule Engine list view.

Closes #8124 