### PR TITLE
[frontend] display alias value in place of alias label in form field (#8053)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteFreeSoloField.jsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteFreeSoloField.jsx
@@ -65,7 +65,7 @@ const AutocompleteFreeSoloField = (props) => {
           }
           return filtered;
         }}
-        getOptionLabel={(option) => (option.label ? option.label : option)}
+        getOptionLabel={(option) => (option.value ? option.value : option)}
         noOptionsText={noOptionsText}
         {...fieldProps}
         renderOption={renderOption}


### PR DESCRIPTION
### Proposed changes

* use value in place of label to remove the `createLabel` in Chip after the selection

### Related issues

* close #8053 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- The `createLabel` is still used on the dropdown menu to differenciate actual and new values
