### PR TITLE
[backend] Be able to use Vulnerability specific fields in playbook filters (#7409)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -85,6 +85,11 @@ export const stixFilters = [
   'fromTypes',
   'toTypes',
   'representative',
+  'x_opencti_cisa_kev',
+  'x_opencti_epss_score',
+  'x_opencti_epss_percentile',
+  'x_opencti_cvss_base_score',
+  'x_opencti_cvss_base_severity',
 ];
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -44,7 +44,11 @@ export const CONFIDENCE_FILTER = 'confidence';
 export const REVOKED_FILTER = 'revoked';
 export const PATTERN_FILTER = 'pattern_type';
 export const MAIN_OBSERVABLE_TYPE_FILTER = 'x_opencti_main_observable_type';
-
+export const CISA_KEV_FILTER = 'x_opencti_cisa_kev';
+export const EPSS_PERCENTILE_FILTER = 'x_opencti_epss_percentile';
+export const EPSS_SCORE_FILTER = 'x_opencti_epss_score';
+export const CVSS_BASE_SCORE_FILTER = 'x_opencti_cvss_base_score';
+export const CVSS_BASE_SEVERITY_FILTER = 'x_opencti_cvss_base_severity';
 // special cases
 export const IDS_FILTER = 'ids';
 export const SIGHTED_BY_FILTER = 'sightedBy';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -30,7 +30,12 @@ import {
   SCORE_FILTER,
   SEVERITY_FILTER,
   TYPE_FILTER,
-  WORKFLOW_FILTER
+  WORKFLOW_FILTER,
+  CISA_KEV_FILTER,
+  EPSS_PERCENTILE_FILTER,
+  EPSS_SCORE_FILTER,
+  CVSS_BASE_SCORE_FILTER,
+  CVSS_BASE_SEVERITY_FILTER
 } from '../filtering-constants';
 import type { Filter } from '../../../generated/graphql';
 import { STIX_RESOLUTION_MAP_PATHS } from '../filtering-resolution';
@@ -327,6 +332,31 @@ export const testConnectedToSideEvents = (stix: any, filter: Filter) => {
   return testStringFilter(filter, aggregatedStixValues);
 };
 
+export const testCisaKev = (stix: any, filter: Filter) => {
+  const stixValue: boolean | null = stix.x_opencti_cisa_kev ?? stix.extensions?.[STIX_EXT_OCTI].cisa_kev ?? null;
+  return testBooleanFilter(filter, stixValue);
+};
+
+export const testEpssPercentile = (stix: any, filter: Filter) => {
+  const stixValue: number | null = stix.x_opencti_epss_percentile ?? stix.extensions?.[STIX_EXT_OCTI].epss_percentile ?? null;
+  return testNumericFilter(filter, stixValue);
+};
+
+export const testEpssScore = (stix: any, filter: Filter) => {
+  const stixValue: number | null = stix.x_opencti_epss_score ?? stix.extensions?.[STIX_EXT_OCTI].epss_score ?? null;
+  return testNumericFilter(filter, stixValue);
+};
+
+export const testCvssScore = (stix: any, filter: Filter) => {
+  const stixValue: number | null = stix.x_opencti_cvss_base_score ?? stix.extensions?.[STIX_EXT_OCTI].base_score ?? null;
+  return testNumericFilter(filter, stixValue);
+};
+
+export const testCvssSeverity = (stix: any, filter: Filter) => {
+  const stixValue: number | null = stix.x_opencti_cvss_base_severity ?? stix.extensions?.[STIX_EXT_OCTI].base_severity ?? null;
+  return testNumericFilter(filter, stixValue);
+};
+
 /**
  * TODO: This mapping could be given by the schema, like we do with stix converters
  */
@@ -350,6 +380,11 @@ export const FILTER_KEY_TESTERS_MAP: Record<string, TesterFunction> = {
   [SCORE_FILTER]: testScore,
   [TYPE_FILTER]: testEntityType,
   [WORKFLOW_FILTER]: testWorkflow,
+  [CISA_KEV_FILTER]: testCisaKev,
+  [EPSS_PERCENTILE_FILTER]: testEpssPercentile,
+  [EPSS_SCORE_FILTER]: testEpssScore,
+  [CVSS_BASE_SCORE_FILTER]: testCvssScore,
+  [CVSS_BASE_SEVERITY_FILTER]: testCvssSeverity,
 
   // special keys (more complex behavior)
   [CONNECTED_TO_INSTANCE_FILTER]: testConnectedTo, // instance trigger, direct events

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -353,8 +353,9 @@ export const testCvssScore = (stix: any, filter: Filter) => {
 };
 
 export const testCvssSeverity = (stix: any, filter: Filter) => {
-  const stixValue: number | null = stix.x_opencti_cvss_base_severity ?? stix.extensions?.[STIX_EXT_OCTI].base_severity ?? null;
-  return testNumericFilter(filter, stixValue);
+  const stixValue: string | null = stix.x_opencti_cvss_base_severity ?? stix.extensions?.[STIX_EXT_OCTI].base_severity ?? null;
+  const value = stixValue ? [stixValue] : [];
+  return testStringFilter(filter, value);
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* CISA KEY / EPSS (score and percentile) / CVSS (score and severity) added on playbook filters
* keys added on front available filters

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7409

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
