### PR TITLE
[frontend] allow transparent background Radar option (#8113)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadar.tsx
@@ -78,7 +78,7 @@ StixCoreObjectOpinionsRadarProps
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       // Need to migrate Chart Charts.js file to TSX
-      options={radarChartOptions(theme, labels, simpleNumberFormat, colors, true, true)}
+      options={radarChartOptions(theme, labels, simpleNumberFormat, colors, true, true, 'transparent')}
       series={chartData}
       type="radar"
       width="100%"

--- a/opencti-platform/opencti-front/src/utils/Charts.js
+++ b/opencti-platform/opencti-front/src/utils/Charts.js
@@ -563,6 +563,7 @@ export const horizontalBarsChartOptions = (
  * @param {string[]} chartColors
  * @param {boolean} legend
  * @param {boolean} offset
+ * @param {string} background
  */
 export const radarChartOptions = (
   theme,
@@ -571,10 +572,11 @@ export const radarChartOptions = (
   chartColors = [],
   legend = false,
   offset = false,
+  background = theme.palette.background.paper,
 ) => ({
   chart: {
     type: 'radar',
-    background: theme.palette.background.paper,
+    background: background,
     toolbar: toolbarOptions,
     offsetY: offset ? -20 : 0,
     parentHeightOffset: 0,

--- a/opencti-platform/opencti-front/src/utils/Charts.js
+++ b/opencti-platform/opencti-front/src/utils/Charts.js
@@ -576,7 +576,7 @@ export const radarChartOptions = (
 ) => ({
   chart: {
     type: 'radar',
-    background: background,
+    background,
     toolbar: toolbarOptions,
     offsetY: offset ? -20 : 0,
     parentHeightOffset: 0,


### PR DESCRIPTION
### Proposed changes

* define background to transparent in report opinions radar

### Related issues

* close #8113 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality