### PR TITLE
[ci] Add upload of test results to JFrog (#7378)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,23 +102,25 @@ steps:
     depends_on:
       - frontend-tests
 
-  - name: upload-frontend-test-results
-    image: plugins/s3
-    failure: ignore
-    when:
-      event:
-        include:
-        - pull_request
-    settings:
-      endpoint: https://s3.testing.octi.staging.filigran.io
-      bucket: octi-drone-artefact
-      path_style: true
-      access_key:
-        from_secret: octi-s3-access-key
-      secret_key:
-        from_secret: octi-s3-secret-key
-      source: /drone/src/opencti-platform/opencti-front/test-results/**/*
-      target: /octi/opencti-front
+  - name: upload-build-artefact
+    image: node:20.16.0
+    environment:
+      JFROG_TOKEN:
+          from_secret: jfrog_token
+      JFROG_BUILD_NAME: opencti-build
+      JFROG_REPOSITORY: opencti-drone
+      JFROG_URL: https://filigran.jfrog.io/artifactory
+    commands:
+      - echo $DRONE_BUILD_NUMBER
+      - apt-get update
+      # see https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory
+      - npm install -g jfrog-cli-v2-jf
+      - set -x
+      # Next line should be done only once it's recording build info
+      - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url="https://filigran.jfrog.io/artifactory" --access-token=$JFROG_TOKEN
+      # Then upload each artefact that we need
+      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
+      - jf rt u frontend-test-results.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
     depends_on:
       - frontend-e2e-tests
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,26 @@ steps:
     depends_on:
       - frontend-tests
 
+  - name: upload-frontend-test-results
+    image: plugins/s3
+    failure: ignore
+    when:
+      event:
+        include:
+        - pull_request
+    settings:
+      endpoint: https://s3.testing.octi.staging.filigran.io
+      bucket: octi-drone-artefact
+      path_style: true
+      access_key:
+        from_secret: octi-s3-access-key
+      secret_key:
+        from_secret: octi-s3-secret-key
+      source: /drone/src/opencti-platform/opencti-front/test-results/**/*
+      target: /octi/opencti-front
+    depends_on:
+      - frontend-e2e-tests
+
   - name: frontend-verify-translation
     image: node:20.16.0
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -112,18 +112,22 @@ steps:
       JFROG_REPOSITORY: opencti-drone
       JFROG_URL: https://filigran.jfrog.io/artifactory
     commands:
-      - echo $DRONE_BUILD_NUMBER
+      - echo "DRONE_BUILD_NUMBER = $DRONE_BUILD_NUMBER"
+      - echo "CI = $CI"
       - apt-get update
       # see https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory
       - npm install -g jfrog-cli-v2-jf
       - set -x
-      # Next line should be done only once it's recording build info
-      - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url="https://filigran.jfrog.io/artifactory" --access-token=$JFROG_TOKEN
-      - sleep 2
-      # Then archive and upload each artefact that we need
+      # Collect git info
+      - jf rt bag $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER
+      # Archive and upload each artefact that we need
       #- tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
       - tar -czvf frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-front/tests_e2e
       - jf rt u frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
+      # Next line should be done only once at the end: it's recording and gathering build info
+      - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN --build-url=$DRONE_BUILD_LINK
+      # Cleaning up old build in JFrog
+      - jf rt bdi $JFROG_BUILD_NAME --max-days=30
     #depends_on:
     #  - frontend-e2e-tests
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -104,6 +104,7 @@ steps:
 
   - name: upload-build-artefact
     image: node:20.16.0
+    failure: ignore
     environment:
       JFROG_TOKEN:
           from_secret: jfrog_token
@@ -118,10 +119,11 @@ steps:
       - set -x
       # Next line should be done only once it's recording build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url="https://filigran.jfrog.io/artifactory" --access-token=$JFROG_TOKEN
+      - sleep 2
       # Then archive and upload each artefact that we need
       #- tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
-      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/tests_e2e
-      - jf rt u frontend-test-results.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
+      - tar -czvf frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-front/tests_e2e
+      - jf rt u frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
     #depends_on:
     #  - frontend-e2e-tests
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -118,11 +118,12 @@ steps:
       - set -x
       # Next line should be done only once it's recording build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url="https://filigran.jfrog.io/artifactory" --access-token=$JFROG_TOKEN
-      # Then upload each artefact that we need
-      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
+      # Then archive and upload each artefact that we need
+      #- tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
+      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/tests_e2e
       - jf rt u frontend-test-results.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
-    depends_on:
-      - frontend-e2e-tests
+    #depends_on:
+    #  - frontend-e2e-tests
 
   - name: frontend-verify-translation
     image: node:20.16.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,15 +121,14 @@ steps:
       # Collect git info
       - jf rt bag $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER
       # Archive and upload each artefact that we need
-      #- tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
-      - tar -czvf frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-front/tests_e2e
+      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
       - jf rt u frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
       # Next line should be done only once at the end: it's recording and gathering build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN --build-url=$DRONE_BUILD_LINK
       # Cleaning up old build in JFrog
       - jf rt bdi $JFROG_BUILD_NAME --max-days=30 --url=$JFROG_URL --access-token=$JFROG_TOKEN
-    #depends_on:
-    #  - frontend-e2e-tests
+    depends_on:
+      - frontend-e2e-tests
 
   - name: frontend-verify-translation
     image: node:20.16.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -127,7 +127,7 @@ steps:
       # Next line should be done only once at the end: it's recording and gathering build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN --build-url=$DRONE_BUILD_LINK
       # Cleaning up old build in JFrog
-      - jf rt bdi $JFROG_BUILD_NAME --max-days=30
+      - jf rt bdi $JFROG_BUILD_NAME --max-days=30 --url=$JFROG_URL --access-token=$JFROG_TOKEN
     #depends_on:
     #  - frontend-e2e-tests
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,7 +121,7 @@ steps:
       # Collect git info
       - jf rt bag $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER
       # Archive and upload each artefact that we need
-      - tar -czvf frontend-test-results.tar.gz opencti-platform/opencti-front/test-results
+      - tar -czvf frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-front/test-results
       - jf rt u frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
       # Next line should be done only once at the end: it's recording and gathering build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN --build-url=$DRONE_BUILD_LINK

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,9 +106,9 @@ steps:
     image: node:20.16.0
     failure: ignore
     when:
-    status:
-      - failure
-      - success
+      status:
+        - failure
+        - success
     environment:
       JFROG_TOKEN:
           from_secret: jfrog_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,12 +116,9 @@ steps:
       JFROG_REPOSITORY: opencti-drone
       JFROG_URL: https://filigran.jfrog.io/artifactory
     commands:
-      - echo "DRONE_BUILD_NUMBER = $DRONE_BUILD_NUMBER"
-      - echo "CI = $CI"
       - apt-get update
       # see https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory
       - npm install -g jfrog-cli-v2-jf
-      - set -x
       # Collect git info
       - jf rt bag $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER
       # Archive and upload each artefact that we need

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,6 +105,10 @@ steps:
   - name: upload-build-artefact
     image: node:20.16.0
     failure: ignore
+    when:
+    status:
+      - failure
+      - success
     environment:
       JFROG_TOKEN:
           from_secret: jfrog_token

--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -31,10 +31,11 @@ export default defineConfig({
         entryFilter: (entry) => true,
         sourceFilter: (sourcePath) => sourcePath.startsWith('src'),
       },
+      /*
       onEnd: async (reportData) => {
         // teams integration with webhook
         await teamsWebhook(reportData);
-      }
+      } */
     }]
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -44,7 +45,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    screenshot: "only-on-failure",
+    screenshot: 'only-on-failure',
+    video: 'on-first-retry',
     ignoreHTTPSErrors: true,
   },
   expect: { timeout: 60000 },

--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
-import teamsWebhook from './tests_e2e/webhooks/teams-webhook.js';
+// import teamsWebhook from './tests_e2e/webhooks/teams-webhook.js';
 // https://playwright.dev/docs/browsers
 
 /**

--- a/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
@@ -35,7 +35,7 @@ const navigateReports = async (page: Page) => {
 
   // -- Knowledge
   await reportDetailsPage.goToKnowledgeTab();
-  await expect(page.getByTestId('report-knowledge-fail')).toBeVisible();
+  await expect(page.getByTestId('report-knowledge')).toBeVisible();
   await page.getByLabel('TimeLine view').click();
   await page.getByLabel('Correlation view').click();
   await page.getByLabel('Tactics matrix view').click();

--- a/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
@@ -35,7 +35,7 @@ const navigateReports = async (page: Page) => {
 
   // -- Knowledge
   await reportDetailsPage.goToKnowledgeTab();
-  await expect(page.getByTestId('report-knowledge')).toBeVisible();
+  await expect(page.getByTestId('report-knowledge-fail')).toBeVisible();
   await page.getByLabel('TimeLine view').click();
   await page.getByLabel('Correlation view').click();
   await page.getByLabel('Tactics matrix view').click();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a drone step to upload frontend test artefact to JFrog for analyses on failures that run on both success and failure of e2e step.

I did not use the drone plugin for JFrog because it's not customizable enough, I used jfrog cli instead.

Build artefact are visible on https://filigran.jfrog.io/ui/builds/

Example with build 22529 (with one e2e fail in purpose)
![image](https://github.com/user-attachments/assets/515fcbe7-8bd6-4d6b-92f9-206337ffbc33)

Jfrog URL can be found on upload artifact step:
![image](https://github.com/user-attachments/assets/33834fa6-626a-4f13-8239-73c93e5fa27d)

And in artifact there is screenshot and video from failure
![image](https://github.com/user-attachments/assets/f7c5e710-8859-471c-b998-6345b62343a1)


### Related issues
* Relates to #7378 work, does not close it.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
