### PR TITLE
[frontend] changed content autosave to trigger onBlur instead of onChange (#8152)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
@@ -15,7 +15,6 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference, useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-import useDebounceCallback from '../../../../utils/hooks/useDebounceCallback';
 
 export const stixCoreObjectMappableContentFieldPatchMutation = graphql`
   mutation StixCoreObjectMappableContentFieldPatchMutation(
@@ -128,9 +127,6 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
     }
   };
 
-  // we debounce the submit so it does not trigger too often, as we are hooked on the RichText onChange
-  const debouncedSubmit = useDebounceCallback(handleSubmitField, 1000);
-
   const matchCase = (text: string, pattern: string) => {
     let result = '';
     // eslint-disable-next-line no-plusplus
@@ -205,7 +201,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
               fullWidth
               multiline
               rows="4"
-              onSubmit={debouncedSubmit}
+              onSubmit={handleSubmitField}
               onSelect={handleTextSelection}
               disabled={!editionMode}
               helperText={
@@ -222,7 +218,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
               name="content"
               label={t_i18n('Content')}
               fullWidth
-              onChange={debouncedSubmit}
+              onSubmit={handleSubmitField}
               onSelect={handleTextSelection}
               askAi={askAi}
               disabled={!editionMode}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* removed debounce and switched autosave to editor onBlur instead of editor onChange
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8152 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
