### PR TITLE
[backend] Change kill_chain_phase.order attribute upsert value (#8182)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixMetaObject-registrationAttributes.ts
@@ -29,7 +29,7 @@ const stixMetaObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
   [ENTITY_TYPE_KILL_CHAIN_PHASE]: [
     { name: 'kill_chain_name', label: 'Kill chain name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'phase_name', label: 'Phase name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'x_opencti_order', label: 'Order', type: 'numeric', precision: 'integer', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: true },
+    { name: 'x_opencti_order', label: 'Order', type: 'numeric', precision: 'integer', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
 };
 R.forEachObjIndexed((value, key) => schemaAttributesDefinition.registerAttributes(key as string, value), stixMetaObjectsAttributes);


### PR DESCRIPTION
### Proposed changes

* Set upsert `false` to attribute order of kill chain phase

### Related issues

* closes #8182 

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
