### PR TITLE
[backend] [Workbench] Campaign object unrecognized in relationships (#6758)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix.ts
@@ -567,6 +567,9 @@ export const stixCoreRelationshipsMapping: RelationshipMappings = {
   [`${ENTITY_TYPE_INTRUSION_SET}_${ENTITY_TYPE_THREAT_ACTOR_GROUP}`]: [
     { name: RELATION_ATTRIBUTED_TO, type: REL_BUILT_IN }
   ],
+  [`${ENTITY_TYPE_INTRUSION_SET}_${ENTITY_TYPE_CAMPAIGN}`]: [
+    { name: RELATION_ATTRIBUTED_TO, type: REL_BUILT_IN }
+  ],
   [`${ENTITY_TYPE_INTRUSION_SET}_${ENTITY_TYPE_TOOL}`]: [
     { name: RELATION_USES, type: REL_BUILT_IN }
   ],


### PR DESCRIPTION
### Proposed changes

* Add missing relationship between an intrusion-set and a campaign 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6758