### PR TITLE
[frontend] Fixing note creation auto-scroll when layout is custom (#6724)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -205,7 +205,7 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
   });
   const scrollToBottom = () => {
     setTimeout(() => {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }, 300);
   };
   const handleToggleWrite = () => {


### PR DESCRIPTION
When creating a new Note from an entity details view,  the form appears.
Before custom overview, the notes were always at the bottom. To facilitate usage, we auto scroll at the bottom of the note creation form so that the form is completely in user's view (otherwise, they would have to manually scroll down to see the form that just opened).

Now notes can be at the top of the page for instance, and this autoscroll push too far because by default it align to Top of the container view. 


### Proposed changes

* align scroll to bottom of container view when auto-scrolling

### Related issues
* #6724 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

