### PR TITLE
Add auto_create_users option

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -389,6 +389,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
     }
     if (strategy === STRATEGY_FACEBOOK) {
       const providerRef = identifier || 'facebook';
+      const autoCreateUsers = mappedConfig.auto_create_users || true;
       const specificConfig = { profileFields: ['id', 'emails', 'name'], scope: 'email' };
       const facebookOptions = { passReqToCallback: true, ...mappedConfig, ...specificConfig };
       const facebookStrategy = new FacebookStrategy(
@@ -397,7 +398,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           const data = profile._json;
           logApp.info('[FACEBOOK] Successfully logged', { profile: data });
           const { email } = data;
-          providerLoginHandler({ email, name: data.first_name }, done);
+          providerLoginHandler({ email, name: data.first_name }, done, { auto_create_users: autoCreateUsers });
         }
       );
       passport.use(providerRef, facebookStrategy);
@@ -406,6 +407,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
     if (strategy === STRATEGY_GOOGLE) {
       const providerRef = identifier || 'google';
       const domains = mappedConfig.domains || [];
+      const autoCreateUsers = mappedConfig.auto_create_users || true;
       const specificConfig = { scope: ['email', 'profile'] };
       const googleOptions = { passReqToCallback: true, ...mappedConfig, ...specificConfig };
       const googleStrategy = new GoogleStrategy(googleOptions, (_, __, ___, profile, done) => {
@@ -418,7 +420,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           authorized = domains.includes(domain);
         }
         if (authorized) {
-          providerLoginHandler({ email, name }, done);
+          providerLoginHandler({ email, name }, done, { auto_create_users: autoCreateUsers });
         } else {
           done({ message: 'Restricted access, ask your administrator' });
         }
@@ -428,6 +430,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
     }
     if (strategy === STRATEGY_GITHUB) {
       const providerRef = identifier || 'github';
+      const autoCreateUsers = mappedConfig.auto_create_users || true;
       const organizations = mappedConfig.organizations || [];
       const scope = organizations.length > 0 ? 'user:email,read:org' : 'user:email';
       const githubOptions = { passReqToCallback: true, ...mappedConfig, scope };
@@ -447,7 +450,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
             done({ message: 'You need a public email in your github account' });
           } else {
             const email = R.head(profile.emails).value;
-            providerLoginHandler({ email, name: displayName }, done);
+            providerLoginHandler({ email, name: displayName }, done, { auto_create_users: autoCreateUsers });
           }
         } else {
           done({ message: 'Restricted access, ask your administrator' });

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1015,7 +1015,7 @@ export const userDeleteOrganizationRelation = async (context, user, userId, toId
 };
 
 export const loginFromProvider = async (userInfo, opts = {}) => {
-  const { providerGroups = [], providerOrganizations = [], autoCreateGroup = false } = opts;
+  const { providerGroups = [], providerOrganizations = [], autoCreateGroup = false, autoCreateUsers = true } = opts;
   const context = executionContext('login_provider');
   // region test the groups existence and eventually auto create groups
   if (providerGroups.length > 0) {
@@ -1048,7 +1048,11 @@ export const loginFromProvider = async (userInfo, opts = {}) => {
   const name = isEmptyField(providedName) ? email : providedName;
   const user = await elLoadBy(context, SYSTEM_USER, 'user_email', email, ENTITY_TYPE_USER);
   if (!user) {
-    // If user doesn't exist, create it. Providers are trusted
+    // If auto user creation is not permitted, forbid access
+    if (!autoCreateUsers) {
+      throw ForbiddenAccess('User account does not exist and auto-creation is disabled. Please contact your administrator.');
+    }
+    // If auto user creation is permitted, trust provider and create new account
     const newUser = { name, firstname, lastname, user_email: email.toLowerCase(), external: true };
     return addUser(context, SYSTEM_USER, newUser).then(() => {
       // After user creation, reapply login to manage roles and groups


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Implement `AUTO_CREATE_USERS` option for Google, GitHub, and Facebook auth

### Related issues

(N/A)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Hello! This is currently an untested draft pull request, as I'm still exploring and understanding the codebase.

This PR adds a configurable option to control the auto-creation of users from providers (Google, GitHub, Facebook). It sets this option to "true" by default, which will retain backwards compatibility with the existing behavior.

I see in the code and documentation that "providers are trusted" and users are automatically created. This means that if you enable Google Authentication, anyone with a Google account can log in. There is an option to restrict to specific email domains, which is great, but more granularity would be nice.

For example, I may want to use Google Authentication but only authorize users I've explicitly added to the platform. Google is the strategy I am personally testing, but this would probably apply to GitHub and Facebook auth as well.

With this new option, setting `PROVIDERS__GOOGLE__CONFIG__AUTO_CREATE_USERS` to false would mean that users could log in with Google Auth, but only if that user has an account already created on the server. This would allow an admin to have strict control over who logs in, even from their own Google domain.

A further iteration would be to allow only auto user creation from specific existing Google groups. I may look at that in the future.

Thank you for this great open source product.
