### PR TITLE
[backend] Force LDAP bindCredentials to be a String and add docker image for dev (#7995)

### DIFF
--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -104,6 +104,62 @@ services:
       ports:
         - "9999:8080"
 
+  # LDAP provider - disabled by default
+  # docker compose --profile ldap up -d
+  # bind_dn is "cn=admin,dc=example,dc=org", bind_credential see LDAP_ADMIN_PASSWORD
+  # search_base is "dc=example,dc=org"
+  opencti-dev-openldap:
+    image: osixia/openldap:1.5.0
+    profiles: [ ldap ]
+    container_name: opencti-dev-openldap
+    environment:
+      LDAP_LOG_LEVEL: "256"
+      LDAP_ORGANISATION: "Example Inc."
+      LDAP_DOMAIN: "example.org"
+      LDAP_BASE_DN: ""
+      LDAP_ADMIN_PASSWORD: "12341234"
+      LDAP_CONFIG_PASSWORD: "config"
+      LDAP_READONLY_USER: "false"
+      LDAP_RFC2307BIS_SCHEMA: "false"
+      LDAP_BACKEND: "mdb"
+      LDAP_TLS: "false"
+      LDAP_TLS_CRT_FILENAME: "ldap.crt"
+      LDAP_TLS_KEY_FILENAME: "ldap.key"
+      LDAP_TLS_DH_PARAM_FILENAME: "dhparam.pem"
+      LDAP_TLS_CA_CRT_FILENAME: "ca.crt"
+      LDAP_TLS_ENFORCE: "false"
+      LDAP_TLS_CIPHER_SUITE: "SECURE256:-VERS-SSL3.0"
+      LDAP_TLS_VERIFY_CLIENT: "demand"
+      LDAP_REPLICATION: "false"
+      KEEP_EXISTING_CONFIG: "false"
+      LDAP_REMOVE_CONFIG_AFTER_SETUP: "true"
+      LDAP_SSL_HELPER_PREFIX: "ldap"
+    tty: true
+    stdin_open: true
+    volumes:
+      - /var/lib/ldap
+      - /etc/ldap/slapd.d
+      - /container/service/slapd/assets/certs/
+    ports:
+      - "389:389"
+      - "636:636"
+    domainname: "example.org"
+    hostname: "ldap-server"
+
+    # UI to configure ldap, localhost:8888, login DN 'cn=admin,dc=example,dc=org'
+    # password see LDAP_ADMIN_PASSWORD above
+  opencti-dev-phpldapadmin:
+    image: osixia/phpldapadmin:latest
+    profiles: [ ldap ]
+    container_name: opencti-dev-phpldapadmin
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: "opencti-dev-openldap"
+      PHPLDAPADMIN_HTTPS: "false"
+    ports:
+      - "8888:80"
+    depends_on:
+      - opencti-dev-openldap
+
 volumes:
   esdata:
     driver: local

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -154,6 +154,8 @@ for (let i = 0; i < providerKeys.length; i += 1) {
     if (strategy === STRATEGY_LDAP) {
       const providerRef = identifier || 'ldapauth';
       const allowSelfSigned = mappedConfig.allow_self_signed || mappedConfig.allow_self_signed === 'true';
+      // Force bindCredentials to be a String
+      mappedConfig.bindCredentials = `${mappedConfig.bindCredentials}`;
       const tlsConfig = R.assoc('tlsOptions', { rejectUnauthorized: !allowSelfSigned }, mappedConfig);
       const ldapOptions = { server: tlsConfig };
       const ldapStrategy = new LdapStrategy(ldapOptions, (user, done) => {
@@ -180,6 +182,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           const orgaDefault = mappedConfig.organizations_default ?? [];
           const orgasMapping = mappedConfig.organizations_management?.organizations_mapping || [];
           const orgaPath = mappedConfig.organizations_management?.organizations_path || ['organizations'];
+
           const availableOrgas = R.flatten(
             orgaPath.map((path) => {
               const value = R.path(path.split('.'), user) || [];


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix the issue by forcing bindCredentials to a String

* Add docker image in docker compose for dev with an "ldap" profile.
* Update documentation, see https://github.com/OpenCTI-Platform/docs/pull/205

Tested locally with `"bind_credentials": "12341234"` and `"bind_credentials": 12341234` both are working fine.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #7995 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
