### PR TITLE
[frontend] allow to disable line selection on datatables

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -34,6 +34,7 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'rootRef'
 | 'onLineClick'
 | 'disableNavigation'
+| 'disableLineSelection'
 | 'entityTypes'> & {
   lineFragment: GraphQLTaggedNode
   preloadedPaginationProps: UsePreloadedPaginationFragment<OperationType>,

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -35,6 +35,8 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'onLineClick'
 | 'disableNavigation'
 | 'disableLineSelection'
+| 'disableToolBar'
+| 'disableSelectAll'
 | 'entityTypes'> & {
   lineFragment: GraphQLTaggedNode
   preloadedPaginationProps: UsePreloadedPaginationFragment<OperationType>,

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -11,6 +11,7 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'rootRef'
 | 'actions'
 | 'disableNavigation'
+| 'disableLineSelection'
 | 'filtersComponent'
 | 'variant'> & {
   data: unknown,

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -12,6 +12,8 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'actions'
 | 'disableNavigation'
 | 'disableLineSelection'
+| 'disableToolBar'
+| 'disableSelectAll'
 | 'filtersComponent'
 | 'variant'> & {
   data: unknown,

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -42,6 +42,8 @@ const DataTableComponent = ({
   disableNavigation,
   disableLineSelection,
   onLineClick,
+  disableToolBar,
+  disableSelectAll,
 }: DataTableProps) => {
   const localStorageColumns = useDataTableLocalStorage<LocalStorageColumns>(`${storageKey}_columns`, {}, true)[0];
   const toggleHelper = useDataTableToggle(storageKey);
@@ -115,6 +117,8 @@ const DataTableComponent = ({
         createButton,
         disableNavigation,
         onLineClick,
+        disableToolBar,
+        disableSelectAll,
       } as DataTableContextProps}
     >
       {filtersComponent ?? (variant === DataTableVariant.inline && (

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -40,13 +40,14 @@ const DataTableComponent = ({
   createButton,
   pageSize,
   disableNavigation,
+  disableLineSelection,
   onLineClick,
 }: DataTableProps) => {
   const localStorageColumns = useDataTableLocalStorage<LocalStorageColumns>(`${storageKey}_columns`, {}, true)[0];
   const toggleHelper = useDataTableToggle(storageKey);
 
   const columnsInitialState = [
-    ...(toggleHelper.onToggleEntity ? [{ id: 'select', visible: true } as DataTableColumn] : []),
+    ...((toggleHelper.onToggleEntity && !disableLineSelection) ? [{ id: 'select', visible: true } as DataTableColumn] : []),
     ...Object.entries(dataColumns).map(([key, column], index) => {
       const currentColumn = localStorageColumns?.[key];
       return R.mergeDeepRight(defaultColumnsMap.get(key) as DataTableColumn, {

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
@@ -41,6 +41,8 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
     availableFilterKeys,
     onAddFilter,
     onSort,
+    disableToolBar,
+    disableSelectAll,
   } = useDataTableContext();
   const { t_i18n } = formatter;
 
@@ -87,11 +89,11 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
           <Checkbox
             checked={selectAll}
             onChange={handleToggleSelectAll}
-            disabled={!handleToggleSelectAll}
+            disabled={!handleToggleSelectAll || disableSelectAll}
           />
         </div>
       )}
-      {numberOfSelectedElements > 0 ? dataTableToolBarComponent : (
+      {numberOfSelectedElements > 0 && !disableToolBar ? dataTableToolBarComponent : (
         <>
           {anchorEl && (
             <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -83,6 +83,8 @@ export interface DataTableContextProps {
   createButton?: DataTableProps['createButton']
   resetColumns: () => void
   disableNavigation: DataTableProps['disableNavigation']
+  disableToolBar: DataTableProps['disableToolBar']
+  disableSelectAll: DataTableProps['disableSelectAll']
   onLineClick: DataTableProps['onLineClick']
 }
 
@@ -122,6 +124,8 @@ export interface DataTableProps {
   pageSize?: string
   disableNavigation?: boolean
   disableLineSelection?: boolean
+  disableToolBar?: boolean
+  disableSelectAll?: boolean
   onLineClick?: (line: any) => void
 }
 

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -121,6 +121,7 @@ export interface DataTableProps {
   createButton?: ReactNode
   pageSize?: string
   disableNavigation?: boolean
+  disableLineSelection?: boolean
   onLineClick?: (line: any) => void
 }
 


### PR DESCRIPTION
### Proposed changes

* possibility to disabled line selection on datatables
* possibility to disable select all checkbox
* possibility to hide the header toolbar on selection

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
