### PR TITLE
[frontend/e2e] Trying to have less flake on background task test (#7378)

### DIFF
--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -46,10 +46,10 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'on-first-retry',
+    video: 'retain-on-failure',
     ignoreHTTPSErrors: true,
   },
-  expect: { timeout: 60000 },
+  expect: { timeout: 30000 },
   timeout: 200000,
   /* Configure projects for major browsers */
   projects: [

--- a/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
@@ -13,9 +13,15 @@ export default class TaskPopup {
     await this.page.getByLabel('Values').click();
 
     // Need to wait the request that fetch labels (in background task popup) - but only on the first call...
-    if (firstTime) {
+    try {
       await this.page.waitForResponse((resp) => resp.url().includes('/graphql') && resp.status() === 200);
+    } catch (e) {
+      // We don't care, sometimes label requires loading, sometimes no....
     }
+
+    // Redo select label to make resilient above try catch.
+    await this.page.getByRole('heading', { name: 'Update entities' }).click();
+    await this.page.getByLabel('Values').click();
 
     await this.page.getByText(labelName).click();
     await this.page.getByRole('button', { name: 'Update' }).click();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
