### PR TITLE
[frontend] Add Attack Patterns to a Container from the Container's Matrix view (#6373)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -5,8 +5,9 @@ import { graphql, createFragmentContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { Route, Routes } from 'react-router-dom';
 import { propOr } from 'ramda';
+import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { QueryRenderer } from '../../../../relay/environment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import GroupingKnowledgeGraph, { groupingKnowledgeGraphQuery } from './GroupingKnowledgeGraph';
 import GroupingKnowledgeCorrelation, { groupingKnowledgeCorrelationQuery } from './GroupingKnowledgeCorrelation';
@@ -16,6 +17,7 @@ import AttackPatternsMatrix from '../../techniques/attack_patterns/AttackPattern
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../../utils/ListParameters';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { insertNode } from '../../../../utils/store';
 
 const styles = () => ({
   container: {
@@ -138,6 +140,32 @@ class GroupingKnowledgeComponent extends Component {
     this.setState({ currentKillChain: value }, () => this.saveView());
   }
 
+  handleAddEntity(entity) {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: this.props.grouping.id,
+        input,
+      },
+      updater: (store) => {
+        insertNode(
+          store,
+          'Pagination_objects',
+          undefined,
+          'containerEdit',
+          this.props.grouping.id,
+          'relationAdd',
+          { input },
+          'to',
+        );
+      },
+    });
+  }
+
   render() {
     const {
       classes,
@@ -234,15 +262,10 @@ class GroupingKnowledgeComponent extends Component {
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
-                        handleChangeKillChain={this.handleChangeKillChain.bind(
-                          this,
-                        )}
-                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(
-                          this,
-                        )}
-                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(
-                          this,
-                        )}
+                        handleChangeKillChain={this.handleChangeKillChain.bind(this)}
+                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
+                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
+                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -105,10 +105,9 @@ const AttackPatternMatrixComponent = (props) => {
     handleToggleModeOnlyActive,
   } = props;
   const attackPatternObjects = useFragment(GroupingAttackPatternsFragment, data.grouping);
-  const attackPatterns = R.pipe(
-    R.map((n) => n.node),
-    R.filter((n) => n.entity_type === 'Attack-Pattern'),
-  )(attackPatternObjects.objects.edges);
+  const attackPatterns = (attackPatternObjects.objects.edges)
+    .map((n) => n.node)
+    .filter((n) => n.entity_type === 'Attack-Pattern');
 
   const handleAddEntity = (entity) => {
     const input = {
@@ -131,7 +130,6 @@ const AttackPatternMatrixComponent = (props) => {
     <AttackPatternsMatrix
       entity={grouping}
       attackPatterns={attackPatterns}
-      searchTerm=""
       currentKillChain={currentKillChain}
       currentModeOnlyActive={currentModeOnlyActive}
       currentColorsReversed={currentColorsReversed}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -18,79 +18,79 @@ import investigationAddFromContainer from '../../../../utils/InvestigationUtils'
 import withRouter from '../../../../utils/compat_router/withRouter';
 
 export const groupingKnowledgeAttackPatternsGraphQuery = graphql`
-  query GroupingKnowledgeAttackPatternsGraphQuery($id: String!) {
-    grouping(id: $id) {
-      id
-      name
-      context
-      x_opencti_graph_data
-      confidence
-      createdBy {
-        ... on Identity {
-          id
-          name
-          entity_type
+    query GroupingKnowledgeAttackPatternsGraphQuery($id: String!) {
+        grouping(id: $id) {
+            id
+            name
+            context
+            x_opencti_graph_data
+            confidence
+            createdBy {
+                ... on Identity {
+                    id
+                    name
+                    entity_type
+                }
+            }
+            objectMarking {
+                id
+                definition_type
+                definition
+                x_opencti_order
+                x_opencti_color
+            }
+            ...GroupingKnowledgeAttackPatterns_fragment
         }
-      }
-      objectMarking {
-        id
-        definition_type
-        definition
-        x_opencti_order
-        x_opencti_color
-      }
-      ...GroupingKnowledge_fragment
     }
-  }
 `;
 
 const GroupingAttackPatternsFragment = graphql`
-  fragment GroupingKnowledge_fragment on Grouping {
-    objects(all: true, types: ["Attack-Pattern"]) {
-      edges {
-        node {
-          ... on AttackPattern {
-            id
-            entity_type
-            parent_types
-            name
-            description
-            x_mitre_platforms
-            x_mitre_permissions_required
-            x_mitre_id
-            x_mitre_detection
-            isSubAttackPattern
-            parentAttackPatterns {
-              edges {
+    fragment GroupingKnowledgeAttackPatterns_fragment on Grouping {
+        objects(all: true, types: ["Attack-Pattern"]) {
+            edges {
                 node {
-                  id
-                  name
-                  description
-                  x_mitre_id
+                    ... on AttackPattern {
+                        id
+                        entity_type
+                        parent_types
+                        name
+                        description
+                        x_mitre_platforms
+                        x_mitre_permissions_required
+                        x_mitre_id
+                        x_mitre_detection
+                        isSubAttackPattern
+                        parentAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        subAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        killChainPhases {
+                            id
+                            kill_chain_name
+                            phase_name
+                            x_opencti_order
+                        }
+                    }
                 }
-              }
             }
-            subAttackPatterns {
-              edges {
-                node {
-                  id
-                  name
-                  description
-                  x_mitre_id
-                }
-              }
-            }
-            killChainPhases {
-              id
-              kill_chain_name
-              phase_name
-              x_opencti_order
-            }
-          }
         }
-      }
     }
-  }
 `;
 
 const AttackPatternMatrixComponent = (props) => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
-import { createFragmentContainer, graphql } from 'react-relay';
-import withStyles from '@mui/styles/withStyles';
+import { createFragmentContainer, createRefetchContainer, graphql, useFragment } from 'react-relay';
 import { Route, Routes } from 'react-router-dom';
 import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -20,17 +19,9 @@ import { constructHandleAddFilter, constructHandleRemoveFilter, emptyFilterGroup
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
-import { insertNode } from '../../../../utils/store';
-
-const styles = () => ({
-  container: {
-    width: '100%',
-    height: '100%',
-  },
-});
 
 export const reportKnowledgeAttackPatternsGraphQuery = graphql`
-  query ReportKnowledgeAttackPatternsGraphQuery($id: String) {
+  query ReportKnowledgeAttackPatternsGraphQuery($id: String!) {
     report(id: $id) {
       id
       name
@@ -51,53 +42,118 @@ export const reportKnowledgeAttackPatternsGraphQuery = graphql`
         x_opencti_order
         x_opencti_color
       }
-      objects(all: true, types: ["Attack-Pattern"]) {
-        edges {
-          node {
-            ... on AttackPattern {
-              id
-              entity_type
-              parent_types
-              name
-              description
-              x_mitre_platforms
-              x_mitre_permissions_required
-              x_mitre_id
-              x_mitre_detection
-              isSubAttackPattern
-              parentAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              subAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              killChainPhases {
+      ...ReportKnowledge_fragment
+  }
+  }
+`;
+
+const ReportAttackPatternsFragment = graphql`
+fragment ReportKnowledge_fragment on Report {
+  objects(all: true, types: ["Attack-Pattern"]) {
+    edges {
+      node {
+        ... on AttackPattern {
+          id
+          entity_type
+          parent_types
+          name
+          description
+          x_mitre_platforms
+          x_mitre_permissions_required
+          x_mitre_id
+          x_mitre_detection
+          isSubAttackPattern
+          parentAttackPatterns {
+            edges {
+              node {
                 id
-                kill_chain_name
-                phase_name
-                x_opencti_order
+                name
+                description
+                x_mitre_id
               }
             }
+          }
+          subAttackPatterns {
+            edges {
+              node {
+                id
+                name
+                description
+                x_mitre_id
+              }
+            }
+          }
+          killChainPhases {
+            id
+            kill_chain_name
+            phase_name
+            x_opencti_order
           }
         }
       }
     }
   }
+}
 `;
+
+const AttackPatternMatrixComponent = (props) => {
+  const {
+    data,
+    report,
+    currentKillChain,
+    currentModeOnlyActive,
+    currentColorsReversed,
+    handleChangeKillChain,
+    handleToggleColorsReversed,
+    handleToggleModeOnlyActive,
+  } = props;
+  const attackPatternObjects = useFragment(ReportAttackPatternsFragment, data.report);
+  const attackPatterns = R.pipe(
+    R.map((n) => n.node),
+    R.filter((n) => n.entity_type === 'Attack-Pattern'),
+  )(attackPatternObjects.objects.edges);
+
+  const handleAddEntity = (entity) => {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: report.id,
+        input,
+      },
+      onCompleted: () => {
+        props.relay.refetch({ id: report.id });
+      },
+    });
+  };
+
+  return (
+    <AttackPatternsMatrix
+      entity={report}
+      attackPatterns={attackPatterns}
+      searchTerm=""
+      currentKillChain={currentKillChain}
+      currentModeOnlyActive={currentModeOnlyActive}
+      currentColorsReversed={currentColorsReversed}
+      handleChangeKillChain={handleChangeKillChain}
+      handleToggleColorsReversed={handleToggleColorsReversed}
+      handleToggleModeOnlyActive={handleToggleModeOnlyActive}
+      handleAdd={handleAddEntity}
+      hideBar={false}
+    />
+  );
+};
+
+const AttackPatternMatrixContainer = createRefetchContainer(
+  AttackPatternMatrixComponent,
+  {
+    data: ReportAttackPatternsFragment,
+  },
+  reportKnowledgeAttackPatternsGraphQuery,
+);
 
 class ReportKnowledgeComponent extends Component {
   constructor(props) {
@@ -216,35 +272,8 @@ class ReportKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
-  handleAddEntity(entity) {
-    const input = {
-      toId: entity.id,
-      relationship_type: 'object',
-    };
-    commitMutation({
-      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
-      variables: {
-        id: this.props.report.id,
-        input,
-      },
-      updater: (store) => {
-        insertNode(
-          store,
-          'Pagination_objects',
-          undefined,
-          'containerEdit',
-          this.props.report.id,
-          'relationAdd',
-          { input },
-          'to',
-        );
-      },
-    });
-  }
-
   render() {
     const {
-      classes,
       report,
       location,
       params: { '*': mode },
@@ -281,7 +310,10 @@ class ReportKnowledgeComponent extends Component {
     };
     return (
       <div
-        className={classes.container}
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid='report-knowledge'
       >
@@ -394,22 +426,16 @@ class ReportKnowledgeComponent extends Component {
                 variables={{ id: report.id }}
                 render={({ props }) => {
                   if (props && props.report) {
-                    const attackPatterns = R.pipe(
-                      R.map((n) => n.node),
-                      R.filter((n) => n.entity_type === 'Attack-Pattern'),
-                    )(props.report.objects.edges);
                     return (
-                      <AttackPatternsMatrix
-                        entity={report}
-                        attackPatterns={attackPatterns}
-                        searchTerm=""
+                      <AttackPatternMatrixContainer
+                        data={props}
+                        report={report}
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
                         handleChangeKillChain={this.handleChangeKillChain.bind(this)}
                         handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
                         handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
-                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }
@@ -459,4 +485,4 @@ const ReportKnowledge = createFragmentContainer(ReportKnowledgeComponent, {
   `,
 });
 
-export default R.compose(withRouter, withStyles(styles))(ReportKnowledge);
+export default R.compose(withRouter)(ReportKnowledge);

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -21,79 +21,79 @@ import investigationAddFromContainer from '../../../../utils/InvestigationUtils'
 import withRouter from '../../../../utils/compat_router/withRouter';
 
 export const reportKnowledgeAttackPatternsGraphQuery = graphql`
-  query ReportKnowledgeAttackPatternsGraphQuery($id: String!) {
-    report(id: $id) {
-      id
-      name
-      x_opencti_graph_data
-      published
-      confidence
-      createdBy {
-        ... on Identity {
-          id
-          name
-          entity_type
+    query ReportKnowledgeAttackPatternsGraphQuery($id: String!) {
+        report(id: $id) {
+            id
+            name
+            x_opencti_graph_data
+            published
+            confidence
+            createdBy {
+                ... on Identity {
+                    id
+                    name
+                    entity_type
+                }
+            }
+            objectMarking {
+                id
+                definition_type
+                definition
+                x_opencti_order
+                x_opencti_color
+            }
+            ...ReportKnowledgeAttackPatterns_fragment
         }
-      }
-      objectMarking {
-        id
-        definition_type
-        definition
-        x_opencti_order
-        x_opencti_color
-      }
-      ...ReportKnowledge_fragment
-  }
-  }
+    }
 `;
 
 const ReportAttackPatternsFragment = graphql`
-fragment ReportKnowledge_fragment on Report {
-  objects(all: true, types: ["Attack-Pattern"]) {
-    edges {
-      node {
-        ... on AttackPattern {
-          id
-          entity_type
-          parent_types
-          name
-          description
-          x_mitre_platforms
-          x_mitre_permissions_required
-          x_mitre_id
-          x_mitre_detection
-          isSubAttackPattern
-          parentAttackPatterns {
+    fragment ReportKnowledgeAttackPatterns_fragment on Report {
+        objects(all: true, types: ["Attack-Pattern"]) {
             edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
+                node {
+                    ... on AttackPattern {
+                        id
+                        entity_type
+                        parent_types
+                        name
+                        description
+                        x_mitre_platforms
+                        x_mitre_permissions_required
+                        x_mitre_id
+                        x_mitre_detection
+                        isSubAttackPattern
+                        parentAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        subAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        killChainPhases {
+                            id
+                            kill_chain_name
+                            phase_name
+                            x_opencti_order
+                        }
+                    }
+                }
             }
-          }
-          subAttackPatterns {
-            edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
-            }
-          }
-          killChainPhases {
-            id
-            kill_chain_name
-            phase_name
-            x_opencti_order
-          }
         }
-      }
     }
-  }
-}
 `;
 
 const AttackPatternMatrixComponent = (props) => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -108,10 +108,9 @@ const AttackPatternMatrixComponent = (props) => {
     handleToggleModeOnlyActive,
   } = props;
   const attackPatternObjects = useFragment(ReportAttackPatternsFragment, data.report);
-  const attackPatterns = R.pipe(
-    R.map((n) => n.node),
-    R.filter((n) => n.entity_type === 'Attack-Pattern'),
-  )(attackPatternObjects.objects.edges);
+  const attackPatterns = (attackPatternObjects.objects.edges)
+    .map((n) => n.node)
+    .filter((n) => n.entity_type === 'Attack-Pattern');
 
   const handleAddEntity = (entity) => {
     const input = {
@@ -134,7 +133,6 @@ const AttackPatternMatrixComponent = (props) => {
     <AttackPatternsMatrix
       entity={report}
       attackPatterns={attackPatterns}
-      searchTerm=""
       currentKillChain={currentKillChain}
       currentModeOnlyActive={currentModeOnlyActive}
       currentColorsReversed={currentColorsReversed}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -5,8 +5,9 @@ import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { Route, Routes } from 'react-router-dom';
+import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { QueryRenderer } from '../../../../relay/environment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import ReportKnowledgeGraph, { reportKnowledgeGraphQuery } from './ReportKnowledgeGraph';
 import ReportKnowledgeCorrelation, { reportKnowledgeCorrelationQuery } from './ReportKnowledgeCorrelation';
@@ -19,6 +20,7 @@ import { constructHandleAddFilter, constructHandleRemoveFilter, emptyFilterGroup
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { insertNode } from '../../../../utils/store';
 
 const styles = () => ({
   container: {
@@ -214,6 +216,32 @@ class ReportKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
+  handleAddEntity(entity) {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: this.props.report.id,
+        input,
+      },
+      updater: (store) => {
+        insertNode(
+          store,
+          'Pagination_objects',
+          undefined,
+          'containerEdit',
+          this.props.report.id,
+          'relationAdd',
+          { input },
+          'to',
+        );
+      },
+    });
+  }
+
   render() {
     const {
       classes,
@@ -378,15 +406,10 @@ class ReportKnowledgeComponent extends Component {
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
-                        handleChangeKillChain={this.handleChangeKillChain.bind(
-                          this,
-                        )}
-                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(
-                          this,
-                        )}
-                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(
-                          this,
-                        )}
+                        handleChangeKillChain={this.handleChangeKillChain.bind(this)}
+                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
+                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
+                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -5,8 +5,9 @@ import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { Route, Routes } from 'react-router-dom';
+import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { QueryRenderer } from '../../../../relay/environment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import IncidentKnowledgeGraph, { incidentKnowledgeGraphQuery } from './IncidentKnowledgeGraph';
 import IncidentKnowledgeCorrelation, { incidentKnowledgeCorrelationQuery } from './IncidentKnowledgeCorrelation';
@@ -19,6 +20,7 @@ import { constructHandleAddFilter, constructHandleRemoveFilter, emptyFilterGroup
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { insertNode } from '../../../../utils/store';
 
 const styles = () => ({
   container: {
@@ -215,6 +217,32 @@ class IncidentKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
+  handleAddEntity(entity) {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: this.props.caseData.id,
+        input,
+      },
+      updater: (store) => {
+        insertNode(
+          store,
+          'Pagination_objects',
+          undefined,
+          'containerEdit',
+          this.props.caseData.id,
+          'relationAdd',
+          { input },
+          'to',
+        );
+      },
+    });
+  }
+
   render() {
     const {
       classes,
@@ -386,15 +414,10 @@ class IncidentKnowledgeComponent extends Component {
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
-                        handleChangeKillChain={this.handleChangeKillChain.bind(
-                          this,
-                        )}
-                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(
-                          this,
-                        )}
-                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(
-                          this,
-                        )}
+                        handleChangeKillChain={this.handleChangeKillChain.bind(this)}
+                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
+                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
+                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -107,10 +107,9 @@ const AttackPatternMatrixComponent = (props) => {
     handleToggleModeOnlyActive,
   } = props;
   const attackPatternObjects = useFragment(IncidentAttackPatternsFragment, data.caseIncident);
-  const attackPatterns = R.pipe(
-    R.map((n) => n.node),
-    R.filter((n) => n.entity_type === 'Attack-Pattern'),
-  )(attackPatternObjects.objects.edges);
+  const attackPatterns = (attackPatternObjects.objects.edges)
+    .map((n) => n.node)
+    .filter((n) => n.entity_type === 'Attack-Pattern');
 
   const handleAddEntity = (entity) => {
     const input = {
@@ -133,7 +132,6 @@ const AttackPatternMatrixComponent = (props) => {
     <AttackPatternsMatrix
       entity={caseData}
       attackPatterns={attackPatterns}
-      searchTerm=""
       currentKillChain={currentKillChain}
       currentModeOnlyActive={currentModeOnlyActive}
       currentColorsReversed={currentColorsReversed}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
-import { createFragmentContainer, graphql } from 'react-relay';
-import withStyles from '@mui/styles/withStyles';
+import { createFragmentContainer, createRefetchContainer, graphql, useFragment } from 'react-relay';
 import { Route, Routes } from 'react-router-dom';
 import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -20,16 +19,6 @@ import { constructHandleAddFilter, constructHandleRemoveFilter, emptyFilterGroup
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
-import { insertNode } from '../../../../utils/store';
-
-const styles = () => ({
-  container: {
-    width: '100%',
-    height: '100%',
-    margin: 0,
-    padding: 0,
-  },
-});
 
 export const incidentKnowledgeAttackPatternsGraphQuery = graphql`
   query IncidentKnowledgeAttackPatternsGraphQuery($id: String!) {
@@ -52,53 +41,118 @@ export const incidentKnowledgeAttackPatternsGraphQuery = graphql`
         x_opencti_order
         x_opencti_color
       }
-      objects(all: true, types: ["Attack-Pattern"]) {
-        edges {
-          node {
-            ... on AttackPattern {
-              id
-              entity_type
-              parent_types
-              name
-              description
-              x_mitre_platforms
-              x_mitre_permissions_required
-              x_mitre_id
-              x_mitre_detection
-              isSubAttackPattern
-              parentAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              subAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              killChainPhases {
+      ...IncidentKnowledge_fragment
+    }
+  }
+`;
+
+const IncidentAttackPatternsFragment = graphql`
+fragment IncidentKnowledge_fragment on CaseIncident {
+  objects(all: true, types: ["Attack-Pattern"]) {
+    edges {
+      node {
+        ... on AttackPattern {
+          id
+          entity_type
+          parent_types
+          name
+          description
+          x_mitre_platforms
+          x_mitre_permissions_required
+          x_mitre_id
+          x_mitre_detection
+          isSubAttackPattern
+          parentAttackPatterns {
+            edges {
+              node {
                 id
-                kill_chain_name
-                phase_name
-                x_opencti_order
+                name
+                description
+                x_mitre_id
               }
             }
+          }
+          subAttackPatterns {
+            edges {
+              node {
+                id
+                name
+                description
+                x_mitre_id
+              }
+            }
+          }
+          killChainPhases {
+            id
+            kill_chain_name
+            phase_name
+            x_opencti_order
           }
         }
       }
     }
   }
+}
 `;
+
+const AttackPatternMatrixComponent = (props) => {
+  const {
+    data,
+    caseData,
+    currentKillChain,
+    currentModeOnlyActive,
+    currentColorsReversed,
+    handleChangeKillChain,
+    handleToggleColorsReversed,
+    handleToggleModeOnlyActive,
+  } = props;
+  const attackPatternObjects = useFragment(IncidentAttackPatternsFragment, data.caseIncident);
+  const attackPatterns = R.pipe(
+    R.map((n) => n.node),
+    R.filter((n) => n.entity_type === 'Attack-Pattern'),
+  )(attackPatternObjects.objects.edges);
+
+  const handleAddEntity = (entity) => {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: caseData.id,
+        input,
+      },
+      onCompleted: () => {
+        props.relay.refetch({ id: caseData.id });
+      },
+    });
+  };
+
+  return (
+    <AttackPatternsMatrix
+      entity={caseData}
+      attackPatterns={attackPatterns}
+      searchTerm=""
+      currentKillChain={currentKillChain}
+      currentModeOnlyActive={currentModeOnlyActive}
+      currentColorsReversed={currentColorsReversed}
+      handleChangeKillChain={handleChangeKillChain}
+      handleToggleColorsReversed={handleToggleColorsReversed}
+      handleToggleModeOnlyActive={handleToggleModeOnlyActive}
+      handleAdd={handleAddEntity}
+      hideBar={false}
+    />
+  );
+};
+
+const AttackPatternMatrixContainer = createRefetchContainer(
+  AttackPatternMatrixComponent,
+  {
+    data: IncidentAttackPatternsFragment,
+  },
+  incidentKnowledgeAttackPatternsGraphQuery,
+);
 
 class IncidentKnowledgeComponent extends Component {
   constructor(props) {
@@ -217,35 +271,8 @@ class IncidentKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
-  handleAddEntity(entity) {
-    const input = {
-      toId: entity.id,
-      relationship_type: 'object',
-    };
-    commitMutation({
-      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
-      variables: {
-        id: this.props.caseData.id,
-        input,
-      },
-      updater: (store) => {
-        insertNode(
-          store,
-          'Pagination_objects',
-          undefined,
-          'containerEdit',
-          this.props.caseData.id,
-          'relationAdd',
-          { input },
-          'to',
-        );
-      },
-    });
-  }
-
   render() {
     const {
-      classes,
       caseData,
       location,
       params: { '*': mode },
@@ -282,7 +309,12 @@ class IncidentKnowledgeComponent extends Component {
     };
     return (
       <div
-        className={classes.container}
+        style={{
+          width: '100%',
+          height: '100%',
+          margin: 0,
+          padding: 0,
+        }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
       >
         {mode !== 'graph' && (
@@ -402,22 +434,16 @@ class IncidentKnowledgeComponent extends Component {
                 variables={{ id: caseData.id }}
                 render={({ props }) => {
                   if (props && props.caseIncident) {
-                    const attackPatterns = R.pipe(
-                      R.map((n) => n.node),
-                      R.filter((n) => n.entity_type === 'Attack-Pattern'),
-                    )(props.caseIncident.objects.edges);
                     return (
-                      <AttackPatternsMatrix
-                        entity={caseData}
-                        attackPatterns={attackPatterns}
-                        searchTerm=""
+                      <AttackPatternMatrixContainer
+                        data={props}
+                        caseData={caseData}
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
                         handleChangeKillChain={this.handleChangeKillChain.bind(this)}
                         handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
                         handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
-                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }
@@ -467,4 +493,4 @@ const IncidentKnowledge = createFragmentContainer(IncidentKnowledgeComponent, {
   `,
 });
 
-export default R.compose(withRouter, withStyles(styles))(IncidentKnowledge);
+export default R.compose(withRouter)(IncidentKnowledge);

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -21,78 +21,78 @@ import investigationAddFromContainer from '../../../../utils/InvestigationUtils'
 import withRouter from '../../../../utils/compat_router/withRouter';
 
 export const incidentKnowledgeAttackPatternsGraphQuery = graphql`
-  query IncidentKnowledgeAttackPatternsGraphQuery($id: String!) {
-    caseIncident(id: $id) {
-      id
-      name
-      x_opencti_graph_data
-      confidence
-      createdBy {
-        ... on Identity {
-          id
-          name
-          entity_type
+    query IncidentKnowledgeAttackPatternsGraphQuery($id: String!) {
+        caseIncident(id: $id) {
+            id
+            name
+            x_opencti_graph_data
+            confidence
+            createdBy {
+                ... on Identity {
+                    id
+                    name
+                    entity_type
+                }
+            }
+            objectMarking {
+                id
+                definition_type
+                definition
+                x_opencti_order
+                x_opencti_color
+            }
+            ...IncidentKnowledgeAttackPatterns_fragment
         }
-      }
-      objectMarking {
-        id
-        definition_type
-        definition
-        x_opencti_order
-        x_opencti_color
-      }
-      ...IncidentKnowledge_fragment
     }
-  }
 `;
 
 const IncidentAttackPatternsFragment = graphql`
-fragment IncidentKnowledge_fragment on CaseIncident {
-  objects(all: true, types: ["Attack-Pattern"]) {
-    edges {
-      node {
-        ... on AttackPattern {
-          id
-          entity_type
-          parent_types
-          name
-          description
-          x_mitre_platforms
-          x_mitre_permissions_required
-          x_mitre_id
-          x_mitre_detection
-          isSubAttackPattern
-          parentAttackPatterns {
+    fragment IncidentKnowledgeAttackPatterns_fragment on CaseIncident {
+        objects(all: true, types: ["Attack-Pattern"]) {
             edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
+                node {
+                    ... on AttackPattern {
+                        id
+                        entity_type
+                        parent_types
+                        name
+                        description
+                        x_mitre_platforms
+                        x_mitre_permissions_required
+                        x_mitre_id
+                        x_mitre_detection
+                        isSubAttackPattern
+                        parentAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        subAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        killChainPhases {
+                            id
+                            kill_chain_name
+                            phase_name
+                            x_opencti_order
+                        }
+                    }
+                }
             }
-          }
-          subAttackPatterns {
-            edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
-            }
-          }
-          killChainPhases {
-            id
-            kill_chain_name
-            phase_name
-            x_opencti_order
-          }
         }
-      }
     }
-  }
-}
 `;
 
 const AttackPatternMatrixComponent = (props) => {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -107,10 +107,9 @@ const AttackPatternMatrixComponent = (props) => {
     handleToggleModeOnlyActive,
   } = props;
   const attackPatternObjects = useFragment(CaseRfiAttackPatternsFragment, data.caseRfi);
-  const attackPatterns = R.pipe(
-    R.map((n) => n.node),
-    R.filter((n) => n.entity_type === 'Attack-Pattern'),
-  )(attackPatternObjects.objects.edges);
+  const attackPatterns = (attackPatternObjects.objects.edges)
+    .map((n) => n.node)
+    .filter((n) => n.entity_type === 'Attack-Pattern');
 
   const handleAddEntity = (entity) => {
     const input = {
@@ -133,7 +132,6 @@ const AttackPatternMatrixComponent = (props) => {
     <AttackPatternsMatrix
       entity={caseData}
       attackPatterns={attackPatterns}
-      searchTerm=""
       currentKillChain={currentKillChain}
       currentModeOnlyActive={currentModeOnlyActive}
       currentColorsReversed={currentColorsReversed}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -21,78 +21,78 @@ import investigationAddFromContainer from '../../../../utils/InvestigationUtils'
 import withRouter from '../../../../utils/compat_router/withRouter';
 
 export const caseRfiKnowledgeAttackPatternsGraphQuery = graphql`
-  query CaseRfiKnowledgeAttackPatternsGraphQuery($id: String!) {
-    caseRfi(id: $id) {
-      id
-      name
-      x_opencti_graph_data
-      confidence
-      createdBy {
-        ... on Identity {
-          id
-          name
-          entity_type
+    query CaseRfiKnowledgeAttackPatternsGraphQuery($id: String!) {
+        caseRfi(id: $id) {
+            id
+            name
+            x_opencti_graph_data
+            confidence
+            createdBy {
+                ... on Identity {
+                    id
+                    name
+                    entity_type
+                }
+            }
+            objectMarking {
+                id
+                definition_type
+                definition
+                x_opencti_order
+                x_opencti_color
+            }
+            ...CaseRfiKnowledgeAttackPatterns_fragment
         }
-      }
-      objectMarking {
-        id
-        definition_type
-        definition
-        x_opencti_order
-        x_opencti_color
-      }
-     ...CaseRfiKnowledge_fragment
     }
-  }
 `;
 
 const CaseRfiAttackPatternsFragment = graphql`
-fragment CaseRfiKnowledge_fragment on CaseRfi {
-  objects(all: true, types: ["Attack-Pattern"]) {
-    edges {
-      node {
-        ... on AttackPattern {
-          id
-          entity_type
-          parent_types
-          name
-          description
-          x_mitre_platforms
-          x_mitre_permissions_required
-          x_mitre_id
-          x_mitre_detection
-          isSubAttackPattern
-          parentAttackPatterns {
+    fragment CaseRfiKnowledgeAttackPatterns_fragment on CaseRfi {
+        objects(all: true, types: ["Attack-Pattern"]) {
             edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
+                node {
+                    ... on AttackPattern {
+                        id
+                        entity_type
+                        parent_types
+                        name
+                        description
+                        x_mitre_platforms
+                        x_mitre_permissions_required
+                        x_mitre_id
+                        x_mitre_detection
+                        isSubAttackPattern
+                        parentAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        subAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        killChainPhases {
+                            id
+                            kill_chain_name
+                            phase_name
+                            x_opencti_order
+                        }
+                    }
+                }
             }
-          }
-          subAttackPatterns {
-            edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
-            }
-          }
-          killChainPhases {
-            id
-            kill_chain_name
-            phase_name
-            x_opencti_order
-          }
         }
-      }
     }
-  }
-}
 `;
 
 const AttackPatternMatrixComponent = (props) => {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -5,8 +5,9 @@ import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { Route, Routes } from 'react-router-dom';
+import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { QueryRenderer } from '../../../../relay/environment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import AttackPatternsMatrix from '../../techniques/attack_patterns/AttackPatternsMatrix';
@@ -19,6 +20,7 @@ import CaseRfiKnowledgeCorrelation, { caseRfiKnowledgeCorrelationQuery } from '.
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { insertNode } from '../../../../utils/store';
 
 const styles = () => ({
   container: {
@@ -215,6 +217,32 @@ class CaseRfiKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
+  handleAddEntity(entity) {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: this.props.caseData.id,
+        input,
+      },
+      updater: (store) => {
+        insertNode(
+          store,
+          'Pagination_objects',
+          undefined,
+          'containerEdit',
+          this.props.caseData.id,
+          'relationAdd',
+          { input },
+          'to',
+        );
+      },
+    });
+  }
+
   render() {
     const {
       classes,
@@ -387,15 +415,10 @@ class CaseRfiKnowledgeComponent extends Component {
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
-                        handleChangeKillChain={this.handleChangeKillChain.bind(
-                          this,
-                        )}
-                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(
-                          this,
-                        )}
-                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(
-                          this,
-                        )}
+                        handleChangeKillChain={this.handleChangeKillChain.bind(this)}
+                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
+                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
+                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -5,8 +5,9 @@ import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { Route, Routes } from 'react-router-dom';
+import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { QueryRenderer } from '../../../../relay/environment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import AttackPatternsMatrix from '../../techniques/attack_patterns/AttackPatternsMatrix';
@@ -19,6 +20,7 @@ import CaseRftKnowledgeCorrelation, { caseRftKnowledgeCorrelationQuery } from '.
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { insertNode } from '../../../../utils/store';
 
 const styles = () => ({
   container: {
@@ -215,6 +217,32 @@ class CaseRftKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
+  handleAddEntity(entity) {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: this.props.caseData.id,
+        input,
+      },
+      updater: (store) => {
+        insertNode(
+          store,
+          'Pagination_objects',
+          undefined,
+          'containerEdit',
+          this.props.caseData.id,
+          'relationAdd',
+          { input },
+          'to',
+        );
+      },
+    });
+  }
+
   render() {
     const {
       classes,
@@ -387,15 +415,10 @@ class CaseRftKnowledgeComponent extends Component {
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
-                        handleChangeKillChain={this.handleChangeKillChain.bind(
-                          this,
-                        )}
-                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(
-                          this,
-                        )}
-                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(
-                          this,
-                        )}
+                        handleChangeKillChain={this.handleChangeKillChain.bind(this)}
+                        handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
+                        handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
+                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
-import { createFragmentContainer, graphql } from 'react-relay';
-import withStyles from '@mui/styles/withStyles';
+import { createFragmentContainer, createRefetchContainer, graphql, useFragment } from 'react-relay';
 import { Route, Routes } from 'react-router-dom';
 import { containerAddStixCoreObjectsLinesRelationAddMutation } from '../../common/containers/ContainerAddStixCoreObjectsLines';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -20,16 +19,6 @@ import CaseRftKnowledgeCorrelation, { caseRftKnowledgeCorrelationQuery } from '.
 import ContentKnowledgeTimeLineBar from '../../common/containers/ContainertKnowledgeTimeLineBar';
 import investigationAddFromContainer from '../../../../utils/InvestigationUtils';
 import withRouter from '../../../../utils/compat_router/withRouter';
-import { insertNode } from '../../../../utils/store';
-
-const styles = () => ({
-  container: {
-    width: '100%',
-    height: '100%',
-    margin: 0,
-    padding: 0,
-  },
-});
 
 export const caseRftKnowledgeAttackPatternsGraphQuery = graphql`
   query CaseRftKnowledgeAttackPatternsGraphQuery($id: String!) {
@@ -52,53 +41,118 @@ export const caseRftKnowledgeAttackPatternsGraphQuery = graphql`
         x_opencti_order
         x_opencti_color
       }
-      objects(all: true, types: ["Attack-Pattern"]) {
-        edges {
-          node {
-            ... on AttackPattern {
-              id
-              entity_type
-              parent_types
-              name
-              description
-              x_mitre_platforms
-              x_mitre_permissions_required
-              x_mitre_id
-              x_mitre_detection
-              isSubAttackPattern
-              parentAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              subAttackPatterns {
-                edges {
-                  node {
-                    id
-                    name
-                    description
-                    x_mitre_id
-                  }
-                }
-              }
-              killChainPhases {
+     ...CaseRftKnowledge_fragment
+    }
+  }
+`;
+
+const CaseRftAttackPatternsFragment = graphql`
+fragment CaseRftKnowledge_fragment on CaseRft {
+  objects(all: true, types: ["Attack-Pattern"]) {
+    edges {
+      node {
+        ... on AttackPattern {
+          id
+          entity_type
+          parent_types
+          name
+          description
+          x_mitre_platforms
+          x_mitre_permissions_required
+          x_mitre_id
+          x_mitre_detection
+          isSubAttackPattern
+          parentAttackPatterns {
+            edges {
+              node {
                 id
-                kill_chain_name
-                phase_name
-                x_opencti_order
+                name
+                description
+                x_mitre_id
               }
             }
+          }
+          subAttackPatterns {
+            edges {
+              node {
+                id
+                name
+                description
+                x_mitre_id
+              }
+            }
+          }
+          killChainPhases {
+            id
+            kill_chain_name
+            phase_name
+            x_opencti_order
           }
         }
       }
     }
   }
+}
 `;
+
+const AttackPatternMatrixComponent = (props) => {
+  const {
+    data,
+    caseData,
+    currentKillChain,
+    currentModeOnlyActive,
+    currentColorsReversed,
+    handleChangeKillChain,
+    handleToggleColorsReversed,
+    handleToggleModeOnlyActive,
+  } = props;
+  const attackPatternObjects = useFragment(CaseRftAttackPatternsFragment, data.caseRft);
+  const attackPatterns = R.pipe(
+    R.map((n) => n.node),
+    R.filter((n) => n.entity_type === 'Attack-Pattern'),
+  )(attackPatternObjects.objects.edges);
+
+  const handleAddEntity = (entity) => {
+    const input = {
+      toId: entity.id,
+      relationship_type: 'object',
+    };
+    commitMutation({
+      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
+      variables: {
+        id: caseData.id,
+        input,
+      },
+      onCompleted: () => {
+        props.relay.refetch({ id: caseData.id });
+      },
+    });
+  };
+
+  return (
+    <AttackPatternsMatrix
+      entity={caseData}
+      attackPatterns={attackPatterns}
+      searchTerm=""
+      currentKillChain={currentKillChain}
+      currentModeOnlyActive={currentModeOnlyActive}
+      currentColorsReversed={currentColorsReversed}
+      handleChangeKillChain={handleChangeKillChain}
+      handleToggleColorsReversed={handleToggleColorsReversed}
+      handleToggleModeOnlyActive={handleToggleModeOnlyActive}
+      handleAdd={handleAddEntity}
+      hideBar={false}
+    />
+  );
+};
+
+const AttackPatternMatrixContainer = createRefetchContainer(
+  AttackPatternMatrixComponent,
+  {
+    data: CaseRftAttackPatternsFragment,
+  },
+  caseRftKnowledgeAttackPatternsGraphQuery,
+);
 
 class CaseRftKnowledgeComponent extends Component {
   constructor(props) {
@@ -217,35 +271,8 @@ class CaseRftKnowledgeComponent extends Component {
     this.setState({ timeLineSearchTerm: value }, () => this.saveView());
   }
 
-  handleAddEntity(entity) {
-    const input = {
-      toId: entity.id,
-      relationship_type: 'object',
-    };
-    commitMutation({
-      mutation: containerAddStixCoreObjectsLinesRelationAddMutation,
-      variables: {
-        id: this.props.caseData.id,
-        input,
-      },
-      updater: (store) => {
-        insertNode(
-          store,
-          'Pagination_objects',
-          undefined,
-          'containerEdit',
-          this.props.caseData.id,
-          'relationAdd',
-          { input },
-          'to',
-        );
-      },
-    });
-  }
-
   render() {
     const {
-      classes,
       caseData,
       location,
       params: { '*': mode },
@@ -282,7 +309,12 @@ class CaseRftKnowledgeComponent extends Component {
     };
     return (
       <div
-        className={classes.container}
+        style={{
+          width: '100%',
+          height: '100%',
+          margin: 0,
+          padding: 0,
+        }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
       >
         {mode !== 'graph' && (
@@ -403,22 +435,16 @@ class CaseRftKnowledgeComponent extends Component {
                 variables={{ id: caseData.id }}
                 render={({ props }) => {
                   if (props && props.caseRft) {
-                    const attackPatterns = R.pipe(
-                      R.map((n) => n.node),
-                      R.filter((n) => n.entity_type === 'Attack-Pattern'),
-                    )(props.caseRft.objects.edges);
                     return (
-                      <AttackPatternsMatrix
-                        entity={caseData}
-                        attackPatterns={attackPatterns}
-                        searchTerm=""
+                      <AttackPatternMatrixContainer
+                        data={props}
+                        caseData={caseData}
                         currentKillChain={currentKillChain}
                         currentModeOnlyActive={currentModeOnlyActive}
                         currentColorsReversed={currentColorsReversed}
                         handleChangeKillChain={this.handleChangeKillChain.bind(this)}
                         handleToggleColorsReversed={this.handleToggleColorsReversed.bind(this)}
                         handleToggleModeOnlyActive={this.handleToggleModeOnlyActive.bind(this)}
-                        handleAdd={this.handleAddEntity.bind(this)}
                       />
                     );
                   }
@@ -468,4 +494,4 @@ const CaseRftKnowledge = createFragmentContainer(CaseRftKnowledgeComponent, {
   `,
 });
 
-export default R.compose(withRouter, withStyles(styles))(CaseRftKnowledge);
+export default R.compose(withRouter)(CaseRftKnowledge);

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -107,10 +107,9 @@ const AttackPatternMatrixComponent = (props) => {
     handleToggleModeOnlyActive,
   } = props;
   const attackPatternObjects = useFragment(CaseRftAttackPatternsFragment, data.caseRft);
-  const attackPatterns = R.pipe(
-    R.map((n) => n.node),
-    R.filter((n) => n.entity_type === 'Attack-Pattern'),
-  )(attackPatternObjects.objects.edges);
+  const attackPatterns = (attackPatternObjects.objects.edges)
+    .map((n) => n.node)
+    .filter((n) => n.entity_type === 'Attack-Pattern');
 
   const handleAddEntity = (entity) => {
     const input = {
@@ -133,7 +132,6 @@ const AttackPatternMatrixComponent = (props) => {
     <AttackPatternsMatrix
       entity={caseData}
       attackPatterns={attackPatterns}
-      searchTerm=""
       currentKillChain={currentKillChain}
       currentModeOnlyActive={currentModeOnlyActive}
       currentColorsReversed={currentColorsReversed}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -21,78 +21,78 @@ import investigationAddFromContainer from '../../../../utils/InvestigationUtils'
 import withRouter from '../../../../utils/compat_router/withRouter';
 
 export const caseRftKnowledgeAttackPatternsGraphQuery = graphql`
-  query CaseRftKnowledgeAttackPatternsGraphQuery($id: String!) {
-    caseRft(id: $id) {
-      id
-      name
-      x_opencti_graph_data
-      confidence
-      createdBy {
-        ... on Identity {
-          id
-          name
-          entity_type
+    query CaseRftKnowledgeAttackPatternsGraphQuery($id: String!) {
+        caseRft(id: $id) {
+            id
+            name
+            x_opencti_graph_data
+            confidence
+            createdBy {
+                ... on Identity {
+                    id
+                    name
+                    entity_type
+                }
+            }
+            objectMarking {
+                id
+                definition_type
+                definition
+                x_opencti_order
+                x_opencti_color
+            }
+            ...CaseRftKnowledgeAttackPatterns_fragment
         }
-      }
-      objectMarking {
-        id
-        definition_type
-        definition
-        x_opencti_order
-        x_opencti_color
-      }
-     ...CaseRftKnowledge_fragment
     }
-  }
 `;
 
 const CaseRftAttackPatternsFragment = graphql`
-fragment CaseRftKnowledge_fragment on CaseRft {
-  objects(all: true, types: ["Attack-Pattern"]) {
-    edges {
-      node {
-        ... on AttackPattern {
-          id
-          entity_type
-          parent_types
-          name
-          description
-          x_mitre_platforms
-          x_mitre_permissions_required
-          x_mitre_id
-          x_mitre_detection
-          isSubAttackPattern
-          parentAttackPatterns {
+    fragment CaseRftKnowledgeAttackPatterns_fragment on CaseRft {
+        objects(all: true, types: ["Attack-Pattern"]) {
             edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
+                node {
+                    ... on AttackPattern {
+                        id
+                        entity_type
+                        parent_types
+                        name
+                        description
+                        x_mitre_platforms
+                        x_mitre_permissions_required
+                        x_mitre_id
+                        x_mitre_detection
+                        isSubAttackPattern
+                        parentAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        subAttackPatterns {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                    description
+                                    x_mitre_id
+                                }
+                            }
+                        }
+                        killChainPhases {
+                            id
+                            kill_chain_name
+                            phase_name
+                            x_opencti_order
+                        }
+                    }
+                }
             }
-          }
-          subAttackPatterns {
-            edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
-            }
-          }
-          killChainPhases {
-            id
-            kill_chain_name
-            phase_name
-            x_opencti_order
-          }
         }
-      }
     }
-  }
-}
 `;
 
 const AttackPatternMatrixComponent = (props) => {

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrix.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternsMatrix.tsx
@@ -16,7 +16,7 @@ interface AttackPatternsMatrixProps {
   currentColorsReversed: boolean;
   hideBar: boolean;
   handleAdd: (entity: TargetEntity) => void;
-  selectedKillChain: string;
+  selectedKillChain?: string;
   hideSwitchKillChainNavOpen?: boolean;
 }
 const AttackPatternsMatrix: FunctionComponent<AttackPatternsMatrixProps> = ({


### PR DESCRIPTION
### Proposed changes
In a container Knowledge tab, in the Tactics matrix view, when clicking on an Attack Pattern, add a button 'Add' that enables to directly add the attack pattern in the container. For the moment there is only a button 'view'

### Related issues
Add Attack Patterns to a Report from the Report's Matrix view #6373