### PR TITLE
[backend] Connector default role should bypass mandatory attributes by default (#8275)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -94,7 +94,7 @@
   "devDependencies": {
     "@playwright/test": "1.45.3",
     "@rollup/plugin-graphql": "2.0.4",
-    "@testing-library/dom": "^10.4.0",
+    "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "16.0.0",
     "@testing-library/user-event": "14.5.2",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -5484,7 +5484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^10.4.0":
+"@testing-library/dom@npm:10.4.0":
   version: 10.4.0
   resolution: "@testing-library/dom@npm:10.4.0"
   dependencies:
@@ -15767,7 +15767,7 @@ __metadata:
     "@rjsf/mui": "npm:5.18.1"
     "@rjsf/utils": "npm:5.18.1"
     "@rollup/plugin-graphql": "npm:2.0.4"
-    "@testing-library/dom": "npm:^10.4.0"
+    "@testing-library/dom": "npm:10.4.0"
     "@testing-library/jest-dom": "npm:6.4.2"
     "@testing-library/react": "npm:16.0.0"
     "@testing-library/user-event": "npm:14.5.2"

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -257,6 +257,7 @@ const createBasicRolesAndCapabilities = async (context) => {
     description: 'Connector role that has the recommended capabilities',
     capabilities: [
       'KNOWLEDGE_KNUPDATE_KNDELETE',
+      'KNOWLEDGE_KNUPDATE_KNBYPASSFIELDS',
       'KNOWLEDGE_KNUPLOAD',
       'KNOWLEDGE_KNASKIMPORT',
       'KNOWLEDGE_KNGETEXPORT_KNASKEXPORT',

--- a/opencti-platform/opencti-graphql/src/migrations/1725699277745-connector-bypass-mandatory-field.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1725699277745-connector-bypass-mandatory-field.js
@@ -1,0 +1,29 @@
+import { logApp } from '../config/conf';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { createRelation } from '../database/middleware';
+import { elLoadById } from '../database/engine';
+import { isNotEmptyField } from '../database/utils';
+
+const message = '[MIGRATION] Add bypass mandatory field to connector role';
+
+export const up = async (next) => {
+  logApp.info(`${message} > started`);
+  const context = executionContext('migration');
+
+  // Resolve the role "Connector" based on standard ID
+  const connectorRole = await elLoadById(context, SYSTEM_USER, 'role--b375ed46-a11c-56d5-a2d4-0c654f61eeee');
+
+  // Add the capability
+  if (isNotEmptyField(connectorRole)) {
+    const byPassMandatoryAttributeCapability = await elLoadById(context, SYSTEM_USER, 'capability--767be0e4-3b1f-5073-bfea-f23f785a36d1');
+    const input = { fromId: connectorRole.id, toId: byPassMandatoryAttributeCapability.id, relationship_type: 'has-capability' };
+    await createRelation(context, SYSTEM_USER, input);
+  }
+
+  logApp.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -683,14 +683,14 @@ describe('Elasticsearch pagination', () => {
     expect(metaByEntityType['external-reference'].length).toEqual(7);
     expect(metaByEntityType['object-marking'].length).toEqual(28);
     expect(metaByEntityType['kill-chain-phase'].length).toEqual(3);
-    expect(data.edges.length).toEqual(248);
+    expect(data.edges.length).toEqual(249);
     let filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');
     // Same query with no pagination
     data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { connectionFormat: false });
     expect(data).not.toBeNull();
-    expect(data.length).toEqual(248);
+    expect(data.length).toEqual(249);
     filterBaseTypes = R.uniq(R.map((e) => e.base_type, data));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -671,7 +671,7 @@ describe('Elasticsearch pagination', () => {
     let data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { includeAuthorities: true });
     expect(data).not.toBeNull();
     const groupByIndices = R.groupBy((e) => e.node._index, data.edges);
-    expect(groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].length).toEqual(93);
+    expect(groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].length).toEqual(94);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_core_relationships-000001`].length).toEqual(24);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_meta_relationships-000001`].length).toEqual(129);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_sighting_relationships-000001`].length).toEqual(2);

--- a/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
@@ -71,7 +71,7 @@ describe('Database sync raw', () => {
       expect(vocabRemoved.map((v) => v.name)).toEqual([]);
       expect(vocabAdded.map((v) => v.name)).toEqual([]);
 
-      expect(vocabBefore.length).toEqual(342);
+      expect(vocabBefore.length).toEqual(341);
 
       const counters = await elAggregationCount(testContext, ADMIN_USER, READ_DATA_INDICES, { types: ['Stix-Object'], field: 'entity_type' });
       const countersMap = new Map(counters.map((i) => [i.label, i.value]));

--- a/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
@@ -71,7 +71,7 @@ describe('Database sync raw', () => {
       expect(vocabRemoved.map((v) => v.name)).toEqual([]);
       expect(vocabAdded.map((v) => v.name)).toEqual([]);
 
-      expect(vocabBefore.length).toEqual(341);
+      expect(vocabBefore.length).toEqual(342);
 
       const counters = await elAggregationCount(testContext, ADMIN_USER, READ_DATA_INDICES, { types: ['Stix-Object'], field: 'entity_type' });
       const countersMap = new Map(counters.map((i) => [i.label, i.value]));


### PR DESCRIPTION
### Proposed changes

Connector default role should bypass mandatory attributes by default:

1. Change the default data init
2. Make a migration to try to migrate existing role

### Related issues

* #8275
