### PR TITLE
[frontend] fixed header colors (#8249)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
@@ -13,7 +13,7 @@ import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings
 // Do not use it for new code.
 const useStyles = makeStyles((theme) => ({
   header: {
-    backgroundColor: theme.palette.background.nav,
+    backgroundColor: theme.palette.background.default,
     padding: '20px 20px 20px 60px',
   },
   closeButton: {
@@ -49,7 +49,7 @@ const StixCyberObservableEditionContainer = (props) => {
         >
           <Close fontSize="small" color="primary" />
         </IconButton>
-        <Typography variant="h6" classes={{ root: classes.title }}>
+        <Typography variant="subtitle2" classes={{ root: classes.title }}>
           {t_i18n('Update an observable')}
         </Typography>
         <SubscriptionAvatars context={editContext} />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

After fix:

![image](https://github.com/user-attachments/assets/c08c1c36-6ef7-4fc3-8dc0-cab2c62e0622)
![image](https://github.com/user-attachments/assets/a9f90938-4c52-409b-ac43-20db9c0053c5)


### Related issues

part of #8249 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

From what I can see, the problem is not limited to Light mode. Here are a few examples of drawers that have the same issue (though there are more):

- Observations -> Observables -> Create
- Observations -> Artifacts -> Create
- Events -> Sightings -> Sighting -> Edit
- Data -> Relationships -> Edit

Should I apply the same quick fix to each, or would it be better to refactor them to use the Drawer component? It looks like the 'correct' drawers use the Drawer component internally, but that would require a major refactor and take more time.
