### PR TITLE
[frontend] fixed workbench creation pop-up in case of error (#8265)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -105,6 +105,20 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
     if (!name.endsWith('.json')) {
       name += '.json';
     }
+
+    const handleCompleted = () => {
+      setSubmitting(false);
+      resetForm();
+      handleCloseCreate();
+      onCompleted?.();
+    };
+
+    const handleError = () => {
+      setSubmitting(false);
+      resetForm();
+      handleCloseCreate();
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const objects: any = [];
     if (entityId) {
@@ -129,15 +143,10 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
           commitWorkbench({
             variables: { file, labels: finalLabels, entityId },
             onCompleted: () => {
-              setSubmitting(false);
-              resetForm();
-              handleCloseCreate();
-              onCompleted?.();
+              handleCompleted();
             },
             onError: () => {
-              setSubmitting(false);
-              resetForm();
-              handleCloseCreate();
+              handleError();
             },
           });
         });
@@ -151,15 +160,10 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
       commitWorkbench({
         variables: { file, labels: finalLabels, entityId },
         onCompleted: () => {
-          setSubmitting(false);
-          resetForm();
-          handleCloseCreate();
-          onCompleted?.();
+          handleCompleted();
         },
         onError: () => {
-          setSubmitting(false);
-          resetForm();
-          handleCloseCreate();
+          handleError();
         },
       });
     }

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileCreator.tsx
@@ -93,6 +93,10 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
   const classes = useStyles();
   const [commitWorkbench] = useApiMutation<WorkbenchFileCreatorMutation>(
     workbenchFileCreatorMutation,
+    undefined,
+    {
+      errorMessage: 'An error occurred while creating the workbench.',
+    },
   );
   const entityId = entity?.id;
   const onSubmitCreate: FormikConfig<WorkbenchFileCreatorFormValues>['onSubmit'] = (values, { setSubmitting, resetForm }) => {
@@ -130,6 +134,11 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
               handleCloseCreate();
               onCompleted?.();
             },
+            onError: () => {
+              setSubmitting(false);
+              resetForm();
+              handleCloseCreate();
+            },
           });
         });
     } else {
@@ -146,6 +155,11 @@ const WorkbenchFileCreator: FunctionComponent<WorkbenchFileCreatorProps> = ({
           resetForm();
           handleCloseCreate();
           onCompleted?.();
+        },
+        onError: () => {
+          setSubmitting(false);
+          resetForm();
+          handleCloseCreate();
         },
       });
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When trying to create a workbench with the same name, it currently shows a generic error:
![image](https://github.com/user-attachments/assets/a69363f8-cb33-4c78-b76a-ba9bcf057f8b)
If I hadn't set that generic error, the message would have been:
"RRNLRequestError: Relay request for WorkbenchFileCreatorMutation failed for the following reason: 1. A file already exists with this name. uploadPending(file: $file, labels: $labels, errorOnExistin ^^^"
Would this be too confusing for users?
* The pop-up no longer freezes after that workflow: 
![image](https://github.com/user-attachments/assets/cef4b70c-ce94-4b21-b3d9-bcce78bef769)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
part of #8265 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Should I implement form validation to check for duplicate workbench names when the "Create" button is pressed? Doing so would allow us to display a more specific error message, such as "A file with this name already exists."
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
