### PR TITLE
[frontend] replaced . with [dot] in filename when exporting dashboard…

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceExportHandler.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceExportHandler.tsx
@@ -24,7 +24,7 @@ const handleExportJson = (workspace: workspaceToExport) => {
       if (result.workspace) {
         const blob = new Blob([result.workspace.toConfigurationExport], { type: 'text/json' });
         const [day, month, year] = new Date().toLocaleDateString('fr-FR').split('/');
-        const fileName = `${year}${month}${day}_octi_dashboard_${workspace.name}`;
+        const fileName = `${year}${month}${day}_octi_dashboard_${workspace.name.replace(/\./g, '[dot]')}`;
         fileDownload(blob, fileName, 'application/json');
       }
     });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

The fix that I came up with is to replace "." with "[dot]"
![image](https://github.com/user-attachments/assets/0a988e60-95e3-4d1b-8c8c-91ce99dcc548)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* part of #8268 

