### PR TITLE
[frontend] Observables exports list of containers should be independant (#8241)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -245,7 +245,7 @@ ContainerStixCyberObservablesComponentProps
               selectAll={selectAll}
               iconExtension={true}
               handleToggleExports={handleToggleExports}
-              exportContext={{ entity_type: 'Stix-Cyber-Observable' }}
+              exportContext={{ entity_id: container.id, entity_type: 'Stix-Cyber-Observable' }}
               keyword={searchTerm}
               openExports={openExports}
               filters={filters}


### PR DESCRIPTION
### Proposed changes
In a container > observable list > export panel : the list of export files should only shows the exports generated from the  container (and not other containers).

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8241
