### PR TITLE
[frontend] RegExs updated to validate more completely the Bulk add of Hash values (#4352)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -527,31 +527,31 @@ const StixCyberObservableCreation = ({
                 initialValues['hashes_SHA-256'] = '';
                 initialValues['hashes_SHA-512'] = '';
                 // Dynamically include validation options for File Hash Options.
-                const md5Regex = /^([a-f0-9]{32}\n*)+$/i;
-                const sha1Regex = /^([a-f0-9]{40}\n*)+$/i;
-                const sha256Regex = /^([a-f0-9]{64}\n*)+$/i;
-                const sha512Regex = /^([a-f0-9]{128}\n*)+$/i;
+                const md5Regex = /(^[a-fA-F0-9]{32})(?:\n[a-fA-F0-9]{32}){0,49}$/i;
+                const sha1Regex = /(^[a-fA-F0-9]{40})(?:\n[a-fA-F0-9]{40}){0,49}$/i;
+                const sha256Regex = /(^[a-fA-F0-9]{64})(?:\n[a-fA-F0-9]{64}){0,49}$/i;
+                const sha512Regex = /(^[a-fA-F0-9]{128})(?:\n[a-fA-F0-9]{128}){0,49}$/i;
                 extraFieldsToValidate = {
                   hashes_MD5: Yup
-                    .string()
+                    .string().matches(md5Regex, t_i18n('MD5 values can only include A-F and 0-9, 32 characters'))
                     .when(['hashes_SHA-1', 'hashes_SHA-256', 'hashes_SHA-512', 'name'], {
                       is: (a, b, c, d) => !a && !b && !c && !d,
                       then: () => Yup.string().matches(md5Regex, t_i18n('MD5 values can only include A-F and 0-9, 32 characters')).required(t_i18n('MD5, SHA-1, SHA-256, SHA-512, or name is required')),
                     }),
                   'hashes_SHA-1': Yup
-                    .string()
+                    .string().matches(sha1Regex, t_i18n('SHA-1 values can only include A-F and 0-9, 40 characters'))
                     .when(['hashes_MD5', 'hashes_SHA-256', 'hashes_SHA-512', 'name'], {
                       is: (a, b, c, d) => !a && !b && !c && !d,
                       then: () => Yup.string().matches(sha1Regex, t_i18n('SHA-1 values can only include A-F and 0-9, 40 characters')).required(t_i18n('MD5, SHA-1, SHA-256, SHA-512, or name is required')),
                     }),
                   'hashes_SHA-256': Yup
-                    .string()
+                    .string().matches(sha256Regex, t_i18n('SHA-256 values can only include A-F and 0-9, 64 characters'))
                     .when(['hashes_MD5', 'hashes_SHA-1', 'hashes_SHA-512', 'name'], {
                       is: (a, b, c, d) => !a && !b && !c && !d,
                       then: () => Yup.string().matches(sha256Regex, t_i18n('SHA-256 values can only include A-F and 0-9, 64 characters')).required(t_i18n('MD5, SHA-1, SHA-256, SHA-512, or name is required')),
                     }),
                   'hashes_SHA-512': Yup
-                    .string()
+                    .string().matches(sha512Regex, t_i18n('SHA-512 values can only include A-F and 0-9, 128 characters'))
                     .when(['hashes_MD5', 'hashes_SHA-1', 'hashes_SHA-256', 'name'], {
                       is: (a, b, c, d) => !a && !b && !c && !d,
                       then: () => Yup.string().matches(sha512Regex, t_i18n('SHA-512 values can only include A-F and 0-9, 128 characters')).required(t_i18n('MD5, SHA-1, SHA-256, SHA-512, or name is required')),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

For hashes that were a multiple of another, the current RegEx would not properly validate. Example: A SHA256 (64 chars) could accidently be pasted into the MD5 (32 chars) field and the yup() validator would not flag it properly, since 32*2 = 64 and the \n was optional in the existing regex.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
- #4352 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
