### PR TITLE
[frontend] Authorized members default value should not contain me user (#8311)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -17,6 +17,7 @@ import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import { AccessRight, ALL_MEMBERS_AUTHORIZED_CONFIG, AuthorizedMemberOption, Creator, CREATOR_AUTHORIZED_CONFIG } from '../../../../utils/authorizedMembers';
 import SwitchField from '../../../../components/fields/SwitchField';
+import useAuth from '../../../../utils/hooks/useAuth';
 
 /**
  * Returns true if the authorized member option is generic.
@@ -41,6 +42,7 @@ interface AuthorizedMembersFieldProps
   showAllMembersLine?: boolean;
   showCreatorLine?: boolean;
   canDeactivate?: boolean;
+  addMeUserWithAdminRights?: boolean;
 }
 
 // Type of data for internal form, not exposed to others.
@@ -72,10 +74,12 @@ const AuthorizedMembersField = ({
   showAllMembersLine = false,
   showCreatorLine = false,
   canDeactivate = false,
+  addMeUserWithAdminRights = false,
 }: AuthorizedMembersFieldProps) => {
   const { t_i18n } = useFormatter();
   const { setFieldValue } = form;
   const { name, value } = field;
+  const { me } = useAuth();
 
   // Value in sync with internal Formik field 'applyAccesses'.
   // Require to use a state in addition to the Formik field because
@@ -172,6 +176,14 @@ const AuthorizedMembersField = ({
           label: owner.name,
           type: owner.entity_type,
           value: owner.id,
+          accessRight: 'admin',
+        });
+      }
+      if (addMeUserWithAdminRights && me.id !== owner?.id) {
+        values.push({
+          label: me.name,
+          type: 'User',
+          value: me.id,
           accessRight: 'admin',
         });
       }

--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -17,7 +17,6 @@ import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import { AccessRight, ALL_MEMBERS_AUTHORIZED_CONFIG, AuthorizedMemberOption, Creator, CREATOR_AUTHORIZED_CONFIG } from '../../../../utils/authorizedMembers';
 import SwitchField from '../../../../components/fields/SwitchField';
-import useAuth from '../../../../utils/hooks/useAuth';
 
 /**
  * Returns true if the authorized member option is generic.
@@ -75,7 +74,6 @@ const AuthorizedMembersField = ({
   canDeactivate = false,
 }: AuthorizedMembersFieldProps) => {
   const { t_i18n } = useFormatter();
-  const { me } = useAuth();
   const { setFieldValue } = form;
   const { name, value } = field;
 
@@ -174,14 +172,6 @@ const AuthorizedMembersField = ({
           label: owner.name,
           type: owner.entity_type,
           value: owner.id,
-          accessRight: 'admin',
-        });
-      }
-      if (me.id !== owner?.id) {
-        values.push({
-          label: me.name,
-          type: 'User',
-          value: me.id,
           accessRight: 'admin',
         });
       }

--- a/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/FormAuthorizedMembers.tsx
@@ -70,6 +70,7 @@ const FormAuthorizedMembers = ({
                   owner={owner}
                   showAllMembersLine={showAllMembersLine}
                   canDeactivate={canDeactivate}
+                  addMeUserWithAdminRights
                 />
               )}
             </Form>

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
@@ -121,14 +121,14 @@ const EntitySettingAttributeEdition = ({
         // due to the fact that this component managed all types of fields and this
         // query is used only for one particular case.
         const data = (await fetchQuery(entitySettingAttributeEditionMembersQuery, {
-          filters: {
+          filters: defaultAuthorizedMembers.length > 0 ? {
             mode: 'and',
             filters: [{
               key: 'ids',
               values: defaultAuthorizedMembers.map((m) => m.id),
             }],
             filterGroups: [],
-          },
+          } : undefined,
         }).toPromise()) as EntitySettingAttributeEditionMembersQuery$data;
         setMembersData(data);
       };


### PR DESCRIPTION
### Proposed changes
Authorized members default values should not add current user with manage access by default.
Authorized members default values can be found in : 
- Security > Customization > Feedback > Authorized members > Activate access restriction
- or in : a feedback I can manage > button manage access > Activate access restriction

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8311
