### PR TITLE
[frontend] no pointer if Item Marking/Status is not clickable (#8314)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemMarkings.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemMarkings.jsx
@@ -138,6 +138,7 @@ const ItemMarkings = ({ variant, markingDefinitions, limit, onClick }) => {
               backgroundColor,
               color: textColor,
               border,
+              cursor: onClick ? 'pointer' : 'default',
             }}
             label={markingDefinition.definition}
             onClick={(e) => {
@@ -226,7 +227,7 @@ const ItemMarkings = ({ variant, markingDefinitions, limit, onClick }) => {
           <Chip
             key={markingDefinition.definition}
             className={className}
-            style={inlineStyles.transparent}
+            style={{ ...inlineStyles.transparent, cursor: onClick ? 'pointer' : 'default' }}
             label={t_i18n(markingDefinition.definition)}
             variant="outlined"
             onClick={(e) => {

--- a/opencti-platform/opencti-front/src/components/ItemStatus.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemStatus.jsx
@@ -58,6 +58,7 @@ const ItemStatus = (props) => {
           color: status.template.color,
           borderColor: status.template.color,
           backgroundColor: hexToRGB(status.template.color),
+          cursor: onClick ? 'pointer' : 'default',
         }}
       />
     );


### PR DESCRIPTION
### Proposed changes
Item Markings and Item Status in entities overview should not have a pointer mouse since they are not clickable

### Related issues
closes #8314