### PR TITLE
[dev] Add a profile to run opensearch locally

### DIFF
--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -45,6 +45,49 @@ services:
       - 5601:5601
     depends_on:
       - opencti-dev-elasticsearch
+
+  # Disabled by default, to run use:
+  # docker compose --profile opensearch up -d
+  # in opencti configuration:
+  # "elasticsearch": {
+  #     "url": "http://localhost:9201",
+  #     "username": "admin",
+  #     "password": "GraceH00per!"
+  opencti-dev-opensearch:
+    profiles: [ opensearch ]
+    container_name: opencti-dev-opensearch
+    image: opensearchproject/opensearch:2.17.0
+    volumes:
+      - osdata:/usr/share/opensearch/data
+      - ossnapshots:/usr/share/opensearch/snapshots
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - bootstrap.memory_lock=true
+      - OPENSEARCH_JAVA_OPTS=-Xms2G -Xmx2G
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=GraceH00per! # minimum 8 character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong.
+    ulimits:
+      memlock:
+        soft: -1 # Set memlock to unlimited (no soft or hard limit)
+        hard: -1
+      nofile:
+        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536
+        hard: 65536
+    ports:
+      - 9201:9200
+      - 9600:9600
+  opencti-dev-opensearch-dashboards:
+    profiles: [ opensearch ]
+    image: opensearchproject/opensearch-dashboards:2.17.0
+    container_name: opencti-dev-opensearch-dashboards
+    ports:
+      - 5602:5601 # Map host port 5601 to container port 5601
+    expose:
+      - 5602 # Expose port 5601 for web access to OpenSearch Dashboards
+    environment:
+      OPENSEARCH_HOSTS: '["http://opencti-dev-opensearch:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: true
+
   opencti-dev-minio:
     container_name: opencti-dev-minio
     image: minio/minio:latest
@@ -164,4 +207,8 @@ volumes:
   esdata:
     driver: local
   essnapshots:
+    driver: local
+  osdata:
+    driver: local
+  ossnapshots:
     driver: local


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add a docker compose profile to run opensearch as searchengine instead of elastic for local development.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* no issue

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
