### PR TITLE
[frontend] deleted 2nd scrollbar from dashboard-details-page (#8401)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
@@ -48,7 +48,6 @@ const RootDashboard = () => {
     <div
       data-testid="dashboard-details-page"
       style={{
-        height: 'calc( 100vh - 50px )',
         overflow: 'auto',
         marginRight: -20,
         paddingRight: 20,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

It seems fine now:
![image](https://github.com/user-attachments/assets/d6fbad20-b0be-44be-8f9d-f4893988ed10)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
part of #8401


