### PR TITLE
[backend] store enum filters values in constants

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -192,6 +192,7 @@
   "Description": "Beschreibung",
   "Descriptions": "Beschreibungen",
   "Detection": "Erkennung",
+  "Digest period": "Auszugszeitraum",
   "Disabled": "Deaktiviert",
   "Display name": "Name anzeigen",
   "DLL service": "DLL-Dienst",

--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -192,7 +192,7 @@
   "Description": "Beschreibung",
   "Descriptions": "Beschreibungen",
   "Detection": "Erkennung",
-  "Digest period": "Auszugszeitraum",
+  "Digest period": "Zusammenfassender Zeitraum",
   "Disabled": "Deaktiviert",
   "Display name": "Name anzeigen",
   "DLL service": "DLL-Dienst",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -192,6 +192,7 @@
   "Description": "Description",
   "Descriptions": "Descriptions",
   "Detection": "Detection",
+  "Digest period": "Digest period",
   "Disabled": "Disabled",
   "Display name": "Display name",
   "DLL service": "DLL service",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -192,6 +192,7 @@
   "Description": "Descripción",
   "Descriptions": "Descripciones",
   "Detection": "Detección",
+  "Digest period": "Periodo de compendio",
   "Disabled": "Desactivado",
   "Display name": "Mostrar nombre",
   "DLL service": "Servicio DLL",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -192,7 +192,7 @@
   "Description": "Descripción",
   "Descriptions": "Descripciones",
   "Detection": "Detección",
-  "Digest period": "Periodo de compendio",
+  "Digest period": "Período resumido",
   "Disabled": "Desactivado",
   "Display name": "Mostrar nombre",
   "DLL service": "Servicio DLL",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -192,6 +192,7 @@
   "Description": "Description",
   "Descriptions": "Descriptions",
   "Detection": "Détection",
+  "Digest period": "Période de digestion",
   "Disabled": "Désactivé",
   "Display name": "Nom d'affichage",
   "DLL service": "Service DLL",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -192,7 +192,7 @@
   "Description": "Description",
   "Descriptions": "Descriptions",
   "Detection": "Détection",
-  "Digest period": "Période de digestion",
+  "Digest period": "Période de résumé",
   "Disabled": "Désactivé",
   "Display name": "Nom d'affichage",
   "DLL service": "Service DLL",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -192,6 +192,7 @@
   "Description": "説明",
   "Descriptions": "説明",
   "Detection": "外部ID",
+  "Digest period": "消化期間",
   "Disabled": "無効",
   "Display name": "表示名",
   "DLL service": "DLLサービス",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -192,7 +192,7 @@
   "Description": "説明",
   "Descriptions": "説明",
   "Detection": "外部ID",
-  "Digest period": "消化期間",
+  "Digest period": "サマリー期間",
   "Disabled": "無効",
   "Display name": "表示名",
   "DLL service": "DLLサービス",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -192,7 +192,7 @@
   "Description": "설명",
   "Descriptions": "설명",
   "Detection": "탐지",
-  "Digest period": "소화 기간",
+  "Digest period": "요약 기간",
   "Disabled": "비활성화됨",
   "Display name": "표시 이름",
   "DLL service": "DLL 서비스",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -192,6 +192,7 @@
   "Description": "설명",
   "Descriptions": "설명",
   "Detection": "탐지",
+  "Digest period": "소화 기간",
   "Disabled": "비활성화됨",
   "Display name": "표시 이름",
   "DLL service": "DLL 서비스",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -192,6 +192,7 @@
   "Description": "描述",
   "Descriptions": "说明",
   "Detection": "检测",
+  "Digest period": "消化期",
   "Disabled": "禁用",
   "Display name": "显示名称",
   "DLL service": "DLL 服务",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -192,7 +192,7 @@
   "Description": "描述",
   "Descriptions": "说明",
   "Detection": "检测",
-  "Digest period": "消化期",
+  "Digest period": "總結期",
   "Disabled": "禁用",
   "Display name": "显示名称",
   "DLL service": "DLL 服务",

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -79,6 +79,7 @@ const AUTH_BEARER = 'Bearer';
 const AUTH_BASIC = 'BasicAuth';
 export const TAXIIAPI = 'TAXIIAPI';
 const PLATFORM_ORGANIZATION = 'settings_platform_organization';
+export const MEMBERS_ENTITY_TYPES = [ENTITY_TYPE_USER, ENTITY_TYPE_IDENTITY_ORGANIZATION, ENTITY_TYPE_GROUP];
 
 const roleSessionRefresh = async (context, user, roleId) => {
   // Get all groups that have this role
@@ -198,7 +199,7 @@ export const findParticipants = (context, user, args) => {
 
 export const findAllMembers = (context, user, args) => {
   const { entityTypes = null } = args;
-  const types = entityTypes || [ENTITY_TYPE_USER, ENTITY_TYPE_IDENTITY_ORGANIZATION, ENTITY_TYPE_GROUP];
+  const types = entityTypes || MEMBERS_ENTITY_TYPES;
   return listEntities(context, user, types, args);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/vulnerability.js
+++ b/opencti-platform/opencti-graphql/src/domain/vulnerability.js
@@ -7,6 +7,8 @@ import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { RELATION_HAS } from '../schema/stixCoreRelationship';
 import { ENTITY_SOFTWARE } from '../schema/stixCyberObservable';
 
+export const CVSS_SEVERITY_VALUES = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'Unknown'];
+
 export const findById = (context, user, vulnerabilityId) => {
   return storeLoadById(context, user, vulnerabilityId, ENTITY_TYPE_VULNERABILITY);
 };

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -34,12 +34,17 @@ import { isStixMatchFilterGroup } from '../utils/filtering/filtering-stix/stix-f
 import { replaceFilterKey } from '../utils/filtering/filtering-utils';
 import { CONNECTED_TO_INSTANCE_FILTER, CONNECTED_TO_INSTANCE_SIDE_EVENTS_FILTER } from '../utils/filtering/filtering-constants';
 import type { FilterGroup } from '../generated/graphql';
+import { DigestPeriod, TriggerEventType, TriggerType } from '../generated/graphql';
 
 const NOTIFICATION_LIVE_KEY = conf.get('notification_manager:lock_live_key');
 const NOTIFICATION_DIGEST_KEY = conf.get('notification_manager:lock_digest_key');
 export const EVENT_NOTIFICATION_VERSION = '1';
 const CRON_SCHEDULE_TIME = 60000; // 1 minute
 const STREAM_SCHEDULE_TIME = 10000;
+export const TRIGGER_EVENT_TYPES_VALUES = Object.values(TriggerEventType);
+export const TRIGGER_TYPE_VALUES = Object.values(TriggerType);
+export const DIGEST_PERIOD_VALUES = Object.values(DigestPeriod);
+export const TRIGGER_SCOPE_VALUES = ['knowledge', 'activity'];
 
 export interface ResolvedTrigger {
   users: Array<AuthUser>
@@ -155,7 +160,7 @@ const generateAssigneeTrigger = (user: AuthUser) => {
     name: 'Default Trigger for Assignee/Participant',
     trigger_type: 'live',
     trigger_scope: 'knowledge',
-    event_types: ['create', 'update', 'delete'],
+    event_types: TRIGGER_EVENT_TYPES_VALUES,
     notifiers: user.personal_notifiers,
     filters: JSON.stringify(filters),
     instance_trigger: false,
@@ -526,7 +531,7 @@ export const generateDefaultTrigger = (notifiers: string[], type: string) => {
     name: `Default Trigger for ${type}`,
     trigger_type: 'live',
     trigger_scope: 'knowledge',
-    event_types: ['create', 'update', 'delete'],
+    event_types: TRIGGER_EVENT_TYPES_VALUES,
     notifiers,
     filters: '',
     instance_trigger: false,

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
@@ -14,6 +14,7 @@ import type { AuthContext } from '../types/user';
 import type { FileEdge, RetentionRule } from '../generated/graphql';
 import { deleteFile } from '../database/file-storage';
 import { DELETABLE_FILE_STATUSES, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { RetentionRuleScope, RetentionUnit } from '../generated/graphql';
 
 const RETENTION_MANAGER_ENABLED = booleanConf('retention_manager:enabled', false);
 const RETENTION_MANAGER_START_ENABLED = booleanConf('retention_manager:enabled', true);
@@ -23,6 +24,8 @@ const RETENTION_MANAGER_START_ENABLED = booleanConf('retention_manager:enabled',
 const SCHEDULE_TIME = conf.get('retention_manager:interval') || 60000;
 const RETENTION_MANAGER_KEY = conf.get('retention_manager:lock_key') || 'retention_manager_lock';
 const RETENTION_BATCH_SIZE = conf.get('retention_manager:batch_size') || 100;
+export const RETENTION_SCOPE_VALUES = Object.values(RetentionRuleScope);
+export const RETENTION_UNIT_VALUES = Object.values(RetentionUnit);
 
 export const deleteElement = async (context: AuthContext, scope: string, nodeId: string, nodeEntityType?: string) => {
   if (scope === 'knowledge') {

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -27,6 +27,7 @@ import {
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../schema/stixMetaObject';
 import { EVENT_ACCESS_VALUES, EVENT_SCOPE_VALUES, EVENT_STATUS_VALUES, EVENT_TYPE_VALUES } from '../../manager/activityListener';
+import { RETENTION_SCOPE_VALUES, RETENTION_UNIT_VALUES } from '../../manager/retentionManager';
 
 const HistoryDefinition: AttributeDefinition[] = [
   { name: 'event_type', label: 'Event type', type: 'string', format: 'enum', values: EVENT_TYPE_VALUES, editDefault: false, mandatoryType: 'internal', multiple: false, upsert: false, isFilterable: true },
@@ -505,11 +506,11 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     { name: 'filters', label: 'Filters', type: 'string', format: 'text', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: false },
     { name: 'max_retention', label: 'Maximum retention', type: 'numeric', precision: 'integer', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
-    { name: 'retention_unit', label: 'Maximum retention unit', type: 'string', format: 'enum', values: ['minutes', 'hours', 'days'], mandatoryType: 'no', editDefault: true, multiple: false, upsert: false, isFilterable: true },
+    { name: 'retention_unit', label: 'Maximum retention unit', type: 'string', format: 'enum', values: RETENTION_UNIT_VALUES, mandatoryType: 'no', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     { name: 'last_execution_date', label: 'Last execution date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'last_deleted_count', label: 'Last deleted count', precision: 'integer', type: 'numeric', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'remaining_count', label: 'Remaining count', precision: 'integer', type: 'numeric', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'scope', label: 'Scope', type: 'string', format: 'enum', values: ['knowledge', 'file', 'workbench'], mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'scope', label: 'Scope', type: 'string', format: 'enum', values: RETENTION_SCOPE_VALUES, mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   [ENTITY_TYPE_SYNC]: [
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
@@ -40,6 +40,7 @@ import {
   ENTITY_TYPE_TOOL,
   ENTITY_TYPE_VULNERABILITY
 } from '../../schema/stixDomainObject';
+import { CVSS_SEVERITY_VALUES } from '../../domain/vulnerability';
 
 const stixDomainObjectAttributes: Array<AttributeDefinition> = [
   created,
@@ -236,7 +237,7 @@ const stixDomainObjectsAttributes: { [k: string]: Array<AttributeDefinition> } =
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_cvss_base_score', label: 'CVSS3 Score', type: 'numeric', precision: 'float', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
-    { name: 'x_opencti_cvss_base_severity', label: 'CVSS3 Severity', type: 'string', format: 'enum', values: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'Unknown'], mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
+    { name: 'x_opencti_cvss_base_severity', label: 'CVSS3 Severity', type: 'string', format: 'enum', values: CVSS_SEVERITY_VALUES, mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_cvss_attack_vector', label: 'CVSS3 Attack vector', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_cvss_integrity_impact', label: 'CVSS3 Integrity impact', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_cvss_availability_impact', label: 'CVSS3 Availability impact', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -10,7 +10,7 @@ import type { AuthContext, AuthUser } from '../../../types/user';
 import { type DomainFindById } from '../../../domain/domainTypes';
 import type { BasicStoreEntityDocument } from './document-types';
 import type { BasicStoreCommon, BasicStoreObject } from '../../../types/store';
-import { type File, FilterMode, FilterOperator, OrderingMode } from '../../../generated/graphql';
+import { type File, FilterMode, FilterOperator, OrderingMode, State } from '../../../generated/graphql';
 import { loadExportWorksAsProgressFiles } from '../../../domain/work';
 import { elSearchFiles } from '../../../database/file-search';
 import { isUserHasCapability, SETTINGS_SUPPORT, SYSTEM_USER } from '../../../utils/access';
@@ -26,6 +26,7 @@ export const IMPORT_STORAGE_PATH = 'import';
 export const EXPORT_STORAGE_PATH = 'export';
 
 export const DELETABLE_FILE_STATUSES = ['complete', 'timeout'];
+export const UPLOAD_STATUS_VALUES = Object.values(State);
 export const getIndexFromDate = async (context: AuthContext) => {
   const searchOptions = {
     first: 1,

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
@@ -3,6 +3,7 @@ import { schemaAttributesDefinition } from '../../../schema/schema-attributes';
 import { type AttributeDefinition, createdAt, creators, entityType, id, internalId, standardId, updatedAt } from '../../../schema/attribute-definition';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../schema/stixMetaObject';
 import { ABSTRACT_STIX_CORE_OBJECT } from '../../../schema/general';
+import { State } from '../../../generated/graphql';
 
 const attributes: Array<AttributeDefinition> = [
   id,
@@ -17,7 +18,7 @@ const attributes: Array<AttributeDefinition> = [
   { name: 'information', label: 'Information', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   { name: 'lastModified', label: 'Last modification date', type: 'date', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   { name: 'lastModifiedSinceMin', label: 'Last modification since', type: 'numeric', precision: 'integer', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-  { name: 'uploadStatus', label: 'Upload status', type: 'string', format: 'enum', values: ['wait', 'progress', 'complete', 'timeout'], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+  { name: 'uploadStatus', label: 'Upload status', type: 'string', format: 'enum', values: Object.values(State), mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   { name: 'objectMarking', label: 'Object markings', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_MARKING_DEFINITION], mandatoryType: 'internal', editDefault: false, multiple: true, upsert: false, isFilterable: false },
   {
     name: 'metaData',

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
@@ -3,7 +3,7 @@ import { schemaAttributesDefinition } from '../../../schema/schema-attributes';
 import { type AttributeDefinition, createdAt, creators, entityType, id, internalId, standardId, updatedAt } from '../../../schema/attribute-definition';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../schema/stixMetaObject';
 import { ABSTRACT_STIX_CORE_OBJECT } from '../../../schema/general';
-import { State } from '../../../generated/graphql';
+import { UPLOAD_STATUS_VALUES } from './document-domain';
 
 const attributes: Array<AttributeDefinition> = [
   id,
@@ -18,7 +18,7 @@ const attributes: Array<AttributeDefinition> = [
   { name: 'information', label: 'Information', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   { name: 'lastModified', label: 'Last modification date', type: 'date', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   { name: 'lastModifiedSinceMin', label: 'Last modification since', type: 'numeric', precision: 'integer', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-  { name: 'uploadStatus', label: 'Upload status', type: 'string', format: 'enum', values: Object.values(State), mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+  { name: 'uploadStatus', label: 'Upload status', type: 'string', format: 'enum', values: UPLOAD_STATUS_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   { name: 'objectMarking', label: 'Object markings', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_MARKING_DEFINITION], mandatoryType: 'internal', editDefault: false, multiple: true, upsert: false, isFilterable: false },
   {
     name: 'metaData',

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -44,7 +44,7 @@ const TRIGGER_DEFINITION: ModuleDefinition<StoreEntityTrigger, StixTrigger> = {
     { name: 'filters', label: 'Filters', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'recipients', label: 'Recipients', type: 'string', format: 'id', entityTypes: MEMBERS_ENTITY_TYPES, mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'trigger_ids', label: 'Trigger IDs', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
-    { name: 'period', label: 'Period', type: 'string', format: 'enum', values: DIGEST_PERIOD_VALUES, mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'period', label: 'Digest period', type: 'string', format: 'enum', values: DIGEST_PERIOD_VALUES, mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'trigger_time', label: 'Trigger time', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'trigger_type', label: 'Trigger type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'instance_trigger', label: 'Instance trigger', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -12,9 +12,10 @@ import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_CORE_OBJECT } from '../../schem
 import type { ModuleDefinition } from '../../schema/module';
 import { registerDefinition } from '../../schema/module';
 import { authorizedAuthorities, authorizedMembers } from '../../schema/attribute-definition';
-import { ENTITY_TYPE_GROUP, ENTITY_TYPE_USER } from '../../schema/internalObject';
+import { ENTITY_TYPE_USER } from '../../schema/internalObject';
 import { ENTITY_TYPE_NOTIFIER } from '../notifier/notifier-types';
-import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
+import { MEMBERS_ENTITY_TYPES } from '../../domain/user';
+import { DIGEST_PERIOD_VALUES, TRIGGER_EVENT_TYPES_VALUES, TRIGGER_SCOPE_VALUES, TRIGGER_TYPE_VALUES } from '../../manager/notificationManager';
 
 // Outcomes
 // TODO
@@ -36,16 +37,16 @@ const TRIGGER_DEFINITION: ModuleDefinition<StoreEntityTrigger, StixTrigger> = {
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'created', label: 'Created', type: 'date', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'updated', label: 'Updated', type: 'date', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'event_types', label: 'Event types', type: 'string', format: 'enum', values: ['create', 'update', 'delete'], mandatoryType: 'external', editDefault: true, multiple: true, upsert: false, isFilterable: true },
-    { name: 'trigger_scope', label: 'Trigger scope', type: 'string', format: 'enum', values: ['knowledge', 'activity'], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'event_types', label: 'Event types', type: 'string', format: 'enum', values: TRIGGER_EVENT_TYPES_VALUES, mandatoryType: 'external', editDefault: true, multiple: true, upsert: false, isFilterable: true },
+    { name: 'trigger_scope', label: 'Trigger scope', type: 'string', format: 'enum', values: TRIGGER_SCOPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'outcomes', label: 'Outcomes', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'notifiers', label: 'Notifiers', type: 'string', format: 'id', mandatoryType: 'external', editDefault: true, multiple: true, upsert: false, entityTypes: [ENTITY_TYPE_NOTIFIER], isFilterable: true },
     { name: 'filters', label: 'Filters', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'recipients', label: 'Recipients', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_USER, ENTITY_TYPE_GROUP, ENTITY_TYPE_IDENTITY_ORGANIZATION], mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
+    { name: 'recipients', label: 'Recipients', type: 'string', format: 'id', entityTypes: MEMBERS_ENTITY_TYPES, mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'trigger_ids', label: 'Trigger IDs', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
-    { name: 'period', label: 'Period', type: 'string', format: 'enum', values: ['hour', 'day', 'week', 'month'], mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'period', label: 'Period', type: 'string', format: 'enum', values: DIGEST_PERIOD_VALUES, mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'trigger_time', label: 'Trigger time', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'trigger_type', label: 'Trigger type', type: 'string', format: 'enum', values: ['digest', 'live'], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'trigger_type', label: 'Trigger type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'instance_trigger', label: 'Instance trigger', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     authorizedMembers,
     authorizedAuthorities,
@@ -71,7 +72,7 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
     },
   },
   attributes: [
-    { name: 'notification_type', label: 'Notification type', type: 'string', format: 'enum', values: ['live', 'digest'], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'notification_type', label: 'Notification type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     {
       name: 'notification_content',
       type: 'object',
@@ -97,7 +98,7 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
           mappings: [
             { name: 'message', label: 'Notification message', type: 'string', format: 'text', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
             { name: 'instance_id', label: 'Notification related instance', type: 'string', format: 'id', entityTypes: [ABSTRACT_STIX_CORE_OBJECT], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-            { name: 'operation', label: 'Notification operation', type: 'string', format: 'enum', values: ['create', 'update', 'delete'], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+            { name: 'operation', label: 'Notification operation', type: 'string', format: 'enum', values: TRIGGER_EVENT_TYPES_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
           ]
         },
       ]


### PR DESCRIPTION
### Proposed changes
Enum filters values where hardwritten in registration attributes files. 
Now we refer to constants to avoid missing values in filters, as it was the case in https://github.com/OpenCTI-Platform/opencti/issues/8414

### Related issues
avoid issues like https://github.com/OpenCTI-Platform/opencti/issues/8414