### PR TITLE
[frontend] Fix/restore Mouse middle Click open in a new tab behavior

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -160,7 +160,7 @@ const DataTableLine = ({
     } else if (onLineClick) {
       onLineClick(data);
     } else if (navigable) {
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.button === 1) {
         window.open(link, '_blank');
       } else {
         navigate(link);


### PR DESCRIPTION
### Proposed changes

* Restore the default behavior for Mouse middle click that should trigger a new tab opening when used on links. 

### Related issues

* Same as for the `CTRL+Click`, see: https://github.com/OpenCTI-Platform/opencti/issues/8394
* See: https://github.com/OpenCTI-Platform/opencti/issues/8394#issuecomment-2364068885

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality


### Further comments

I have not tested it in production, just an intuition…