### PR TITLE
[frontend] Change the "representation" key used in an investigation for an observable of type "File" (#7634)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -107,6 +107,7 @@
   "Add to container": "Zum Container hinzufügen",
   "added a note": "eine Notiz hinzugefügt",
   "Additional mandatory attributes": "Zusätzliche obligatorische Attribute",
+  "Additional Names": "Zusätzliche Namen",
   "Admin": "Verwaltung",
   "Administrative areas": "Administrative Bereiche",
   "advanced": "fortgeschritten",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -107,6 +107,7 @@
   "Add to container": "Add to container",
   "added a note": "added a note",
   "Additional mandatory attributes": "Additional mandatory attributes",
+  "Additional Names": "Additional Names",
   "Admin": "Admin",
   "Administrative areas": "Administrative areas",
   "advanced": "advanced",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -107,6 +107,7 @@
   "Add to container": "Añadir a contenedor",
   "added a note": "agregó una nota",
   "Additional mandatory attributes": "Atributos obligatorios adicionales",
+  "Additional Names": "Nombres adicionales",
   "Admin": "Administrador",
   "Administrative areas": "Áreas administrativas",
   "advanced": "Avanzada",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -107,6 +107,7 @@
   "Add to container": "Ajouter au conteneur",
   "added a note": "a ajouté une note",
   "Additional mandatory attributes": "Attributs obligatoires supplémentaires",
+  "Additional Names": "Noms supplémentaires",
   "Admin": "Admin",
   "Administrative areas": "Domaines administratifs",
   "advanced": "avancé",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -107,6 +107,7 @@
   "Add to container": "コンテナに追加",
   "added a note": "メモを追加しました",
   "Additional mandatory attributes": "追加の必須属性",
+  "Additional Names": "追加名",
   "Admin": "管理者",
   "Administrative areas": "管理エリア",
   "advanced": "高度",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -107,6 +107,7 @@
   "Add to container": "컨테이너에 추가",
   "added a note": "노트 추가됨",
   "Additional mandatory attributes": "추가 필수 속성",
+  "Additional Names": "추가 이름",
   "Admin": "관리자",
   "Administrative areas": "행정 구역",
   "advanced": "고급",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -107,6 +107,7 @@
   "Add to container": "添加到容器",
   "added a note": "添加了注释",
   "Additional mandatory attributes": "额外的强制属性",
+  "Additional Names": "其他名称",
   "Admin": "管理员",
   "Administrative areas": "管理区",
   "advanced": "高级",

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
@@ -1542,6 +1542,11 @@ const GroupingKnowledgeGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on Label {
                 value

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
@@ -1555,6 +1555,11 @@ const ReportKnowledgeGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on Label {
                 value

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraph.jsx
@@ -1569,6 +1569,11 @@ const IncidentKnowledgeGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on Label {
                 value

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraph.jsx
@@ -1569,6 +1569,11 @@ const CaseRfiKnowledgeGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on Label {
                 value

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraph.jsx
@@ -1568,6 +1568,11 @@ const CaseRftKnowledgeGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on Label {
                 value

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -2610,6 +2610,11 @@ const InvestigationGraph = createFragmentContainer(
               }
               ... on StixFile {
                 observableName: name
+                x_opencti_additional_names
+                hashes {
+                  algorithm
+                  hash
+                }
               }
               ... on StixMetaObject {
                 created

--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -805,7 +805,7 @@ export const buildGraphData = (objects, graphData, t) => {
                 .filter((additionalName) => additionalName !== n.observableName)
                 .join(', ')
               : '';
-            const additionalNamesString = additionalNames ? `\nAdditional-Names: ${additionalNames}` : '';
+            const additionalNamesString = additionalNames ? `\n${t('Additional Names')}: ${additionalNames}` : '';
             return `${label}: ${displayValue}${hashesList ? `\n${hashesList}` : ''}${additionalInfo}${additionalNamesString}\n${dateFormat(defaultDate(n))}`;
           }
           return `${getMainRepresentative(n)}\n${dateFormat(defaultDate(n))}`;

--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -769,30 +769,59 @@ export const buildGraphData = (objects, graphData, t) => {
               ? 'relationship'
               : n.entity_type
           ] || graphLevel.Unknown,
-        name: `${
-          n.relationship_type
-            ? `<strong>${t(
-              `relationship_${n.relationship_type}`,
-            )}</strong>\n${t('Created the')} ${dateFormat(n.created)}\n${t(
-              'Start time',
-            )} ${
-              isNone(n.start_time || n.first_seen)
-                ? '-'
-                : dateFormat(n.start_time || n.first_seen)
+        name: (() => {
+          if (n.relationship_type) {
+            return `<strong>${t(`relationship_${n.relationship_type}`)}</strong>\n${t('Created the')} ${dateFormat(n.created)}\n${t('Start time')} ${
+              isNone(n.start_time || n.first_seen) ? '-' : dateFormat(n.start_time || n.first_seen)
             }\n${t('Stop time')} ${
-              isNone(n.stop_time || n.last_seen)
-                ? '-'
-                : dateFormat(n.stop_time || n.last_seen)
-            }`
-            : getMainRepresentative(n)
-        }\n${dateFormat(defaultDate(n))}`,
+              isNone(n.stop_time || n.last_seen) ? '-' : dateFormat(n.stop_time || n.last_seen)
+            }\n${dateFormat(defaultDate(n))}`;
+          } if (n.entity_type === 'StixFile' && n.observable_value) {
+            const hashAlgorithms = ['SHA-512', 'SHA-256', 'SHA-1', 'MD5'];
+            // Find if the observable_value matches one of the hashes
+            let displayValue = n.observable_value;
+            let label = 'Name';
+            const matchingHash = n.hashes.find((hashObj) => hashObj.hash === n.observable_value && hashAlgorithms.includes(hashObj.algorithm));
+            if (matchingHash) {
+              displayValue = matchingHash.hash;
+              label = `${matchingHash.algorithm}`;
+            } else if (n.observable_value === n.observableName) {
+            // Find if observable_value matches observableName
+              displayValue = n.observable_value;
+              label = 'Name';
+            }
+            // List of other hashes to display (without duplicating the observable_value)
+            const hashesList = n.hashes && Array.isArray(n.hashes)
+              ? n.hashes
+                .filter((hashObj) => hashObj.hash !== displayValue)
+                .map((hashObj) => `${hashObj.algorithm}: ${hashObj.hash}`)
+                .join('\n')
+              : '';
+            // Add name (observableName) if available and different from observable_value
+            const additionalInfo = (n.observableName && n.observableName !== displayValue) ? `\nName: ${n.observableName}` : '';
+            // Add additional_names if available and different from `observableName`.
+            const additionalNames = n.x_opencti_additional_names && Array.isArray(n.x_opencti_additional_names)
+              ? n.x_opencti_additional_names
+                .filter((additionalName) => additionalName !== n.observableName)
+                .join(', ')
+              : '';
+            const additionalNamesString = additionalNames ? `\nAdditional-Names: ${additionalNames}` : '';
+            return `${label}: ${displayValue}${hashesList ? `\n${hashesList}` : ''}${additionalInfo}${additionalNamesString}\n${dateFormat(defaultDate(n))}`;
+          }
+          return `${getMainRepresentative(n)}\n${dateFormat(defaultDate(n))}`;
+        })(),
         defaultDate: jsDate(defaultDate(n)),
-        label: n.parent_types.includes('basic-relationship')
-          ? t(`relationship_${n.relationship_type}`)
-          : truncate(
+        label: (() => {
+          if (n.parent_types.includes('basic-relationship')) {
+            return t(`relationship_${n.relationship_type}`);
+          } if (n.entity_type === 'StixFile' && n.observable_value) {
+            return n.observable_value;
+          }
+          return truncate(
             getMainRepresentative(n),
             n.entity_type === 'Attack-Pattern' ? 30 : 20,
-          ),
+          );
+        })(),
         img:
           graphImages[
             n.parent_types.includes('basic-relationship')

--- a/opencti-platform/opencti-front/src/utils/graph/EntityDetails.tsx
+++ b/opencti-platform/opencti-front/src/utils/graph/EntityDetails.tsx
@@ -247,6 +247,11 @@ const entityDetailsQuery = graphql`
       }
       ... on StixFile {
         observableName: name
+        x_opencti_additional_names
+        hashes {
+          algorithm
+          hash
+        }
       }
       ... on Event {
         name
@@ -313,12 +318,55 @@ EntityDetailsComponentProps
   const entityDescription = stixCoreObject.description || stixCoreObject.x_opencti_description;
   return (
     <div>
-      <Typography variant="h3" gutterBottom={true} className={classes.label}>
-        {t_i18n('Value')}
-      </Typography>
-      <Tooltip title={getMainRepresentative(stixCoreObject)}>
-        <span>{truncate(getMainRepresentative(stixCoreObject), 40)}</span>
-      </Tooltip>
+      {stixCoreObject.entity_type !== 'StixFile' && (
+      <>
+        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+          {t_i18n('Value')}
+        </Typography>
+        <Tooltip title={getMainRepresentative(stixCoreObject)}>
+          <span>{truncate(getMainRepresentative(stixCoreObject), 40)}</span>
+        </Tooltip>
+      </>
+      )}
+      {stixCoreObject.entity_type === 'StixFile' && (
+      <>
+        {stixCoreObject.hashes && stixCoreObject.hashes.map((hashObj, index) => (hashObj ? (
+          <div key={`${hashObj.algorithm}-${index}`}>
+            <Typography variant="h3" gutterBottom={true} className={classes.label}>
+              {hashObj.algorithm ? String(hashObj.algorithm) : ''}
+            </Typography>
+            <Tooltip title={hashObj.hash ? String(hashObj.hash) : ''}>
+              <span>{truncate(hashObj.hash, 40)}</span>
+            </Tooltip>
+          </div>
+        ) : null))}
+
+        {stixCoreObject.observableName && (
+        <>
+          <Typography variant="h3" gutterBottom={true} className={classes.label}>
+            {t_i18n('Name')}
+          </Typography>
+          <span>{stixCoreObject.observableName}</span>
+        </>
+        )}
+
+        {stixCoreObject.x_opencti_additional_names && (
+          (() => {
+            const filteredAdditionalNames = stixCoreObject.x_opencti_additional_names.filter(
+              (additionalName) => additionalName !== stixCoreObject.observableName,
+            );
+            return filteredAdditionalNames.length > 0 ? (
+              <>
+                <Typography variant="h3" gutterBottom={true} className={classes.label}>
+                  {t_i18n('Additional Names')}
+                </Typography>
+                <span>{filteredAdditionalNames.join(', ')}</span>
+              </>
+            ) : null;
+          })()
+        )}
+      </>
+      )}
       <Typography variant="h3" gutterBottom={true} className={classes.label}>
         {t_i18n('Type')}
       </Typography>


### PR DESCRIPTION
### Proposed changes

- Change the "representation" key used in an investigation and knowledge for an observable of type "File".
- In the graph, make it possible to search an observable "File" by hash.
- Add more detail about the observable  in the "Investigation Entity detail" card  (hashes and names).
- On tooltip, add additional information about the observable  (hashes and names).



### Related issues

- https://github.com/OpenCTI-Platform/opencti/issues/7634
- https://github.com/OpenCTI-Platform/opencti/issues/7255