### PR TITLE
[frontend] Ability to duplicate a CSV feed data sharing, a CSV feed ingestion, a CSV mapper (#7400)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -203,6 +203,8 @@
   "DST Payload": "DST Nutzlast",
   "DST port": "DST-Anschluss",
   "Due date": "Fälligkeitsdatum",
+  "Duplicate a CSV ingester": "Duplizieren Sie einen CSV-Ingester",
+  "Duplicate a feed": "Einspeisung duplizieren",
   "Element ID": "Element-ID",
   "Email": "E-Mail",
   "Email date": "E-Mail Datum",

--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -204,6 +204,7 @@
   "DST port": "DST-Anschluss",
   "Due date": "Fälligkeitsdatum",
   "Duplicate a CSV ingester": "Duplizieren Sie einen CSV-Ingester",
+  "Duplicate a CSV mapper": "Duplizieren eines CSV-Mappers",
   "Duplicate a feed": "Einspeisung duplizieren",
   "Element ID": "Element-ID",
   "Email": "E-Mail",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -204,6 +204,7 @@
   "DST port": "DST port",
   "Due date": "Due date",
   "Duplicate a CSV ingester": "Duplicate a CSV ingester",
+  "Duplicate a CSV mapper": "Duplicate a CSV mapper",
   "Duplicate a feed": "Duplicate a feed",
   "Element ID": "Element ID",
   "Email": "Email",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -203,6 +203,8 @@
   "DST Payload": "DST Payload",
   "DST port": "DST port",
   "Due date": "Due date",
+  "Duplicate a CSV ingester": "Duplicate a CSV ingester",
+  "Duplicate a feed": "Duplicate a feed",
   "Element ID": "Element ID",
   "Email": "Email",
   "Email date": "Email date",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -203,6 +203,8 @@
   "DST Payload": "Carga útil DST",
   "DST port": "Puerto DST",
   "Due date": "Fecha de vencimiento",
+  "Duplicate a CSV ingester": "Duplicar una entrada CSV",
+  "Duplicate a feed": "Duplicar un feed",
   "Element ID": "Elemento ID",
   "Email": "Correo electrónico",
   "Email date": "Fecha de correo electrónico",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -204,6 +204,7 @@
   "DST port": "Puerto DST",
   "Due date": "Fecha de vencimiento",
   "Duplicate a CSV ingester": "Duplicar una entrada CSV",
+  "Duplicate a CSV mapper": "Duplicar un mapeador CSV",
   "Duplicate a feed": "Duplicar un feed",
   "Element ID": "Elemento ID",
   "Email": "Correo electrónico",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -204,6 +204,7 @@
   "DST port": "Port DST",
   "Due date": "Date d'échéance",
   "Duplicate a CSV ingester": "Dupliquer un injecteur CSV",
+  "Duplicate a CSV mapper": "Dupliquer un mappeur CSV",
   "Duplicate a feed": "Dupliquer un flux",
   "Element ID": "ID de l'élément",
   "Email": "Email",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -203,6 +203,8 @@
   "DST Payload": "DST Payload",
   "DST port": "Port DST",
   "Due date": "Date d'échéance",
+  "Duplicate a CSV ingester": "Dupliquer un injecteur CSV",
+  "Duplicate a feed": "Dupliquer un flux",
   "Element ID": "ID de l'élément",
   "Email": "Email",
   "Email date": "Date de l'email",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -203,6 +203,8 @@
   "DST Payload": "DSTペイロード",
   "DST port": "DSTポート",
   "Due date": "個人的な動機",
+  "Duplicate a CSV ingester": "CSVインジェスターの複製",
+  "Duplicate a feed": "フィードの複製",
   "Element ID": "要素ID",
   "Email": "電子メール",
   "Email date": "メール送信日",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -204,6 +204,7 @@
   "DST port": "DSTポート",
   "Due date": "個人的な動機",
   "Duplicate a CSV ingester": "CSVインジェスターの複製",
+  "Duplicate a CSV mapper": "CSVマッパーを複製する",
   "Duplicate a feed": "フィードの複製",
   "Element ID": "要素ID",
   "Email": "電子メール",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -203,6 +203,8 @@
   "DST Payload": "DST 페이로드",
   "DST port": "DST 포트",
   "Due date": "기한 날짜",
+  "Duplicate a CSV ingester": "CSV 수집기 복제",
+  "Duplicate a feed": "피드 복제하기",
   "Element ID": "요소 ID",
   "Email": "이메일",
   "Email date": "이메일 날짜",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -204,6 +204,7 @@
   "DST port": "DST 포트",
   "Due date": "기한 날짜",
   "Duplicate a CSV ingester": "CSV 수집기 복제",
+  "Duplicate a CSV mapper": "CSV 매퍼 복제",
   "Duplicate a feed": "피드 복제하기",
   "Element ID": "요소 ID",
   "Email": "이메일",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -203,6 +203,8 @@
   "DST Payload": "DST 有效载荷",
   "DST port": "DST 端口",
   "Due date": "到期日",
+  "Duplicate a CSV ingester": "复制 CSV 输入器",
+  "Duplicate a feed": "复制一个饲料",
   "Element ID": "元素 ID",
   "Email": "电子邮件",
   "Email date": "电子邮件日期",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -204,6 +204,7 @@
   "DST port": "DST 端口",
   "Due date": "到期日",
   "Duplicate a CSV ingester": "复制 CSV 输入器",
+  "Duplicate a CSV mapper": "复制 CSV 映射器",
   "Duplicate a feed": "复制一个饲料",
   "Element ID": "元素 ID",
   "Email": "电子邮件",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -856,6 +856,7 @@
   "Due Date": "Fälligkeitsdatum",
   "Duplicate": "Duplizieren",
   "Duplicate a CSV ingester": "Duplizieren Sie einen CSV-Ingester",
+  "Duplicate a CSV mapper": "Duplizieren eines CSV-Mappers",
   "Duplicate a feed": "Einspeisung duplizieren",
   "Duplicate the dashboard": "Duplizieren Sie das Dashboard",
   "Dynamic source filters": "Dynamische Quellfilter",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -855,6 +855,8 @@
   "Download this support package": "Laden Sie dieses Support-Paket herunter",
   "Due Date": "Fälligkeitsdatum",
   "Duplicate": "Duplizieren",
+  "Duplicate a CSV ingester": "Duplizieren Sie einen CSV-Ingester",
+  "Duplicate a feed": "Einspeisung duplizieren",
   "Duplicate the dashboard": "Duplizieren Sie das Dashboard",
   "Dynamic source filters": "Dynamische Quellfilter",
   "Dynamic target filters": "Dynamische Zielfilter",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -856,6 +856,7 @@
   "Due Date": "Due Date",
   "Duplicate": "Duplicate",
   "Duplicate a CSV ingester": "Duplicate a CSV ingester",
+  "Duplicate a CSV mapper": "Duplicate a CSV mapper",
   "Duplicate a feed": "Duplicate a feed",
   "Duplicate the dashboard": "Duplicate the dashboard",
   "Dynamic source filters": "Dynamic source filters",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -855,6 +855,8 @@
   "Download this support package": "Download this support package",
   "Due Date": "Due Date",
   "Duplicate": "Duplicate",
+  "Duplicate a CSV ingester": "Duplicate a CSV ingester",
+  "Duplicate a feed": "Duplicate a feed",
   "Duplicate the dashboard": "Duplicate the dashboard",
   "Dynamic source filters": "Dynamic source filters",
   "Dynamic target filters": "Dynamic target filters",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -855,6 +855,8 @@
   "Download this support package": "Descargar este paquete de soporte",
   "Due Date": "Fecha de vencimiento",
   "Duplicate": "Duplicar",
+  "Duplicate a CSV ingester": "Duplicar una entrada CSV",
+  "Duplicate a feed": "Duplicar un feed",
   "Duplicate the dashboard": "Duplicar el salpicadero",
   "Dynamic source filters": "Filtros de fuente dinámicos",
   "Dynamic target filters": "Filtros dinámicos de destino",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -856,6 +856,7 @@
   "Due Date": "Fecha de vencimiento",
   "Duplicate": "Duplicar",
   "Duplicate a CSV ingester": "Duplicar una entrada CSV",
+  "Duplicate a CSV mapper": "Duplicar un mapeador CSV",
   "Duplicate a feed": "Duplicar un feed",
   "Duplicate the dashboard": "Duplicar el salpicadero",
   "Dynamic source filters": "Filtros de fuente dinámicos",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -855,6 +855,8 @@
   "Download this support package": "Télécharger ce paquet de support",
   "Due Date": "Date d'échéance",
   "Duplicate": "Dupliquer",
+  "Duplicate a CSV ingester": "Dupliquer un injecteur CSV",
+  "Duplicate a feed": "Dupliquer un flux",
   "Duplicate the dashboard": "Dupliquer le tableau de bord",
   "Dynamic source filters": "Filtres de source dynamique",
   "Dynamic target filters": "Filtres dynamiques cibles",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -856,6 +856,7 @@
   "Due Date": "Date d'échéance",
   "Duplicate": "Dupliquer",
   "Duplicate a CSV ingester": "Dupliquer un injecteur CSV",
+  "Duplicate a CSV mapper": "Dupliquer un mappeur CSV",
   "Duplicate a feed": "Dupliquer un flux",
   "Duplicate the dashboard": "Dupliquer le tableau de bord",
   "Dynamic source filters": "Filtres de source dynamique",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -856,6 +856,7 @@
   "Due Date": "期日",
   "Duplicate": "重複",
   "Duplicate a CSV ingester": "CSVインジェスターの複製",
+  "Duplicate a CSV mapper": "CSVマッパーを複製する",
   "Duplicate a feed": "フィードの複製",
   "Duplicate the dashboard": "ダッシュボードの複製",
   "Dynamic source filters": "ダイナミック・ソース・フィルタ",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -855,6 +855,8 @@
   "Download this support package": "このサポートパッケージをダウンロードする",
   "Due Date": "期日",
   "Duplicate": "重複",
+  "Duplicate a CSV ingester": "CSVインジェスターの複製",
+  "Duplicate a feed": "フィードの複製",
   "Duplicate the dashboard": "ダッシュボードの複製",
   "Dynamic source filters": "ダイナミック・ソース・フィルタ",
   "Dynamic target filters": "動的ターゲットフィルタ",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -855,6 +855,8 @@
   "Download this support package": "이 지원 패키지를 다운로드",
   "Due Date": "마감일",
   "Duplicate": "복제",
+  "Duplicate a CSV ingester": "CSV 수집기 복제",
+  "Duplicate a feed": "피드 복제하기",
   "Duplicate the dashboard": "대시보드 복제",
   "Dynamic source filters": "동적 소스 필터",
   "Dynamic target filters": "동적 대상 필터",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -856,6 +856,7 @@
   "Due Date": "마감일",
   "Duplicate": "복제",
   "Duplicate a CSV ingester": "CSV 수집기 복제",
+  "Duplicate a CSV mapper": "CSV 매퍼 복제",
   "Duplicate a feed": "피드 복제하기",
   "Duplicate the dashboard": "대시보드 복제",
   "Dynamic source filters": "동적 소스 필터",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -855,6 +855,8 @@
   "Download this support package": "下载此支持软件包",
   "Due Date": "到期日",
   "Duplicate": "复制",
+  "Duplicate a CSV ingester": "复制 CSV 输入器",
+  "Duplicate a feed": "复制一个饲料",
   "Duplicate the dashboard": "复制仪表板",
   "Dynamic source filters": "动态源过滤器",
   "Dynamic target filters": "动态目标过滤器",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -856,6 +856,7 @@
   "Due Date": "到期日",
   "Duplicate": "复制",
   "Duplicate a CSV ingester": "复制 CSV 输入器",
+  "Duplicate a CSV mapper": "复制 CSV 映射器",
   "Duplicate a feed": "复制一个饲料",
   "Duplicate the dashboard": "复制仪表板",
   "Dynamic source filters": "动态源过滤器",

--- a/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
@@ -99,7 +99,7 @@ const CsvMappers = () => {
                 />
               </React.Suspense>
             </ListLines>
-            <CsvMapperCreationContainer paginationOptions={paginationOptions}/>
+            <CsvMapperCreationContainer paginationOptions={paginationOptions} open={false}/>
           </div>
         </CsvMappersProvider>
       </Suspense>

--- a/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/CsvMappers.tsx
@@ -99,7 +99,9 @@ const CsvMappers = () => {
                 />
               </React.Suspense>
             </ListLines>
-            <CsvMapperCreationContainer paginationOptions={paginationOptions} open={false}/>
+            <CsvMapperCreationContainer paginationOptions={paginationOptions} open={false} onClose={() => {
+            }}
+            />
           </div>
         </CsvMappersProvider>
       </Suspense>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -5,7 +5,7 @@ import IngestionMenu from '@components/data/IngestionMenu';
 import IngestionCsvLines, { ingestionCsvLinesQuery } from '@components/data/ingestionCsv/IngestionCsvLines';
 import { IngestionCsvLinesPaginationQuery, IngestionCsvLinesPaginationQuery$variables } from '@components/data/ingestionCsv/__generated__/IngestionCsvLinesPaginationQuery.graphql';
 import { IngestionCsvLineDummy } from '@components/data/ingestionCsv/IngestionCsvLine';
-import IngestionCsvCreation from '@components/data/ingestionCsv/IngestionCsvCreation';
+import { IngestionCsvCreationContainer } from '@components/data/ingestionCsv/IngestionCsvCreation';
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
@@ -127,8 +127,12 @@ const IngestionCsv = () => {
       <IngestionMenu/>
       {renderLines()}
       <Security needs={[INGESTION_SETINGESTIONS]}>
-        <IngestionCsvCreation
+        <IngestionCsvCreationContainer
+          open={false}
+          handleClose={() => {
+          }}
           paginationOptions={paginationOptions}
+          isDuplicated={false}
         />
       </Security>
     </div>

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreation.tsx
@@ -32,11 +32,11 @@ const csvMapperCreation = graphql`
 `;
 
 interface CsvMapperCreationFormProps {
-  paginationOptions?: csvMappers_MappersQuery$variables
+  paginationOptions: csvMappers_MappersQuery$variables
   isDuplicated?: boolean
   onClose?: () => void
   open: boolean
-  mappingCsv?: CsvMapperEditionContainerFragment_csvMapper$key,
+  mappingCsv?: CsvMapperEditionContainerFragment_csvMapper$key | null,
 }
 
 const CsvMapperCreation: FunctionComponent<CsvMapperCreationFormProps> = ({
@@ -53,10 +53,10 @@ const CsvMapperCreation: FunctionComponent<CsvMapperCreationFormProps> = ({
   ) || { csvMapperSchemaAttributes: [] };
 
   const computeDefaultValues = useComputeDefaultValues();
-  const csvMapper = mappingCsv && (useFragment(
+  const csvMapper = useFragment(
     csvMapperEditionContainerFragment,
     mappingCsv,
-  ));
+  );
   const onSubmit: FormikConfig<CsvMapperFormData>['onSubmit'] = (
     values,
     { resetForm, setSubmitting, setErrors },
@@ -80,6 +80,7 @@ const CsvMapperCreation: FunctionComponent<CsvMapperCreationFormProps> = ({
         'csvMapperAdd',
       ),
       onCompleted: () => {
+        setSubmitting(false);
         resetForm();
         if (onClose) {
           onClose();

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreation.tsx
@@ -1,14 +1,22 @@
 import React, { FunctionComponent } from 'react';
 import { FormikConfig } from 'formik';
-import { graphql } from 'react-relay';
-import CsvMapperForm from '@components/data/csvMapper/CsvMapperForm';
+import { graphql, useFragment } from 'react-relay';
 import { CsvMapperFormData } from '@components/data/csvMapper/CsvMapper';
 import { CsvMapperAddInput } from '@components/data/csvMapper/__generated__/CsvMapperCreationContainerMutation.graphql';
-import { formDataToCsvMapper } from '@components/data/csvMapper/CsvMapperUtils';
 import { csvMappers_MappersQuery$variables } from '@components/data/csvMapper/__generated__/csvMappers_MappersQuery.graphql';
+import { CsvMapperEditionContainerFragment_csvMapper$key } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerFragment_csvMapper.graphql';
+import { useCsvMappersData } from '@components/data/csvMapper/csvMappers.data';
+import {
+  CsvMapperRepresentationAttributesForm_allSchemaAttributes$key,
+} from '@components/data/csvMapper/representations/attributes/__generated__/CsvMapperRepresentationAttributesForm_allSchemaAttributes.graphql';
+import { CsvMapperRepresentationAttributesFormFragment } from '@components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributesForm';
+import { csvMapperToFormData, formDataToCsvMapper } from '@components/data/csvMapper/CsvMapperUtils';
+import CsvMapperForm from '@components/data/csvMapper/CsvMapperForm';
+import { csvMapperEditionContainerFragment } from '@components/data/csvMapper/CsvMapperEditionContainer';
 import { insertNode } from '../../../../utils/store';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { handleErrorInForm } from '../../../../relay/environment';
+import { useComputeDefaultValues } from '../../../../utils/hooks/useDefaultValues';
 
 const csvMapperCreation = graphql`
   mutation CsvMapperCreationContainerMutation($input: CsvMapperAddInput!) {
@@ -24,16 +32,31 @@ const csvMapperCreation = graphql`
 `;
 
 interface CsvMapperCreationFormProps {
-  onClose?: () => void;
-  paginationOptions: csvMappers_MappersQuery$variables;
+  paginationOptions?: csvMappers_MappersQuery$variables
+  isDuplicated?: boolean
+  onClose?: () => void
+  open: boolean
+  mappingCsv?: CsvMapperEditionContainerFragment_csvMapper$key,
 }
 
 const CsvMapperCreation: FunctionComponent<CsvMapperCreationFormProps> = ({
+  mappingCsv,
+  isDuplicated,
   onClose,
   paginationOptions,
 }) => {
   const [commit] = useApiMutation(csvMapperCreation);
+  const { schemaAttributes } = useCsvMappersData();
+  const data = useFragment<CsvMapperRepresentationAttributesForm_allSchemaAttributes$key>(
+    CsvMapperRepresentationAttributesFormFragment,
+    schemaAttributes,
+  ) || { csvMapperSchemaAttributes: [] };
 
+  const computeDefaultValues = useComputeDefaultValues();
+  const csvMapper = mappingCsv && (useFragment(
+    csvMapperEditionContainerFragment,
+    mappingCsv,
+  ));
   const onSubmit: FormikConfig<CsvMapperFormData>['onSubmit'] = (
     values,
     { resetForm, setSubmitting, setErrors },
@@ -69,17 +92,22 @@ const CsvMapperCreation: FunctionComponent<CsvMapperCreationFormProps> = ({
     });
   };
 
-  const initialValues: CsvMapperFormData = {
-    id: '',
-    name: '',
-    has_header: false,
-    separator: ',',
-    skip_line_char: '',
-    entity_representations: [],
-    relationship_representations: [],
-  };
+  const initialValues: CsvMapperFormData = isDuplicated && csvMapper
+    ? csvMapperToFormData(
+      csvMapper,
+      data.csvMapperSchemaAttributes,
+      computeDefaultValues,
+    ) : {
+      id: '',
+      name: '',
+      has_header: false,
+      separator: ',',
+      skip_line_char: '',
+      entity_representations: [],
+      relationship_representations: [],
+    };
 
-  return <CsvMapperForm csvMapper={initialValues} onSubmit={onSubmit} />;
+  return <CsvMapperForm csvMapper={initialValues} onSubmit={onSubmit} isDuplicated={isDuplicated}/>;
 };
 
 export default CsvMapperCreation;

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreationContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreationContainer.tsx
@@ -2,23 +2,45 @@ import React, { FunctionComponent } from 'react';
 import Drawer, { DrawerVariant } from '@components/common/drawer/Drawer';
 import CsvMapperCreation from '@components/data/csvMapper/CsvMapperCreation';
 import { csvMappers_MappersQuery$variables } from '@components/data/csvMapper/__generated__/csvMappers_MappersQuery.graphql';
+import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
+import { CsvMapperEditionContainerQuery } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerQuery.graphql';
+import { csvMapperEditionContainerQuery } from '@components/data/csvMapper/CsvMapperEditionContainer';
+import { CsvMapperEditionContainerFragment_csvMapper$key } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerFragment_csvMapper.graphql';
 import { useFormatter } from '../../../../components/i18n';
 
 interface CsvMapperCreationProps {
-  paginationOptions: csvMappers_MappersQuery$variables;
+  paginationOptions?: csvMappers_MappersQuery$variables;
+  queryRef?: PreloadedQuery<CsvMapperEditionContainerQuery>,
+  mappingCsv?: CsvMapperEditionContainerFragment_csvMapper$key,
+  isDuplicated?: boolean;
+  onClose?: () => void;
+  open: boolean;
 }
 
 const CsvMapperCreationContainer: FunctionComponent<CsvMapperCreationProps> = ({
+  queryRef,
+  onClose,
+  isDuplicated,
+  open,
   paginationOptions,
 }) => {
   const { t_i18n } = useFormatter();
+  const mappingCsv = queryRef ? (usePreloadedQuery(csvMapperEditionContainerQuery, queryRef).csvMapper) : null;
 
   return (
     <Drawer
-      title={t_i18n('Create a CSV mapper')}
-      variant={DrawerVariant.createWithPanel}
+      title={isDuplicated ? t_i18n('Duplicate a CSV mapper') : t_i18n('Create a CSV mapper')}
+      open={open}
+      onClose={onClose}
+      variant={isDuplicated ? undefined : DrawerVariant.createWithPanel}
     >
-      <CsvMapperCreation paginationOptions={paginationOptions} />
+      <CsvMapperCreation
+        mappingCsv={mappingCsv}
+        paginationOptions={paginationOptions}
+        onClose={onClose}
+        isDuplicated={isDuplicated}
+        open={open}
+      />
     </Drawer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreationContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperCreationContainer.tsx
@@ -5,13 +5,11 @@ import { csvMappers_MappersQuery$variables } from '@components/data/csvMapper/__
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { CsvMapperEditionContainerQuery } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerQuery.graphql';
 import { csvMapperEditionContainerQuery } from '@components/data/csvMapper/CsvMapperEditionContainer';
-import { CsvMapperEditionContainerFragment_csvMapper$key } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerFragment_csvMapper.graphql';
 import { useFormatter } from '../../../../components/i18n';
 
 interface CsvMapperCreationProps {
-  paginationOptions?: csvMappers_MappersQuery$variables;
+  paginationOptions: csvMappers_MappersQuery$variables;
   queryRef?: PreloadedQuery<CsvMapperEditionContainerQuery>,
-  mappingCsv?: CsvMapperEditionContainerFragment_csvMapper$key,
   isDuplicated?: boolean;
   onClose?: () => void;
   open: boolean;
@@ -25,7 +23,7 @@ const CsvMapperCreationContainer: FunctionComponent<CsvMapperCreationProps> = ({
   paginationOptions,
 }) => {
   const { t_i18n } = useFormatter();
-  const mappingCsv = queryRef ? (usePreloadedQuery(csvMapperEditionContainerQuery, queryRef).csvMapper) : null;
+  const mappingCsv = queryRef ? (usePreloadedQuery(csvMapperEditionContainerQuery, queryRef)).csvMapper : null;
 
   return (
     <Drawer

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperEditionContainer.tsx
@@ -7,7 +7,7 @@ import Drawer from '@components/common/drawer/Drawer';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 
-const csvMapperEditionContainerFragment = graphql`
+export const csvMapperEditionContainerFragment = graphql`
   fragment CsvMapperEditionContainerFragment_csvMapper on CsvMapper {
     id
     name

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -61,9 +61,10 @@ interface CsvMapperFormProps {
     values: CsvMapperFormData,
     formikHelpers: FormikHelpers<CsvMapperFormData>,
   ) => void;
+  isDuplicated?: boolean,
 }
 
-const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSubmit }) => {
+const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSubmit, isDuplicated }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
 
@@ -140,6 +141,16 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
       ...values.relationship_representations,
       representationInitialization('relationship'),
     ]);
+  };
+
+  const getButtonText = () => {
+    if (isDuplicated) {
+      return t_i18n('Duplicate');
+    }
+    if (csvMapper.id) {
+      return t_i18n('Update');
+    }
+    return t_i18n('Create');
   };
 
   // -- ERRORS --
@@ -334,7 +345,7 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
                   disabled={isSubmitting}
                   classes={{ root: classes.button }}
                 >
-                  {csvMapper.id ? t_i18n('Update') : t_i18n('Create')}
+                  {getButtonText()}
                 </Button>
               </div>
               <CsvMapperTestDialog

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
@@ -8,6 +8,7 @@ import { PopoverProps } from '@mui/material/Popover';
 import CsvMapperEditionContainer, { csvMapperEditionContainerQuery } from '@components/data/csvMapper/CsvMapperEditionContainer';
 import { CsvMapperEditionContainerQuery } from '@components/data/csvMapper/__generated__/CsvMapperEditionContainerQuery.graphql';
 import { csvMappers_MappersQuery$variables } from '@components/data/csvMapper/__generated__/csvMappers_MappersQuery.graphql';
+import CsvMapperCreationContainer from '@components/data/csvMapper/CsvMapperCreationContainer';
 import { useFormatter } from '../../../../components/i18n';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import useDeletion from '../../../../utils/hooks/useDeletion';
@@ -45,6 +46,15 @@ const CsvMapperPopover: FunctionComponent<CsvMapperPopoverProps> = ({
     handleClose();
   };
 
+  // -- Duplication --
+  const [displayDuplicate, setDisplayDuplicate] = useState(false);
+
+  const handleOpenDuplicate = () => {
+    setDisplayDuplicate(true);
+    loadQuery({ id: csvMapperId });
+    handleClose();
+  };
+
   // -- Deletion --
 
   const [commit] = useApiMutation(csvMapperPopoverDelete);
@@ -78,6 +88,7 @@ const CsvMapperPopover: FunctionComponent<CsvMapperPopoverProps> = ({
       </IconButton>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
         <MenuItem onClick={handleOpenUpdate}>{t_i18n('Update')}</MenuItem>
+        <MenuItem onClick={handleOpenDuplicate}>{t_i18n('Duplicate')}</MenuItem>
         <MenuItem onClick={deletion.handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
       </Menu>
       {queryRef && (
@@ -86,6 +97,12 @@ const CsvMapperPopover: FunctionComponent<CsvMapperPopoverProps> = ({
             queryRef={queryRef}
             onClose={() => setDisplayUpdate(false)}
             open={displayUpdate}
+          />
+          <CsvMapperCreationContainer
+            queryRef={queryRef}
+            isDuplicated={true}
+            onClose={() => setDisplayDuplicate(false)}
+            open={displayDuplicate}
           />
         </React.Suspense>
       )}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperPopover.tsx
@@ -101,6 +101,7 @@ const CsvMapperPopover: FunctionComponent<CsvMapperPopoverProps> = ({
           <CsvMapperCreationContainer
             queryRef={queryRef}
             isDuplicated={true}
+            paginationOptions={paginationOptions}
             onClose={() => setDisplayDuplicate(false)}
             open={displayDuplicate}
           />

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -145,7 +145,7 @@ interface FeedCreationFormProps {
   open: boolean;
   isDuplicated: boolean;
   onDrawerClose: () => void;
-  feed?: FeedAddInput;
+  feed: FeedAddInput | undefined;
 }
 
 const feedCreationValidation = (t_i18n: (s: string) => string) => Yup.object().shape({
@@ -175,7 +175,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
       ...n,
       mappings: R.indexBy(R.prop('type'), n.mappings),
     }))
-    : []; // Si `feed_attributes` est null ou undefined, initialisez avec un tableau vide
+    : [];
 
   const [feedAttributes, setFeedAttributes] = useState(feedAttributesInitialState);
   const { ignoredAttributesInFeeds } = useAttributes();
@@ -183,7 +183,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const handleClose = () => {
     setSelectedTypes([]);
     helpers.handleClearAllFilters();
-    setFeedAttributes({ 0: {} });
+    setFeedAttributes(feedAttributesInitialState);
     if (!isDuplicated) {
       onDrawerClose();
     }

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -161,7 +161,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const { onDrawerClose, open, paginationOptions, isDuplicated, feed } = props;
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const [selectedTypes, setSelectedTypes] = useState<string[]>(isDuplicated && feed ? feed.feed_types : []);
+  const [selectedTypes, setSelectedTypes] = useState(feed?.feed_types);
   const [filters, helpers] = useFiltersState(emptyFilterGroup);
 
   const completeFilterKeysMap: Map<string, Map<string, FilterDefinition>> = useFetchFilterKeysSchema();
@@ -173,7 +173,6 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
       mappings: R.indexBy(R.prop('type'), n.mappings),
     }))
     : [];
-
   // TODO: typing this state properly implies deep refactoring
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [feedAttributes, setFeedAttributes] = useState<{ [key: string]: any }>({ 0: {} });
@@ -634,7 +633,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
                         >
                           {t_i18n('Cancel')}
                         </Button>
-                        {isDuplicated && feed ? (
+                        {isDuplicated ? (
                           <Button
                             variant="contained"
                             color="secondary"

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -161,7 +161,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const { onDrawerClose, open, paginationOptions, isDuplicated, feed } = props;
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const [selectedTypes, setSelectedTypes] = useState<string[]>(isDuplicated && feed ? feed.feed_types : []);
   const [filters, helpers] = useFiltersState(emptyFilterGroup);
 
   const completeFilterKeysMap: Map<string, Map<string, FilterDefinition>> = useFetchFilterKeysSchema();
@@ -170,8 +170,14 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
 
   // TODO: typing this state properly implies deep refactoring
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [feedAttributes, setFeedAttributes] = useState<{ [key: string]: any }>({ 0: {} });
+  const feedAttributesInitialState = feed && feed.feed_attributes
+    ? feed.feed_attributes.map((n) => ({
+      ...n,
+      mappings: R.indexBy(R.prop('type'), n.mappings),
+    }))
+    : []; // Si `feed_attributes` est null ou undefined, initialisez avec un tableau vide
 
+  const [feedAttributes, setFeedAttributes] = useState(feedAttributesInitialState);
   const { ignoredAttributesInFeeds } = useAttributes();
 
   const handleClose = () => {
@@ -253,7 +259,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
       },
     });
   };
-
+  console.log('selectedTypes', selectedTypes);
   const areAttributesValid = () => {
     if (
       selectedTypes.length === 0

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -636,15 +636,27 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
                         >
                           {t_i18n('Cancel')}
                         </Button>
-                        <Button
-                          variant="contained"
-                          color="secondary"
-                          onClick={submitForm}
-                          disabled={isSubmitting || !areAttributesValid()}
-                          classes={{ root: classes.button }}
-                        >
-                          {t_i18n('Create')}
-                        </Button>
+                        {isDuplicated && feed ? (
+                          <Button
+                            variant="contained"
+                            color="secondary"
+                            onClick={submitForm}
+                            disabled={isSubmitting || !areAttributesValid()}
+                            classes={{ root: classes.button }}
+                          >
+                            {t_i18n('Duplicate')}
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="contained"
+                            color="secondary"
+                            onClick={submitForm}
+                            disabled={isSubmitting || !areAttributesValid()}
+                            classes={{ root: classes.button }}
+                          >
+                            {t_i18n('Create')}
+                          </Button>
+                        )}
                       </div>
                     </Form>
                   )}

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -181,6 +181,9 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const { ignoredAttributesInFeeds } = useAttributes();
 
   const onHandleClose = () => {
+    setSelectedTypes([]);
+    helpers.handleClearAllFilters();
+    setFeedAttributes({ 0: {} });
     if (isDuplicated) {
       onDrawerClose();
     }
@@ -637,27 +640,15 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
                         >
                           {t_i18n('Cancel')}
                         </Button>
-                        {isDuplicated ? (
-                          <Button
-                            variant="contained"
-                            color="secondary"
-                            onClick={submitForm}
-                            disabled={isSubmitting || !areAttributesValid()}
-                            classes={{ root: classes.button }}
-                          >
-                            {t_i18n('Duplicate')}
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="contained"
-                            color="secondary"
-                            onClick={submitForm}
-                            disabled={isSubmitting || !areAttributesValid()}
-                            classes={{ root: classes.button }}
-                          >
-                            {t_i18n('Create')}
-                          </Button>
-                        )}
+                        <Button
+                          variant="contained"
+                          color="secondary"
+                          onClick={submitForm}
+                          disabled={isSubmitting || !areAttributesValid()}
+                          classes={{ root: classes.button }}
+                        >
+                          {isDuplicated ? t_i18n('Duplicate') : t_i18n('Create')}
+                        </Button>
                       </div>
                     </Form>
                   )}

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -166,10 +166,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
 
   const completeFilterKeysMap: Map<string, Map<string, FilterDefinition>> = useFetchFilterKeysSchema();
   const availableFilterKeys = useAvailableFilterKeysForEntityTypes(selectedTypes).filter((k) => k !== 'entity_type');
-  console.log('FEED', feed);
 
-  // TODO: typing this state properly implies deep refactoring
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const feedAttributesInitialState = feed && feed.feed_attributes
     ? feed.feed_attributes.map((n) => ({
       ...n,
@@ -177,7 +174,9 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
     }))
     : [];
 
-  const [feedAttributes, setFeedAttributes] = useState(feedAttributesInitialState);
+  // TODO: typing this state properly implies deep refactoring
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [feedAttributes, setFeedAttributes] = useState<{ [key: string]: any }>({ 0: {} });
   const { ignoredAttributesInFeeds } = useAttributes();
 
   const handleClose = () => {
@@ -212,7 +211,6 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const [commit] = useApiMutation(feedCreationMutation);
 
   const onSubmit: FormikConfig<FeedAddInput>['onSubmit'] = (values, { setSubmitting, resetForm }) => {
-    console.log('VALUES', values);
     const finalFeedAttributes = R.values(feedAttributes).map((n) => ({
       attribute: n.attribute,
       mappings: R.values(n.mappings),
@@ -259,7 +257,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
       },
     });
   };
-  console.log('selectedTypes', selectedTypes);
+
   const areAttributesValid = () => {
     if (
       selectedTypes.length === 0
@@ -372,7 +370,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
                 [R.ascend(R.prop('label'))],
                 result,
               );
-              console.log('ENTITYTYPES', entitiesTypes);
+
               return (
                 <Formik<FeedAddInput>
                   initialValues={initialValues}
@@ -583,7 +581,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
                                                 ),
                                               );
                                             }
-                                            console.log('feedAttributes', feedAttributes);
+
                                             return (
                                               <Select
                                                 style={{ width: 150 }}

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -161,7 +161,7 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
   const { onDrawerClose, open, paginationOptions, isDuplicated, feed } = props;
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const [selectedTypes, setSelectedTypes] = useState(feed?.feed_types);
+  const [selectedTypes, setSelectedTypes] = useState(feed?.feed_types ?? []);
   const [filters, helpers] = useFiltersState(emptyFilterGroup);
 
   const completeFilterKeysMap: Map<string, Map<string, FilterDefinition>> = useFetchFilterKeysSchema();

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedCreation.tsx
@@ -141,7 +141,10 @@ interface FeedAddInput {
 }
 
 interface FeedCreationFormProps {
-  paginationOptions: PaginationOptions
+  paginationOptions: PaginationOptions;
+  open: boolean;
+  isDuplicated: boolean;
+  onDrawerClose: () => void;
 }
 
 const feedCreationValidation = (t_i18n: (s: string) => string) => Yup.object().shape({
@@ -154,7 +157,7 @@ const feedCreationValidation = (t_i18n: (s: string) => string) => Yup.object().s
 });
 
 const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
-  const { paginationOptions } = props;
+  const { onDrawerClose, open, paginationOptions, isDuplicated } = props;
   const classes = useStyles();
   const { t_i18n } = useFormatter();
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
@@ -173,6 +176,9 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
     setSelectedTypes([]);
     helpers.handleClearAllFilters();
     setFeedAttributes({ 0: {} });
+    if (!isDuplicated) {
+      onDrawerClose();
+    }
   };
 
   const handleSelectTypes = (types: string[]) => {
@@ -303,11 +309,12 @@ const FeedCreation: FunctionComponent<FeedCreationFormProps> = (props) => {
     );
     setFeedAttributes(R.assoc(i, newFeedAttribute, feedAttributes));
   };
-
+  console.log('OPEN', open);
   return (
     <Drawer
-      title={t_i18n('Create a feed')}
-      variant={DrawerVariant.createWithPanel}
+      title={isDuplicated ? (t_i18n('Duplicate a feed')) : (t_i18n('Create a feed'))}
+      variant={isDuplicated ? undefined : DrawerVariant.createWithPanel}
+      open={open}
       onClose={handleClose}
     >
       {({ onClose }) => (

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedEdition.jsx
@@ -30,10 +30,10 @@ import { stixCyberObservablesLinesAttributesQuery } from '../../observations/sti
 import Filters from '../../common/lists/Filters';
 import { feedCreationAllTypesQuery } from './FeedCreation';
 import {
-  useAvailableFilterKeysForEntityTypes,
   cleanFilters,
   deserializeFilterGroupForFrontend,
   serializeFilterGroupForBackend,
+  useAvailableFilterKeysForEntityTypes,
   useFetchFilterKeysSchema,
 } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
@@ -160,7 +160,6 @@ class FeedPopover extends Component {
           variables={{ id: feedId }}
           render={({ props }) => {
             if (props) {
-              console.log('PROPS', props);
               return (
                 <>
                   <FeedEdition
@@ -179,7 +178,6 @@ class FeedPopover extends Component {
           variables={{ id: feedId }}
           render={({ props }) => {
             if (props) {
-              console.log('PROPS', props);
               return (
                 <FeedCreation
                   feed={props.feed}

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
@@ -17,6 +17,7 @@ import { ConnectionHandler } from 'relay-runtime';
 import inject18n from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import FeedEdition from './FeedEdition';
+import FeedCreation from './FeedCreation';
 
 const styles = () => ({
   container: {
@@ -53,6 +54,7 @@ class FeedPopover extends Component {
       displayUpdate: false,
       displayDelete: false,
       deleting: false,
+      displayDuplicate: false,
     };
   }
 
@@ -71,6 +73,15 @@ class FeedPopover extends Component {
 
   handleCloseUpdate() {
     this.setState({ displayUpdate: false });
+  }
+
+  handleOpenDuplicate() {
+    this.setState({ displayDuplicate: true });
+    this.handleClose();
+  }
+
+  handleCloseDuplicate() {
+    this.setState({ displayDuplicate: false });
   }
 
   handleOpenDelete() {
@@ -127,6 +138,9 @@ class FeedPopover extends Component {
           <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
             {t('Update')}
           </MenuItem>
+          <MenuItem onClick={this.handleOpenDuplicate.bind(this)}>
+            {t('Duplicate')}
+          </MenuItem>
           <MenuItem onClick={this.handleOpenDelete.bind(this)}>
             {t('Delete')}
           </MenuItem>
@@ -137,11 +151,20 @@ class FeedPopover extends Component {
           render={({ props }) => {
             if (props) {
               return (
-                <FeedEdition
-                  feed={props.feed}
-                  handleClose={this.handleCloseUpdate.bind(this)}
-                  open={this.state.displayUpdate}
-                />
+                <>
+                  <FeedEdition
+                    feed={props.feed}
+                    handleClose={this.handleCloseUpdate.bind(this)}
+                    open={this.state.displayUpdate}
+                  />
+                  <FeedCreation
+                    feed={props.feed}
+                    onDrawerClose={this.handleCloseDuplicate.bind(this)}
+                    open={this.state.displayDuplicate}
+                    paginationOptions={this.props.paginationOptions}
+                    isDuplicated={true}
+                  />
+                </>
               );
             }
             return <div />;

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
@@ -46,6 +46,16 @@ const feedEditionQuery = graphql`
   }
 `;
 
+const feedDuplicateQuery = graphql`
+  query FeedPopoverDuplicateQuery($id: String!) {
+    feed(id: $id) {
+      id
+      name
+      ...FeedCreation
+    }
+  }
+`;
+
 class FeedPopover extends Component {
   constructor(props) {
     super(props);
@@ -150,6 +160,7 @@ class FeedPopover extends Component {
           variables={{ id: feedId }}
           render={({ props }) => {
             if (props) {
+              console.log('PROPS', props);
               return (
                 <>
                   <FeedEdition
@@ -157,14 +168,26 @@ class FeedPopover extends Component {
                     handleClose={this.handleCloseUpdate.bind(this)}
                     open={this.state.displayUpdate}
                   />
-                  <FeedCreation
-                    feed={props.feed}
-                    onDrawerClose={this.handleCloseDuplicate.bind(this)}
-                    open={this.state.displayDuplicate}
-                    paginationOptions={this.props.paginationOptions}
-                    isDuplicated={true}
-                  />
                 </>
+              );
+            }
+            return <div/>;
+          }}
+        />
+        <QueryRenderer
+          query={feedDuplicateQuery}
+          variables={{ id: feedId }}
+          render={({ props }) => {
+            if (props) {
+              console.log('PROPS', props);
+              return (
+                <FeedCreation
+                  feed={props.feed}
+                  onDrawerClose={this.handleCloseDuplicate.bind(this)}
+                  open={this.state.displayDuplicate}
+                  paginationOptions={this.props.paginationOptions}
+                  isDuplicated={true}
+                />
               );
             }
             return <div />;

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -434,7 +434,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
                 variant="contained"
                 color="secondary"
                 onClick={submitForm}
-                disabled={isSubmitting}
+                disabled={isSubmitting || isCreateDisabled}
                 classes={{ root: classes.button }}
               >
                 {t_i18n('Duplicate')}
@@ -444,7 +444,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
                 variant="contained"
                 color="secondary"
                 onClick={submitForm}
-                disabled={isSubmitting}
+                disabled={isSubmitting || isCreateDisabled}
                 classes={{ root: classes.button }}
               >
                 {t_i18n('Create')}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -467,7 +467,6 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
   );
 };
 export const IngestionCsvCreationContainer: FunctionComponent<IngestionCsvCreationContainerProps> = ({
-
   queryRef,
   handleClose,
   open,
@@ -497,5 +496,3 @@ export const IngestionCsvCreationContainer: FunctionComponent<IngestionCsvCreati
     </Drawer>
   );
 };
-
-export default IngestionCsvCreation;

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -66,7 +66,7 @@ interface IngestionCsvCreationContainerProps {
   isDuplicated: boolean,
 }
 
-export interface IngestionAddInput {
+export interface IngestionCsvAddInput {
   name: string
   message?: string | null
   references?: ExternalReferencesValues
@@ -120,8 +120,8 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     setCreatorId(option.value);
   };
   const updateObjectMarkingField = async (
-    setFieldValue: (field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionAddInput>>,
-    values: IngestionAddInput,
+    setFieldValue: (field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionCsvAddInput>>,
+    values: IngestionCsvAddInput,
   ) => {
     await setFieldValue('markings', values.markings);
   };
@@ -133,8 +133,8 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
       setFieldValue,
       values,
     }:{
-      setFieldValue: ((field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionAddInput>>);
-      values: IngestionAddInput
+      setFieldValue: ((field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionCsvAddInput>>);
+      values: IngestionCsvAddInput
     },
   ) => {
     const hasUserChoiceCsvMapperRepresentations = resolveHasUserChoiceCsvMapper(option);
@@ -160,7 +160,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
   });
 
   const [commit] = useApiMutation(ingestionCsvCreationMutation);
-  const onSubmit: FormikConfig<IngestionAddInput>['onSubmit'] = (
+  const onSubmit: FormikConfig<IngestionCsvAddInput>['onSubmit'] = (
     values,
     { setSubmitting, resetForm },
   ) => {
@@ -203,7 +203,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     });
   };
   const queryRef = useQueryLoading<CsvMapperFieldSearchQuery>(csvMapperQuery);
-  const initialValues: IngestionAddInput = isDuplicated && ingestionCsvData ? {
+  const initialValues: IngestionCsvAddInput = isDuplicated && ingestionCsvData ? {
     name: ingestionCsvData.name,
     description: ingestionCsvData.description,
     uri: ingestionCsvData.uri,
@@ -241,7 +241,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     markings: [],
   };
   return (
-    <Formik<IngestionAddInput>
+    <Formik<IngestionCsvAddInput>
       initialValues={initialValues}
       validationSchema={ingestionCsvCreationValidation}
       onSubmit={onSubmit}
@@ -344,62 +344,62 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
             </MenuItem>
           </Field>
           {values.authentication_type === 'basic' && (
-          <>
-            <Field
-              component={TextField}
-              variant="standard"
-              name="username"
-              label={t_i18n('Username')}
-              fullWidth={true}
-              style={fieldSpacingContainerStyle}
-            />
-            <Field
-              component={TextField}
-              variant="standard"
-              name="password"
-              label={t_i18n('Password')}
-              fullWidth={true}
-              style={fieldSpacingContainerStyle}
-            />
-          </>
+            <>
+              <Field
+                component={TextField}
+                variant="standard"
+                name="username"
+                label={t_i18n('Username')}
+                fullWidth={true}
+                style={fieldSpacingContainerStyle}
+              />
+              <Field
+                component={TextField}
+                variant="standard"
+                name="password"
+                label={t_i18n('Password')}
+                fullWidth={true}
+                style={fieldSpacingContainerStyle}
+              />
+            </>
           )}
           {values.authentication_type === 'bearer' && (
-          <Field
-            component={TextField}
-            variant="standard"
-            name="authentication_value"
-            label={t_i18n('Token')}
-            fullWidth={true}
-            style={fieldSpacingContainerStyle}
-          />
+            <Field
+              component={TextField}
+              variant="standard"
+              name="authentication_value"
+              label={t_i18n('Token')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
           )}
           {values.authentication_type === 'certificate' && (
-          <>
-            <Field
-              component={TextField}
-              variant="standard"
-              name="cert"
-              label={t_i18n('Certificate (base64)')}
-              fullWidth={true}
-              style={fieldSpacingContainerStyle}
-            />
-            <Field
-              component={TextField}
-              variant="standard"
-              name="key"
-              label={t_i18n('Key (base64)')}
-              fullWidth={true}
-              style={fieldSpacingContainerStyle}
-            />
-            <Field
-              component={TextField}
-              variant="standard"
-              name="ca"
-              label={t_i18n('CA certificate (base64)')}
-              fullWidth={true}
-              style={fieldSpacingContainerStyle}
-            />
-          </>
+            <>
+              <Field
+                component={TextField}
+                variant="standard"
+                name="cert"
+                label={t_i18n('Certificate (base64)')}
+                fullWidth={true}
+                style={fieldSpacingContainerStyle}
+              />
+              <Field
+                component={TextField}
+                variant="standard"
+                name="key"
+                label={t_i18n('Key (base64)')}
+                fullWidth={true}
+                style={fieldSpacingContainerStyle}
+              />
+              <Field
+                component={TextField}
+                variant="standard"
+                name="ca"
+                label={t_i18n('CA certificate (base64)')}
+                fullWidth={true}
+                style={fieldSpacingContainerStyle}
+              />
+            </>
           )}
           <Box sx={{ width: '100%', marginTop: 5 }}>
             <Alert

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -290,39 +290,39 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
             showConfidence
           />
           {
-                  queryRef && (
-                    <React.Suspense fallback={<Loader variant={LoaderVariant.inElement}/>}>
-                      <Box sx={{ width: '100%', marginTop: 5 }}>
-                        <Alert
-                          severity="info"
-                          variant="outlined"
-                          style={{ padding: '0px 10px 0px 10px' }}
-                        >
-                          {t_i18n('Depending on the selected CSV mapper configurations, marking definition levels can be set in the dedicated field.')}<br/>
-                          <br/>
-                          {t_i18n('If the CSV mapper is configured with "Use default markings definitions of the user", the default markings of the user responsible for data creation are applied to the ingested entities. Otherwise, you can choose markings to apply.')}<br/>
-                        </Alert>
-                      </Box>
-                      <CsvMapperField
-                        name="csv_mapper_id"
-                        onChange={(_, option) => onCsvMapperSelection(option, { setFieldValue, values })}
-                        isOptionEqualToValue={(option: Option, { value }: Option) => option.value === value}
-                        queryRef={queryRef}
-                      />
-                    </React.Suspense>
-                  )
-                }
+              queryRef && (
+              <React.Suspense fallback={<Loader variant={LoaderVariant.inElement}/>}>
+                <Box sx={{ width: '100%', marginTop: 5 }}>
+                  <Alert
+                    severity="info"
+                    variant="outlined"
+                    style={{ padding: '0px 10px 0px 10px' }}
+                  >
+                    {t_i18n('Depending on the selected CSV mapper configurations, marking definition levels can be set in the dedicated field.')}<br/>
+                    <br/>
+                    {t_i18n('If the CSV mapper is configured with "Use default markings definitions of the user", the default markings of the user responsible for data creation are applied to the ingested entities. Otherwise, you can choose markings to apply.')}<br/>
+                  </Alert>
+                </Box>
+                <CsvMapperField
+                  name="csv_mapper_id"
+                  onChange={(_, option) => onCsvMapperSelection(option, { setFieldValue, values })}
+                  isOptionEqualToValue={(option: Option, { value }: Option) => option.value === value}
+                  queryRef={queryRef}
+                />
+              </React.Suspense>
+              )
+          }
           {
-                hasUserChoiceCsvMapper && (
-                  <ObjectMarkingField
-                    name="markings"
-                    label={t_i18n('Marking definition levels')}
-                    style={fieldSpacingContainerStyle}
-                    allowedMarkingOwnerId={isGranted ? creatorId : undefined}
-                    setFieldValue={setFieldValue}
-                  />
-                )
-              }
+              hasUserChoiceCsvMapper && (
+              <ObjectMarkingField
+                name="markings"
+                label={t_i18n('Marking definition levels')}
+                style={fieldSpacingContainerStyle}
+                allowedMarkingOwnerId={isGranted ? creatorId : undefined}
+                setFieldValue={setFieldValue}
+              />
+              )
+          }
           <Field
             component={SelectField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useState } from 'react';
 import { Field, Form, Formik, FormikErrors } from 'formik';
 import Button from '@mui/material/Button';
 import * as Yup from 'yup';
-import { graphql } from 'react-relay';
+import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
 import MenuItem from '@mui/material/MenuItem';
 import makeStyles from '@mui/styles/makeStyles';
 import Alert from '@mui/material/Alert';
@@ -15,6 +15,11 @@ import CsvMapperField, { csvMapperQuery } from '@components/common/form/CsvMappe
 import IngestionCsvMapperTestDialog from '@components/data/ingestionCsv/IngestionCsvMapperTestDialog';
 import { CsvMapperFieldSearchQuery } from '@components/common/form/__generated__/CsvMapperFieldSearchQuery.graphql';
 import ObjectMarkingField from '@components/common/form/ObjectMarkingField';
+import { ingestionCsvEditionContainerQuery } from '@components/data/ingestionCsv/IngestionCsvEditionContainer';
+import { ingestionCsvEditionFragment } from '@components/data/ingestionCsv/IngestionCsvEdition';
+import { IngestionCsvEditionFragment_ingestionCsv$key } from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionFragment_ingestionCsv.graphql';
+import { IngestionCsvEditionContainerQuery } from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionContainerQuery.graphql';
+import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -29,6 +34,9 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useGranted, { SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import { USER_CHOICE_MARKING_CONFIG } from '../../../../utils/csvMapperUtils';
+import { convertMapper, convertUser } from '../../../../utils/edition';
+import { BASIC_AUTH, CERT_AUTH, extractCA, extractCert, extractKey, extractPassword, extractUsername } from '../../../../utils/ingestionAuthentificationUtils';
+import useAuth from '../../../../utils/hooks/useAuth';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -50,17 +58,24 @@ const ingestionCsvCreationMutation = graphql`
   }
 `;
 
-interface IngestionCsvCreationProps {
-  paginationOptions: IngestionCsvLinesPaginationQuery$variables;
+interface IngestionCsvCreationContainerProps {
+  queryRef?: PreloadedQuery<IngestionCsvEditionContainerQuery>,
+  handleClose: () => void,
+  open: boolean,
+  paginationOptions: IngestionCsvLinesPaginationQuery$variables,
+  isDuplicated: boolean,
+  ingestionCsv?: IngestionCsvEditionFragment_ingestionCsv$key
 }
 
-export interface IngestionCsvCreationForm {
-  name: string
-  description: string
+export interface IngestionAddInput {
+  name: string | null
+  message?: string | null
+  references?: ExternalReferencesValues
+  description?: string | null
   uri: string
-  csv_mapper_id: string | Option
-  authentication_type: IngestionAuthType
-  authentication_value: string
+  csv_mapper_id?: string | Option
+  authentication_type: IngestionAuthType | string
+  authentication_value: string | null
   current_state_date: Date | null
   user_id: string | Option
   username?: string
@@ -69,6 +84,13 @@ export interface IngestionCsvCreationForm {
   key?: string
   ca?: string
   markings: Option[],
+}
+
+interface IngestionCsvCreationProps {
+  paginationOptions: IngestionCsvLinesPaginationQuery$variables;
+  isDuplicated: boolean
+  handleClose: () => void
+  ingestionCsv?: IngestionCsvEditionFragment_ingestionCsv$key | null
 }
 
 const resolveHasUserChoiceCsvMapper = (option: Option & {
@@ -83,21 +105,23 @@ const resolveHasUserChoiceCsvMapper = (option: Option & {
   );
 };
 
-const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ paginationOptions }) => {
+const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ paginationOptions, isDuplicated, handleClose, ingestionCsv }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
   const [open, setOpen] = useState(false);
+  const ingestionCsvData = useFragment(ingestionCsvEditionFragment, ingestionCsv);
   const [isCreateDisabled, setIsCreateDisabled] = useState(true);
   const [hasUserChoiceCsvMapper, setHasUserChoiceCsvMapper] = useState(false);
   const [creatorId, setCreatorId] = useState('');
   const isGranted = useGranted([SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN]);
+  const { me } = useAuth();
 
   const onCreatorSelection = async (option: Option) => {
     setCreatorId(option.value);
   };
   const updateObjectMarkingField = async (
-    setFieldValue: (field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionCsvCreationForm>>,
-    values: IngestionCsvCreationForm,
+    setFieldValue: (field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionAddInput>>,
+    values: IngestionAddInput,
   ) => {
     await setFieldValue('markings', values.markings);
   };
@@ -109,8 +133,8 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
       setFieldValue,
       values,
     }:{
-      setFieldValue: ((field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionCsvCreationForm>>);
-      values: IngestionCsvCreationForm
+      setFieldValue: ((field: string, value: Option[], shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionAddInput>>);
+      values: IngestionAddInput
     },
   ) => {
     const hasUserChoiceCsvMapperRepresentations = resolveHasUserChoiceCsvMapper(option);
@@ -136,7 +160,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
   });
 
   const [commit] = useApiMutation(ingestionCsvCreationMutation);
-  const onSubmit: FormikConfig<IngestionCsvCreationForm>['onSubmit'] = (
+  const onSubmit: FormikConfig<IngestionAddInput>['onSubmit'] = (
     values,
     { setSubmitting, resetForm },
   ) => {
@@ -146,16 +170,16 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     } else if (values.authentication_type === 'certificate') {
       authenticationValue = `${values.cert}:${values.key}:${values.ca}`;
     }
-    const markings = values.markings.map((option) => option.value);
+    const markings = values?.markings?.map((option) => option.value);
     const input = {
       name: values.name,
       description: values.description,
       uri: values.uri,
-      csv_mapper_id: typeof values.csv_mapper_id === 'string' ? values.csv_mapper_id : values.csv_mapper_id.value,
+      csv_mapper_id: typeof values.csv_mapper_id === 'string' ? values.csv_mapper_id : values?.csv_mapper_id?.value,
       authentication_type: values.authentication_type,
       authentication_value: authenticationValue,
       current_state_date: values.current_state_date,
-      user_id: typeof values.user_id === 'string' ? values.user_id : values.user_id.value,
+      user_id: typeof values.user_id === 'string' ? values.user_id : values.user_id?.value,
       markings: markings ?? [],
     };
     commit({
@@ -177,78 +201,95 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
       },
     });
   };
-
   const queryRef = useQueryLoading<CsvMapperFieldSearchQuery>(csvMapperQuery);
+
+  const initialValues: IngestionAddInput = isDuplicated && ingestionCsvData ? {
+    name: ingestionCsvData.name,
+    description: ingestionCsvData.description,
+    uri: ingestionCsvData.uri,
+    csv_mapper_id: convertMapper(ingestionCsvData, 'csvMapper'),
+    authentication_type: ingestionCsvData.authentication_type,
+    authentication_value: ingestionCsvData.authentication_value,
+    current_state_date: ingestionCsvData.current_state_date,
+    user_id: convertUser(ingestionCsvData, 'user'),
+    username: ingestionCsvData.authentication_type === BASIC_AUTH ? extractUsername(ingestionCsvData.authentication_value) : undefined,
+    password: ingestionCsvData.authentication_type === BASIC_AUTH ? extractPassword(ingestionCsvData.authentication_value) : undefined,
+    cert: ingestionCsvData.authentication_type === CERT_AUTH ? extractCert(ingestionCsvData.authentication_value) : undefined,
+    key: ingestionCsvData.authentication_type === CERT_AUTH ? extractKey(ingestionCsvData.authentication_value) : undefined,
+    ca: ingestionCsvData.authentication_type === CERT_AUTH ? extractCA(ingestionCsvData.authentication_value) : undefined,
+    markings: me.allowed_marking?.filter(
+      (marking) => ingestionCsvData.markings?.includes(marking.id),
+    ).map((marking) => ({
+      label: marking.definition ?? '',
+      value: marking.id,
+    })),
+  } : {
+    name: '',
+    description: '',
+    uri: '',
+    csv_mapper_id: '',
+    authentication_type: 'none',
+    authentication_value: '',
+    current_state_date: null,
+    user_id: '',
+    username: '',
+    password: '',
+    cert: '',
+    key: '',
+    ca: '',
+    markings: [],
+  };
   return (
-    <Drawer
-      title={t_i18n('Create a CSV ingester')}
-      variant={DrawerVariant.createWithPanel}
+
+    <Formik<IngestionAddInput>
+      initialValues={initialValues}
+      validationSchema={ingestionCsvCreationValidation}
+      onSubmit={onSubmit}
+      onReset={handleClose}
     >
-      {({ onClose }) => (
-        <Formik<IngestionCsvCreationForm>
-          initialValues={{
-            name: '',
-            description: '',
-            uri: '',
-            csv_mapper_id: '',
-            authentication_type: 'none',
-            authentication_value: '',
-            current_state_date: null,
-            user_id: '',
-            username: '',
-            password: '',
-            cert: '',
-            key: '',
-            ca: '',
-            markings: [],
-          }}
-          validationSchema={ingestionCsvCreationValidation}
-          onSubmit={onSubmit}
-          onReset={onClose}
-        >
-          {({ submitForm, handleReset, isSubmitting, values, setFieldValue }) => (
-            <Form style={{ margin: '20px 0 20px 0' }}>
-              <Field
-                component={TextField}
-                variant="standard"
-                name="name"
-                label={t_i18n('Name')}
-                fullWidth={true}
-              />
-              <Field
-                component={TextField}
-                variant="standard"
-                name="description"
-                label={t_i18n('Description')}
-                fullWidth={true}
-                style={fieldSpacingContainerStyle}
-              />
-              <Field
-                component={DateTimePickerField}
-                name="current_state_date"
-                textFieldProps={{
-                  label: t_i18n('Import from date (empty = all Csv possible items)'),
-                  variant: 'standard',
-                  fullWidth: true,
-                  style: fieldSpacingContainerStyle,
-                }}
-              />
-              <Field
-                component={TextField}
-                variant="standard"
-                name="uri"
-                label={t_i18n('CSV URL')}
-                fullWidth={true}
-                style={fieldSpacingContainerStyle}
-              />
-              <CreatorField
-                name="user_id"
-                label={t_i18n('User responsible for data creation (empty = System)')}
-                containerStyle={fieldSpacingContainerStyle}
-                onChange={(_, option) => onCreatorSelection(option)}
-                showConfidence
-              />
-              {
+      {({ submitForm, handleReset, isSubmitting, values, setFieldValue }) => (
+        <Form style={{ margin: '20px 0 20px 0' }}>
+          <Field
+            component={TextField}
+            variant="standard"
+            name="name"
+            label={t_i18n('Name')}
+            fullWidth={true}
+          />
+          <Field
+            component={TextField}
+            variant="standard"
+            name="description"
+            label={t_i18n('Description')}
+            fullWidth={true}
+            style={fieldSpacingContainerStyle}
+          />
+          <Field
+            component={DateTimePickerField}
+            name="current_state_date"
+            textFieldProps={{
+              label: t_i18n('Import from date (empty = all Csv possible items)'),
+              variant: 'standard',
+              fullWidth: true,
+              style: fieldSpacingContainerStyle,
+            }}
+          />
+          <Field
+            component={TextField}
+            variant="standard"
+            name="uri"
+            label={t_i18n('CSV URL')}
+            fullWidth={true}
+            style={fieldSpacingContainerStyle}
+          />
+          <CreatorField
+            name="user_id"
+            label={t_i18n('User responsible for data creation (empty = System)')}
+            containerStyle={fieldSpacingContainerStyle}
+            onChange={(_, option) => onCreatorSelection(option)}
+            showConfidence
+          />
+          {
                   queryRef && (
                     <React.Suspense fallback={<Loader variant={LoaderVariant.inElement}/>}>
                       <Box sx={{ width: '100%', marginTop: 5 }}>
@@ -271,7 +312,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
                     </React.Suspense>
                   )
                 }
-              {
+          {
                 hasUserChoiceCsvMapper && (
                   <ObjectMarkingField
                     name="markings"
@@ -282,131 +323,172 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
                   />
                 )
               }
-              <Field
-                component={SelectField}
-                variant="standard"
-                name="authentication_type"
-                label={t_i18n('Authentication type')}
-                fullWidth={true}
-                containerstyle={{
-                  width: '100%',
-                  marginTop: 20,
-                }}
-              >
-                <MenuItem value="none">{t_i18n('None')}</MenuItem>
-                <MenuItem value="basic">
-                  {t_i18n('Basic user / password')}
-                </MenuItem>
-                <MenuItem value="bearer">{t_i18n('Bearer token')}</MenuItem>
-                <MenuItem value="certificate">
-                  {t_i18n('Client certificate')}
-                </MenuItem>
-              </Field>
-              {values.authentication_type === 'basic' && (
-              <>
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="username"
-                  label={t_i18n('Username')}
-                  fullWidth={true}
-                  style={fieldSpacingContainerStyle}
-                />
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="password"
-                  label={t_i18n('Password')}
-                  fullWidth={true}
-                  style={fieldSpacingContainerStyle}
-                />
-              </>
-              )}
-              {values.authentication_type === 'bearer' && (
-              <Field
-                component={TextField}
-                variant="standard"
-                name="authentication_value"
-                label={t_i18n('Token')}
-                fullWidth={true}
-                style={fieldSpacingContainerStyle}
-              />
-              )}
-              {values.authentication_type === 'certificate' && (
-              <>
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="cert"
-                  label={t_i18n('Certificate (base64)')}
-                  fullWidth={true}
-                  style={fieldSpacingContainerStyle}
-                />
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="key"
-                  label={t_i18n('Key (base64)')}
-                  fullWidth={true}
-                  style={fieldSpacingContainerStyle}
-                />
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="ca"
-                  label={t_i18n('CA certificate (base64)')}
-                  fullWidth={true}
-                  style={fieldSpacingContainerStyle}
-                />
-              </>
-              )}
-              <Box sx={{ width: '100%', marginTop: 5 }}>
-                <Alert
-                  severity="info"
-                  variant="outlined"
-                  style={{ padding: '0px 10px 0px 10px' }}
-                >
-                  {t_i18n('Please, verify the validity of the selected CSV mapper for the given URL.')}<br/>
-                  {t_i18n('Only successful tests allow the ingestion creation.')}
-                </Alert>
-              </Box>
-              <div className={classes.buttons}>
-                <Button
-                  variant="contained"
-                  onClick={handleReset}
-                  disabled={isSubmitting}
-                  classes={{ root: classes.button }}
-                >
-                  {t_i18n('Cancel')}
-                </Button>
-                <Button
-                  variant="contained"
-                  color={isCreateDisabled ? 'secondary' : 'primary'}
-                  onClick={() => setOpen(true)}
-                  classes={{ root: classes.button }}
-                  disabled={!(values.uri && values.csv_mapper_id)}
-                >
-                  {t_i18n('Verify')}
-                </Button>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  onClick={submitForm}
-                  disabled={isSubmitting || isCreateDisabled}
-                  classes={{ root: classes.button }}
-                >
-                  {t_i18n('Create')}
-                </Button>
-              </div>
-              <IngestionCsvMapperTestDialog
-                open={open}
-                onClose={() => setOpen(false)}
-                values={values}
-                setIsCreateDisabled={setIsCreateDisabled}
-              />
-            </Form>
+          <Field
+            component={SelectField}
+            variant="standard"
+            name="authentication_type"
+            label={t_i18n('Authentication type')}
+            fullWidth={true}
+            containerstyle={{
+              width: '100%',
+              marginTop: 20,
+            }}
+          >
+            <MenuItem value="none">{t_i18n('None')}</MenuItem>
+            <MenuItem value="basic">
+              {t_i18n('Basic user / password')}
+            </MenuItem>
+            <MenuItem value="bearer">{t_i18n('Bearer token')}</MenuItem>
+            <MenuItem value="certificate">
+              {t_i18n('Client certificate')}
+            </MenuItem>
+          </Field>
+          {values.authentication_type === 'basic' && (
+          <>
+            <Field
+              component={TextField}
+              variant="standard"
+              name="username"
+              label={t_i18n('Username')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
+            <Field
+              component={TextField}
+              variant="standard"
+              name="password"
+              label={t_i18n('Password')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
+          </>
           )}
-        </Formik>
+          {values.authentication_type === 'bearer' && (
+          <Field
+            component={TextField}
+            variant="standard"
+            name="authentication_value"
+            label={t_i18n('Token')}
+            fullWidth={true}
+            style={fieldSpacingContainerStyle}
+          />
+          )}
+          {values.authentication_type === 'certificate' && (
+          <>
+            <Field
+              component={TextField}
+              variant="standard"
+              name="cert"
+              label={t_i18n('Certificate (base64)')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
+            <Field
+              component={TextField}
+              variant="standard"
+              name="key"
+              label={t_i18n('Key (base64)')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
+            <Field
+              component={TextField}
+              variant="standard"
+              name="ca"
+              label={t_i18n('CA certificate (base64)')}
+              fullWidth={true}
+              style={fieldSpacingContainerStyle}
+            />
+          </>
+          )}
+          <Box sx={{ width: '100%', marginTop: 5 }}>
+            <Alert
+              severity="info"
+              variant="outlined"
+              style={{ padding: '0px 10px 0px 10px' }}
+            >
+              {t_i18n('Please, verify the validity of the selected CSV mapper for the given URL.')}<br/>
+              {t_i18n('Only successful tests allow the ingestion creation.')}
+            </Alert>
+          </Box>
+          <div className={classes.buttons}>
+            <Button
+              variant="contained"
+              onClick={handleReset}
+              disabled={isSubmitting}
+              classes={{ root: classes.button }}
+            >
+              {t_i18n('Cancel')}
+            </Button>
+            <Button
+              variant="contained"
+              color={isCreateDisabled ? 'secondary' : 'primary'}
+              onClick={() => setOpen(true)}
+              classes={{ root: classes.button }}
+              disabled={!(values.uri && values.csv_mapper_id)}
+            >
+              {t_i18n('Verify')}
+            </Button>
+            {isDuplicated ? (
+              <Button
+                variant="contained"
+                color="secondary"
+                onClick={submitForm}
+                disabled={isSubmitting}
+                classes={{ root: classes.button }}
+              >
+                {t_i18n('Duplicate')}
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                color="secondary"
+                onClick={submitForm}
+                disabled={isSubmitting}
+                classes={{ root: classes.button }}
+              >
+                {t_i18n('Create')}
+              </Button>
+            )}
+          </div>
+          <IngestionCsvMapperTestDialog
+            open={open}
+            onClose={() => setOpen(false)}
+            values={values}
+            setIsCreateDisabled={setIsCreateDisabled}
+          />
+        </Form>
+      )}
+    </Formik>
+  );
+};
+export const IngestionCsvCreationContainer: FunctionComponent<IngestionCsvCreationContainerProps> = ({
+
+  queryRef,
+  handleClose,
+  open,
+  paginationOptions,
+  isDuplicated,
+}) => {
+  const { t_i18n } = useFormatter();
+
+  const ingestionCsv = queryRef
+    ? usePreloadedQuery(ingestionCsvEditionContainerQuery, queryRef).ingestionCsv
+    : null;
+  return (
+    <Drawer
+      title={isDuplicated ? t_i18n('Duplicate a CSV ingester') : t_i18n('Create a CSV ingester')}
+      open={open}
+      onClose={handleClose}
+      variant={isDuplicated ? undefined : DrawerVariant.createWithPanel}
+    >
+      {({ onClose }) => (
+        <IngestionCsvCreation
+          ingestionCsv={ingestionCsv}
+          handleClose={onClose}
+          paginationOptions={paginationOptions}
+          isDuplicated={isDuplicated}
+        />
       )}
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -64,7 +64,6 @@ interface IngestionCsvCreationContainerProps {
   open: boolean,
   paginationOptions?: IngestionCsvLinesPaginationQuery$variables | null | undefined,
   isDuplicated: boolean,
-  ingestionCsv?: IngestionCsvEditionFragment_ingestionCsv$key
 }
 
 export interface IngestionAddInput {
@@ -172,8 +171,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
       authenticationValue = `${values.cert}:${values.key}:${values.ca}`;
     }
     const markings = values.markings?.map((option) => option.value);
-    // console.log('markings', markings);
-    // console.log('status', values.current_state_date);
+
     const input = {
       name: values.name,
       description: values.description,
@@ -205,7 +203,6 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     });
   };
   const queryRef = useQueryLoading<CsvMapperFieldSearchQuery>(csvMapperQuery);
-  // console.log('current status', ingestionCsvData);
   const initialValues: IngestionAddInput = isDuplicated && ingestionCsvData ? {
     name: ingestionCsvData.name,
     description: ingestionCsvData.description,
@@ -244,7 +241,6 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     markings: [],
   };
   return (
-
     <Formik<IngestionAddInput>
       initialValues={initialValues}
       validationSchema={ingestionCsvCreationValidation}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
@@ -54,7 +54,7 @@ export const ingestionCsvEditionPatch = graphql`
   } 
 `;
 
-const ingestionCsvEditionFragment = graphql`
+export const ingestionCsvEditionFragment = graphql`
   fragment IngestionCsvEditionFragment_ingestionCsv on IngestionCsv {
     id
     name

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvPopover.tsx
@@ -14,6 +14,7 @@ import IngestionCsvEditionContainer, { ingestionCsvEditionContainerQuery } from 
 import { ingestionCsvEditionPatch } from '@components/data/ingestionCsv/IngestionCsvEdition';
 import { IngestionCsvLinesPaginationQuery$variables } from '@components/data/ingestionCsv/__generated__/IngestionCsvLinesPaginationQuery.graphql';
 import { IngestionCsvEditionContainerQuery } from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionContainerQuery.graphql';
+import { IngestionCsvCreationContainer } from '@components/data/ingestionCsv/IngestionCsvCreation';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { deleteNode } from '../../../../utils/store';
 import { useFormatter } from '../../../../components/i18n';
@@ -54,6 +55,15 @@ const IngestionCsvPopover: FunctionComponent<IngestionCsvPopoverProps> = ({
     loadQuery({ id: ingestionCsvId });
     handleClose();
   };
+
+  // -- Duplicate --
+  const [displayDuplicate, setDisplayDuplicate] = useState<boolean>(false);
+  const handleOpenDuplicate = () => {
+    setDisplayDuplicate(true);
+    loadQuery({ id: ingestionCsvId });
+    handleClose();
+  };
+
   const handleOpenStart = () => {
     setDisplayStart(true);
     handleClose();
@@ -158,17 +168,29 @@ const IngestionCsvPopover: FunctionComponent<IngestionCsvPopoverProps> = ({
           <MenuItem onClick={handleOpenUpdate}>
             {t_i18n('Update')}
           </MenuItem>
+          <MenuItem onClick={handleOpenDuplicate}>
+            {t_i18n('Duplicate')}
+          </MenuItem>
           <MenuItem onClick={handleOpenDelete}>
             {t_i18n('Delete')}
           </MenuItem>
         </Menu>
         {queryRef && (
           <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
-            <IngestionCsvEditionContainer
-              queryRef={queryRef}
-              handleClose={() => setDisplayUpdate(false)}
-              open={displayUpdate}
-            />
+            <>
+              <IngestionCsvEditionContainer
+                queryRef={queryRef}
+                handleClose={() => setDisplayUpdate(false)}
+                open={displayUpdate}
+              />
+              <IngestionCsvCreationContainer
+                queryRef={queryRef}
+                handleClose={() => setDisplayDuplicate(false)}
+                open={displayDuplicate}
+                paginationOptions={paginationOptions}
+                isDuplicated={true}
+              />
+            </>
           </React.Suspense>
         )}
         <Dialog

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvPopover.tsx
@@ -30,7 +30,7 @@ const ingestionCsvPopoverDeletionMutation = graphql`
 interface IngestionCsvPopoverProps {
   ingestionCsvId: string;
   running?: boolean | null;
-  paginationOptions?: IngestionCsvLinesPaginationQuery$variables;
+  paginationOptions?: IngestionCsvLinesPaginationQuery$variables | null | undefined;
 }
 
 const IngestionCsvPopover: FunctionComponent<IngestionCsvPopoverProps> = ({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* in list of CSV: transform the popover component to open and to give right values to drawer
* in  creation form: modify the creation component for the duplication: prefilled with initial values, updatable..

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

* #7400

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
