### PR TITLE
[frontend] remove valid_until column in indicators list (#8520)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -900,6 +900,13 @@ const defaultColumns: DataTableProps['dataColumns'] = {
       return (<Tooltip title={file?.metaData?.mimetype}><>{b(file?.size)}</></Tooltip>);
     },
   },
+  valid_until: {
+    id: 'valid_until',
+    label: 'Valid until',
+    percentWidth: 10,
+    isSortable: true,
+    render: ({ valid_until }, { nsdt }) => <Tooltip title={nsdt(valid_until)}>{nsdt(valid_until)}</Tooltip>,
+  },
 };
 
 export const defaultColumnsMap = new Map<string, Partial<DataTableColumn>>(Object.entries(defaultColumns));

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -166,11 +166,7 @@ const Indicators = () => {
       percentWidth: 10,
       render: ({ created }, { nsdt }) => <Tooltip title={nsdt(created)}>{nsdt(created)}</Tooltip>,
     },
-    valid_until: {
-      label: 'Valid until',
-      percentWidth: 10,
-      isSortable: true,
-    },
+    valid_until: { },
     objectMarking: {
       percentWidth: 10,
       isSortable: isRuntimeSort ?? false,

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -153,20 +153,27 @@ const Indicators = () => {
   );
 
   const dataColumns: DataTableProps['dataColumns'] = {
-    pattern_type: {},
-    name: { percentWidth: 21 },
+    pattern_type: {
+      percentWidth: 11,
+    },
+    name: {
+      percentWidth: 24,
+    },
     createdBy: {
       isSortable: isRuntimeSort ?? false,
+      percentWidth: 12,
     },
     creator: {
       isSortable: isRuntimeSort ?? false,
+      percentWidth: 12,
     },
-    objectLabel: {},
+    objectLabel: {
+      percentWidth: 15,
+    },
     created: {
-      percentWidth: 10,
+      percentWidth: 15,
       render: ({ created }, { nsdt }) => <Tooltip title={nsdt(created)}>{nsdt(created)}</Tooltip>,
     },
-    valid_until: { },
     objectMarking: {
       percentWidth: 10,
       isSortable: isRuntimeSort ?? false,


### PR DESCRIPTION
### Proposed changes
we chose to remove the column valid_until from the indocator list view as it's already too crowded.

Note that I added valid_until field specs to `DataTableUtils` (same format as indicator creation date, date+time) if we change our mind.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #8520

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality


