### PR TITLE
[backend] Fix missing entites in shared report (#8333)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -550,7 +550,7 @@ const executeProcessing = async (context, user, job, scope) => {
   return errors;
 };
 
-const taskHandler = async () => {
+export const taskHandler = async () => {
   let lock;
   try {
     // Lock the manager

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -57,7 +57,7 @@ import { isStixCyberObservable } from '../schema/stixCyberObservable';
 import { promoteObservableToIndicator } from '../domain/stixCyberObservable';
 import { indicatorEditField, promoteIndicatorToObservables } from '../modules/indicator/indicator-domain';
 import { askElementEnrichmentForConnector } from '../domain/stixCoreObject';
-import { RELATION_GRANTED_TO, RELATION_OBJECT } from '../schema/stixRefRelationship';
+import { objectOrganization, RELATION_GRANTED_TO, RELATION_OBJECT } from '../schema/stixRefRelationship';
 import {
   ACTION_TYPE_COMPLETE_DELETE,
   ACTION_TYPE_DELETE,
@@ -79,6 +79,7 @@ import { BackgroundTaskScope } from '../generated/graphql';
 import { ENTITY_TYPE_INTERNAL_FILE } from '../schema/internalObject';
 import { deleteFile } from '../database/file-storage';
 import { checkUserIsAdminOnDashboard } from '../modules/publicDashboard/publicDashboard-utils';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 
 // Task manager responsible to execute long manual tasks
 // Each API will start is task manager.
@@ -406,7 +407,7 @@ const executeShare = async (context, user, actionContext, element) => {
   for (let indexCreate = 0; indexCreate < values.length; indexCreate += 1) {
     const target = values[indexCreate];
     const currentGrants = element[buildRefRelationKey(RELATION_GRANTED_TO)] ?? [];
-    if (!currentGrants.includes(target)) {
+    if (!currentGrants.includes(target) && objectOrganization.isRefExistingForTypes(element.entity_type, ENTITY_TYPE_IDENTITY_ORGANIZATION)) {
       await createRelation(context, user, { fromId: element.id, toId: target, relationship_type: RELATION_GRANTED_TO });
     }
   }

--- a/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
@@ -727,7 +727,9 @@ export const objectOrganization: RefAttribute = {
   multiple: true,
   upsert: true,
   isRefExistingForTypes(this, fromType, toType) {
-    return !(fromType === ENTITY_TYPE_EVENT || isStixDomainObjectIdentity(fromType)
+    return !(fromType === ENTITY_TYPE_EVENT
+        || fromType === ENTITY_TYPE_IDENTITY_ORGANIZATION
+        || fromType === ENTITY_TYPE_IDENTITY_SECTOR
         || isStixDomainObjectLocation(fromType))
       && this.toTypes.includes(toType);
   },

--- a/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
@@ -23,7 +23,6 @@ import {
   ENTITY_TYPE_IDENTITY_SYSTEM,
   ENTITY_TYPE_LOCATION_COUNTRY,
   isStixDomainObjectContainer,
-  isStixDomainObjectIdentity,
   isStixDomainObjectLocation
 } from './stixDomainObject';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE, ENTITY_TYPE_KILL_CHAIN_PHASE, ENTITY_TYPE_LABEL, ENTITY_TYPE_MARKING_DEFINITION } from './stixMetaObject';

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-sharing-test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { ADMIN_API_TOKEN, ADMIN_USER, API_URI, FIVE_MINUTES, getOrganizationIdByName, PYTHON_PATH, TEST_ORGANIZATION, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { adminQueryWithSuccess, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
+import { findById } from '../../../src/domain/report';
+import { execChildPython } from '../../../src/python/pythonBridge';
+
+const ORGANIZATION_SHARING_QUERY = gql`
+  mutation StixCoreObjectSharingGroupAddMutation(
+    $id: ID!
+    $organizationId: ID!
+  ) {
+    stixCoreObjectEdit(id: $id) {
+      restrictionOrganizationAdd(organizationId: $organizationId) {
+        id
+        objectOrganization {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const importOpts: string[] = [API_URI, ADMIN_API_TOKEN, './tests/data/organization-sharing/20241003_Report_to_test_orga_sharing_full.json'];
+
+describe('Database provision', () => {
+  it('Should import creation succeed', async () => {
+    // Inject data
+    const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_importer.py', importOpts);
+    expect(execution).not.toBeNull();
+    expect(execution.status).toEqual('success');
+  }, FIVE_MINUTES);
+  // Python lib is fixed but we need to wait for a new release
+  it('Should import update succeed', async () => {
+    const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_importer.py', importOpts);
+    expect(execution).not.toBeNull();
+    expect(execution.status).toEqual('success');
+  }, FIVE_MINUTES);
+});
+
+describe('Organization sharing standard behavior for container', () => {
+  let reportInternalId: string;
+  let organizationId: string;
+  it('should load Report', async () => {
+    const report = await findById(testContext, ADMIN_USER, 'report--ce32448d-733b-5e34-ac4f-2759ce5db1ae');
+    expect(report).not.toBeUndefined();
+    reportInternalId = report.id;
+  });
+  it.skip('should platform organization sharing and EE activated', async () => {
+    // await enableEEAndSetOrganization(PLATFORM_ORGANIZATION);
+  });
+  it.skip('should share Report with Organization', async () => {
+    // Get organization id
+    organizationId = await getOrganizationIdByName(TEST_ORGANIZATION.name);
+    const organizationSharingQueryResult = await adminQueryWithSuccess({
+      query: ORGANIZATION_SHARING_QUERY,
+      variables: { id: reportInternalId, organizationId }
+    });
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd).not.toBeNull();
+    expect(organizationSharingQueryResult?.data?.stixCoreObjectEdit.restrictionOrganizationAdd.objectOrganization[0].name).toEqual(TEST_ORGANIZATION.name);
+
+    // Need background task magic to happens for sharing
+    //  await taskHandler();
+  });
+  it.skip('should Editor user access all objects', async () => {
+    const REPORT_STIX_DOMAIN_ENTITIES = gql`
+      query report($id: String!) {
+        report(id: $id) {
+          id
+          standard_id
+          objects(first: 30) {
+            edges {
+              node {
+                ... on BasicObject {
+                  id
+                  standard_id
+                }
+                ... on BasicRelationship {
+                  id
+                  standard_id
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    const queryResult = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: REPORT_STIX_DOMAIN_ENTITIES,
+      variables: { id: reportInternalId },
+    });
+    expect(queryResult.data.report.objects.edges.length).toEqual(10);
+  });
+  it('should all entities deleted', async () => {
+    const PURGE_QUERY = gql`
+      mutation ReportPopoverDeletionMutation(
+        $id: ID!
+        $purgeElements: Boolean
+      ) {
+        reportEdit(id: $id) {
+          delete(purgeElements: $purgeElements)
+        }
+      }
+    `;
+    const purgeQueryResult = await adminQueryWithSuccess({
+      query: PURGE_QUERY,
+      variables: {
+        id: reportInternalId,
+        purgeElements: true
+      }
+    });
+    expect(purgeQueryResult.data.reportEdit.delete).toEqual(reportInternalId);
+  });
+  it.skip('should plateform organization sharing and EE deactivated', async () => {
+    // await enableCEAndUnSetOrganization();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -58,8 +58,8 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['marking-definition'].length).toBe(2);
       expect(updateEventsByTypes['campaign'].length).toBe(7);
       expect(updateEventsByTypes['relationship'].length).toBe(8);
-      expect(updateEventsByTypes['identity'].length).toBe(16);
-      expect(updateEventsByTypes['malware'].length).toBe(16);
+      expect(updateEventsByTypes['identity'].length).toBe(18);
+      expect(updateEventsByTypes['malware'].length).toBe(17);
       expect(updateEventsByTypes['intrusion-set'].length).toBe(4);
       expect(updateEventsByTypes['data-component'].length).toBe(4);
       expect(updateEventsByTypes['location'].length).toBe(14);
@@ -70,19 +70,19 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['external-reference'].length).toBe(1);
       expect(updateEventsByTypes['grouping'].length).toBe(3);
       expect(updateEventsByTypes['incident'].length).toBe(3);
-      expect(updateEventsByTypes['indicator'].length).toBe(4);
+      expect(updateEventsByTypes['indicator'].length).toBe(5);
       expect(updateEventsByTypes['label'].length).toBe(1);
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
-      expect(updateEventsByTypes['report'].length).toBe(12);
+      expect(updateEventsByTypes['report'].length).toBe(13);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(7);
       expect(updateEventsByTypes['sighting'].length).toBe(4);
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(163);
+      expect(updateEvents.length).toBe(169);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -23,11 +23,11 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes['kill-chain-phase'].length).toBe(3);
       expect(createEventsByTypes['course-of-action'].length).toBe(3);
       expect(createEventsByTypes.label.length).toBe(15);
-      expect(createEventsByTypes.identity.length).toBe(32);
-      expect(createEventsByTypes.location.length).toBe(15);
+      expect(createEventsByTypes.identity.length).toBe(36);
+      expect(createEventsByTypes.location.length).toBe(16);
       expect(createEventsByTypes.relationship.length).toBe(136);
       expect(createEventsByTypes.sighting.length).toBe(4);
-      expect(createEventsByTypes.indicator.length).toBe(36);
+      expect(createEventsByTypes.indicator.length).toBe(37);
       expect(createEventsByTypes['attack-pattern'].length).toBe(9);
       expect(createEventsByTypes['threat-actor'].length).toBe(13);
       expect(createEventsByTypes['observed-data'].length).toBe(1);
@@ -37,16 +37,16 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes['ipv4-addr'].length).toBe(1);
       expect(createEventsByTypes['data-component'].length).toBe(5);
       expect(createEventsByTypes['data-source'].length).toBe(1);
-      expect(createEventsByTypes.malware.length).toBe(44);
+      expect(createEventsByTypes.malware.length).toBe(45);
       expect(createEventsByTypes.software.length).toBe(1);
       expect(createEventsByTypes.file.length).toBe(4);
       expect(createEventsByTypes.campaign.length).toBe(5);
       expect(createEventsByTypes.incident.length).toBe(2);
-      expect(createEventsByTypes.report.length).toBe(35);
+      expect(createEventsByTypes.report.length).toBe(36);
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(342); // 328 created at init + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(784);
+      expect(createEvents.length).toBe(793);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -95,7 +95,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(135);
+      expect(deleteEvents.length).toBe(144);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/data/organization-sharing/20241003_Report_to_test_orga_sharing_full.json
+++ b/opencti-platform/opencti-graphql/tests/data/organization-sharing/20241003_Report_to_test_orga_sharing_full.json
@@ -1,0 +1,167 @@
+{
+    "type": "bundle",
+    "id": "bundle--f1b36847-cd8d-4f32-9754-caaa8e5a8806",
+    "objects": [
+        {
+            "id": "report--ce32448d-733b-5e34-ac4f-2759ce5db1ae",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T08:04:39.000Z",
+            "modified": "2024-10-03T09:18:53.159Z",
+            "name": "Report to share",
+            "published": "2024-10-03T08:04:39.000Z",
+            "x_opencti_workflow_id": "f5958163-7dec-41b3-b5cc-4e3cf6251efc",
+            "x_opencti_id": "93d0dd3f-a894-4808-bdb9-ff151b0b1517",
+            "x_opencti_type": "Report",
+            "type": "report",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ],
+            "object_refs": [
+                "email-addr--4879e703-0b80-52b8-983c-fc87774643c9",
+                "malware--d5c2c089-04db-5e3a-a694-62e266b14fef",
+                "location--d1693b3f-fcd4-5996-aede-f78d1144c1ce",
+                "indicator--0001a19f-b9b0-5250-9696-6caa8676b867",
+                "identity--efcffe42-72f2-59ef-a0db-8c532f716dbe",
+                "identity--05c082f1-f7d5-59e5-8c99-2e5c7b8685bd",
+                "identity--bb20232a-5a0a-59fa-85ae-ffb4eabef6a8",
+                "identity--9e5e6cbd-570d-5c0f-a587-3eb6c1e8aaff"
+            ]
+        },
+        {
+            "id": "email-addr--4879e703-0b80-52b8-983c-fc87774643c9",
+            "spec_version": "2.1",
+            "x_opencti_score": 50,
+            "value": "mail@mail.com",
+            "x_opencti_id": "4eafced1-a3a5-4f97-9f0d-fc11f4669b4e",
+            "x_opencti_type": "Email-Addr",
+            "type": "email-addr",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ]
+        },
+        {
+            "id": "malware--d5c2c089-04db-5e3a-a694-62e266b14fef",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T09:17:25.707Z",
+            "modified": "2024-10-03T09:19:03.159Z",
+            "name": "Malware test",
+            "is_family": false,
+            "x_opencti_id": "8b3d6843-ebf9-40dc-8925-e607ec8dd82c",
+            "x_opencti_type": "Malware",
+            "type": "malware",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ]
+        },
+        {
+            "id": "location--d1693b3f-fcd4-5996-aede-f78d1144c1ce",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T09:17:04.719Z",
+            "modified": "2024-10-03T09:17:04.719Z",
+            "name": "City test",
+            "x_opencti_location_type": "City",
+            "city": "City test",
+            "x_opencti_id": "91976bed-0b41-4102-8c0e-2a6a9f0c9992",
+            "x_opencti_type": "City",
+            "type": "location"
+        },
+        {
+            "id": "indicator--0001a19f-b9b0-5250-9696-6caa8676b867",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T09:16:33.263Z",
+            "modified": "2024-10-03T09:19:03.307Z",
+            "pattern_type": "stix",
+            "pattern": "[ipv4-addr:value = '185.158.114.133']",
+            "name": "Indicator test",
+            "valid_from": "2024-10-03T09:16:33.246Z",
+            "valid_until": "2024-10-23T14:51:12.680Z",
+            "x_opencti_score": 50,
+            "x_opencti_detection": false,
+            "x_opencti_main_observable_type": "IPv4-Addr",
+            "x_opencti_id": "26b238ef-4842-4f5b-88bc-56b418a7d2ba",
+            "x_opencti_type": "Indicator",
+            "type": "indicator",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ]
+        },
+        {
+            "id": "identity--efcffe42-72f2-59ef-a0db-8c532f716dbe",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T08:07:38.834Z",
+            "modified": "2024-10-03T09:10:14.464Z",
+            "identity_class": "class",
+            "name": "sectorTest",
+            "x_opencti_id": "76924091-a311-4287-9f33-bae073e3a38c",
+            "x_opencti_type": "Sector",
+            "type": "identity"
+        },
+        {
+            "id": "identity--05c082f1-f7d5-59e5-8c99-2e5c7b8685bd",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T08:07:21.487Z",
+            "modified": "2024-10-03T09:10:44.651Z",
+            "identity_class": "organization",
+            "name": "organizationTest",
+            "x_opencti_id": "f03bd1e9-7460-49e9-8581-f02f6198d4d5",
+            "x_opencti_type": "Organization",
+            "type": "identity"
+        },
+        {
+            "id": "identity--bb20232a-5a0a-59fa-85ae-ffb4eabef6a8",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T08:07:08.545Z",
+            "modified": "2024-10-03T09:19:03.410Z",
+            "identity_class": "system",
+            "name": "systemTest",
+            "x_opencti_id": "5b75efd0-9431-47a5-9d71-3fb5d958e846",
+            "x_opencti_type": "System",
+            "type": "identity",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ]
+        },
+        {
+            "id": "identity--9e5e6cbd-570d-5c0f-a587-3eb6c1e8aaff",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T08:06:49.519Z",
+            "modified": "2024-10-03T09:19:03.498Z",
+            "identity_class": "individual",
+            "name": "individualTest",
+            "x_opencti_id": "85f4c4e2-53f2-4d08-8d37-b39273fb8680",
+            "x_opencti_type": "Individual",
+            "type": "identity",
+            "x_opencti_granted_refs": [
+                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
+            ]
+        },
+        {
+            "id": "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-10-03T09:12:43.360Z",
+            "modified": "2024-10-03T09:12:43.360Z",
+            "name": "Organization User 1 Test",
+            "x_opencti_id": "7a711a76-e5da-44cd-9ec8-544a6d3215a7",
+            "x_opencti_type": "Organization",
+            "type": "identity"
+        }
+    ]
+}

--- a/opencti-platform/opencti-graphql/tests/data/organization-sharing/20241003_Report_to_test_orga_sharing_full.json
+++ b/opencti-platform/opencti-graphql/tests/data/organization-sharing/20241003_Report_to_test_orga_sharing_full.json
@@ -1,6 +1,6 @@
 {
     "type": "bundle",
-    "id": "bundle--f1b36847-cd8d-4f32-9754-caaa8e5a8806",
+    "id": "bundle--b03625a3-1035-4f8c-a9ee-ca8c708ff9a1",
     "objects": [
         {
             "id": "report--ce32448d-733b-5e34-ac4f-2759ce5db1ae",
@@ -15,9 +15,6 @@
             "x_opencti_id": "93d0dd3f-a894-4808-bdb9-ff151b0b1517",
             "x_opencti_type": "Report",
             "type": "report",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ],
             "object_refs": [
                 "email-addr--4879e703-0b80-52b8-983c-fc87774643c9",
                 "malware--d5c2c089-04db-5e3a-a694-62e266b14fef",
@@ -36,10 +33,7 @@
             "value": "mail@mail.com",
             "x_opencti_id": "4eafced1-a3a5-4f97-9f0d-fc11f4669b4e",
             "x_opencti_type": "Email-Addr",
-            "type": "email-addr",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ]
+            "type": "email-addr"
         },
         {
             "id": "malware--d5c2c089-04db-5e3a-a694-62e266b14fef",
@@ -52,10 +46,7 @@
             "is_family": false,
             "x_opencti_id": "8b3d6843-ebf9-40dc-8925-e607ec8dd82c",
             "x_opencti_type": "Malware",
-            "type": "malware",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ]
+            "type": "malware"
         },
         {
             "id": "location--d1693b3f-fcd4-5996-aede-f78d1144c1ce",
@@ -88,10 +79,7 @@
             "x_opencti_main_observable_type": "IPv4-Addr",
             "x_opencti_id": "26b238ef-4842-4f5b-88bc-56b418a7d2ba",
             "x_opencti_type": "Indicator",
-            "type": "indicator",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ]
+            "type": "indicator"
         },
         {
             "id": "identity--efcffe42-72f2-59ef-a0db-8c532f716dbe",
@@ -130,10 +118,7 @@
             "name": "systemTest",
             "x_opencti_id": "5b75efd0-9431-47a5-9d71-3fb5d958e846",
             "x_opencti_type": "System",
-            "type": "identity",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ]
+            "type": "identity"
         },
         {
             "id": "identity--9e5e6cbd-570d-5c0f-a587-3eb6c1e8aaff",
@@ -146,21 +131,6 @@
             "name": "individualTest",
             "x_opencti_id": "85f4c4e2-53f2-4d08-8d37-b39273fb8680",
             "x_opencti_type": "Individual",
-            "type": "identity",
-            "x_opencti_granted_refs": [
-                "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd"
-            ]
-        },
-        {
-            "id": "identity--90d3f8c8-2512-586b-ac60-1f8722b6abcd",
-            "spec_version": "2.1",
-            "revoked": false,
-            "confidence": 100,
-            "created": "2024-10-03T09:12:43.360Z",
-            "modified": "2024-10-03T09:12:43.360Z",
-            "name": "Organization User 1 Test",
-            "x_opencti_id": "7a711a76-e5da-44cd-9ec8-544a6d3215a7",
-            "x_opencti_type": "Organization",
             "type": "identity"
         }
     ]

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1108;
+export const RAW_EVENTS_SIZE = 1114;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';
@@ -275,7 +275,7 @@ export const PLATFORM_ADMIN_GROUP: Group = {
 TESTING_GROUPS.push(PLATFORM_ADMIN_GROUP);
 
 // Organization
-interface Organization {
+export interface Organization {
   name: string,
   id: string
 }

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1090;
+export const RAW_EVENTS_SIZE = 1108;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* check if granted ref relation is possible for `Organization` before relation creation (to avoid backend error)
*  specified that `Organization` and `Sector` are not concerned by stix ref instead of considering all `Identity`
* add organization sharing test => 2 update organizations
* add a json report file => 8create / 8delete / )
* counters: 
* 9 create ( 1 report + 8 entites )
* 6 update (orga sharing) 
* 9 delete 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/8333


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
