### PR TITLE
[frontend] fix danger zone display in capabilities (#8284)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
@@ -33,7 +33,7 @@ const CapabilitiesList: FunctionComponent<CapabilitiesListProps> = ({
 
   return (
     <List>
-      {(isSensitiveModificationEnabled && role.can_manage_sensitive_config) && (
+      {(isSensitiveModificationEnabled && role.can_manage_sensitive_config !== false) && (
         <ListItem
           key="sensitive"
           dense={true}

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -162,7 +162,7 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
             <ListItemSecondaryAction>
               <Checkbox
                 onChange={(event) => handleSensitiveToggle(event)}
-                checked={role.can_manage_sensitive_config ? role.can_manage_sensitive_config : false}
+                checked={role.can_manage_sensitive_config !== false} // beware: undefined value means access is granted
                 style={{ color: theme.palette.dangerZone.main }}
                 disabled={false}
               />


### PR DESCRIPTION
If the flag is null or undefined, access is granted.

#8284 