### PR TITLE
wip

### DIFF
--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -261,7 +261,6 @@ describe('Indicator resolver standard behavior', () => {
     });
     console.log('firstIndicatorInternalId : ', firstIndicatorInternalId);
     console.log('queryResult.data?.indicatorFieldPatch : ', queryResult.data?.indicatorFieldPatch);
-    expect(queryResult.data?.indicatorFieldPatch.x_opencti_observables_values).toBeDefined();
   });
   it('should add relation in indicator', async () => {
     const RELATION_ADD_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -246,6 +246,23 @@ describe('Indicator resolver standard behavior', () => {
     });
     expect(queryResult.data?.indicatorContextClean.id).toEqual(firstIndicatorInternalId);
   });
+  it('should update indicator observables values on pattern edit', async () => {
+    const UPDATE_QUERY = gql`
+      mutation IndicatorFieldPatch($id: ID!, $input: [EditInput!]!) {
+        indicatorFieldPatch(id: $id, input: $input) {
+          id
+          name
+        }
+      }
+    `;
+    const queryResult = await queryAsAdminWithSuccess({
+      query: UPDATE_QUERY,
+      variables: { id: firstIndicatorInternalId, input: { key: 'pattern', value: ['[domain-name:value = \'www.payah.test\']'] } },
+    });
+    console.log('firstIndicatorInternalId : ', firstIndicatorInternalId);
+    console.log('queryResult.data?.indicatorFieldPatch : ', queryResult.data?.indicatorFieldPatch);
+    expect(queryResult.data?.indicatorFieldPatch.x_opencti_observables_values).toBeDefined();
+  });
   it('should add relation in indicator', async () => {
     const RELATION_ADD_QUERY = gql`
         mutation IndicatorRelationAdd($id: ID!, $input: StixRefRelationshipAddInput!) {

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -70,7 +70,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['external-reference'].length).toBe(1);
       expect(updateEventsByTypes['grouping'].length).toBe(3);
       expect(updateEventsByTypes['incident'].length).toBe(3);
-      expect(updateEventsByTypes['indicator'].length).toBe(4);
+      expect(updateEventsByTypes['indicator'].length).toBe(5);
       expect(updateEventsByTypes['label'].length).toBe(1);
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
@@ -82,7 +82,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(163);
+      expect(updateEvents.length).toBe(164);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1090;
+export const RAW_EVENTS_SIZE = 1091;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
Test branch for a potential bug in streams:

I have added a test that changes the pattern of an indicator. 
This naturally changes the standard stix id of the indicator.

=> error in raw stream sync.

```
{"category":"APP","errors":[{"attributes":{"genre":"BUSINESS","http_status":400},"message":"Cannot delete the stix element, indicator--ac07b543-765f-57b4-868d-6b2be61629a8 cannot be found.","name":"FUNCTIONAL_ERROR","stack":"GraphQLError: Cannot delete the stix element, indicator--ac07b543-765f-57b4-868d-6b2be61629a8 cannot be found.\n    at error (/tmp/raw-start-platform/opencti-graphql/src/config/errors.js:7:10)\n    at FunctionalError (/tmp/raw-start-platform/opencti-graphql/src/config/errors.js:94:50)\n    at stixDelete (/tmp/raw-start-platform/opencti-graphql/src/domain/stix.js:51:9)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)"}],"inner_relation_creation":0,"level":"error","message":"Cannot delete the stix element, indicator--ac07b543-765f-57b4-868d-6b2be61629a8 cannot be found.","operation":"Unspecified","query_attributes":[[{"arguments":[],"name":"delete"}]],"size":56,"source":"backend","time":6,"timestamp":"2024-10-04T13:30:33.689Z","type":"WRITE_ERROR","user":{"group_ids":["5fb5f176-131f-4db5-9515-34f71e9342ce"],"ip":"::ffff:192.168.192.12","organization_ids":[],"socket":"query","user_id":"88ec0c6a-13ce-5e39-b486-354fe4a7084f","user_metadata":{}},"version":"6.3.5"}
```