### PR TITLE
[backend] use component name in traces and fix warn issue.(#8352)(#8310)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -156,8 +156,9 @@ export const playbookExecutor = async ({
       const end = utcDate();
       const durationDiff = end.diff(start);
       const duration = moment.duration(durationDiff);
+
       const observation: ObservationFn = {
-        message: `${nextStep.component.name.trim()} successfully executed in ${duration.humanize()}`,
+        message: `${nextStep.instance.name.trim()} successfully executed in ${duration.humanize()}`,
         status: 'success',
         executionId,
         previousStepId: previousStep?.instance?.id,

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -156,7 +156,6 @@ export const playbookExecutor = async ({
       const end = utcDate();
       const durationDiff = end.diff(start);
       const duration = moment.duration(durationDiff);
-
       const observation: ObservationFn = {
         message: `${nextStep.instance.name.trim()} successfully executed in ${duration.humanize()}`,
         status: 'success',

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -110,7 +110,7 @@ const PLAYBOOK_LOGGER_COMPONENT_SCHEMA: JSONSchemaType<LoggerConfiguration> = {
       oneOf: [
         { const: 'debug', title: 'debug' },
         { const: 'info', title: 'info' },
-        { const: 'warning', title: 'warning' },
+        { const: 'warn', title: 'warn' },
         { const: 'error', title: 'error' }
       ]
     },

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -178,7 +178,6 @@ export const playbookReplaceNode = async (context: AuthContext, user: AuthUser, 
     }
     return n;
   });
-
   const patch: any = { playbook_definition: JSON.stringify(definition) };
   const { element: updatedElem } = await patchAttribute(context, user, id, ENTITY_TYPE_PLAYBOOK, patch);
   return notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].EDIT_TOPIC, updatedElem, user).then(() => nodeId);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -178,6 +178,7 @@ export const playbookReplaceNode = async (context: AuthContext, user: AuthUser, 
     }
     return n;
   });
+
   const patch: any = { playbook_definition: JSON.stringify(definition) };
   const { element: updatedElem } = await patchAttribute(context, user, id, ENTITY_TYPE_PLAYBOOK, patch);
   return notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].EDIT_TOPIC, updatedElem, user).then(() => nodeId);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix the 'warn' level
* Use component user define name in traces instead of generic component name.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #8352
* closes #8310

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
