### PR TITLE
[frontend] Enable enrichment with the selectAll of observables and stix-domain-objects of the same type (#5582)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1282,10 +1282,9 @@ class DataTableToolBar extends Component {
     this.setState((prevState) => ({ promoteToContainer: !prevState.promoteToContainer }));
   }
 
-  getSelectedTypes(observableTypes) {
-    const entityTypeFilterValues = getEntityTypeTwoFirstLevelsFilterValues(this.props.filters, observableTypes);
+  getSelectedTypes(observableTypes, domainObjectTypes) {
+    const entityTypeFilterValues = getEntityTypeTwoFirstLevelsFilterValues(this.props.filters, observableTypes, domainObjectTypes);
     const selectedElementsList = Object.values(this.props.selectedElements || {});
-
     const selectedTypes = R.uniq([...selectedElementsList.map((o) => o.entity_type), ...entityTypeFilterValues]
       .filter((entity_type) => entity_type !== undefined));
     return { entityTypeFilterValues, selectedElementsList, selectedTypes };
@@ -1325,7 +1324,8 @@ class DataTableToolBar extends Component {
       <UserContext.Consumer>
         {({ schema, settings }) => {
           const stixCyberObservableSubTypes = schema.scos.map((sco) => sco.id);
-          const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes);
+          const stixDomainObjectSubTypes = schema.sdos.map((sdo) => sdo.id);
+          const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes, stixDomainObjectSubTypes);
           // Some filter types are high level, we do not want to check them as "Different"
           // We might need to add some other types here before refactoring the toolbar
           const typesAreDifferent = (selectedTypes.filter((type) => !['Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type))).length > 1;
@@ -1342,7 +1342,7 @@ class DataTableToolBar extends Component {
                   && notScannableTypes.includes(entityTypeFilterValues[0]));
           // endregion
           // region enrich
-          const isManualEnrichSelect = !selectAll && (selectedTypes.filter((st) => !['Stix-Cyber-Observable'].includes(st))).length === 1;
+          const isManualEnrichSelect = !selectAll && (selectedTypes.filter((st) => !['Stix-Cyber-Observable', 'Stix-Domain-Object'].includes(st))).length === 1;
           const isAllEnrichSelect = selectAll
               && entityTypeFilterValues.length === 1
               && entityTypeFilterValues[0] !== 'Stix-Cyber-Observable'

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -203,7 +203,7 @@ export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup) =
 // exemple: Observable AND (Domain-Name) --> [Domain-Name]
 // exemple: Domain-Name OR Observable --> [Domain-Name, Observable]
 // exemple: Stix-Domain-Object AND (Malware OR (Country AND Location)) --> [Stix-Domain-Object, Malware]
-export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, observableTypes?: string[]) => {
+export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, observableTypes?: string[], domainObjectTypes?: string []) => {
   if (!filters) {
     return [];
   }
@@ -216,6 +216,9 @@ export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, o
       // if all second values are observables sub types : remove observable from firstLevelValue
       if (secondLevelValues.every((type) => observableTypes?.includes(type))) {
         firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Cyber-Observable');
+      }
+      if (secondLevelValues.every((type) => domainObjectTypes?.includes(type))) {
+        firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Domain-Object');
       }
       return [...firstLevelValues, ...secondLevelValues];
     }

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -210,9 +210,9 @@ export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, o
   let firstLevelValues = findFilterFromKey(filters.filters, 'entity_type', 'eq')?.values ?? [];
 
   if (filters.mode === 'and') {
-    const subFilters = filters.filterGroups.map((fg) => fg.filters).flat();
-    if (subFilters.length > 0) {
-      const secondLevelValues = findFilterFromKey(subFilters, 'entity_type', 'eq')?.values ?? [];
+    const subFiltersSeparatedWithAnd = filters.filterGroups.filter((fg) => fg.mode === 'and').map((fg) => fg.filters).flat();
+    if (subFiltersSeparatedWithAnd.length > 0) {
+      const secondLevelValues = findFilterFromKey(subFiltersSeparatedWithAnd, 'entity_type', 'eq')?.values ?? [];
       // if all second values are observables sub types : remove observable from firstLevelValue
       if (secondLevelValues.every((type) => observableTypes?.includes(type))) {
         firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Cyber-Observable');

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -198,6 +198,31 @@ export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup) =
   return inputFilters;
 };
 
+// fetch the entity type filters possible values of first and second levels
+// and remove Observable if the filters target only some sub observable types
+// exemple: Observable AND (Domain-Name) --> [Domain-Name]
+// exemple: Domain-Name OR Observable --> [Domain-Name, Observable]
+// exemple: Stix-Domain-Object AND (Malware OR (Country AND Location)) --> [Stix-Domain-Object, Malware]
+export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, observableTypes?: string[]) => {
+  if (!filters) {
+    return [];
+  }
+  let firstLevelValues = findFilterFromKey(filters.filters, 'entity_type', 'eq')?.values ?? [];
+
+  if (filters.mode === 'and') {
+    const subFilters = filters.filterGroups.map((fg) => fg.filters).flat();
+    if (subFilters.length > 0) {
+      const secondLevelValues = findFilterFromKey(subFilters, 'entity_type', 'eq')?.values ?? [];
+      // if all second values are observables sub types : remove observable from firstLevelValue
+      if (secondLevelValues.every((type) => observableTypes?.includes(type))) {
+        firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Cyber-Observable');
+      }
+      return [...firstLevelValues, ...secondLevelValues];
+    }
+  }
+  return firstLevelValues;
+};
+
 // construct filters and options for widgets
 export const buildFiltersAndOptionsForWidgets = (
   inputFilters: FilterGroup | undefined,

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -202,17 +202,19 @@ export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup) =
 // and remove Observable if the filters target only some sub observable types
 // exemple: Observable AND (Domain-Name) --> [Domain-Name]
 // exemple: Domain-Name OR Observable --> [Domain-Name, Observable]
-// exemple: Stix-Domain-Object AND (Malware OR (Country AND Location)) --> [Stix-Domain-Object, Malware]
+// exemple: Stix-Domain-Object AND (Malware OR (Country AND City)) --> [Stix-Domain-Object, Malware]
 export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, observableTypes?: string[], domainObjectTypes?: string []) => {
   if (!filters) {
     return [];
   }
   let firstLevelValues = findFilterFromKey(filters.filters, 'entity_type', 'eq')?.values ?? [];
-
-  if (filters.mode === 'and') {
-    const subFiltersSeparatedWithAnd = filters.filterGroups.filter((fg) => fg.mode === 'and').map((fg) => fg.filters).flat();
-    if (subFiltersSeparatedWithAnd.length > 0) {
-      const secondLevelValues = findFilterFromKey(subFiltersSeparatedWithAnd, 'entity_type', 'eq')?.values ?? [];
+  const subFiltersSeparatedWithAnd = filters.filterGroups
+    .filter((fg) => fg.mode === 'and' || (fg.mode === 'or' && fg.filters.length === 1))
+    .map((fg) => fg.filters)
+    .flat();
+  if (subFiltersSeparatedWithAnd.length > 0) {
+    const secondLevelValues = findFilterFromKey(subFiltersSeparatedWithAnd, 'entity_type', 'eq')?.values ?? [];
+    if (filters.mode === 'and') {
       // if all second values are observables sub types : remove observable from firstLevelValue
       if (secondLevelValues.every((type) => observableTypes?.includes(type))) {
         firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Cyber-Observable');
@@ -220,8 +222,8 @@ export const getEntityTypeTwoFirstLevelsFilterValues = (filters?: FilterGroup, o
       if (secondLevelValues.every((type) => domainObjectTypes?.includes(type))) {
         firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Domain-Object');
       }
-      return [...firstLevelValues, ...secondLevelValues];
     }
+    return [...firstLevelValues, ...secondLevelValues];
   }
   return firstLevelValues;
 };

--- a/opencti-platform/opencti-front/src/utils/tests/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/filtersUtils.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import React from 'react';
-import { useBuildFilterKeysMapFromEntityType } from '../filters/filtersUtils';
+import { getEntityTypeTwoFirstLevelsFilterValues, useBuildFilterKeysMapFromEntityType } from '../filters/filtersUtils';
 import { createMockUserContext, ProvidersWrapper, ProvidersWrapperProps } from './test-render';
 import { BYPASS } from '../hooks/useGranted';
 import filterKeysSchema from './FilterUtilsConstants';
@@ -42,6 +42,140 @@ describe('Filters utils', () => {
       };
       const { result } = renderHook(() => useBuildFilterKeysMapFromEntityType(entityTypes), { wrapper });
       expect(result.current).toStrictEqual(filterKeysSchema.get(stixCoreObjectKey));
+    });
+  });
+
+  describe('getEntityTypeTwoFirstLevelsFilterValues', () => {
+    it('should return only observable subtypes when filter with AND Observables', () => {
+      // filters: Observable AND Domain-Name
+      // result: Domain-Name
+      const filters = {
+        mode: 'and',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] }],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [{ key: 'entity_type', operator: 'eq', values: ['Domain-Name'] }],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
+      expect(result).toEqual(['Domain-Name']);
+    });
+
+    it('should return both the observable subtypes and observable when filter with OR Observables and filter groups', () => {
+      // filters: Observable OR Domain-Name
+      // result: Observable, Domain-Name
+      const filters = {
+        mode: 'or',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] }],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: 'entity_type', operator: 'eq', values: ['Domain-Name'] },
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
+      expect(result).toEqual(['Stix-Cyber-Observable', 'Domain-Name']);
+    });
+
+    it('should return both the observable subtypes and observable when filter with OR Observables', () => {
+      // filters: Domain-Name OR Observable
+      // result: Domain-Name, Observable
+      const filters = {
+        mode: 'or',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Domain-Name', 'Stix-Cyber-Observable'] }],
+        filterGroups: [],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
+      expect(result).toEqual(['Domain-Name', 'Stix-Cyber-Observable']);
+    });
+
+    it('should return only observable subtypes when filter with AND Observables and filter groups', () => {
+      // filters: Observable AND (Domain-Name AND label=label1)
+      // result: Domain-Name
+      const filters = {
+        mode: 'and',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] }],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: 'entity_type', operator: 'eq', values: ['Domain-Name'] },
+              { key: 'objectLabel', operator: 'eq', values: ['label1'] },
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
+      expect(result).toEqual(['Domain-Name']);
+    });
+
+    it('should return only observable when filter with OR Observables and filter groups', () => {
+      // filters: Observable AND (Domain-Name OR label=label1)
+      // result: Observable
+      const filters = {
+        mode: 'and',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] }],
+        filterGroups: [
+          {
+            mode: 'or',
+            filters: [
+              { key: 'entity_type', operator: 'eq', values: ['Domain-Name'] },
+              { key: 'objectLabel', operator: 'eq', values: ['label1'] },
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
+      expect(result).toEqual(['Stix-Cyber-Observable']);
+    });
+
+    it('should return only observable subtypes when filter with AND Observables', () => {
+      // filters: Observable AND (Domain-Name OR File)
+      // result: Domain-Name, File
+      const filters = {
+        mode: 'and',
+        filters: [
+          { key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] },
+        ],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: 'entity_type', operator: 'eq', values: ['Domain-Name', 'File'] },
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
+      expect(result).toEqual(['Domain-Name', 'File']);
+    });
+
+    it('should return only the domain subtype when filter with OR and only one type is provided', () => {
+      // filters: Stix-Domain-Object AND Malware
+      // result: Malware
+      const filters = {
+        mode: 'and',
+        filters: [{ key: 'entity_type', operator: 'eq', values: ['Stix-Domain-Object'] }],
+        filterGroups: [
+          {
+            mode: 'or',
+            filters: [{ key: 'entity_type', operator: 'eq', values: ['Malware'] }],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Malware', 'Artifact', 'Country', 'City']);
+      expect(result).toEqual(['Malware']);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Enable several observables with the same entity-type to be enriched.
* Same in Data / Entities with Stix-Domain-Object.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/5582


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
