### PR TITLE
[frontend] Containers list in Analysis tab of Organization display as Author (#8681)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
@@ -54,9 +54,9 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
   } = useAuth();
   const isRuntimeSort = isRuntimeFieldEnable() ?? false;
   const LOCAL_STORAGE_KEY = `containers${
-    stixDomainObjectOrStixCoreRelationship
-      ? `-${stixDomainObjectOrStixCoreRelationship.id}`
-      : `-${authorId}`
+    authorId
+      ? `-${authorId}`
+      : `-${stixDomainObjectOrStixCoreRelationship.id}`
   }`;
 
   const { viewStorage, paginationOptions, helpers } = usePaginationLocalStorage(
@@ -91,7 +91,7 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
       { key: 'entity_type', operator: 'eq', mode: 'or', values: ['Container'] },
       ...(reportFilterClass ? [{ key: 'report_types', values: [reportFilterClass], operator: 'eq', mode: 'or' }] : []),
       ...(authorId ? [{ key: 'createdBy', values: [authorId], operator: 'eq', mode: 'or' }] : []),
-      ...(stixDomainObjectOrStixCoreRelationship?.id ? [{ key: 'objects', values: [stixDomainObjectOrStixCoreRelationship.id], operator: 'eq', mode: 'or' }] : []),
+      ...(!authorId && stixDomainObjectOrStixCoreRelationship?.id ? [{ key: 'objects', values: [stixDomainObjectOrStixCoreRelationship.id], operator: 'eq', mode: 'or' }] : []),
     ],
     filterGroups: userFilters && isFilterGroupNotEmpty(userFilters) ? [userFilters] : [],
   };
@@ -165,6 +165,7 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
         filters={filters}
         paginationOptions={queryPaginationOptions}
         numberOfElements={numberOfElements}
+        setNumberOfElements={helpers.handleSetNumberOfElements}
         disableCards={true}
         enableGraph={true}
       >


### PR DESCRIPTION
### Proposed changes
In the Analysis tab of an Organization display as Author : display the list of the containers whose author is the organization 
Former behavior:  display the list of the containers whose author is the organization and that are contained in the organization

### Complete behavior
 in the Analysis tab of an Organization, we should have :
- if organization display as Author : the containers that have the organization has author (and not the containers that contain the organization)
- if organization display as Knowledge : only the containers that contain the organization

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8681
