### PR TITLE
[frontend] Add defaultStartTime and stopTime for StixCoreRelationship creation (#8575)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -456,6 +456,9 @@ class GroupingKnowledgeGraphBar extends Component {
         : [selectedNodes[0]];
     }
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
+
+    const defaultTime = now();
+
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => (
@@ -986,10 +989,10 @@ class GroupingKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
+                          lastLinkFirstSeen || minutesBefore(1, defaultTime)
                         }
                         stopTime={
-                          lastLinkLastSeen || now()
+                          lastLinkLastSeen || defaultTime
                         }
                         confidence={grouping.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -986,10 +986,10 @@ class GroupingKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || dateFormat(grouping.published)
+                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
                         }
                         stopTime={
-                          lastLinkLastSeen || dateFormat(grouping.published)
+                          lastLinkLastSeen || now()
                         }
                         confidence={grouping.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -459,6 +459,7 @@ class ReportKnowledgeGraphBar extends Component {
         : [selectedNodes[0]];
     }
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
+    const defaultTime = now();
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => (
@@ -989,10 +990,10 @@ class ReportKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
+                          lastLinkFirstSeen || minutesBefore(1, defaultTime)
                         }
                         stopTime={
-                          lastLinkLastSeen || now()
+                          lastLinkLastSeen || defaultTime
                         }
                         confidence={report.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -989,10 +989,10 @@ class ReportKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || dateFormat(report.published)
+                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
                         }
                         stopTime={
-                          lastLinkLastSeen || dateFormat(report.published)
+                          lastLinkLastSeen || now()
                         }
                         confidence={report.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -459,6 +459,9 @@ class IncidentKnowledgeGraphBar extends Component {
         : [selectedNodes[0]];
     }
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
+
+    const defaultTime = now();
+
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => (
@@ -992,10 +995,10 @@ class IncidentKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
+                          lastLinkFirstSeen || minutesBefore(1, defaultTime)
                         }
                         stopTime={
-                          lastLinkLastSeen || now()
+                          lastLinkLastSeen || defaultTime
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -992,10 +992,10 @@ class IncidentKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || dateFormat(caseData.published)
+                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
                         }
                         stopTime={
-                          lastLinkLastSeen || dateFormat(caseData.published)
+                          lastLinkLastSeen || now()
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -989,10 +989,10 @@ class CaseRfiKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || dateFormat(caseData.published)
+                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
                         }
                         stopTime={
-                          lastLinkLastSeen || dateFormat(caseData.published)
+                          lastLinkLastSeen || now()
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -459,6 +459,9 @@ class CaseRfiKnowledgeGraphBar extends Component {
         : [selectedNodes[0]];
     }
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
+
+    const defaultTime = now();
+
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => (
@@ -989,10 +992,10 @@ class CaseRfiKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
+                          lastLinkFirstSeen || minutesBefore(1, defaultTime)
                         }
                         stopTime={
-                          lastLinkLastSeen || now()
+                          lastLinkLastSeen || defaultTime
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -459,6 +459,9 @@ class CaseRftKnowledgeGraphBar extends Component {
         : [selectedNodes[0]];
     }
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
+
+    const defaultTime = now();
+
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => (
@@ -989,10 +992,10 @@ class CaseRftKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
+                          lastLinkFirstSeen || minutesBefore(1, defaultTime)
                         }
                         stopTime={
-                          lastLinkLastSeen || now()
+                          lastLinkLastSeen || defaultTime
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -46,7 +46,7 @@ import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/st
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -989,10 +989,10 @@ class CaseRftKnowledgeGraphBar extends Component {
                         fromObjects={relationFromObjects}
                         toObjects={relationToObjects}
                         startTime={
-                          lastLinkFirstSeen || dateFormat(caseData.published)
+                          lastLinkFirstSeen || validStartTimeForRelationCreation(now())
                         }
                         stopTime={
-                          lastLinkLastSeen || dateFormat(caseData.published)
+                          lastLinkLastSeen || now()
                         }
                         confidence={caseData.confidence}
                         handleClose={this.handleCloseCreateRelationship.bind(

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.js
@@ -22,6 +22,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
+import { minutesBefore, now } from '../../../../utils/Time';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -138,13 +139,15 @@ const StixCoreRelationshipCreationForm = ({
       ? 'related-to'
       : '';
 
+  const defaultTime = now();
+
   const initialValues = useDefaultValues(
     STIX_CORE_RELATIONSHIP_TYPE,
     {
       relationship_type: defaultRelationshipType,
       confidence: defaultConfidence,
-      start_time: !isNone(defaultStartTime) ? defaultStartTime : null,
-      stop_time: !isNone(defaultStopTime) ? defaultStopTime : null,
+      start_time: !isNone(defaultStartTime) ? defaultStartTime : minutesBefore(1, defaultTime),
+      stop_time: !isNone(defaultStopTime) ? defaultStopTime : defaultTime,
       description: '',
       killChainPhases: [],
       externalReferences: [],

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -21,7 +21,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';
 import { itemColor } from '../../../../utils/Colors';
-import { dayStartDate, parse } from '../../../../utils/Time';
+import { minutesBefore, now, parse } from '../../../../utils/Time';
 import ItemIcon from '../../../../components/ItemIcon';
 import SelectField from '../../../../components/fields/SelectField';
 import StixNestedRefRelationCreationFromEntityLines, { stixNestedRefRelationshipCreationFromEntityLinesQuery } from './StixNestedRefRelationshipCreationFromEntityLines';
@@ -701,10 +701,12 @@ const StixNestedRefRelationshipCreationFromEntity = ({
     // nested objects with different entity type will soon be implemented
     if (!isSameEntityType) relationshipTypes = [];
     const defaultRelationshipType = R.head(relationshipTypes);
+
+    const defaultTime = now();
     const initialValues = {
       relationship_type: defaultRelationshipType,
-      start_time: dayStartDate(),
-      stop_time: dayStartDate(),
+      start_time: minutesBefore(1, defaultTime),
+      stop_time: defaultTime,
     };
 
     return (

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
@@ -47,7 +47,7 @@ import { parseDomain } from '../../../../utils/Graph';
 import { INVESTIGATION_INUPDATE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { truncate } from '../../../../utils/String';
-import { dateFormat } from '../../../../utils/Time';
+import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -918,8 +918,8 @@ class InvestigationGraphBar extends Component {
                           open={openCreatedRelation}
                           fromObjects={relationFromObjects}
                           toObjects={relationToObjects}
-                          startTime={lastLinkFirstSeen || null}
-                          stopTime={lastLinkLastSeen || null}
+                          startTime={lastLinkFirstSeen || validStartTimeForRelationCreation(now())}
+                          stopTime={lastLinkLastSeen || now()}
                           confidence={50}
                           handleClose={this.handleCloseCreateRelationship.bind(
                             this,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraphBar.jsx
@@ -47,7 +47,7 @@ import { parseDomain } from '../../../../utils/Graph';
 import { INVESTIGATION_INUPDATE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { truncate } from '../../../../utils/String';
-import { dateFormat, now, validStartTimeForRelationCreation } from '../../../../utils/Time';
+import { dateFormat, minutesBefore, now } from '../../../../utils/Time';
 import StixCoreRelationshipCreation from '../../common/stix_core_relationships/StixCoreRelationshipCreation';
 import StixCoreRelationshipEdition from '../../common/stix_core_relationships/StixCoreRelationshipEdition';
 import StixDomainObjectEdition from '../../common/stix_domain_objects/StixDomainObjectEdition';
@@ -357,6 +357,8 @@ class InvestigationGraphBar extends Component {
     const stixCoreObjectOrRelationshipId = (selectedNodes[0]?.id ?? null) || (selectedLinks[0]?.id ?? null);
 
     const isRollBackToLastPreExpansionStateDisabled = !getPreExpansionStateList();
+
+    const defaultTime = now();
 
     return (
       <UserContext.Consumer>
@@ -918,8 +920,8 @@ class InvestigationGraphBar extends Component {
                           open={openCreatedRelation}
                           fromObjects={relationFromObjects}
                           toObjects={relationToObjects}
-                          startTime={lastLinkFirstSeen || validStartTimeForRelationCreation(now())}
-                          stopTime={lastLinkLastSeen || now()}
+                          startTime={lastLinkFirstSeen || minutesBefore(1, defaultTime)}
+                          stopTime={lastLinkLastSeen || defaultTime}
                           confidence={50}
                           handleClose={this.handleCloseCreateRelationship.bind(
                             this,

--- a/opencti-platform/opencti-front/src/utils/Time.js
+++ b/opencti-platform/opencti-front/src/utils/Time.js
@@ -82,6 +82,12 @@ export const dateFormat = (data, specificFormat = null) => {
     : '';
 };
 
+export const validStartTimeForRelationCreation = (time) => {
+  const date = new Date(time);
+  date.setMinutes(date.getMinutes() - 1);
+  return date.toISOString();
+};
+
 export const formatTimeForToday = (time) => {
   const today = dateFormat(new Date(), 'YYYY-MM-DD');
   return `${today}T${time}`;

--- a/opencti-platform/opencti-front/src/utils/Time.js
+++ b/opencti-platform/opencti-front/src/utils/Time.js
@@ -82,12 +82,6 @@ export const dateFormat = (data, specificFormat = null) => {
     : '';
 };
 
-export const validStartTimeForRelationCreation = (time) => {
-  const date = new Date(time);
-  date.setMinutes(date.getMinutes() - 1);
-  return date.toISOString();
-};
-
 export const formatTimeForToday = (time) => {
   const today = dateFormat(new Date(), 'YYYY-MM-DD');
   return `${today}T${time}`;


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add default value for relation ship creation from knowledge graph and investigation graph
* remove 1 minute to make sure startime and stoptime are different

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #https://github.com/OpenCTI-Platform/opencti/issues/8575

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
