### PR TITLE
[backend] deduplication check is now done with SYSTEM user (#8740)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1919,7 +1919,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
     if (aliasedInputs.length > 0) {
       const aliases = R.uniq(aliasedInputs.map((a) => a.value).flat().filter((a) => isNotEmptyField(a)).map((a) => a.trim()));
       const aliasesIds = generateAliasesId(aliases, initial);
-      const existingEntities = await internalFindByIds(context, user, aliasesIds, { type: initial.entity_type });
+      const existingEntities = await internalFindByIds(context, SYSTEM_USER, aliasesIds, { type: initial.entity_type });
       const differentEntities = R.filter((e) => e.internal_id !== initial.internal_id, existingEntities);
       if (differentEntities.length > 0) {
         throw FunctionalError('This update will produce a duplicate', {
@@ -1956,10 +1956,10 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
     let existingEntityPromise = Promise.resolve(undefined);
     let existingByHashedPromise = Promise.resolve([]);
     if (eventualNewStandardId) {
-      existingEntityPromise = internalLoadById(context, user, eventualNewStandardId, { type: initial.entity_type });
+      existingEntityPromise = internalLoadById(context, SYSTEM_USER, eventualNewStandardId, { type: initial.entity_type });
     }
     if (isStixCyberObservableHashedObservable(initial.entity_type)) {
-      existingByHashedPromise = listEntitiesByHashes(context, user, initial.entity_type, updated.hashes)
+      existingByHashedPromise = listEntitiesByHashes(context, SYSTEM_USER, initial.entity_type, updated.hashes)
         .then((entities) => entities.filter((e) => e.id !== initial.internal_id));
     }
     const [existingEntity, existingByHashed] = await Promise.all([existingEntityPromise, existingByHashedPromise]);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -1403,7 +1403,7 @@ describe('Elements deduplication behaviors', () => {
       name: group1Name,
       objectMarking: [WHITE_TLP.standard_id],
     };
-    await createThreat(sourceGroup1);
+    const group1 = await createThreat(sourceGroup1);
     // group 2
     const sourceGroup2 = {
       name: group2Name,
@@ -1411,10 +1411,15 @@ describe('Elements deduplication behaviors', () => {
     };
     const group2 = await createThreat(sourceGroup2);
 
+    // Update should be prevented by deduplication
     const inputUpdate = { key: 'name', value: [group1Name] };
     const update = () => updateAttribute(testContext, WHITE_USER, group2.id, ENTITY_TYPE_THREAT_ACTOR_GROUP, [inputUpdate]);
     await expect(update()).rejects.toEqual(
       new GraphQLError('This update will produce a duplicate')
     );
+
+    // Cleanup
+    await deleteElementById(testContext, ADMIN_USER, group1.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
+    await deleteElementById(testContext, ADMIN_USER, group2.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -1391,3 +1391,30 @@ describe('Elements upsert behaviors', () => {
     await deleteElementById(testContext, ADMIN_USER, stixId, ENTITY_TYPE_MALWARE);
   });
 });
+describe('Elements deduplication behaviors', () => {
+  it('should prevent update resulting in duplicate entities', async () => {
+    const WHITE_TLP = { standard_id: 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9', internal_id: null };
+    const WHITE_USER = buildStandardUser([WHITE_TLP]);
+    const greenMarking = 'marking-definition--34098fce-860f-48ae-8e50-ebd3cc5e41da';
+    const group1Name = 'THREAT_NAME_1';
+    const group2Name = 'THREAT_NAME_2';
+    // group 1
+    const sourceGroup1 = {
+      name: group1Name,
+      objectMarking: [WHITE_TLP.standard_id],
+    };
+    await createThreat(sourceGroup1);
+    // group 2
+    const sourceGroup2 = {
+      name: group2Name,
+      objectMarking: [greenMarking],
+    };
+    const group2 = await createThreat(sourceGroup2);
+
+    const inputUpdate = { key: 'name', value: [group1Name] };
+    const update = () => updateAttribute(testContext, WHITE_USER, group2.id, ENTITY_TYPE_THREAT_ACTOR_GROUP, [inputUpdate]);
+    await expect(update()).rejects.toEqual(
+      new GraphQLError('This update will produce a duplicate')
+    );
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -29,7 +29,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.sighting.length).toBe(4);
       expect(createEventsByTypes.indicator.length).toBe(37);
       expect(createEventsByTypes['attack-pattern'].length).toBe(9);
-      expect(createEventsByTypes['threat-actor'].length).toBe(13);
+      expect(createEventsByTypes['threat-actor'].length).toBe(15);
       expect(createEventsByTypes['observed-data'].length).toBe(1);
       expect(createEventsByTypes['tracking-number'].length).toBe(1);
       expect(createEventsByTypes.credential.length).toBe(1);
@@ -46,7 +46,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(342); // 328 created at init + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(795);
+      expect(createEvents.length).toBe(797);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -95,7 +95,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(146);
+      expect(deleteEvents.length).toBe(148);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1122;
+export const RAW_EVENTS_SIZE = 1126;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* deduplication check was done with user, causing duplicated entities not accessible to the user to not be taken into account. Deduplication check is now done with SYSTEM user to prevent that

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8740

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
