### PR TITLE
[backend] Make pattern upsertable for rename platform sync

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -23,8 +23,8 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
   attributes: [
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
-    { name: 'pattern_type', label: 'Pattern type', type: 'string', format: 'vocabulary', vocabularyCategory: 'pattern_type_ov', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
-    { name: 'pattern_version', label: 'Pattern version', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'pattern_type', label: 'Pattern type', type: 'string', format: 'vocabulary', vocabularyCategory: 'pattern_type_ov', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'pattern_version', label: 'Pattern version', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
     { name: 'pattern', label: 'Pattern', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'indicator_types', label: 'Indicator types', type: 'string', format: 'vocabulary', vocabularyCategory: 'indicator_type_ov', mandatoryType: 'customizable', editDefault: true, multiple: true, upsert: true, isFilterable: true },
     { name: 'valid_from', label: 'Valid from', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -25,7 +25,7 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'pattern_type', label: 'Pattern type', type: 'string', format: 'vocabulary', vocabularyCategory: 'pattern_type_ov', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     { name: 'pattern_version', label: 'Pattern version', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'pattern', label: 'Pattern', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
+    { name: 'pattern', label: 'Pattern', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'indicator_types', label: 'Indicator types', type: 'string', format: 'vocabulary', vocabularyCategory: 'indicator_type_ov', mandatoryType: 'customizable', editDefault: true, multiple: true, upsert: true, isFilterable: true },
     { name: 'valid_from', label: 'Valid from', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'valid_until', label: 'Valid until', type: 'date', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -107,6 +107,8 @@ const UPDATE_QUERY = gql`
     indicatorFieldPatch(id: $id, input: $input) {
       id
       name
+      standard_id
+      pattern
     }
   }
 `;
@@ -114,7 +116,7 @@ const UPDATE_QUERY = gql`
 describe('Indicator resolver standard behavior', () => {
   let firstIndicatorInternalId: string;
   let secondIndicatorInternalId: string;
-  const indicatorStixId = 'indicator--f6ad652c-166a-43e6-98b8-8ff078e2349f';
+  let indicatorStixId = 'indicator--f6ad652c-166a-43e6-98b8-8ff078e2349f';
   const indicatorForTestName = 'Indicator in indicator-test';
 
   it('should indicator created', async () => {
@@ -242,6 +244,16 @@ describe('Indicator resolver standard behavior', () => {
       variables: { id: firstIndicatorInternalId, input: { key: 'name', value: ['Indicator - test'] } },
     });
     expect(queryResult.data?.indicatorFieldPatch.name).toEqual('Indicator - test');
+  });
+  it('should update indicator pattern, causing change in stix id', async () => {
+    const queryResult = await queryAsAdminWithSuccess({
+      query: UPDATE_QUERY,
+      variables: { id: firstIndicatorInternalId, input: { key: 'pattern', value: ["[domain-name:value = 'www.newvalue.com']"] } },
+    });
+    const newIndicator = queryResult.data?.indicatorFieldPatch;
+    expect(newIndicator?.pattern).toEqual("[domain-name:value = 'www.newvalue.com']");
+    expect(newIndicator?.standard_id).not.toEqual(indicatorStixId);
+    indicatorStixId = newIndicator?.standard_id; // update id for next tests
   });
   it('should context patch indicator', async () => {
     const CONTEXT_PATCH_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -70,7 +70,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['external-reference'].length).toBe(1);
       expect(updateEventsByTypes['grouping'].length).toBe(3);
       expect(updateEventsByTypes['incident'].length).toBe(3);
-      expect(updateEventsByTypes['indicator'].length).toBe(5);
+      expect(updateEventsByTypes['indicator'].length).toBe(6);
       expect(updateEventsByTypes['label'].length).toBe(1);
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
@@ -82,7 +82,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(174);
+      expect(updateEvents.length).toBe(175);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1131;
+export const RAW_EVENTS_SIZE = 1132;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -29,7 +29,7 @@ export const queryAsAdminWithSuccess = async (request: { query: any, variables: 
   if (requestResult.errors) {
     logApp.info('Unexpected error; requestResult:', { requestResult });
   }
-  expect(requestResult.errors, `This errors should not be there: ${requestResult.errors}`).toBeUndefined();
+  expect(requestResult.errors, `This errors should not be there: ${JSON.stringify(requestResult.errors)}`).toBeUndefined();
   return requestResult;
 };
 
@@ -42,7 +42,7 @@ export const adminQueryWithSuccess = async (request: { query: any, variables: an
   if (requestResult.errors) {
     logApp.info('Unexpected error; requestResult:', { requestResult });
   }
-  expect(requestResult.errors, `This errors should not be there: ${requestResult.errors}`).toBeUndefined();
+  expect(requestResult.errors, `This errors should not be there: ${JSON.stringify(requestResult.errors)}`).toBeUndefined();
   return requestResult;
 };
 


### PR DESCRIPTION
### Proposed changes

* make the stix pattern of the observables upsertable, to solve change in stixid not properly send into stream sync

### Related issues
Closes #8611

See this issue for repro case.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
