### PR TITLE
[frontend] Fix delete button behaviour

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReference.tsx
@@ -49,7 +49,7 @@ ExternalReferenceComponentProps
       <ExternalReferenceHeader
         externalReference={externalReference}
         PopoverComponent={
-          <ExternalReferencePopover id={externalReference.id} handleRemove={undefined} />
+          <ExternalReferencePopover id={externalReference.id} handleRemove={undefined} variant={'inLine'}/>
         }
         EditComponent={isFABReplaced && (
           <Security needs={[KNOWLEDGE_KNUPDATE]}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionContainer.jsx
@@ -5,7 +5,6 @@ import { useFormatter } from '../../../../components/i18n';
 import GroupingEditionOverview from './GroupingEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useHelper from '../../../../utils/hooks/useHelper';
-import GroupingDeletion from './GroupingDeletion';
 
 const GroupingEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
@@ -30,11 +29,6 @@ const GroupingEditionContainer = (props) => {
           context={editContext}
           handleClose={handleClose}
         />
-        {isFABReplaced && (
-          <GroupingDeletion
-            groupingId={grouping.id}
-          />
-        )}
       </>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import GroupingDeletion from './GroupingDeletion';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
@@ -19,6 +20,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const groupingMutationFieldPatch = graphql`
   mutation GroupingEditionOverviewFieldPatchMutation(
@@ -85,6 +87,8 @@ const GROUPING_TYPE = 'Grouping';
 const GroupingEditionOverviewComponent = (props) => {
   const { grouping, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { mandatoryAttributes } = useIsMandatoryAttribute(GROUPING_TYPE);
 
@@ -288,16 +292,23 @@ const GroupingEditionOverviewComponent = (props) => {
               setFieldValue={setFieldValue}
               onChange={editor.changeMarking}
             />
-            {enableReferences && (
-              <CommitMessage
-                submitForm={submitForm}
-                disabled={isSubmitting || !isValid || !dirty}
-                setFieldValue={setFieldValue}
-                open={false}
-                values={values.references}
-                id={grouping.id}
-              />
-            )}
+            <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+              {isFABReplaced && (
+                <GroupingDeletion
+                  groupingId={grouping.id}
+                />
+              )}
+              {enableReferences && (
+                <CommitMessage
+                  submitForm={submitForm}
+                  disabled={isSubmitting || !isValid || !dirty}
+                  setFieldValue={setFieldValue}
+                  open={false}
+                  values={values.references}
+                  id={grouping.id}
+                />
+              )}
+            </div>
           </Form>
         </div>
       )}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -293,11 +293,12 @@ const GroupingEditionOverviewComponent = (props) => {
               onChange={editor.changeMarking}
             />
             <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-              {isFABReplaced && (
-                <GroupingDeletion
-                  groupingId={grouping.id}
-                />
-              )}
+              {isFABReplaced
+                ? <GroupingDeletion
+                    groupingId={grouping.id}
+                  />
+                : <div/>
+              }
               {enableReferences && (
                 <CommitMessage
                   submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionContainer.tsx
@@ -9,14 +9,12 @@ import {
 } from '@components/analyses/malware_analyses/__generated__/MalwareAnalysisEditionOverview_malwareAnalysis.graphql';
 import { MalwareAnalysisEditionDetails_malwareAnalysis$key } from '@components/analyses/malware_analyses/__generated__/MalwareAnalysisEditionDetails_malwareAnalysis.graphql';
 import useHelper from 'src/utils/hooks/useHelper';
-import { useParams } from 'react-router-dom';
 import { useFormatter } from '../../../../components/i18n';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import MalwareAnalysisEditionOverview from './MalwareAnalysisEditionOverview';
 import { MalwareAnalysisEditionContainerQuery } from './__generated__/MalwareAnalysisEditionContainerQuery.graphql';
 import MalwareAnalysisEditionDetails from './MalwareAnalysisEditionDetails';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import MalwareAnalysisDeletion from './MalwareAnalysisDeletion';
 
 interface MalwareAnalysisEditionContainerProps {
   queryRef: PreloadedQuery<MalwareAnalysisEditionContainerQuery>
@@ -46,7 +44,6 @@ const MalwareAnalysisEditionContainer: FunctionComponent<MalwareAnalysisEditionC
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const { malwareAnalysisId } = useParams() as { malwareAnalysisId: string };
   const { malwareAnalysis } = usePreloadedQuery(malwareAnalysisEditionQuery, queryRef);
 
   const [currentTab, setCurrentTab] = useState(0);
@@ -90,9 +87,6 @@ const MalwareAnalysisEditionContainer: FunctionComponent<MalwareAnalysisEditionC
               enableReferences={useIsEnforceReference('Malware-Analysis')}
               handleClose={onClose}
             />
-          )}
-          {isFABReplaced && (
-            <MalwareAnalysisDeletion id={malwareAnalysisId} />
           )}
         </>
       )}

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
+import MalwareAnalysisDeletion from '@components/analyses/malware_analyses/MalwareAnalysisDeletion';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -25,6 +26,7 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import { parse } from '../../../../utils/Time';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionOverviewFieldPatchMutation(
@@ -144,6 +146,10 @@ MalwareAnalysisEditionOverviewProps
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
+
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+
   const { mandatoryAttributes } = useIsMandatoryAttribute(MALWARE_ANALYSIS_TYPE);
   const basicShape = yupShapeConditionalRequired({
     product: Yup.string(),
@@ -372,16 +378,21 @@ MalwareAnalysisEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting}
-            setFieldValue={setFieldValue}
-            values={values.references}
-            id={malwareAnalysis.id}
-            open={false}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <MalwareAnalysisDeletion id={malwareAnalysis.id} />
+            )}
+            {enableReferences && (
+            <CommitMessage
+              submitForm={submitForm}
+              disabled={isSubmitting}
+              setFieldValue={setFieldValue}
+              values={values.references}
+              id={malwareAnalysis.id}
+              open={false}
+            />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionOverview.tsx
@@ -379,9 +379,10 @@ MalwareAnalysisEditionOverviewProps
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <MalwareAnalysisDeletion id={malwareAnalysis.id} />
-            )}
+            {isFABReplaced
+              ? <MalwareAnalysisDeletion id={malwareAnalysis.id}/>
+              : <div/>
+              }
             {enableReferences && (
             <CommitMessage
               submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionContainer.jsx
@@ -5,7 +5,6 @@ import { useFormatter } from '../../../../components/i18n';
 import ReportEditionOverview from './ReportEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
-import ReportDeletion from './ReportDeletion';
 
 const ReportEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
@@ -31,11 +30,6 @@ const ReportEditionContainer = (props) => {
           context={editContext}
           handleClose={handleClose}
         />
-        {isFABReplaced && (
-          <ReportDeletion
-            reportId={report.id}
-          />
-        )}
       </>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -352,11 +352,11 @@ const ReportEditionOverviewComponent = (props) => {
             required={mandatoryAttributes.includes('objectMarking')}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-            <ReportDeletion
-              reportId={report.id}
-            />
-            )}
+            {isFABReplaced
+              ? <ReportDeletion
+                  reportId={report.id}
+                />
+              : <div/>}
             {enableReferences && (
             <CommitMessage
               submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import ReportDeletion from './ReportDeletion';
 import { buildDate, parse } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -23,6 +24,7 @@ import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const reportMutationFieldPatch = graphql`
   mutation ReportEditionOverviewFieldPatchMutation(
@@ -89,6 +91,8 @@ const REPORT_TYPE = 'Report';
 const ReportEditionOverviewComponent = (props) => {
   const { report, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { mandatoryAttributes } = useIsMandatoryAttribute(REPORT_TYPE);
   const basicShape = yupShapeConditionalRequired({
@@ -347,7 +351,13 @@ const ReportEditionOverviewComponent = (props) => {
             onChange={editor.changeMarking}
             required={mandatoryAttributes.includes('objectMarking')}
           />
-          {enableReferences && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+            <ReportDeletion
+              reportId={report.id}
+            />
+            )}
+            {enableReferences && (
             <CommitMessage
               submitForm={submitForm}
               disabled={isSubmitting || !isValid || !dirty}
@@ -356,7 +366,8 @@ const ReportEditionOverviewComponent = (props) => {
               values={values.references}
               id={report.id}
             />
-          )}
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopover.jsx
@@ -3,6 +3,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVert from '@mui/icons-material/MoreVert';
 import ToggleButton from '@mui/material/ToggleButton';
+import ReportPopoverDeletion from './ReportPopoverDeletion';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
 import { useFormatter } from '../../../../components/i18n';
 import { reportEditionQuery } from './ReportEdition';
@@ -10,7 +11,6 @@ import ReportEditionContainer from './ReportEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { QueryRenderer } from '../../../../relay/environment';
-import ReportDeletion from './ReportDeletion';
 import useHelper from '../../../../utils/hooks/useHelper';
 
 const ReportPopover = ({ id }) => {
@@ -66,7 +66,7 @@ const ReportPopover = ({ id }) => {
           </Security>
         </Menu>
         <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
-        <ReportDeletion
+        <ReportPopoverDeletion
           reportId={id}
           displayDelete={displayDelete}
           handleClose={handleClose}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopoverDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportPopoverDeletion.tsx
@@ -1,0 +1,130 @@
+import { graphql } from 'react-relay';
+import DialogContent from '@mui/material/DialogContent';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import React, { FunctionComponent, useState } from 'react';
+import { useTheme } from '@mui/styles';
+import { useNavigate } from 'react-router-dom';
+import DialogContentText from '@mui/material/DialogContentText';
+import { ReportPopoverDeletionQuery$data } from '@components/analyses/reports/__generated__/ReportPopoverDeletionQuery.graphql';
+import { QueryRenderer } from '../../../../relay/environment';
+import { useFormatter } from '../../../../components/i18n';
+
+import type { Theme } from '../../../../components/Theme';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const reportPopoverDeletionQuery = graphql`
+  query ReportPopoverDeletionQuery($id: String) {
+    report(id: $id) {
+      deleteWithElementsCount
+    }
+  }
+`;
+
+const reportPopoverDeletionMutation = graphql`
+  mutation ReportPopoverDeletionMutation($id: ID!, $purgeElements: Boolean) {
+    reportEdit(id: $id) {
+      delete(purgeElements: $purgeElements)
+    }
+  }
+`;
+
+interface ReportPopoverDeletionProps {
+  reportId: string;
+  displayDelete: boolean;
+  handleClose: () => void;
+  handleCloseDelete: () => void;
+}
+
+const ReportPopoverDeletion: FunctionComponent<ReportPopoverDeletionProps> = ({
+  reportId,
+  displayDelete,
+  handleClose,
+  handleCloseDelete,
+}) => {
+  const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
+  const navigate = useNavigate();
+  const [purgeElements, setPurgeElements] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [commitMutation] = useApiMutation(reportPopoverDeletionMutation);
+  const submitDelete = () => {
+    setDeleting(true);
+    commitMutation({
+      variables: { id: reportId, purgeElements },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/analyses/reports');
+      },
+    });
+  };
+  return (
+    <Dialog
+      open={displayDelete}
+      TransitionComponent={Transition}
+      PaperProps={{ elevation: 1 }}
+      onClose={handleCloseDelete}
+    >
+      <DialogContent>
+        <DialogContentText>
+          {t_i18n('Do you want to delete this report?')}
+        </DialogContentText>
+        <QueryRenderer
+          query={reportPopoverDeletionQuery}
+          variables={{ id: reportId }}
+          render={(result: { props: ReportPopoverDeletionQuery$data }) => {
+            const numberOfDeletions = result.props?.report?.deleteWithElementsCount ?? 0;
+            if (numberOfDeletions === 0) return <div />;
+            return (
+              <Alert
+                severity="warning"
+                variant="outlined"
+                style={{ marginTop: 20 }}
+              >
+                <AlertTitle>{t_i18n('Cascade delete')}</AlertTitle>
+                {t_i18n('In this report, ')}&nbsp;
+                <strong style={{ color: theme.palette.error.main }}>
+                  {numberOfDeletions}
+                </strong>
+                &nbsp;
+                {t_i18n(
+                  'element(s) are not linked to any other reports and will be orphan after the deletion.',
+                )}
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        disableRipple={true}
+                        checked={purgeElements}
+                        onChange={() => setPurgeElements(!purgeElements)}
+                      />
+                    }
+                    label={t_i18n('Also delete these elements')}
+                  />
+                </FormGroup>
+              </Alert>
+            );
+          }}
+        ></QueryRenderer>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCloseDelete} disabled={deleting}>
+          {t_i18n('Cancel')}
+        </Button>
+        <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+          {t_i18n('Delete')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ReportPopoverDeletion;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -408,9 +408,10 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <CaseIncidentDeletion id={caseData.id}/>
-            )}
+            {isFABReplaced
+              ? <CaseIncidentDeletion id={caseData.id}/>
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -407,19 +407,21 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={caseData.id}
-            />
-          )}
-          {isFABReplaced && (
-            <CaseIncidentDeletion id={caseData.id} />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <CaseIncidentDeletion id={caseData.id}/>
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={caseData.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -402,9 +402,10 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <CaseRfiDeletion id={caseData.id}/>
-            )}
+            {isFABReplaced
+              ? <CaseRfiDeletion id={caseData.id}/>
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -272,7 +272,7 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
         dirty,
       }) => (
         <Form style={{ margin: '20px 0 20px 0' }}>
-          <AlertConfidenceForEntity entity={caseData} />
+          <AlertConfidenceForEntity entity={caseData}/>
           <Field
             component={TextField}
             variant="standard"
@@ -401,19 +401,21 @@ const CaseRfiEditionOverview: FunctionComponent<CaseRfiEditionOverviewProps> = (
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={caseData.id}
-            />
-          )}
-          {isFABReplaced && (
-            <CaseRfiDeletion id={caseData.id} />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <CaseRfiDeletion id={caseData.id}/>
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={caseData.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -402,19 +402,21 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={caseData.id}
-            />
-          )}
-          {isFABReplaced && (
-            <CaseRftDeletion id={caseData.id} />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <CaseRftDeletion id={caseData.id}/>
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={caseData.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -403,9 +403,10 @@ const CaseRftEditionOverview: FunctionComponent<CaseRftEditionOverviewProps> = (
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <CaseRftDeletion id={caseData.id}/>
-            )}
+            {isFABReplaced
+              ? <CaseRftDeletion id={caseData.id}/>
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -337,21 +337,23 @@ FeedbackEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={feedbackData.id}
-            />
-          )}
-          {isFABReplaced && (
-            <FeedbackDeletion
-              id={feedbackData.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <FeedbackDeletion
+                id={feedbackData.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={feedbackData.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -338,11 +338,12 @@ FeedbackEditionOverviewProps
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <FeedbackDeletion
-                id={feedbackData.id}
-              />
-            )}
+            {isFABReplaced
+              ? <FeedbackDeletion
+                  id={feedbackData.id}
+                />
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -347,21 +347,23 @@ AdministrativeAreaEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={administrativeArea.id}
-            />
-          )}
-          {isFABReplaced && (
-            <AdministrativeAreaDeletion
-              id={administrativeArea.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <AdministrativeAreaDeletion
+                id={administrativeArea.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={administrativeArea.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -348,11 +348,12 @@ AdministrativeAreaEditionOverviewProps
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <AdministrativeAreaDeletion
-                id={administrativeArea.id}
-              />
-            )}
+            {isFABReplaced
+              ? <AdministrativeAreaDeletion
+                  id={administrativeArea.id}
+                />
+              : <div/>
+            }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -334,21 +334,23 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={city.id}
-            />
-          )}
-          {isFABReplaced && (
-            <CityDeletion
-              id={city.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <CityDeletion
+                id={city.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={city.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -335,11 +335,12 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <CityDeletion
-                id={city.id}
-              />
-            )}
+            {isFABReplaced
+              ? <CityDeletion
+                  id={city.id}
+                />
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -303,11 +303,12 @@ CountryEditionOverviewProps
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <CountryDeletion
-                id={country.id}
-              />
-            )}
+            {isFABReplaced
+              ? <CountryDeletion
+                  id={country.id}
+                />
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -302,21 +302,23 @@ CountryEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={country.id}
-            />
-          )}
-          {isFABReplaced && (
-            <CountryDeletion
-              id={country.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <CountryDeletion
+                id={country.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={country.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionContainer.jsx
@@ -5,7 +5,6 @@ import PositionEditionOverview from './PositionEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
 import useHelper from '../../../../utils/hooks/useHelper';
-import PositionDeletion from './PositionDeletion';
 
 const PositionEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
@@ -29,11 +28,6 @@ const PositionEditionContainer = (props) => {
           context={editContext}
           handleClose={handleClose}
         />
-        {isFABReplaced && (
-          <PositionDeletion
-            positionId={position.id}
-          />
-        )}
       </>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -3,6 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import * as R from 'ramda';
+import PositionDeletion from './PositionDeletion';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -18,6 +19,7 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const positionMutationFieldPatch = graphql`
   mutation PositionEditionOverviewFieldPatchMutation(
@@ -84,6 +86,9 @@ const positionMutationRelationDelete = graphql`
 const PositionEditionOverviewComponent = (props) => {
   const { position, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
@@ -321,16 +326,23 @@ const PositionEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={position.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <PositionDeletion
+                positionId={position.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={position.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -327,11 +327,12 @@ const PositionEditionOverviewComponent = (props) => {
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <PositionDeletion
-                positionId={position.id}
-              />
-            )}
+            {isFABReplaced
+              ? <PositionDeletion
+                  positionId={position.id}
+                />
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -303,11 +303,12 @@ RegionEdititionOverviewProps
             onChange={editor.changeMarking}
           />
           <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
-            {isFABReplaced && (
-              <RegionDeletion
-                id={region.id}
-              />
-            )}
+            {isFABReplaced
+              ? <RegionDeletion
+                  id={region.id}
+                />
+              : <div/>
+              }
             {enableReferences && (
               <CommitMessage
                 submitForm={submitForm}

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -302,21 +302,23 @@ RegionEdititionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={region.id}
-            />
-          )}
-          {isFABReplaced && (
-            <RegionDeletion
-              id={region.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced && (
+              <RegionDeletion
+                id={region.id}
+              />
+            )}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={region.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix `Delete` button when FF activated => If FF off we see the `Update` button, `Delete` button is inside the `Update` component. If FF is on we dont see any `Delete` button but we see `Popover` component
* Fix `Delete` button aligment when enforce ref are activated (FF need to be off, enforce ref activated for entites sucha as "Analyses / Case and Location)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* this is related to PRs merged in order to remove popover component for `Analyses`, `Cases`,` Location`
* this is under` FF`, to see the problem you need to remove the `FF` (feature activated)
* ` "disabled_dev_features": ["FAB_REPLACEMENT"] => FF activated, feature deactivated`
* `"disabled_dev_features": [] => FF deactivated, feature activated`

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
