### PR TITLE
[backend] keep base entity file if files names conflicts at entities merging (#8809)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage-helper.ts
@@ -135,6 +135,7 @@ export const deleteAllBucketContent = async (context: AuthContext, user: AuthUse
 
 /**
  * Move all file from source entity to target entity and then cleanup directories on S3.
+ * If a file with the same name exists both in source entity and target entity, the kept file is the one in target entity
  * @param context
  * @param user
  * @param sourceEntity
@@ -148,19 +149,24 @@ export const moveAllFilesFromEntityToAnother = async (context: AuthContext, user
       const sourcePath = `${ALL_MERGEABLE_FOLDERS[folderI]}/${sourceEntity.entity_type}/${sourceEntity.internal_id}`;
       const targetPath = `${ALL_MERGEABLE_FOLDERS[folderI]}/${targetEntity.entity_type}/${targetEntity.internal_id}`;
       const importFilesToMove = await allFilesForPaths(context, user, [sourcePath]);
+      const targetFiles = await allFilesForPaths(context, user, [targetPath]);
+      const targetFilesNames = targetFiles.map((f) => f.name);
 
       for (let fileI = 0; fileI < importFilesToMove.length; fileI += 1) {
         const sourceFileDocument = importFilesToMove[fileI];
-        const sourceFileS3Id = `${sourcePath}/${sourceFileDocument.name}`;
-        const targetFileS3Id = `${targetPath}/${sourceFileDocument.name}`;
-        logApp.info(`[FILE STORAGE] Moving from ${sourceFileS3Id} to: ${targetFileS3Id}`);
-        const copyProps = { sourceId: sourceFileS3Id, targetId: targetFileS3Id, sourceDocument: sourceFileDocument, targetEntityId: targetEntity.internal_id };
-        const newFile = await copyFile(context, copyProps);
-        if (newFile) {
-          const newFileForEntity = storeFileConverter(user, newFile);
-          updatedXOpenctiFiles.push(newFileForEntity);
+        const sourceFileName = sourceFileDocument.name;
+        if (!targetFilesNames.includes(sourceFileName)) { // move the file only if no files with this name already exist in target
+          const sourceFileS3Id = `${sourcePath}/${sourceFileName}`;
+          const targetFileS3Id = `${targetPath}/${sourceFileName}`;
+          logApp.info(`[FILE STORAGE] Moving from ${sourceFileS3Id} to: ${targetFileS3Id}`);
+          const copyProps = { sourceId: sourceFileS3Id, targetId: targetFileS3Id, sourceDocument: sourceFileDocument, targetEntityId: targetEntity.internal_id };
+          const newFile = await copyFile(context, copyProps);
+          if (newFile) {
+            const newFileForEntity = storeFileConverter(user, newFile);
+            updatedXOpenctiFiles.push(newFileForEntity);
 
-          await deleteFile(context, user, sourceFileS3Id); // TODO to be removed ? This will be done by merge delete no ?
+            await deleteFile(context, user, sourceFileS3Id); // TODO to be removed ? This will be done by merge delete no ?
+          }
         }
       }
     } catch (err) {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1143,13 +1143,10 @@ const mergeEntitiesRaw = async (context, user, targetEntity, sourceEntities, tar
   // Merge files on S3 and update x_opencti_files path in source => it will be added to target by the merge operation.
   logApp.info('[OPENCTI] Copying files on S3 before merging x_opencti_files');
   const sourceEntitiesWithFiles = sourceEntities.filter((entity) => { return entity.x_opencti_files ? entity.x_opencti_files.length > 0 : true; });
-
   for (let i = 0; i < sourceEntitiesWithFiles.length; i += 1) {
-    const entity = sourceEntitiesWithFiles[i];
-    if (entity.x_opencti_files) {
-      if (sourceEntitiesWithFiles[i].x_opencti_files.length > 0) {
-        sourceEntitiesWithFiles[i].x_opencti_files = await moveAllFilesFromEntityToAnother(context, user, sourceEntitiesWithFiles[i], targetEntity);
-      }
+    const sourceEntity = sourceEntitiesWithFiles[i];
+    if (sourceEntity.x_opencti_files && sourceEntity.x_opencti_files.length > 0) {
+      sourceEntity.x_opencti_files = await moveAllFilesFromEntityToAnother(context, user, sourceEntity, targetEntity);
     }
   }
   logApp.info('[OPENCTI] Copy of files on S3 ended.');


### PR DESCRIPTION
### Proposed changes
When merging entities, if files with same name exist in source and target entities, keep the files from the target entity.

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8809