### PR TITLE
[backend] fix taxii cursor number error (#8675)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-domain.ts
@@ -1,3 +1,4 @@
+import type { Moment } from 'moment/moment';
 import { type BasicStoreEntityIngestionTaxii, ENTITY_TYPE_INGESTION_TAXII } from './ingestion-types';
 import { createEntity, deleteElementById, patchAttribute, updateAttribute } from '../../database/middleware';
 import { listAllEntities, listEntitiesPaginated, storeLoadById } from '../../database/middleware-loader';
@@ -47,8 +48,18 @@ export const addIngestion = async (context: AuthContext, user: AuthUser, input: 
   return element;
 };
 
-export const patchTaxiiIngestion = async (context: AuthContext, user: AuthUser, id: string, patch: object) => {
-  const patched = await patchAttribute(context, user, id, ENTITY_TYPE_INGESTION_TAXII, patch);
+export interface TaxiiIngestionPatch {
+  current_state_cursor?: string | undefined,
+  last_execution_date?: string,
+  added_after_start?: Moment,
+}
+
+export const patchTaxiiIngestion = async (context: AuthContext, user: AuthUser, id: string, patch: TaxiiIngestionPatch) => {
+  const verifiedPatch = patch;
+  if (patch.current_state_cursor) {
+    verifiedPatch.current_state_cursor = `${patch.current_state_cursor}`;
+  }
+  const patched = await patchAttribute(context, user, id, ENTITY_TYPE_INGESTION_TAXII, verifiedPatch);
   return patched.element;
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Force taxii cursor to be a string before saving in database.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #8675 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
