### PR TITLE
[frontend] use doc_code for connector errors (#8614)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "Dieser Vorgang kann nicht rückgängig gemacht werden.",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Diese Operationen gelten nur für Labels oder Markierungen, die im Kontext dieses Playbooks hinzugefügt werden, wie z. B. Anreicherung oder andere Wissensmanipulationen, nicht aber, wenn die Labels oder Markierungen bereits in der Plattform geschrieben sind.",
   "This page is not found on this OpenCTI application.": "Diese Seite wird in dieser OpenCTI-Anwendung nicht gefunden.",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "Diese Seite listet nur die ersten 100 vom Connector zurückgegebenen Fehler auf, um die Lesbarkeit zu gewährleisten",
+  "This page lists only the first 100 errors returned by the connector": "Diese Seite listet nur die ersten 100 vom Connector zurückgegebenen Fehler auf",
   "This panel shows by default the latest created entities, use the search to find more.": "Dieses Panel zeigt standardmäßig die zuletzt erstellten Entitäten an, verwenden Sie die Suche, um weitere zu finden.",
   "This relation is inferred": "Diese Beziehung wird abgeleitet",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "Dieser Bericht enthält zu viele Objekte, um als Diagramm angezeigt zu werden. Wir arbeiten an einer neuen Visualisierung, die es in Zukunft ermöglichen wird, große Diagramme darzustellen.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "This operation cannot be undone.",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.",
   "This page is not found on this OpenCTI application.": "This page is not found on this OpenCTI application.",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "This page lists only the first 100 errors returned by the connector to ensure readability",
+  "This page lists only the first 100 errors returned by the connector": "This page lists only the first 100 errors returned by the connector",
   "This panel shows by default the latest created entities, use the search to find more.": "This panel shows by default the latest created entities, use the search to find more.",
   "This relation is inferred": "This relation is inferred",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "Esta operación no puede deshacerse.",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Estas operaciones sólo se aplicarán a las etiquetas o marcas añadidas en el contexto de este libro de jugadas, como el enriquecimiento u otras manipulaciones del conocimiento, pero no si las etiquetas o marcas ya están escritas en la plataforma.",
   "This page is not found on this OpenCTI application.": "Esta página no se ha encontrado en esta aplicación de OpenCTI.",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "Esta página lista solo los primeros 100 errores devueltos por el conector para garantizar la legibilidad",
+  "This page lists only the first 100 errors returned by the connector": "Esta página lista solo los primeros 100 errores devueltos por el conector",
   "This panel shows by default the latest created entities, use the search to find more.": "Este planel muestra por defecto las entidades creadas en último lugar, usa la búsqueda para encontrar más.",
   "This relation is inferred": "Esta relación se ha inferido",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "Este informe contiene demasiados objetos para mostrarse como un grafo. Estamos trabajando en una nueva visualización que permitirá mostrar gráficos grandes en el futuro.",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "Cette opération ne peut être annulée.",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "Ces opérations ne s'appliqueront qu'aux étiquettes ou marquages ajoutés dans le contexte de ce playbook, comme l'enrichissement ou d'autres manipulations de connaissances, mais pas si les étiquettes ou marquages sont déjà écrits dans la plateforme.",
   "This page is not found on this OpenCTI application.": "Cette page est introuvable sur cette application OpenCTI.",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "Cette page liste seulement les 100 premières erreurs renvoyées par le connecteur pour assurer la lisibilité",
+  "This page lists only the first 100 errors returned by the connector": "Cette page liste seulement les 100 premières erreurs renvoyées par le connecteur",
   "This panel shows by default the latest created entities, use the search to find more.": "Ce panneau montre par défaut les dernières entités créées, utilisez la recherche pour en trouver plus.",
   "This relation is inferred": "Cette relation est inférée",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "Ce rapport contient trop d'objets pour être affiché comme un graphe. Nous travaillons sur une nouvelle visualisation qui permettra d'afficher de grands graphes à l'avenir.",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "この操作は元に戻せません。",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "この操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたラベルやマーキングに対してのみ適用されます。",
   "This page is not found on this OpenCTI application.": "このページは、OpenCTIアプリケーション上で見つかりませんでした。",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "このページには、可読性を確保するためにコネクタから返された最初の100件のエラーのみが表示されます",
+  "This page lists only the first 100 errors returned by the connector": "このページには、コネクタから返された最初の100件のエラーのみが表示されます",
   "This panel shows by default the latest created entities, use the search to find more.": "デフォルトではこのパネルには最近作成されたエンティティが表示されますが、検索を使うことでより多くのエンティティを表示できます。",
   "This relation is inferred": "このリレーションが推測されました",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "このレポートには、非常に多いオブジェクトが含まれているため、グラフを表示できません。将来的には大きなグラフを表示できるように取り組んでいます。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "이 작업은 되돌릴 수 없습니다.",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "이 작업은 강화 또는 기타 지식 조작과 같은 플레이북 맥락에서 추가된 레이블 또는 마킹에만 적용되며, 레이블 또는 마킹이 이미 플랫폼에 작성된 경우에는 적용되지 않습니다.",
   "This page is not found on this OpenCTI application.": "이 페이지는 이 OpenCTI 애플리케이션에서 찾을 수 없습니다.",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "이 페이지에는 가독성을 위해 커넥터에서 반환된 처음 100개의 오류만 나열됩니다",
+  "This page lists only the first 100 errors returned by the connector": "이 페이지에는 커넥터에서 반환된 처음 100개의 오류만 나열됩니다",
   "This panel shows by default the latest created entities, use the search to find more.": "이 패널은 기본적으로 최근에 생성된 엔터티를 표시하며, 더 많은 엔터티를 찾기 위해 검색을 사용하십시오.",
   "This relation is inferred": "이 관계는 추론된 것입니다",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "이 보고서는 그래프로 표시하기에는 너무 많은 객체를 포함하고 있습니다. 우리는 향후 대형 그래프를 표시할 수 있는 새로운 시각화를 작업 중입니다.",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2695,7 +2695,7 @@
   "This operation cannot be undone.": "此操作不可撤销。",
   "This operations will only apply on labels or markings added in the context of this playbook such as enrichment or other knowledge manipulations but not if the labels or markings are already written in the platform.": "此操作仅适用于在此播放列表中添加的标签或标记，如充实或其他知识操作，但不适用于平台中已写入的标签或标记。",
   "This page is not found on this OpenCTI application.": "在平台上找不到此页面。",
-  "This page lists only the first 100 errors returned by the connector to ensure readability": "此页面仅列出了连接器返回的前100个错误，以确保可读性",
+  "This page lists only the first 100 errors returned by the connector": "此页面仅列出了连接器返回的前100个错误",
   "This panel shows by default the latest created entities, use the search to find more.": "此面板默认显示最新创建的实体，请使用搜索查找更多信息。",
   "This relation is inferred": "该关系是推理出来的",
   "This report contains too many objects to be displayed as a graph. We are working on a new visualization which will allow large graph to be displayed in the future.": "此报告包含的对象过多，无法显示为图形。我们正在研究一种新的可视化，这将允许展示更大的图形。",

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
@@ -258,7 +258,7 @@ const ConnectorWorksComponent: FunctionComponent<ConnectorWorksComponentProps> =
         onClose={handleCloseDrawerErrors}
       >
         <>
-          <Alert severity="info">{t_i18n('This page lists only the first 100 errors returned by the connector to ensure readability')}</Alert>
+          <Alert severity="info">{t_i18n('This page lists only the first 100 errors returned by the connector')}</Alert>
           <Tabs value={tabValue} onChange={(_, newValue) => setTabValue(newValue)}>
             <Tab label={`${t_i18n('Critical')} (${criticals.length})`} value="Critical" />
             <Tab label={`${t_i18n('Warning')} (${warnings.length})`} value="Warning" />

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
@@ -64,13 +64,13 @@ const ConnectorWorksErrorLine: FunctionComponent<ConnectorWorksErrorLineProps> =
             <a href={'https://docs.opencti.io/latest/deployment/troubleshooting'} target="_blank" rel="noreferrer">{t_i18n('Unknown')}</a>
           )}
         </TableCell>
-        <TableCell>{error.isParsed ? error.parsedError.message : error.rawError.message}</TableCell>
+        <TableCell>{error.isParsed ? error.parsedError.message : error.rawError.message ?? '-'}</TableCell>
         <TableCell>
           {error.isParsed ? (
             displayEntityOrId(error.parsedError.entity)
           ) : (
             <Tooltip title={t_i18n('Click on details to see more information')}>
-              {truncate(error.rawError.source, truncateLimit)}
+              {truncate(error.rawError.source ?? '-', truncateLimit)}
             </Tooltip>
           )}
         </TableCell>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
@@ -25,7 +25,7 @@ interface ConnectorWorksErrorLineProps {
 const ConnectorWorksErrorLine: FunctionComponent<ConnectorWorksErrorLineProps> = ({ error }) => {
   const { t_i18n, nsdt } = useFormatter();
   const [openModalErrorDetails, setOpenModalErrorDetails] = useState<boolean>(false);
-  const truncateLimit = 80;
+  const truncateLimit = 60;
 
   const handleToggleModalError = () => {
     setOpenModalErrorDetails(!openModalErrorDetails);
@@ -58,8 +58,8 @@ const ConnectorWorksErrorLine: FunctionComponent<ConnectorWorksErrorLineProps> =
       <TableRow key={error.rawError.timestamp}>
         <TableCell>{nsdt(error.rawError.timestamp)}</TableCell>
         <TableCell>
-          {error.isParsed ? (
-            <a href={`https://docs.opencti.io/latest/deployment/troubleshooting/#${error.parsedError.category}`} target="_blank" rel="noreferrer">{error.parsedError.category}</a>
+          {error.isParsed && error.parsedError.doc_code ? (
+            <a href={`https://docs.opencti.io/latest/deployment/troubleshooting/#${error.parsedError.doc_code}`} target="_blank" rel="noreferrer">{error.parsedError.doc_code}</a>
           ) : (
             <a href={'https://docs.opencti.io/latest/deployment/troubleshooting'} target="_blank" rel="noreferrer">{t_i18n('Unknown')}</a>
           )}

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorksErrorLine.tsx
@@ -59,7 +59,7 @@ const ConnectorWorksErrorLine: FunctionComponent<ConnectorWorksErrorLineProps> =
         <TableCell>{nsdt(error.rawError.timestamp)}</TableCell>
         <TableCell>
           {error.isParsed && error.parsedError.doc_code ? (
-            <a href={`https://docs.opencti.io/latest/deployment/troubleshooting/#${error.parsedError.doc_code}`} target="_blank" rel="noreferrer">{error.parsedError.doc_code}</a>
+            <a href={`https://docs.opencti.io/latest/deployment/troubleshooting/#${error.parsedError.doc_code.toLowerCase()}`} target="_blank" rel="noreferrer">{error.parsedError.doc_code}</a>
           ) : (
             <a href={'https://docs.opencti.io/latest/deployment/troubleshooting'} target="_blank" rel="noreferrer">{t_i18n('Unknown')}</a>
           )}

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { getLevel, parseError } from '@components/data/connectors/parseWorkErrors';
+
+describe('Function: getLevel', () => {
+  it('should return Critical', () => {
+    expect(getLevel('ELEMENT_ID_COLLISION')).toEqual('Critical');
+  });
+
+  it('should return Warning', () => {
+    expect(getLevel('INCORRECT_INDICATOR_FORMAT')).toEqual('Warning');
+  });
+
+  it('should return Unclassified', () => {
+    expect(getLevel('OTHER_ERROR')).toEqual('Unclassified');
+  });
+});
+
+describe('Function: parseError', () => {
+  it('should return a full parsed error with an entity', () => {
+    expect(parseError({
+      timestamp: '2024-10-11T20:10:06.700Z',
+      message: '{\'name\': \'INTERNAL_SERVER_ERROR\', \'error_message\': \'Test error report\'}',
+      sequence: null,
+      source: '{"type": "report", "spec_version": "2.1", "id": "report--423ae31f-5344-55de-970b-cc902b3d0000"}',
+    })).toEqual({
+      isParsed: true,
+      level: 'Critical',
+      parsedError: {
+        category: 'INTERNAL_SERVER_ERROR',
+        doc_code: 'INTERNAL_SERVER_ERROR',
+        message: 'Test error report',
+        entity: {
+          standard_id: 'report--423ae31f-5344-55de-970b-cc902b3d0000',
+          representative: { main: 'report--423ae31f-5344-55de-970b-cc902b3d0000' },
+          from: undefined,
+          to: undefined,
+        },
+      },
+      rawError: {
+        timestamp: '2024-10-11T20:10:06.700Z',
+        message: '{\'name\': \'INTERNAL_SERVER_ERROR\', \'error_message\': \'Test error report\'}',
+        sequence: null,
+        source: '{"type": "report", "spec_version": "2.1", "id": "report--423ae31f-5344-55de-970b-cc902b3d0000"}',
+      },
+    });
+  });
+
+  it('should return a full parsed error with a relationship', () => {
+    expect(parseError({
+      timestamp: '2024-10-11T20:10:06.708Z',
+      message: '{\'name\': \'UNSUPPORTED_ERROR\', \'error_message\': \'Test error relationship\', \'doc_code\': \'RESTRICTED_ELEMENT\'}',
+      sequence: null,
+      source: '{"type": "relationship", "spec_version": "2.1", "id": "relationship--3bb06e4f-0702-40da-a7db-3ae8e8800000", "created_by_ref": "identity--180d3ffd-a014-54ff-a817-211dddd00000", "created": "2024-10-11T17:19:43.689008Z", "modified": "2024-10-11T17:19:43.689008Z", "relationship_type": "originates-from", "source_ref": "intrusion-set--826cb3d9-0de3-5af7-9e95-f64fa1000000", "target_ref": "location--efa1b9b0-dc59-5bad-baa2-4fc495e00000", "object_marking_refs": ["marking-definition--f88d31f6-486f-44da-b317-01333bde0000"], "nb_deps": 1, "x_opencti_granted_refs": null, "x_opencti_workflow_id": null}',
+    })).toEqual({
+      isParsed: true,
+      level: 'Warning',
+      parsedError: {
+        category: 'UNSUPPORTED_ERROR',
+        doc_code: 'RESTRICTED_ELEMENT',
+        message: 'Test error relationship',
+        entity: {
+          standard_id: 'relationship--3bb06e4f-0702-40da-a7db-3ae8e8800000',
+          representative: { main: 'relationship--3bb06e4f-0702-40da-a7db-3ae8e8800000' },
+          from: {
+            standard_id: 'intrusion-set--826cb3d9-0de3-5af7-9e95-f64fa1000000',
+          },
+          to: {
+            standard_id: 'location--efa1b9b0-dc59-5bad-baa2-4fc495e00000',
+          },
+        },
+      },
+      rawError: {
+        timestamp: '2024-10-11T20:10:06.708Z',
+        message: '{\'name\': \'UNSUPPORTED_ERROR\', \'error_message\': \'Test error relationship\', \'doc_code\': \'RESTRICTED_ELEMENT\'}',
+        sequence: null,
+        source: '{"type": "relationship", "spec_version": "2.1", "id": "relationship--3bb06e4f-0702-40da-a7db-3ae8e8800000", "created_by_ref": "identity--180d3ffd-a014-54ff-a817-211dddd00000", "created": "2024-10-11T17:19:43.689008Z", "modified": "2024-10-11T17:19:43.689008Z", "relationship_type": "originates-from", "source_ref": "intrusion-set--826cb3d9-0de3-5af7-9e95-f64fa1000000", "target_ref": "location--efa1b9b0-dc59-5bad-baa2-4fc495e00000", "object_marking_refs": ["marking-definition--f88d31f6-486f-44da-b317-01333bde0000"], "nb_deps": 1, "x_opencti_granted_refs": null, "x_opencti_workflow_id": null}',
+      },
+    });
+  });
+
+  it('should return a full parsed error with a bundle', () => {
+    expect(parseError({
+      timestamp: '2024-10-11T20:10:06.788Z',
+      message: '{\'name\': \'MISSING_REFERENCE_ERROR\', \'error_message\': \'Element(s) not found [with bundle]\', \'doc_code\': \'ELEMENT_NOT_FOUND\'}',
+      sequence: null,
+      source: '{"type": "bundle", "id": "bundle--3d4b0539-a7c0-45b5-8f3f-edebe4000000", "spec_version": "2.1", "x_opencti_seq": 8, "objects": [{"type": "relationship", "spec_version": "2.1", "id": "relationship--41ea9593-cfc4-5d4b-b31d-ca9e4dd00000", "relationship_type": "targets", "source_ref": "malware--fc7e8c2e-6aa7-55cf-9f29-69c66d800000", "target_ref": "identity--f67fbf06-f3cd-58b3-bad9-ed0b45800000", "nb_deps": 8}]}',
+    })).toEqual({
+      isParsed: true,
+      level: 'Warning',
+      parsedError: {
+        category: 'MISSING_REFERENCE_ERROR',
+        doc_code: 'ELEMENT_NOT_FOUND',
+        message: 'Element(s) not found [with bundle]',
+        entity: {
+          standard_id: 'relationship--41ea9593-cfc4-5d4b-b31d-ca9e4dd00000',
+          representative: { main: 'relationship--41ea9593-cfc4-5d4b-b31d-ca9e4dd00000' },
+          from: {
+            standard_id: 'malware--fc7e8c2e-6aa7-55cf-9f29-69c66d800000',
+          },
+          to: {
+            standard_id: 'identity--f67fbf06-f3cd-58b3-bad9-ed0b45800000',
+          },
+        },
+      },
+      rawError: {
+        timestamp: '2024-10-11T20:10:06.788Z',
+        message: '{\'name\': \'MISSING_REFERENCE_ERROR\', \'error_message\': \'Element(s) not found [with bundle]\', \'doc_code\': \'ELEMENT_NOT_FOUND\'}',
+        sequence: null,
+        source: '{"type": "bundle", "id": "bundle--3d4b0539-a7c0-45b5-8f3f-edebe4000000", "spec_version": "2.1", "x_opencti_seq": 8, "objects": [{"type": "relationship", "spec_version": "2.1", "id": "relationship--41ea9593-cfc4-5d4b-b31d-ca9e4dd00000", "relationship_type": "targets", "source_ref": "malware--fc7e8c2e-6aa7-55cf-9f29-69c66d800000", "target_ref": "identity--f67fbf06-f3cd-58b3-bad9-ed0b45800000", "nb_deps": 8}]}',
+      },
+    });
+  });
+
+  it('should return a partial parsed error', () => {
+    expect(parseError({
+      timestamp: '2024-10-11T20:10:06.788Z',
+      message: '[This message can\'t be parsed]',
+      sequence: null,
+      source: '{"type": "report", "spec_version": "2.1", "id": "report--423ae31f-5344-55de-970b-cc902b3d0000"}',
+    })).toEqual({
+      isParsed: false,
+      level: 'Unclassified',
+      rawError: {
+        timestamp: '2024-10-11T20:10:06.788Z',
+        message: '[This message can\'t be parsed]',
+        sequence: null,
+        source: '{"type": "report", "spec_version": "2.1", "id": "report--423ae31f-5344-55de-970b-cc902b3d0000"}',
+      },
+    });
+  });
+
+  it('should manage null value', () => {
+    expect(parseError({
+      timestamp: null,
+      message: null,
+      sequence: null,
+      source: null,
+    })).toEqual({
+      isParsed: false,
+      level: 'Unclassified',
+      rawError: {
+        timestamp: null,
+        message: null,
+        sequence: null,
+        source: null,
+      },
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.tsx
@@ -186,6 +186,8 @@ const parseWorkErrors = async (errorsList: WorkMessages): Promise<ParsedWorkMess
     }
   });
 
+  if (ids.length < 1) return parsedList;
+  // else : try to resolve entities
   const entities = await fetchQuery(
     environment,
     parseWorkErrorsQuery,

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/parseWorkErrors.tsx
@@ -80,8 +80,8 @@ const parseWorkErrorsQuery = graphql`
   }
 `;
 
+type Entities = (NonNullable<NonNullable<NonNullable<NonNullable<parseWorkErrorsQuery$data>['stixObjectOrStixRelationships']>['edges']>[number]>['node'] | undefined)[];
 export type ResolvedEntity = NonNullable<NonNullable<NonNullable<parseWorkErrorsQuery$data['stixObjectOrStixRelationships']>['edges']>[number]>['node'];
-
 type ErrorLevel = 'Critical' | 'Warning' | 'Unclassified';
 
 export interface FullParsedWorkMessage {
@@ -130,65 +130,89 @@ const warningDocCodes = [
   'MISSING_REFERENCE_ERROR',
 ];
 
+export const getLevel = (code: string): ErrorLevel => {
+  if (criticalDocCodes.includes(code)) return 'Critical';
+  if (warningDocCodes.includes(code)) return 'Warning';
+  return 'Unclassified';
+};
+
+export const parseError = (error: NonNullable<NonNullable<WorkMessages>[number]>): ParsedWorkMessage => {
+  // Try/Catch to prevent JSON.parse Exception
+  try {
+    const parsedSource = JSON5.parse(error.source ?? '');
+    const source = parsedSource.type === 'bundle' ? parsedSource.objects[0] : parsedSource;
+    const message = JSON5.parse((error.message ?? ''));
+    const entityId = source.id;
+    const fromId = source.source_ref;
+    const toId = source.target_ref;
+
+    const parsedError = {
+      category: message.name,
+      doc_code: message.doc_code ?? message.name,
+      message: message.error_message,
+      entity: {
+        standard_id: entityId,
+        representative: { main: getMainRepresentative(source, entityId) },
+        from: fromId ? {
+          standard_id: fromId,
+        } : undefined,
+        to: toId ? {
+          standard_id: toId,
+        } : undefined,
+      },
+    };
+
+    return {
+      isParsed: true,
+      level: getLevel(message.doc_code ?? message.name ?? ''),
+      parsedError,
+      rawError: error,
+    };
+  } catch (_) {
+    return {
+      isParsed: false,
+      level: 'Unclassified',
+      rawError: error,
+    };
+  }
+};
+
+export const resolveError = (error: ParsedWorkMessage, entities: Entities): ParsedWorkMessage => {
+  if (error.isParsed) {
+    const errorParsed = error;
+    entities.forEach((entity) => {
+      if (!entity) return;
+      if (entity.standard_id === error.parsedError.entity.standard_id) {
+        errorParsed.parsedError.entity = entity;
+      } else if (entity.standard_id === error.parsedError.entity.from?.standard_id) {
+        errorParsed.parsedError.entity = { ...error.parsedError.entity, from: entity };
+      } else if (entity.standard_id === error.parsedError.entity.to?.standard_id) {
+        errorParsed.parsedError.entity = { ...error.parsedError.entity, to: entity };
+      }
+    });
+    return errorParsed;
+  }
+  return error;
+};
+
 // Create custom error object from stringified error
 const parseWorkErrors = async (errorsList: WorkMessages): Promise<ParsedWorkMessage[]> => {
   const ids: string[] = [];
 
-  const getLevel = (code: string): ErrorLevel => {
-    if (criticalDocCodes.includes(code)) return 'Critical';
-    if (warningDocCodes.includes(code)) return 'Warning';
-    return 'Unclassified';
-  };
-
   const parsedList: ParsedWorkMessage[] = (errorsList ?? []).flatMap((error) => {
     if (!error) return [];
-    // Try/Catch to prevent JSON.parse Exception
-    try {
-      const parsedSource = JSON5.parse(error.source ?? '');
-      const source = parsedSource.type === 'bundle' ? parsedSource.objects[0] : parsedSource;
-      const message = JSON5.parse((error.message ?? ''));
-      const entityId = source.id;
-      const fromId = source.source_ref;
-      const toId = source.target_ref;
-
-      ids.push(entityId);
-      if (fromId) ids.push(fromId);
-      if (toId) ids.push(toId);
-
-      const parsedError = {
-        category: message.name,
-        doc_code: message.doc_code ?? message.name,
-        message: message.error_message,
-        entity: {
-          standard_id: entityId,
-          representative: { main: getMainRepresentative(source, entityId) },
-          from: fromId ? {
-            standard_id: fromId,
-          } : undefined,
-          to: toId ? {
-            standard_id: toId,
-          } : undefined,
-        },
-      };
-
-      return {
-        isParsed: true,
-        level: getLevel(message.doc_code ?? message.name ?? ''),
-        parsedError,
-        rawError: error,
-      };
-    } catch (_) {
-      return {
-        isParsed: false,
-        level: 'Unclassified',
-        rawError: error,
-      };
+    const errorParsed = parseError(error);
+    if (errorParsed.isParsed) {
+      ids.push(errorParsed.parsedError.entity.standard_id ?? '');
+      if (errorParsed.parsedError.entity.from) ids.push(errorParsed.parsedError.entity.from.standard_id ?? '');
+      if (errorParsed.parsedError.entity.to) ids.push(errorParsed.parsedError.entity.to.standard_id ?? '');
     }
+    return errorParsed;
   });
 
   if (ids.length < 1) return parsedList;
-  // else : try to resolve entities
-  const entities = await fetchQuery(
+  // try to resolve entities
+  const entities: Entities = await fetchQuery(
     environment,
     parseWorkErrorsQuery,
     { ids },
@@ -197,26 +221,9 @@ const parseWorkErrors = async (errorsList: WorkMessages): Promise<ParsedWorkMess
     .then((data) => {
       return ((data as parseWorkErrorsQuery$data)?.stixObjectOrStixRelationships?.edges ?? []).map((n) => n?.node);
     });
-
-  parsedList.map((error) => {
-    if (error.isParsed) {
-      const err = error;
-      entities.forEach((entity) => {
-        if (!entity) return;
-        if (entity.standard_id === error.parsedError.entity.standard_id) {
-          err.parsedError.entity = entity;
-        } else if (entity.standard_id === error.parsedError.entity.from?.standard_id) {
-          err.parsedError.entity = { ...error.parsedError.entity, from: entity };
-        } else if (entity.standard_id === error.parsedError.entity.to?.standard_id) {
-          err.parsedError.entity = { ...error.parsedError.entity, to: entity };
-        }
-      });
-      return err;
-    }
-    return error;
+  return parsedList.map((error) => {
+    return resolveError(error, entities);
   });
-
-  return parsedList;
 };
 
 export default parseWorkErrors;

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -226,7 +226,7 @@ export const addStixCyberObservable = async (context, user, input) => {
   // Check the consistency of the observable.
   const observableSyntaxResult = checkObservableSyntax(type, observableInput);
   if (observableSyntaxResult !== true) {
-    throw FunctionalError('Observable is not correctly formatted', { type, input: observableInput });
+    throw FunctionalError('Observable is not correctly formatted', { type, input: observableInput, doc_code: 'INCORRECT_OBSERVABLE_FORMAT' });
   }
   // If everything ok, create adapt/create the observable
   const created = await createEntity(context, user, observableInput, type);

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -226,7 +226,7 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   const formattedPattern = cleanupIndicatorPattern(patternType, indicator.pattern);
   const check = await checkIndicatorSyntax(context, user, patternType, formattedPattern);
   if (check === false) {
-    throw FunctionalError(`Indicator of type ${indicator.pattern_type} is not correctly formatted.`);
+    throw FunctionalError(`Indicator of type ${indicator.pattern_type} is not correctly formatted.`, { doc_code: 'INCORRECT_INDICATOR_FORMAT' });
   }
   const indicatorBaseScore = indicator.x_opencti_score ?? 50;
   const isDecayActivated = await isModuleActivated('INDICATOR_DECAY_MANAGER');

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -170,7 +170,7 @@ export const controlUserConfidenceAgainstElement = <T extends ObjectWithConfiden
     if (noThrow) {
       return false;
     }
-    throw FunctionalError('User effective max confidence level is insufficient to update this element', { user_id: user.id, element_id: existingElement.id });
+    throw FunctionalError('User effective max confidence level is insufficient to update this element', { user_id: user.id, element_id: existingElement.id, doc_code: 'INSUFFICIENT_CONFIDENCE_LEVEL' });
   }
 
   return true; // ok


### PR DESCRIPTION
### Proposed changes

* Add `doc_code` in some connector errors
* Use this doc_code in the data/ingestion/connector / (select one)  / (open error drawer) / errors table
* Fallback on error name

### Related issues

* close #8614 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality