### PR TITLE
[frontend] Add support for dynamic configurable required fields to Threats

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
@@ -15,7 +15,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { Option } from '../../common/form/ReferenceField';
@@ -88,13 +88,14 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(CAMPAIGN_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
-  };
-  const campaignValidator = useSchemaCreationValidation(
-    CAMPAIGN_TYPE,
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -171,7 +172,9 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
   return (
     <Formik<CampaignAddInput>
       initialValues={initialValues}
-      validationSchema={campaignValidator}
+      validationSchema={validator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -207,6 +210,7 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={mandatoryAttributes.includes('name')}
               fullWidth={true}
               askAi={true}
               detectDuplicate={[
@@ -224,6 +228,7 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={mandatoryAttributes.includes('description')}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -232,22 +237,26 @@ export const CampaignCreationForm: FunctionComponent<CampaignFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={mandatoryAttributes.includes('createdBy')}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={mandatoryAttributes.includes('objectLabel')}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={mandatoryAttributes.includes('objectMarking')}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={mandatoryAttributes.includes('externalReferences')}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -105,7 +105,7 @@ const CampaignEditionOverviewComponent = (props) => {
     x_opencti_workflow_id: Yup.object(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
-  
+
   const campaignValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -103,8 +103,9 @@ const CampaignEditionOverviewComponent = (props) => {
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
-
+  
   const campaignValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -102,6 +102,7 @@ const CampaignEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    createdBy: Yup.object().nullable(),
     x_opencti_workflow_id: Yup.object(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
@@ -16,7 +16,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import { IntrusionSetCreationMutation, IntrusionSetCreationMutation$variables } from './__generated__/IntrusionSetCreationMutation.graphql';
 import { IntrusionSetsCardsPaginationQuery$variables } from './__generated__/IntrusionSetsCardsPaginationQuery.graphql';
@@ -90,13 +90,16 @@ IntrusionSetFormProps
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    INTRUSION_SET_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     confidence: Yup.number(),
     description: Yup.string().nullable(),
-  };
-  const intrusionSetValidator = useSchemaCreationValidation(
-    INTRUSION_SET_TYPE,
+  }, mandatoryAttributes);
+  const intrusionSetValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const [commit] = useApiMutation<IntrusionSetCreationMutation>(
@@ -173,6 +176,8 @@ IntrusionSetFormProps
     <Formik<IntrusionSetAddInput>
       initialValues={initialValues}
       validationSchema={intrusionSetValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -208,6 +213,7 @@ IntrusionSetFormProps
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               askAi={true}
               detectDuplicate={[
@@ -225,6 +231,7 @@ IntrusionSetFormProps
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -232,22 +239,26 @@ IntrusionSetFormProps
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -16,7 +16,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -84,6 +84,8 @@ export const intrusionSetMutationRelationDelete = graphql`
   }
 `;
 
+const INTRUSION_SET_TYPE = 'Intrusion-Set';
+
 const IntrusionSetEditionOverviewComponent = (props) => {
   const { intrusionSet, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
@@ -91,15 +93,18 @@ const IntrusionSetEditionOverviewComponent = (props) => {
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    INTRUSION_SET_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const intrusionSetValidator = useSchemaEditionValidation(
-    'Intrusion-Set',
+  }, mandatoryAttributes);
+  const intrusionSetValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -186,6 +191,8 @@ const IntrusionSetEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={intrusionSetValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -202,6 +209,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -222,6 +230,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -251,6 +260,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -260,6 +270,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -102,6 +102,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const intrusionSetValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -101,6 +101,7 @@ const IntrusionSetEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    createdBy: Yup.object().nullable(),
     x_opencti_workflow_id: Yup.object(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
@@ -16,7 +16,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorsGroupCardsPaginationQuery$variables } from './__generated__/ThreatActorsGroupCardsPaginationQuery.graphql';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
@@ -49,6 +49,8 @@ const ThreatActorGroupMutation = graphql`
     }
   }
 `;
+
+const THREAT_ACTOR_GROUP_TYPE = 'Threat-Actor-Group';
 
 interface ThreatActorGroupAddInput {
   name: string;
@@ -90,14 +92,17 @@ ThreatActorGroupFormProps
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    THREAT_ACTOR_GROUP_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string(),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
-  };
-  const threatActorGroupValidator = useSchemaCreationValidation(
-    'Threat-Actor-Group',
+  }, mandatoryAttributes);
+  const threatActorGroupValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -177,6 +182,8 @@ ThreatActorGroupFormProps
     <Formik<ThreatActorGroupAddInput>
       initialValues={initialValues}
       validationSchema={threatActorGroupValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -212,6 +219,7 @@ ThreatActorGroupFormProps
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               askAi={true}
               detectDuplicate={[
@@ -225,6 +233,7 @@ ThreatActorGroupFormProps
               type="threat-actor-group-type-ov"
               name="threat_actor_types"
               label={t_i18n('Threat actor types')}
+              required={(mandatoryAttributes.includes('threat_actor_types'))}
               multiple={true}
               containerStyle={fieldSpacingContainerStyle}
               onChange={setFieldValue}
@@ -237,6 +246,7 @@ ThreatActorGroupFormProps
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -245,22 +255,26 @@ ThreatActorGroupFormProps
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -16,7 +16,7 @@ import StatusField from '../../common/form/StatusField';
 import { convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatus } from '../../../../utils/edition';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { useFormatter } from '../../../../components/i18n';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -85,6 +85,8 @@ export const ThreatActorGroupMutationRelationDelete = graphql`
   }
 `;
 
+const THREAT_ACTOR_GROUP_TYPE = 'Threat-Actor-Group';
+
 const ThreatActorGroupEditionOverviewComponent = (props) => {
   const { threatActorGroup, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
@@ -92,16 +94,17 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(THREAT_ACTOR_GROUP_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const ThreatActorGroupValidator = useSchemaEditionValidation(
-    'Threat-Actor-Group',
+  }, mandatoryAttributes);
+  const ThreatActorGroupValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const queries = {
@@ -190,6 +193,8 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={{ ...initialValues, references: [] }}
       validationSchema={ThreatActorGroupValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -206,6 +211,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -219,6 +225,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
             type="threat-actor-group-type-ov"
             name="threat_actor_types"
             label={t_i18n('Threat actor types')}
+            required={(mandatoryAttributes.includes('threat_actor_types'))}
             containerStyle={{ width: '100%', marginTop: 20 }}
             multiple={true}
             onFocus={editor.changeFocus}
@@ -238,6 +245,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -267,6 +275,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -276,6 +285,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -101,6 +101,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    createdBy: Yup.object().nullable(),
     x_opencti_workflow_id: Yup.object(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -102,6 +102,7 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const ThreatActorGroupValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -23,7 +23,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
@@ -146,11 +146,13 @@ ThreatActorIndividualFormProps
   const { heightsConverterSave, weightsConverterSave } = useUserMetric();
   const [currentTab, setCurrentTab] = useState(0);
   const handleChangeTab = (_: React.SyntheticEvent, value: number) => setCurrentTab(value);
-  const basicShape = {
-    name: Yup.string().required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(THREAT_ACTOR_INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string(),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
+    objectMarking: Yup.array().nullable(),
     first_seen: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -198,9 +200,9 @@ ThreatActorIndividualFormProps
           .typeError(t_i18n('The value must be a date (yyyy-MM-dd)')),
       }),
     ),
-  };
-  const threatActorIndividualValidator = useSchemaCreationValidation(
-    THREAT_ACTOR_INDIVIDUAL_TYPE,
+  }, mandatoryAttributes);
+  const threatActorIndividualValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -324,6 +326,8 @@ ThreatActorIndividualFormProps
     <Formik<ThreatActorIndividualAddInput>
       initialValues={initialValues}
       validationSchema={threatActorIndividualValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -388,6 +392,7 @@ ThreatActorIndividualFormProps
                   style={{ marginTop: 20 }}
                   name="name"
                   label={t_i18n('Name')}
+                  required={(mandatoryAttributes.includes('name'))}
                   fullWidth={true}
                   askAi={true}
                   detectDuplicate={[
@@ -401,6 +406,7 @@ ThreatActorIndividualFormProps
                   type="threat-actor-individual-type-ov"
                   name="threat_actor_types"
                   label={t_i18n('Threat actor types')}
+                  required={(mandatoryAttributes.includes('threat_actor_types'))}
                   multiple={true}
                   containerStyle={{ width: '100%', marginTop: 20 }}
                   onChange={setFieldValue}
@@ -413,6 +419,7 @@ ThreatActorIndividualFormProps
                   component={MarkdownField}
                   name="description"
                   label={t_i18n('Description')}
+                  required={(mandatoryAttributes.includes('description'))}
                   fullWidth={true}
                   multiline={true}
                   rows="4"
@@ -421,22 +428,26 @@ ThreatActorIndividualFormProps
                 />
                 <CreatedByField
                   name="createdBy"
+                  required={(mandatoryAttributes.includes('createdBy'))}
                   style={fieldSpacingContainerStyle}
                   setFieldValue={setFieldValue}
                 />
                 <ObjectLabelField
                   name="objectLabel"
+                  required={(mandatoryAttributes.includes('objectLabel'))}
                   style={fieldSpacingContainerStyle}
                   setFieldValue={setFieldValue}
                   values={values.objectLabel}
                 />
                 <ObjectMarkingField
                   name="objectMarking"
+                  required={(mandatoryAttributes.includes('objectMarking'))}
                   style={fieldSpacingContainerStyle}
                   setFieldValue={setFieldValue}
                 />
                 <ExternalReferencesField
                   name="externalReferences"
+                  required={(mandatoryAttributes.includes('externalReferences'))}
                   style={fieldSpacingContainerStyle}
                   setFieldValue={setFieldValue}
                   values={values.externalReferences}
@@ -458,6 +469,7 @@ ThreatActorIndividualFormProps
                 <Field
                   component={DateTimePickerField}
                   name="first_seen"
+                  required={(mandatoryAttributes.includes('first_seen'))}
                   textFieldProps={{
                     label: t_i18n('First seen'),
                     variant: 'standard',
@@ -468,6 +480,7 @@ ThreatActorIndividualFormProps
                 <Field
                   component={DateTimePickerField}
                   name="last_seen"
+                  required={(mandatoryAttributes.includes('last_seen'))}
                   textFieldProps={{
                     label: t_i18n('Last seen'),
                     variant: 'standard',
@@ -479,6 +492,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Sophistication')}
                   type="threat_actor_individual_sophistication_ov"
                   name="sophistication"
+                  required={(mandatoryAttributes.includes('sophistication'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={false}
@@ -487,6 +501,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Resource level')}
                   type="attack-resource-level-ov"
                   name="resource_level"
+                  required={(mandatoryAttributes.includes('resource_level'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={false}
@@ -495,6 +510,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Roles')}
                   type="threat-actor-individual-role-ov"
                   name="roles"
+                  required={(mandatoryAttributes.includes('roles'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={true}
@@ -503,6 +519,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Primary motivation')}
                   type="attack-motivation-ov"
                   name="primary_motivation"
+                  required={(mandatoryAttributes.includes('primary_motivation'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={false}
@@ -511,6 +528,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Secondary motivations')}
                   type="attack-motivation-ov"
                   name="secondary_motivations"
+                  required={(mandatoryAttributes.includes('secondary_motivations'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={true}
@@ -519,6 +537,7 @@ ThreatActorIndividualFormProps
                   label={t_i18n('Personal motivations')}
                   type="attack-motivation-ov"
                   name="personal_motivations"
+                  required={(mandatoryAttributes.includes('personal_motivations'))}
                   containerStyle={fieldSpacingContainerStyle}
                   variant="edit"
                   multiple={true}
@@ -527,6 +546,7 @@ ThreatActorIndividualFormProps
                   component={TextField}
                   name="goals"
                   label={t_i18n('Goals (1 / line)')}
+                  required={(mandatoryAttributes.includes('goals'))}
                   fullWidth={true}
                   multiline={true}
                   rows="4"
@@ -540,6 +560,7 @@ ThreatActorIndividualFormProps
                   id="PlaceOfBirth"
                   name="bornIn"
                   label={t_i18n('Place of Birth')}
+                  required={(mandatoryAttributes.includes('bornIn'))}
                   containerStyle={fieldSpacingContainerStyle}
                   onChange={setFieldValue}
                 />
@@ -547,6 +568,7 @@ ThreatActorIndividualFormProps
                   id="Ethnicity"
                   name="ethnicity"
                   label={t_i18n('Ethnicity')}
+                  required={(mandatoryAttributes.includes('ethnicity'))}
                   containerStyle={fieldSpacingContainerStyle}
                   onChange={setFieldValue}
                 />
@@ -565,6 +587,7 @@ ThreatActorIndividualFormProps
                 <OpenVocabField
                   name="marital_status"
                   label={t_i18n('Marital Status')}
+                  required={(mandatoryAttributes.includes('marital_status'))}
                   type="marital_status_ov"
                   variant="edit"
                   onChange={setFieldValue}
@@ -575,6 +598,7 @@ ThreatActorIndividualFormProps
                 <OpenVocabField
                   name="gender"
                   label={t_i18n('Gender')}
+                  required={(mandatoryAttributes.includes('gender'))}
                   type="gender_ov"
                   variant="edit"
                   onChange={setFieldValue}
@@ -587,6 +611,7 @@ ThreatActorIndividualFormProps
                   name="job_title"
                   id="job_title"
                   label={t_i18n('Job Title')}
+                  required={(mandatoryAttributes.includes('job_title'))}
                   fullWidth={true}
                   multiline={false}
                   rows="1"
@@ -600,6 +625,7 @@ ThreatActorIndividualFormProps
                 <OpenVocabField
                   name="eye_color"
                   label={t_i18n('Eye Color')}
+                  required={(mandatoryAttributes.includes('eye_color'))}
                   type="eye_color_ov"
                   variant="edit"
                   onChange={setFieldValue}
@@ -610,6 +636,7 @@ ThreatActorIndividualFormProps
                 <OpenVocabField
                   name="hair_color"
                   label={t_i18n('Hair Color')}
+                  required={(mandatoryAttributes.includes('hair_color'))}
                   type="hair_color_ov"
                   variant="edit"
                   onChange={setFieldValue}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
@@ -23,7 +23,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { isEmptyField } from '../../../../utils/utils';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 
 const threatActorIndividualEditionDemographicsFocus = graphql`
@@ -76,6 +76,8 @@ const threatActorIndividualEditionDemographicsFragment = graphql`
   }
 `;
 
+const THREAT_ACTOR_INDIVIDUAL_TYPE = 'Threat-Actor-Individual';
+
 interface ThreatActorIndividualEditionDemographicsComponentProps {
   threatActorIndividualRef: ThreatActorIndividualEditionDemographics_ThreatActorIndividual$key;
   enableReferences: boolean;
@@ -92,7 +94,9 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
     threatActorIndividualEditionDemographicsFragment,
     threatActorIndividualRef,
   );
-  const basicShape = {
+
+  const { mandatoryAttributes } = useIsMandatoryAttribute(THREAT_ACTOR_INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
     date_of_birth: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a date (yyyy-MM-dd)')),
@@ -103,9 +107,9 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
     job_title: Yup.string().nullable().max(250, t_i18n('The value is too long')),
     bornIn: Yup.object().nullable(),
     ethnicity: Yup.object().nullable(),
-  };
-  const threatActorIndividualValidator = useSchemaEditionValidation(
-    'Threat-Actor-Individual',
+  }, mandatoryAttributes);
+  const threatActorIndividualValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -181,7 +185,9 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
         enableReinitialize={true}
         initialValues={initialValues}
         validationSchema={threatActorIndividualValidator}
-        onSubmit={() => {}}
+        validateOnChange={true}
+        validateOnBlur={true}
+        onSubmit={() => { }}
       >
         {({ submitForm, isSubmitting, setFieldValue, isValid, dirty }) => (
           <div>
@@ -191,6 +197,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
                 id="PlaceOfBirth"
                 name="bornIn"
                 label={t_i18n('Place of Birth')}
+                required={(mandatoryAttributes.includes('bornIn'))}
                 containerStyle={fieldSpacingContainerStyle}
                 onChange={(name, value) => {
                   setFieldValue(name, value);
@@ -201,6 +208,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
                 id="Ethnicity"
                 name="ethnicity"
                 label={t_i18n('Ethnicity')}
+                required={(mandatoryAttributes.includes('ethnicity'))}
                 containerStyle={fieldSpacingContainerStyle}
                 onChange={(name, value) => {
                   setFieldValue(name, value);
@@ -229,6 +237,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
               <OpenVocabField
                 name="marital_status"
                 label={t_i18n('Marital Status')}
+                required={(mandatoryAttributes.includes('marital_status'))}
                 type="marital_status_ov"
                 variant="edit"
                 onChange={(name, value) => setFieldValue(name, value)}
@@ -241,6 +250,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
               <OpenVocabField
                 name="gender"
                 label={t_i18n('Gender')}
+                required={(mandatoryAttributes.includes('gender'))}
                 type="gender_ov"
                 variant="edit"
                 onChange={(name, value) => setFieldValue(name, value)}
@@ -255,6 +265,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
                 name="job_title"
                 id="job_title"
                 label={t_i18n('Job Title')}
+                required={(mandatoryAttributes.includes('job_title'))}
                 fullWidth={true}
                 multiline={false}
                 rows="1"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
@@ -21,7 +21,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorIndividualEditionDetails_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionDetails_ThreatActorIndividual.graphql';
 import { ThreatActorIndividualEditionDetailsFocusMutation } from './__generated__/ThreatActorIndividualEditionDetailsFocusMutation.graphql';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -81,6 +81,8 @@ const threatActorIndividualEditionDetailsFragment = graphql`
   }
 `;
 
+const THREAT_ACTOR_INDIVIDUAL_TYPE = 'Threat-Actor-Individual';
+
 interface ThreatActorIndividualEditionDetailsProps {
   threatActorIndividualRef: ThreatActorIndividualEditionDetails_ThreatActorIndividual$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -109,7 +111,9 @@ ThreatActorIndividualEditionDetailsProps
   const [commitEditionDetailsFocus] = useApiMutation<ThreatActorIndividualEditionDetailsFocusMutation>(
     ThreatActorIndividualEditionDetailsFocus,
   );
-  const basicShape = {
+
+  const { mandatoryAttributes } = useIsMandatoryAttribute(THREAT_ACTOR_INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
     first_seen: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -124,9 +128,9 @@ ThreatActorIndividualEditionDetailsProps
     personal_motivations: Yup.array().nullable(),
     goals: Yup.string().nullable(),
     references: Yup.array(),
-  };
-  const individualThreatActorValidator = useSchemaEditionValidation(
-    'Threat-Actor-Individual',
+  }, mandatoryAttributes);
+  const individualThreatActorValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -239,6 +243,8 @@ ThreatActorIndividualEditionDetailsProps
         enableReinitialize={true}
         initialValues={initialValues as never}
         validationSchema={individualThreatActorValidator}
+        validateOnChange={true}
+        validateOnBlur={true}
         onSubmit={onSubmit}
       >
         {({
@@ -259,6 +265,7 @@ ThreatActorIndividualEditionDetailsProps
                 onSubmit={handleSubmitField}
                 textFieldProps={{
                   label: t_i18n('First seen'),
+                  required: (mandatoryAttributes.includes('first_seen')),
                   variant: 'standard',
                   fullWidth: true,
                   helperText: (
@@ -276,6 +283,7 @@ ThreatActorIndividualEditionDetailsProps
                 onSubmit={handleSubmitField}
                 textFieldProps={{
                   label: t_i18n('Last seen'),
+                  required: (mandatoryAttributes.includes('last_seen')),
                   variant: 'standard',
                   fullWidth: true,
                   style: { marginTop: 20 },
@@ -291,6 +299,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Sophistication')}
                 type="threat_actor_individual_sophistication_ov"
                 name="sophistication"
+                required={(mandatoryAttributes.includes('sophistication'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -303,6 +312,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Resource level')}
                 type="attack-resource-level-ov"
                 name="resource_level"
+                required={(mandatoryAttributes.includes('resource_level'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -315,6 +325,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Roles')}
                 type="threat-actor-individual-role-ov"
                 name="roles"
+                required={(mandatoryAttributes.includes('roles'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -327,6 +338,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Primary motivation')}
                 type="attack-motivation-ov"
                 name="primary_motivation"
+                required={(mandatoryAttributes.includes('primary_motivation'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -339,6 +351,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Secondary motivations')}
                 type="attack-motivation-ov"
                 name="secondary_motivations"
+                required={(mandatoryAttributes.includes('secondary_motivations'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -351,6 +364,7 @@ ThreatActorIndividualEditionDetailsProps
                 label={t_i18n('Personal motivations')}
                 type="attack-motivation-ov"
                 name="personal_motivations"
+                required={(mandatoryAttributes.includes('personal_motivations'))}
                 onFocus={handleChangeFocus}
                 onChange={(name, value) => setFieldValue(name, value)}
                 onSubmit={handleSubmitField}
@@ -363,6 +377,7 @@ ThreatActorIndividualEditionDetailsProps
                 component={TextField}
                 name="goals"
                 label={t_i18n('Goals (1 / line)')}
+                required={(mandatoryAttributes.includes('goals'))}
                 fullWidth={true}
                 multiline={true}
                 rows="4"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -16,7 +16,7 @@ import StatusField from '../../common/form/StatusField';
 import { convertAssignees, convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatus } from '../../../../utils/edition';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { useFormatter } from '../../../../components/i18n';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { Option } from '../../common/form/ReferenceField';
@@ -121,6 +121,8 @@ const threatActorIndividualEditionOverviewFragment = graphql`
   }
 `;
 
+const THREAT_ACTOR_INDIVIDUAL_TYPE = 'Threat-Actor-Individual';
+
 interface ThreatActorIndividualEditionOverviewProps {
   threatActorIndividualRef: ThreatActorIndividualEditionOverview_ThreatActorIndividual$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -150,16 +152,18 @@ ThreatActorIndividualEditionOverviewProps
     threatActorIndividualEditionOverviewFragment,
     threatActorIndividualRef,
   );
-  const basicShape = {
+
+  const { mandatoryAttributes } = useIsMandatoryAttribute(THREAT_ACTOR_INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     threat_actor_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const ThreatActorIndividualValidator = useSchemaEditionValidation(
-    'Threat-Actor-Individual',
+  }, mandatoryAttributes);
+  const ThreatActorIndividualValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const queries = {
@@ -246,6 +250,8 @@ ThreatActorIndividualEditionOverviewProps
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={ThreatActorIndividualValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -262,6 +268,7 @@ ThreatActorIndividualEditionOverviewProps
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -274,6 +281,7 @@ ThreatActorIndividualEditionOverviewProps
             type="threat-actor-individual-type-ov"
             name="threat_actor_types"
             label={t_i18n('Threat actor types')}
+            required={(mandatoryAttributes.includes('threat_actor_types'))}
             containerStyle={{ width: '100%', marginTop: 20 }}
             multiple={true}
             onFocus={editor.changeFocus}
@@ -293,6 +301,7 @@ ThreatActorIndividualEditionOverviewProps
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -321,6 +330,7 @@ ThreatActorIndividualEditionOverviewProps
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -330,6 +340,7 @@ ThreatActorIndividualEditionOverviewProps
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -160,6 +160,7 @@ ThreatActorIndividualEditionOverviewProps
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
+    createdBy: Yup.object().nullable(),
     x_opencti_workflow_id: Yup.object(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
@@ -331,7 +332,7 @@ ThreatActorIndividualEditionOverviewProps
           )}
           <CreatedByField
             name="createdBy"
-            required={(mandatoryAttributes.includes('createBy'))}
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -161,6 +161,7 @@ ThreatActorIndividualEditionOverviewProps
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const ThreatActorIndividualValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Threats' section of the platform, to include creating and editing the following entity types:
* Threat Actor Group
* Threat Actor Individual
* Intrusion Set
* Campaign

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

* All creation forms include the field `objectLabel` but the edit forms do not. This field is not in the 'Customization' menu. Adding it would break the edit forms.
