### PR TITLE
[backend] add ability to enrich in draft context (#6577)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -12014,6 +12014,7 @@ type DraftWorkspace implements InternalObject & BasicObject {
   standard_id: String!
   parent_types: [String!]!
   name: String!
+  entity_id: String
 }
 
 enum DraftWorkspacesOrdering {
@@ -12032,4 +12033,5 @@ type DraftWorkspaceEdge {
 
 input DraftWorkspaceAddInput {
   name: String!
+  entity_id: String
 }

--- a/opencti-platform/opencti-graphql/src/domain/enrichment.js
+++ b/opencti-platform/opencti-graphql/src/domain/enrichment.js
@@ -38,12 +38,12 @@ export const createEntityAutoEnrichment = async (context, user, element, scope) 
         internal: {
           work_id: work.id, // Related action for history
           applicant_id: null, // No specific user asking for the import
+          draft_id: draftContext ?? null,
         },
         event: {
           event_type: CONNECTOR_INTERNAL_ENRICHMENT,
           entity_id: elementStandardId,
           entity_type: element.entity_type,
-          draft_id: draftContext ?? null,
         },
       };
       return pushToConnector(connector.internal_id, message);

--- a/opencti-platform/opencti-graphql/src/domain/enrichment.js
+++ b/opencti-platform/opencti-graphql/src/domain/enrichment.js
@@ -10,18 +10,22 @@ import { isStixMatchFilterGroup } from '../utils/filtering/filtering-stix/stix-f
 import { isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import { SYSTEM_USER } from '../utils/access';
 import { convertStoreToStix } from '../database/stix-converter';
+import { getDraftContext } from '../utils/draftContext';
 
 export const createEntityAutoEnrichment = async (context, user, element, scope) => {
   if (!isStixObject(element.entity_type)) {
     return null; // we only enrich stix core objects
   }
+  const draftContext = getDraftContext(context, user);
+  const contextOutOfDraft = { ...context, draft_context: '' };
   const elementStandardId = element.standard_id;
   // Get the list of compatible connectors
   const targetConnectors = await findConnectorsForElementEnrichment(context, user, element, scope);
   // Create a work for each connector
+  const workMessage = draftContext ? `Enrichment (${elementStandardId}) in draft ${draftContext}` : `Enrichment (${elementStandardId})`;
   const workList = await Promise.all(
     map((connector) => {
-      return createWork(context, user, connector, `Enrichment (${elementStandardId})`, elementStandardId).then((work) => {
+      return createWork(contextOutOfDraft, user, connector, workMessage, elementStandardId).then((work) => {
         return { connector, work };
       });
     }, targetConnectors)
@@ -39,6 +43,7 @@ export const createEntityAutoEnrichment = async (context, user, element, scope) 
           event_type: CONNECTOR_INTERNAL_ENRICHMENT,
           entity_id: elementStandardId,
           entity_type: element.entity_type,
+          draft_id: draftContext ?? null,
         },
       };
       return pushToConnector(connector.internal_id, message);

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -222,12 +222,12 @@ export const askElementEnrichmentForConnector = async (context, user, enrichedId
     internal: {
       work_id: work.id, // Related action for history
       applicant_id: null, // No specific user asking for the import
+      draft_id: draftContext ?? null,
     },
     event: {
       event_type: CONNECTOR_INTERNAL_ENRICHMENT,
       entity_id: element.standard_id,
       entity_type: element.entity_type,
-      draft_id: draftContext ?? null,
     },
   };
   await pushToConnector(connector.internal_id, message);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6401,6 +6401,7 @@ export type DomainNameAddInput = {
 
 export type DraftWorkspace = BasicObject & InternalObject & {
   __typename?: 'DraftWorkspace';
+  entity_id?: Maybe<Scalars['String']['output']>;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
@@ -6409,6 +6410,7 @@ export type DraftWorkspace = BasicObject & InternalObject & {
 };
 
 export type DraftWorkspaceAddInput = {
+  entity_id?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
 };
 
@@ -33884,6 +33886,7 @@ export type DomainNameResolvers<ContextType = any, ParentType extends ResolversP
 }>;
 
 export type DraftWorkspaceResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftWorkspace'] = ResolversParentTypes['DraftWorkspace']> = ResolversObject<{
+  entity_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -6,6 +6,7 @@ type DraftWorkspace implements InternalObject & BasicObject {
     parent_types: [String!]!
     # DraftWorkspace
     name: String!
+    entity_id: String
 }
 
 # Ordering
@@ -48,6 +49,7 @@ type Query {
 
 input DraftWorkspaceAddInput {
     name: String!
+    entity_id: String
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
@@ -19,7 +19,8 @@ const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, St
   },
   attributes: [
     { ...createdAt },
-    { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true }
+    { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'entity_id', label: 'Related entity', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   relations: [],
   relationsRefs: [],

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
+import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_CORE_OBJECT } from '../../schema/general';
 import { type ModuleDefinition, registerDefinition } from '../../schema/module';
 import { createdAt } from '../../schema/attribute-definition';
 import { ENTITY_TYPE_DRAFT_WORKSPACE, type StixDraftWorkspace, type StoreEntityDraftWorkspace } from './draftWorkspace-types';
@@ -20,7 +20,7 @@ const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, St
   attributes: [
     { ...createdAt },
     { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'entity_id', label: 'Related entity', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'entity_id', label: 'Related entity', type: 'string', format: 'id', entityTypes: [ABSTRACT_STIX_CORE_OBJECT], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   relations: [],
   relationsRefs: [],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add enrichment in draft context: both manual and auto enrichment
* add draft entity_id context to know where the draft was created from

Related PR : https://github.com/OpenCTI-Platform/client-python/pull/783/

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6577 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
