### PR TITLE
[frontend] Popover event menu support for FAB_REPLACEMENT feature flag

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -130,6 +130,7 @@ const RootGrouping = () => {
                     enableQuickExport={true}
                     enableAskAi={true}
                     redirectToContent={true}
+                    enableEnricher={true}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -102,6 +102,7 @@ const RootNote = () => {
                         }
                         redirectToContent={false}
                         disableAuthorizedMembers={true}
+                        enableEnricher={true}
                       />
                     }
                   >
@@ -115,6 +116,7 @@ const RootNote = () => {
                       }
                       redirectToContent={false}
                       disableAuthorizedMembers={true}
+                      enableEnricher={true}
                     />
                   </CollaborativeSecurity>
                   <Box sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 3 }}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -130,6 +130,7 @@ const RootReport = () => {
                     enableAskAi={true}
                     overview={isOverview}
                     redirectToContent={true}
+                    enableEnricher={true}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -127,6 +127,7 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
         enableQuickSubscription={true}
         enableAskAi={true}
         redirectToContent={true}
+        enableEnricher={true}
       />
       <Box
         sx={{

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -122,6 +122,7 @@ const RootCaseRfiComponent = ({ queryRef, caseId }) => {
         enableQuickSubscription={true}
         enableAskAi={true}
         redirectToContent={true}
+        enableEnricher={true}
       />
       <Box
         sx={{

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -121,6 +121,7 @@ const RootCaseRftComponent = ({ queryRef, caseId }) => {
         enableQuickSubscription={true}
         enableAskAi={true}
         redirectToContent={true}
+        enableEnricher={true}
       />
       <Box
         sx={{

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -128,6 +128,7 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
         disableSharing={true}
         enableQuickSubscription
         redirectToContent={true}
+        enableEnricher={true}
       />
       <Box
         sx={{

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -108,6 +108,7 @@ const RootTaskComponent = ({ queryRef, taskId }) => {
             enableSuggestions={false}
             redirectToContent={true}
             disableAuthorizedMembers={true}
+            enableEnricher={true}
           />
           <Box
             sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -466,6 +466,7 @@ const ContainerHeader = (props) => {
     investigationAddFromContainer,
     enableAskAi,
     redirectToContent,
+    enableEnricher,
   } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -1102,7 +1103,7 @@ const ContainerHeader = (props) => {
                 {React.cloneElement(PopoverComponent, { id: container.id })}
               </Security>
             )}
-            {isFABReplaced && (
+            {isFABReplaced && enableEnricher && (
               <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
                 <StixCoreObjectEnrichment
                   stixCoreObjectId={container.id}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const IncidentDeletionDeleteMutation = graphql`
+  mutation IncidentDeletionDeleteMutation($id: ID!) {
+    incidentEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const IncidentDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Incident') },
+  });
+  const [commit] = useApiMutation(
+    IncidentDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/events/incidents');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this incident?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default IncidentDeletion;

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionContainer.tsx
@@ -6,13 +6,13 @@ import Tab from '@mui/material/Tab';
 import Drawer, { DrawerControlledDialType, DrawerVariant } from '@components/common/drawer/Drawer';
 import { IncidentEditionOverview_incident$key } from '@components/events/incidents/__generated__/IncidentEditionOverview_incident.graphql';
 import { IncidentEditionDetails_incident$key } from '@components/events/incidents/__generated__/IncidentEditionDetails_incident.graphql';
-import useHelper from 'src/utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import IncidentEditionOverview from './IncidentEditionOverview';
 import IncidentEditionDetails from './IncidentEditionDetails';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { IncidentEditionContainerQuery } from './__generated__/IncidentEditionContainerQuery.graphql';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 interface IncidentEditionContainerProps {
   queryRef: PreloadedQuery<IncidentEditionContainerQuery>

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -26,6 +26,8 @@ import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import { GenericContext } from '../../common/model/GenericContextModel';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import type { Theme } from '../../../../components/Theme';
+import IncidentDeletion from './IncidentDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionOverviewFieldPatchMutation(
@@ -245,6 +247,8 @@ IncidentEditionOverviewProps
     confidence: incident.confidence,
     references: [],
   };
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   return (
     <Formik
       enableReinitialize={true}
@@ -371,7 +375,14 @@ IncidentEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <IncidentDeletion
+                  id={incident.id}
+                />
+              : <div/>
+              }
+            {enableReferences && (
             <CommitMessage
               submitForm={submitForm}
               disabled={isSubmitting || !isValid || !dirty}
@@ -380,7 +391,8 @@ IncidentEditionOverviewProps
               setFieldValue={setFieldValue}
               id={incident.id}
             />
-          )}
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentPopover.tsx
@@ -20,6 +20,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { IncidentEditionContainerQuery } from './__generated__/IncidentEditionContainerQuery.graphql';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const IncidentPopoverDeletionMutation = graphql`
   mutation IncidentPopoverDeletionMutation($id: ID!) {
@@ -72,43 +73,48 @@ const IncidentPopover = ({ id }: { id: string }) => {
       },
     });
   };
-  return (
-    <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <Dialog
-        PaperProps={{ elevation: 1 }}
-        open={displayDelete}
-        keepMounted={true}
-        TransitionComponent={Transition}
-        onClose={handleCloseDelete}
-      >
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to delete this incident?')}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete} disabled={deleting}>
-            {t_i18n('Cancel')}
-          </Button>
-          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-            {t_i18n('Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {queryRef && (
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+
+  return isFABReplaced
+    ? (<></>)
+    : (
+      <>
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <Dialog
+          PaperProps={{ elevation: 1 }}
+          open={displayDelete}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          onClose={handleCloseDelete}
+        >
+          <DialogContent>
+            <DialogContentText>
+              {t_i18n('Do you want to delete this incident?')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
+            </Button>
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+        {queryRef && (
         <React.Suspense fallback={<div />}>
           <IncidentEditionContainer
             queryRef={queryRef}
@@ -116,9 +122,9 @@ const IncidentPopover = ({ id }: { id: string }) => {
             open={displayEdit}
           />
         </React.Suspense>
-      )}
-    </>
-  );
+        )}
+      </>
+    );
 };
 
 export default IncidentPopover;

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const ObservedDataDeletionDeleteMutation = graphql`
+  mutation ObservedDataDeletionDeleteMutation($id: ID!) {
+    observedDataEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const ObservedDataDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Observed-Data') },
+  });
+  const [commit] = useApiMutation(
+    ObservedDataDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/events/observed_data');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this observed data?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ObservedDataDeletion;

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataEditionOverview.jsx
@@ -19,6 +19,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import ObservedDataDeletion from './ObservedDataDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 export const observedDataMutationFieldPatch = graphql`
   mutation ObservedDataEditionOverviewFieldPatchMutation(
@@ -84,7 +86,8 @@ const observedDataMutationRelationDelete = graphql`
 const ObservedDataEditionOverviewComponent = (props) => {
   const { observedData, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     first_observed: Yup.date()
       .required(t_i18n('This field is required'))
@@ -301,16 +304,24 @@ const ObservedDataEditionOverviewComponent = (props) => {
               setFieldValue={setFieldValue}
               onChange={editor.changeMarking}
             />
-            {enableReferences && (
-              <CommitMessage
-                submitForm={submitForm}
-                disabled={isSubmitting || !isValid || !dirty}
-                setFieldValue={setFieldValue}
-                open={false}
-                values={values.references}
-                id={observedData.id}
-              />
-            )}
+            <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+              {isFABReplaced
+                ? <ObservedDataDeletion
+                    id={observedData.id}
+                  />
+                : <div />
+              }
+              {enableReferences && (
+                <CommitMessage
+                  submitForm={submitForm}
+                  disabled={isSubmitting || !isValid || !dirty}
+                  setFieldValue={setFieldValue}
+                  open={false}
+                  values={values.references}
+                  id={observedData.id}
+                />
+              )}
+            </div>
           </Form>
         </div>
       )}

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataPopover.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +10,14 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { observedDataEditionQuery } from './ObservedDataEdition';
 import ObservedDataEditionContainer from './ObservedDataEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ObservedDataPopoverDeletionMutation = graphql`
   mutation ObservedDataPopoverDeletionMutation($id: ID!) {
@@ -28,109 +27,73 @@ const ObservedDataPopoverDeletionMutation = graphql`
   }
 `;
 
-class ObservedDataPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayExport: false,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const ObservedDataPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: ObservedDataPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/events/observed_data');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/events/observed_data');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this observed data?')}
+              {t_i18n('Do you want to delete this observed data?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -142,8 +105,8 @@ class ObservedDataPopover extends Component {
               return (
                 <ObservedDataEditionContainer
                   observedData={props.observedData}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -152,14 +115,6 @@ class ObservedDataPopover extends Component {
         />
       </>
     );
-  }
-}
-
-ObservedDataPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(ObservedDataPopover);
+export default ObservedDataPopover;

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -13,7 +13,7 @@ import ObservedData from './ObservedData';
 import ObservedDataPopover from './ObservedDataPopover';
 import FileManager from '../../common/files/FileManager';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import ContainerHeader from '../../common/containers/ContainerHeader';
 import Loader from '../../../../components/Loader';
 import ContainerStixDomainObjects from '../../common/containers/ContainerStixDomainObjects';
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
@@ -120,9 +120,8 @@ class RootObservedData extends Component {
                     { label: observedData.name, current: true },
                   ]}
                   />
-                  <StixDomainObjectHeader
-                    entityType="Observed-Data"
-                    stixDomainObject={observedData}
+                  <ContainerHeader
+                    container={observedData}
                     PopoverComponent={<ObservedDataPopover />}
                     EditComponent={(
                       <Security needs={[KNOWLEDGE_KNUPDATE]}>
@@ -131,6 +130,7 @@ class RootObservedData extends Component {
                     )}
                     redirectToContent = {false}
                     disableAuthorizedMembers={true}
+                    enableEnricher={false}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -13,7 +13,7 @@ import ObservedData from './ObservedData';
 import ObservedDataPopover from './ObservedDataPopover';
 import FileManager from '../../common/files/FileManager';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
-import ContainerHeader from '../../common/containers/ContainerHeader';
+import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import Loader from '../../../../components/Loader';
 import ContainerStixDomainObjects from '../../common/containers/ContainerStixDomainObjects';
 import ContainerStixCyberObservables from '../../common/containers/ContainerStixCyberObservables';
@@ -120,8 +120,9 @@ class RootObservedData extends Component {
                     { label: observedData.name, current: true },
                   ]}
                   />
-                  <ContainerHeader
-                    container={observedData}
+                  <StixDomainObjectHeader
+                    entityType="Observed-Data"
+                    stixDomainObject={observedData}
                     PopoverComponent={<ObservedDataPopover />}
                     EditComponent={(
                       <Security needs={[KNOWLEDGE_KNUPDATE]}>

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -425,30 +425,38 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
                 }
                 disabled={inferred}
               />
-              {enableReferences && (
-                <CommitMessage
-                  submitForm={submitForm}
-                  disabled={isSubmitting || !isValid || !dirty}
-                  setFieldValue={setFieldValue}
-                  open={false}
-                  values={values.references}
-                  id={stixSightingRelationship.id}
-                  noStoreUpdate={noStoreUpdate}
-                />
-              )}
+              <div style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'flex-end',
+                gap: '10px',
+              }}
+              >
+                {enableReferences && (
+                  <CommitMessage
+                    submitForm={submitForm}
+                    disabled={isSubmitting || !isValid || !dirty}
+                    setFieldValue={setFieldValue}
+                    open={false}
+                    values={values.references}
+                    id={stixSightingRelationship.id}
+                    noStoreUpdate={noStoreUpdate}
+                  />
+                )}
+                {typeof handleDelete === 'function' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => handleDelete()}
+                    classes={{ root: classes.button }}
+                    disabled={inferred}
+                  >
+                    {t_i18n('Delete')}
+                  </Button>
+                )}
+              </div>
             </Form>
           )}
         </Formik>
-        {typeof handleDelete === 'function' && (
-          <Button
-            variant="contained"
-            onClick={() => handleDelete()}
-            classes={{ root: classes.button }}
-            disabled={inferred}
-          >
-            {t_i18n('Delete')}
-          </Button>
-        )}
       </div>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -427,11 +427,21 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
               />
               <div style={{
                 display: 'flex',
-                alignItems: 'flex-end',
-                justifyContent: 'flex-end',
-                gap: '10px',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                width: '100%',
               }}
               >
+                {typeof handleDelete === 'function' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => handleDelete()}
+                    classes={{ root: classes.button }}
+                    disabled={inferred}
+                  >
+                    {t_i18n('Delete')}
+                  </Button>
+                )}
                 {enableReferences && (
                   <CommitMessage
                     submitForm={submitForm}
@@ -442,16 +452,6 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
                     id={stixSightingRelationship.id}
                     noStoreUpdate={noStoreUpdate}
                   />
-                )}
-                {typeof handleDelete === 'function' && (
-                  <Button
-                    variant="contained"
-                    onClick={() => handleDelete()}
-                    classes={{ root: classes.button }}
-                    disabled={inferred}
-                  >
-                    {t_i18n('Delete')}
-                  </Button>
                 )}
               </div>
             </Form>


### PR DESCRIPTION
### Proposed changes

These changes apply to the Events menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

* Remove the ... popover icon.
* Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
    * Note - Sightings already has delete on drawer by default.
* Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* This work is complementary to the FAB replacement PRs that have been merged of:
  * #8106 
  * #8121 
  * #8199
* Addresses the behavior seen for areas this capability has not merged against brought up in Issue #8704

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
