### PR TITLE
[frontend] Add support for dynamic configurable required fields to Observations

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
@@ -49,12 +49,22 @@ class KillChainPhasesField extends Component {
   }
 
   render() {
-    const { t, name, style, classes, onChange, helpertext, disabled } = this.props;
+    const {
+      t,
+      name,
+      style,
+      classes,
+      onChange,
+      helpertext,
+      disabled,
+      required = false,
+    } = this.props;
     return (
       <Field
         component={AutocompleteField}
         style={style}
         name={name}
+        required={required}
         multiple={true}
         disabled={disabled}
         textfieldprops={{
@@ -62,6 +72,7 @@ class KillChainPhasesField extends Component {
           label: t('Kill chain phases'),
           helperText: helpertext,
           onFocus: this.searchKillChainPhases.bind(this),
+          required,
         }}
         noOptionsText={t('No available options')}
         options={this.state.killChainPhases}

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -211,6 +211,7 @@ const ArtifactCreation = ({
                   setFieldValue={setFieldValue}
                   formikErrors={errors}
                   noMargin
+                  required
                 />
                 <Field
                   component={MarkdownField}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -35,7 +35,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { IndicatorCreationMutation, IndicatorCreationMutation$variables } from './__generated__/IndicatorCreationMutation.graphql';
 import { parse } from '../../../../utils/Time';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
@@ -123,15 +123,14 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INDICATOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     indicator_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
-    pattern: Yup.string().trim().required(t_i18n('This field is required')),
-    pattern_type: Yup.string().trim().required(t_i18n('This field is required')),
-    x_opencti_main_observable_type: Yup.string().trim().required(
-      t_i18n('This field is required'),
-    ),
+    pattern: Yup.string(),
+    pattern_type: Yup.string(),
+    x_opencti_main_observable_type: Yup.string(),
     valid_from: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -147,9 +146,9 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
     description: Yup.string().nullable(),
     x_opencti_detection: Yup.boolean().nullable(),
     createObservables: Yup.boolean().nullable(),
-  };
-  const indicatorValidator = useSchemaCreationValidation(
-    INDICATOR_TYPE,
+  }, mandatoryAttributes);
+  const indicatorValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -233,6 +232,8 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
     <Formik<IndicatorAddInput>
       initialValues={initialValues}
       validationSchema={indicatorValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -243,12 +244,14 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
           />
           <OpenVocabField
             label={t_i18n('Indicator types')}
             type="indicator-type-ov"
             name="indicator_types"
+            required={(mandatoryAttributes.includes('indicator_types'))}
             multiple={true}
             containerStyle={fieldSpacingContainerStyle}
             onChange={(n, v) => setFieldValue(n, v)}
@@ -261,6 +264,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             label={t_i18n('Pattern type')}
             type="pattern_type_ov"
             name="pattern_type"
+            required={(mandatoryAttributes.includes('pattern_type'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
@@ -270,6 +274,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             variant="standard"
             name="pattern"
             label={t_i18n('Pattern')}
+            required={(mandatoryAttributes.includes('pattern'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -279,6 +284,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
           <TypesField
             name="x_opencti_main_observable_type"
             label={t_i18n('Main observable type')}
+            required={(mandatoryAttributes.includes('x_opencti_main_observable_type'))}
             containerstyle={fieldSpacingContainerStyle}
           />
           <Field
@@ -286,6 +292,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             name="valid_from"
             textFieldProps={{
               label: t_i18n('Valid from'),
+              required: (mandatoryAttributes.includes('valid_from')),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -296,6 +303,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             name="valid_until"
             textFieldProps={{
               label: t_i18n('Valid until'),
+              required: (mandatoryAttributes.includes('valid_until')),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -305,6 +313,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             label={t_i18n('Platforms')}
             type="platforms_ov"
             name="x_mitre_platforms"
+            required={(mandatoryAttributes.includes('x_mitre_platforms'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
             multiple={true}
@@ -314,6 +323,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             variant="standard"
             name="x_opencti_score"
             label={t_i18n('Score')}
+            required={(mandatoryAttributes.includes('x_opencti_score'))}
             type="number"
             fullWidth={true}
             style={fieldSpacingContainerStyle}
@@ -322,6 +332,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -329,25 +340,30 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -21,7 +21,7 @@ import { buildDate, parse } from '../../../../utils/Time';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import IndicatorDeletion from './IndicatorDeletion';
@@ -77,6 +77,8 @@ const indicatorMutationRelationDelete = graphql`
   }
 `;
 
+const INDICATOR_TYPE = 'Indicator';
+
 const IndicatorEditionOverviewComponent = ({
   indicator,
   handleClose,
@@ -86,11 +88,12 @@ const IndicatorEditionOverviewComponent = ({
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INDICATOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     indicator_types: Yup.array(),
     confidence: Yup.number(),
-    pattern: Yup.string().trim().required(t_i18n('This field is required')),
+    pattern: Yup.string().trim(),
     valid_from: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -107,9 +110,9 @@ const IndicatorEditionOverviewComponent = ({
     x_opencti_detection: Yup.boolean(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const indicatorValidator = useSchemaEditionValidation(
-    'Indicator',
+  }, mandatoryAttributes);
+  const indicatorValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -217,6 +220,8 @@ const IndicatorEditionOverviewComponent = ({
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={indicatorValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -234,6 +239,7 @@ const IndicatorEditionOverviewComponent = ({
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -245,6 +251,7 @@ const IndicatorEditionOverviewComponent = ({
             label={t_i18n('Indicator types')}
             type="indicator-type-ov"
             name="indicator_types"
+            required={(mandatoryAttributes.includes('indicator_types'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -266,6 +273,7 @@ const IndicatorEditionOverviewComponent = ({
             variant="standard"
             name="pattern"
             label={t_i18n('Indicator pattern')}
+            required={(mandatoryAttributes.includes('pattern'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -283,6 +291,7 @@ const IndicatorEditionOverviewComponent = ({
             onSubmit={handleSubmitField}
             textFieldProps={{
               label: t_i18n('Valid from'),
+              required: (mandatoryAttributes.includes('valid_from')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -298,6 +307,7 @@ const IndicatorEditionOverviewComponent = ({
             onSubmit={handleSubmitField}
             textFieldProps={{
               label: t_i18n('Valid until'),
+              required: (mandatoryAttributes.includes('valid_until')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -310,6 +320,7 @@ const IndicatorEditionOverviewComponent = ({
             label={t_i18n('Platforms')}
             type="platforms_ov"
             name="x_mitre_platforms"
+            required={(mandatoryAttributes.includes('x_mitre_platforms'))}
             variant={'edit'}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -321,6 +332,7 @@ const IndicatorEditionOverviewComponent = ({
             component={TextField}
             variant="standard"
             name="x_opencti_score"
+            required={(mandatoryAttributes.includes('x_opencti_score'))}
             label={t_i18n('Score')}
             type="number"
             fullWidth={true}
@@ -338,6 +350,7 @@ const IndicatorEditionOverviewComponent = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -350,6 +363,7 @@ const IndicatorEditionOverviewComponent = ({
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -378,6 +392,7 @@ const IndicatorEditionOverviewComponent = ({
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -387,6 +402,7 @@ const IndicatorEditionOverviewComponent = ({
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
@@ -399,6 +415,7 @@ const IndicatorEditionOverviewComponent = ({
             type="checkbox"
             name="x_opencti_detection"
             label={t_i18n('Detection')}
+            required={(mandatoryAttributes.includes('x_opencti_detection'))}
             containerstyle={{ marginTop: 20 }}
             onChange={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -110,6 +110,8 @@ const IndicatorEditionOverviewComponent = ({
     x_opencti_detection: Yup.boolean(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    killChainPhases: Yup.array().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const indicatorValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,
@@ -367,10 +369,7 @@ const IndicatorEditionOverviewComponent = ({
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
-              <SubscriptionFocus
-                context={context}
-                fieldName="killChainPhases"
-              />
+              <SubscriptionFocus context={context} fieldName="killChainPhases" />
             }
             onChange={editor.changeKillChainPhases}
           />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
@@ -19,7 +19,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { parse } from '../../../../utils/Time';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { InfrastructureCreationMutation, InfrastructureCreationMutation$variables } from './__generated__/InfrastructureCreationMutation.graphql';
@@ -96,8 +96,9 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INFRASTRUCTURE_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     infrastructure_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
@@ -111,9 +112,9 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
         'The last seen date can\'t be before first seen date',
       )
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
-  };
-  const infrastructureValidator = useSchemaCreationValidation(
-    INFRASTRUCTURE_TYPE,
+  }, mandatoryAttributes);
+  const infrastructureValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -203,6 +204,8 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
     <Formik<InfrastructureAddInput>
       initialValues={initialValues}
       validationSchema={infrastructureValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -239,6 +242,7 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Infrastructure']}
             />
@@ -246,6 +250,7 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
               label={t_i18n('Infrastructure types')}
               type="infrastructure-type-ov"
               name="infrastructure_types"
+              required={(mandatoryAttributes.includes('infrastructure_types'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple={true}
               onChange={(name, value) => setFieldValue(name, value)}
@@ -259,6 +264,7 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
               name="first_seen"
               textFieldProps={{
                 label: t_i18n('First seen'),
+                required: (mandatoryAttributes.includes('first_seen')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -269,6 +275,7 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
               name="last_seen"
               textFieldProps={{
                 label: t_i18n('Last seen'),
+                required: (mandatoryAttributes.includes('last_seen')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -276,12 +283,14 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
             />
             <KillChainPhasesField
               name="killChainPhases"
+              required={(mandatoryAttributes.includes('killChainPhases'))}
               style={fieldSpacingContainerStyle}
             />
             <Field
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -289,21 +298,25 @@ export const InfrastructureCreationForm: FunctionComponent<InfrastructureFormPro
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -19,7 +19,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { InfrastructureEditionOverview_infrastructure$key } from './__generated__/InfrastructureEditionOverview_infrastructure.graphql';
 import { Option } from '../../common/form/ReferenceField';
@@ -133,6 +133,8 @@ export const infrastructureEditionOverviewFragment = graphql`
   }
 `;
 
+const INFRASTRUCTURE_TYPE = 'Infrastructure';
+
 interface InfrastructureEditionOverviewProps {
   infrastructureData: InfrastructureEditionOverview_infrastructure$key,
   context?: readonly (GenericContext | null)[] | null;
@@ -162,8 +164,11 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
   const infrastructure = useFragment(infrastructureEditionOverviewFragment, infrastructureData);
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    INFRASTRUCTURE_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     infrastructure_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
@@ -175,9 +180,9 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const infrastructureValidator = useSchemaEditionValidation(
-    'Infrastructure',
+  }, mandatoryAttributes);
+  const infrastructureValidator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -262,6 +267,8 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={infrastructureValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -279,6 +286,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -290,6 +298,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             label={t_i18n('Infrastructure types')}
             type="infrastructure_type_ov"
             name="infrastructure_types"
+            required={(mandatoryAttributes.includes('infrastructure_types'))}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
@@ -312,6 +321,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             onChange={editor.changeField}
             textFieldProps={{
               label: t_i18n('First seen'),
+              required: (mandatoryAttributes.includes('first_seen')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -327,6 +337,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             onChange={editor.changeField}
             textFieldProps={{
               label: t_i18n('Last seen'),
+              required: (mandatoryAttributes.includes('last_seen')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -337,6 +348,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -351,6 +363,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -379,6 +392,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -388,6 +402,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -180,6 +180,8 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    killChainPhases: Yup.array().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const infrastructureValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Observations' section of the platform, to include creating and editing the following entity types:

* Infrastructure
* Indicator

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

* This PR does not include support for configurable required fields on 'Observable' and 'Artifact' because no field customization options are available in Settings for these types.

* Both creation forms include the field objectLabel but the edit forms do not. This field is not in the 'Customization' menu. Adding it would break the edit forms.
