### PR TITLE
[frontend] Popover techniques menu support for FAB_REPLACEMENT feature flag

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const AttackPatternDeletionDeleteMutation = graphql`
+  mutation AttackPatternDeletionDeleteMutation($id: ID!) {
+    attackPatternEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const AttackPatternDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Attack-Pattern') },
+  });
+  const [commit] = useApiMutation(
+    AttackPatternDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/attack_patterns');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this attack pattern?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default AttackPatternDeletion;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionContainer.jsx
@@ -13,7 +13,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 const AttackPatternEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { handleClose, attackPattern, open, controlledDial } = props;
   const { editContext } = attackPattern;
@@ -27,9 +27,9 @@ const AttackPatternEditionContainer = (props) => {
       title={t_i18n('Update an attack pattern')}
       open={open}
       onClose={handleClose}
-      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
-      controlledDial={FABReplaced ? controlledDial : undefined}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       <>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -20,6 +20,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import AttackPatternDeletion from './AttackPatternDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const attackPatternMutationFieldPatch = graphql`
   mutation AttackPatternEditionOverviewFieldPatchMutation(
@@ -86,8 +88,9 @@ export const attackPatternMutationRelationDelete = graphql`
 const AttackPatternEditionOverviewComponent = (props) => {
   const { attackPattern, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
-
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     x_mitre_id: Yup.string().nullable(),
@@ -288,7 +291,13 @@ const AttackPatternEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <AttackPatternDeletion
+                  id={attackPattern.id}
+                />
+              : <div/>}
+            {enableReferences && (
             <CommitMessage
               submitForm={submitForm}
               disabled={isSubmitting || !isValid || !dirty}
@@ -297,7 +306,8 @@ const AttackPatternEditionOverviewComponent = (props) => {
               values={values.references}
               id={attackPattern.id}
             />
-          )}
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternPopover.jsx
@@ -1,24 +1,23 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import ToggleButton from '@mui/material/ToggleButton';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { attackPatternEditionQuery } from './AttackPatternEdition';
 import AttackPatternEditionContainer from './AttackPatternEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const AttackPatternPopoverDeletionMutation = graphql`
   mutation AttackPatternPopoverDeletionMutation($id: ID!) {
@@ -28,108 +27,73 @@ const AttackPatternPopoverDeletionMutation = graphql`
   }
 `;
 
-class AttackPatternPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const AttackPatternPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: AttackPatternPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/techniques/attack_patterns');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/attack_patterns');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this attack pattern?')}
+              {t_i18n('Do you want to delete this attack pattern?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -141,8 +105,8 @@ class AttackPatternPopover extends Component {
               return (
                 <AttackPatternEditionContainer
                   attackPattern={props.attackPattern}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -151,14 +115,6 @@ class AttackPatternPopover extends Component {
         />
       </>
     );
-  }
-}
-
-AttackPatternPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(AttackPatternPopover);
+export default AttackPatternPopover;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -137,7 +137,7 @@ const RootAttackPattern = ({ attackPatternId, queryRef }: RootAttackPatternProps
             <StixDomainObjectHeader
               entityType="Attack-Pattern"
               stixDomainObject={attackPattern}
-              PopoverComponent={<AttackPatternPopover />}
+              PopoverComponent={<AttackPatternPopover id={attackPattern.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <AttackPatternEdition attackPatternId={attackPattern.id} />

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionContainer.jsx
@@ -9,7 +9,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 const CourseOfActionEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { handleClose, courseOfAction, open, controlledDial } = props;
   const { editContext } = courseOfAction;
@@ -19,9 +19,9 @@ const CourseOfActionEditionContainer = (props) => {
       title={t_i18n('Update a course of action')}
       open={open}
       onClose={handleClose}
-      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
-      controlledDial={FABReplaced ? controlledDial : undefined}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       <CourseOfActionEditionOverview
         courseOfAction={courseOfAction}

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -18,6 +18,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import CourseOfActionDeletion from './CouseOfActionDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const courseOfActionMutationFieldPatch = graphql`
   mutation CourseOfActionEditionOverviewFieldPatchMutation(
@@ -84,7 +86,8 @@ const courseOfActionMutationRelationDelete = graphql`
 const CourseOfActionEditionOverviewComponent = (props) => {
   const { courseOfAction, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -319,16 +322,23 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={courseOfAction.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <CourseOfActionDeletion
+                  id={courseOfAction.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={courseOfAction.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { courseOfActionEditionQuery } from './CourseOfActionEdition';
 import CourseOfActionEditionContainer from './CourseOfActionEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const CourseOfActionPopoverDeletionMutation = graphql`
   mutation CourseOfActionPopoverDeletionMutation($id: ID!) {
@@ -28,108 +27,73 @@ const CourseOfActionPopoverDeletionMutation = graphql`
   }
 `;
 
-class CourseOfActionPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const CourseOfActionPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: CourseOfActionPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/techniques/courses_of_action');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/courses_of_action');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
-          open={this.state.displayDelete}
-          keepMounted={true}
-          TransitionComponent={Transition}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          onClose={this.handleCloseDelete.bind(this)}
+          TransitionComponent={Transition}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this course of action?')}
+              {t_i18n('Do you want to delete this course of action?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -141,8 +105,8 @@ class CourseOfActionPopover extends Component {
               return (
                 <CourseOfActionEditionContainer
                   courseOfAction={props.courseOfAction}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -151,13 +115,6 @@ class CourseOfActionPopover extends Component {
         />
       </>
     );
-  }
-}
-
-CourseOfActionPopover.propTypes = {
-  id: PropTypes.string,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(CourseOfActionPopover);
+export default CourseOfActionPopover;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CouseOfActionDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CouseOfActionDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const CourseOfActionDeletionDeleteMutation = graphql`
+  mutation CouseOfActionDeletionDeleteMutation($id: ID!) {
+    courseOfActionEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const CourseOfActionDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Course-Of-Action') },
+  });
+  const [commit] = useApiMutation(
+    CourseOfActionDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/courses_of_action');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this course of action?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default CourseOfActionDeletion;

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const DataComponentDeletionDeleteMutation = graphql`
+  mutation DataComponentDeletionDeleteMutation($id: ID!) {
+    dataComponentDelete(id: $id)
+  }
+`;
+
+const DataComponentDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Data-Component') },
+  });
+  const [commit] = useApiMutation(
+    DataComponentDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/data_components');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this data component?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default DataComponentDeletion;

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionContainer.tsx
@@ -35,18 +35,18 @@ const DataComponentEditionContainer: FunctionComponent<DataComponentEditionConta
 }) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { dataComponent } = usePreloadedQuery(dataComponentEditionQuery, queryRef);
 
   if (dataComponent) {
     return (
       <Drawer
         title={t_i18n('Update a data component')}
-        variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+        variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
         context={dataComponent.editContext}
         onClose={handleClose}
         open={open}
-        controlledDial={FABReplaced ? controlledDial : undefined}
+        controlledDial={isFABReplaced ? controlledDial : undefined}
       >
         {({ onClose }) => (
           <DataComponentEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -20,6 +20,8 @@ import { adaptFieldValue } from '../../../../utils/String';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import DataComponentDeletion from './DataComponentDeletion';
 
 const dataComponentMutationFieldPatch = graphql`
   mutation DataComponentEditionOverviewFieldPatchMutation(
@@ -140,7 +142,8 @@ const DataComponentEditionOverview: FunctionComponent<
 DataComponentEditionOverviewComponentProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const dataComponent = useFragment(DataComponentEditionOverviewFragment, data);
 
   const basicShape = {
@@ -314,16 +317,23 @@ DataComponentEditionOverviewComponentProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={dataComponent.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <DataComponentDeletion
+                  id={dataComponent.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={dataComponent.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentPopover.tsx
@@ -18,6 +18,7 @@ import Transition from '../../../../components/Transition';
 import { DataComponentEditionContainerQuery } from './__generated__/DataComponentEditionContainerQuery.graphql';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const DataComponentPopoverDeletionMutation = graphql`
   mutation DataComponentPopoverDeletionMutation($id: ID!) {
@@ -33,6 +34,8 @@ const DataComponentPopover: FunctionComponent<{ dataComponentId: string }> = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [displayDelete, setDisplayDelete] = useState<boolean>(false);
   const [displayEdit, setDisplayEdit] = useState<boolean>(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [deleting, setDeleting] = useState<boolean>(false);
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -64,53 +67,55 @@ const DataComponentPopover: FunctionComponent<{ dataComponentId: string }> = ({
     handleClose();
   };
   const handleCloseEdit = () => setDisplayEdit(false);
-  return (
-    <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <Dialog
-        open={displayDelete}
-        keepMounted={true}
-        TransitionComponent={Transition}
-        PaperProps={{ elevation: 1 }}
-        onClose={handleCloseDelete}
-      >
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to delete this data component?')}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete} disabled={deleting}>
-            {t_i18n('Cancel')}
-          </Button>
-          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-            {t_i18n('Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {queryRef && (
-        <React.Suspense fallback={<div />}>
-          <DataComponentEditionContainer
-            queryRef={queryRef}
-            handleClose={handleCloseEdit}
-            open={displayEdit}
-          />
-        </React.Suspense>
-      )}
-    </>
-  );
+  return isFABReplaced
+    ? (<></>)
+    : (
+      <>
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <Dialog
+          open={displayDelete}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          PaperProps={{ elevation: 1 }}
+          onClose={handleCloseDelete}
+        >
+          <DialogContent>
+            <DialogContentText>
+              {t_i18n('Do you want to delete this data component?')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
+            </Button>
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+        {queryRef && (
+          <React.Suspense fallback={<div />}>
+            <DataComponentEditionContainer
+              queryRef={queryRef}
+              handleClose={handleCloseEdit}
+              open={displayEdit}
+            />
+          </React.Suspense>
+        )}
+      </>
+    );
 };
 
 export default DataComponentPopover;

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const DataSourceDeletionDeleteMutation = graphql`
+  mutation DataSourceDeletionDeleteMutation($id: ID!) {
+    dataSourceDelete(id: $id)
+  }
+`;
+
+const DataSourceDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Data-Source') },
+  });
+  const [commit] = useApiMutation(
+    DataSourceDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/data_sources');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this data source?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default DataSourceDeletion;

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionContainer.tsx
@@ -35,19 +35,18 @@ const DataSourceEditionContainer: FunctionComponent<DataSourceEditionContainerPr
 }) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { dataSource } = usePreloadedQuery(dataSourceEditionQuery, queryRef);
 
   if (dataSource) {
     return (
       <Drawer
         title={t_i18n('Update a data source')}
-        variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+        variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
         context={dataSource.editContext}
         onClose={handleClose}
         open={open}
-        controlledDial={FABReplaced ? controlledDial : undefined}
+        controlledDial={isFABReplaced ? controlledDial : undefined}
       >
         {({ onClose }) => (
           <DataSourceEditionOverview

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -22,6 +22,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { dataComponentEditionOverviewFocus } from '../data_components/DataComponentEditionOverview';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import DataSourceDeletion from './DataSourceDeletion';
 
 const dataSourceMutationFieldPatch = graphql`
   mutation DataSourceEditionOverviewFieldPatchMutation(
@@ -148,7 +150,8 @@ DataSourceEditionOverviewProps
 > = ({ data, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
   const dataSource = useFragment(dataSourceEditionOverviewFragment, data);
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -347,16 +350,23 @@ DataSourceEditionOverviewProps
             multiple={true}
             editContext={context}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={dataSource.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <DataSourceDeletion
+                  id={dataSource.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={dataSource.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourcePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourcePopover.tsx
@@ -18,6 +18,7 @@ import { DataSourceEditionContainerQuery } from './__generated__/DataSourceEditi
 import DataSourceEditionContainer, { dataSourceEditionQuery } from './DataSourceEditionContainer';
 import Transition from '../../../../components/Transition';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const DataSourcePopoverDeletionMutation = graphql`
   mutation DataSourcePopoverDeletionMutation($id: ID!) {
@@ -33,7 +34,8 @@ const DataSourcePopover = ({ id }: { id: string }) => {
   const [displayDelete, setDisplayDelete] = useState<boolean>(false);
   const [displayEdit, setDisplayEdit] = useState<boolean>(false);
   const [deleting, setDeleting] = useState<boolean>(false);
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [commit] = useApiMutation(DataSourcePopoverDeletionMutation);
   const queryRef = useQueryLoading<DataSourceEditionContainerQuery>(
     dataSourceEditionQuery,
@@ -72,53 +74,55 @@ const DataSourcePopover = ({ id }: { id: string }) => {
     handleClose();
   };
 
-  return (
-    <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <Dialog
-        open={displayDelete}
-        keepMounted={true}
-        TransitionComponent={Transition}
-        PaperProps={{ elevation: 1 }}
-        onClose={handleCloseDelete}
-      >
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to delete this data source?')}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete} disabled={deleting}>
-            {t_i18n('Cancel')}
-          </Button>
-          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-            {t_i18n('Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {queryRef && (
-        <React.Suspense fallback={<div />}>
-          <DataSourceEditionContainer
-            queryRef={queryRef}
-            handleClose={handleClose}
-            open={displayEdit}
-          />
-        </React.Suspense>
-      )}
-    </>
-  );
+  return isFABReplaced
+    ? (<></>)
+    : (
+      <>
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <Dialog
+          open={displayDelete}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          PaperProps={{ elevation: 1 }}
+          onClose={handleCloseDelete}
+        >
+          <DialogContent>
+            <DialogContentText>
+              {t_i18n('Do you want to delete this data source?')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
+            </Button>
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+        {queryRef && (
+          <React.Suspense fallback={<div />}>
+            <DataSourceEditionContainer
+              queryRef={queryRef}
+              handleClose={handleClose}
+              open={displayEdit}
+            />
+          </React.Suspense>
+        )}
+      </>
+    );
 };
 
 export default DataSourcePopover;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const NarrativeDeletionDeleteMutation = graphql`
+  mutation NarrativeDeletionDeleteMutation($id: ID!) {
+    narrativeDelete(id: $id)
+  }
+`;
+
+const NarrativeDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Narrative') },
+  });
+  const [commit] = useApiMutation(
+    NarrativeDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/techniques/narratives');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this narrative?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default NarrativeDeletion;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionContainer.jsx
@@ -9,7 +9,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 const NarrativeEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { handleClose, narrative, open, controlledDial } = props;
   const { editContext } = narrative;
@@ -19,9 +19,9 @@ const NarrativeEditionContainer = (props) => {
       title={t_i18n('Update a narrative')}
       open={open}
       onClose={handleClose}
-      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
-      controlledDial={FABReplaced ? controlledDial : undefined}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       <NarrativeEditionOverview
         narrative={narrative}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -18,6 +18,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import NarrativeDeletion from './NarrativeDeletion';
 
 const narrativeMutationFieldPatch = graphql`
   mutation NarrativeEditionOverviewFieldPatchMutation(
@@ -81,7 +83,8 @@ const narrativeMutationRelationDelete = graphql`
 const NarrativeEditionOverviewComponent = (props) => {
   const { narrative, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -257,16 +260,23 @@ const NarrativeEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={narrative.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <NarrativeDeletion
+                  id={narrative.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={narrative.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -133,7 +133,7 @@ const RootNarrative = ({ narrativeId, queryRef }: RootNarrativeProps) => {
             <StixDomainObjectHeader
               entityType="Narrative"
               stixDomainObject={narrative}
-              PopoverComponent={<NarrativePopover />}
+              PopoverComponent={<NarrativePopover id={narrative.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <NarrativeEdition narrativeId={narrative.id} />


### PR DESCRIPTION
### Proposed changes

These changes apply to the Techniques menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

* Remove the ... popover icon.
* Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
* Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* This work is complementary to the FAB replacement PRs that have been merged of:
  * #8106 
  * #8121 
  * #8199
* Addresses the behavior seen for areas this capability has not merged against brought up in Issue #8704

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
