### PR TITLE
[frontend] add current user first in assignee/participant field (#4333)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "Aktuelle spezifische Zugriffe",
   "Current stable score": "Aktuelle stabile Punktzahl",
   "Current state": "Aktueller Zustand",
+  "Current User": "Aktueller Benutzer",
   "Custom dashboard": "Benutzerdefiniertes Dashboard",
   "Custom dashboards": "Benutzerdefinierte Dashboards",
   "Customization": "Anpassungen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "Current specific accesses",
   "Current stable score": "Current stable score",
   "Current state": "Current state",
+  "Current User": "Current User",
   "Custom dashboard": "Custom dashboard",
   "Custom dashboards": "Custom dashboards",
   "Customization": "Customization",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "Accesos específicos actuales",
   "Current stable score": "Puntuación estable actual",
   "Current state": "Estado actual",
+  "Current User": "Usuario actual",
   "Custom dashboard": "Cuadro de mando personalizado",
   "Custom dashboards": "Cuadros de mando personalizados",
   "Customization": "Personalización",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "Accès spécifiques actuels",
   "Current stable score": "Score stable actuel",
   "Current state": "Etat actuel",
+  "Current User": "Utilisateur actuel",
   "Custom dashboard": "Tableau de bord personnalisé",
   "Custom dashboards": "Tableaux de bord personnalisés",
   "Customization": "Personnalisation",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "現在の特定のアクセス",
   "Current stable score": "現在の安定スコア",
   "Current state": "現在の状態",
+  "Current User": "現在のユーザー",
   "Custom dashboard": "カスタムダッシュボード",
   "Custom dashboards": "カスタムダッシュボード",
   "Customization": "カスタマイズ",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "현재 특정 접근",
   "Current stable score": "현재 안정 점수",
   "Current state": "현재 상태",
+  "Current User": "현재 사용자",
   "Custom dashboard": "맞춤 대시보드",
   "Custom dashboards": "맞춤 대시보드",
   "Customization": "맞춤 설정",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -577,6 +577,7 @@
   "Current specific accesses": "当前特定访问权限",
   "Current stable score": "当前稳定分数",
   "Current state": "当前状态",
+  "Current User": "当前用户",
   "Custom dashboard": "自定义仪表盘",
   "Custom dashboards": "自定义仪表盘",
   "Customization": "定制化",

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
@@ -68,6 +68,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 interface OptionAssignee extends Option {
   type: string;
+  group: string;
 }
 interface ObjectAssigneeFieldProps {
   name: string;
@@ -102,11 +103,15 @@ const ObjectAssigneeField: FunctionComponent<ObjectAssigneeFieldProps> = ({
       .then((data) => {
         const newAssignees = (
           (data as ObjectAssigneeFieldMembersSearchQuery$data)?.members?.edges ?? []
-        ).map((n) => ({
-          label: n.node.name,
-          value: n.node.id,
-          type: n.node.entity_type,
-        })).sort((a, b) => {
+        ).map((n) => {
+          const group = n.node.id === me?.id ? t_i18n('User') : t_i18n('All');
+          return {
+            label: n.node.name,
+            value: n.node.id,
+            type: n.node.entity_type,
+            group,
+          };
+        }).sort((a, b) => {
           // Display first the current user
           if (a.value === me?.id) return -1;
           if (b.value === me?.id) return 1;
@@ -115,7 +120,7 @@ const ObjectAssigneeField: FunctionComponent<ObjectAssigneeFieldProps> = ({
         });
         // Add current user if is not in the only first results displayed
         const isMeDisplayed = newAssignees.find((assignee) => assignee.value === me?.id);
-        if (me && !isMeDisplayed) newAssignees.unshift({ label: me.name, value: me.id, type: 'User' });
+        if (me && !isMeDisplayed) newAssignees.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('User') });
         setAssignees(newAssignees);
       });
   };
@@ -127,6 +132,7 @@ const ObjectAssigneeField: FunctionComponent<ObjectAssigneeFieldProps> = ({
       disabled={disabled}
       required={required}
       multiple={true}
+      groupBy={(option: OptionAssignee) => option.group}
       textfieldprops={{
         variant: 'standard',
         label: label ?? t_i18n('Assignee(s)'),

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
@@ -104,23 +104,24 @@ const ObjectAssigneeField: FunctionComponent<ObjectAssigneeFieldProps> = ({
         const newAssignees = (
           (data as ObjectAssigneeFieldMembersSearchQuery$data)?.members?.edges ?? []
         ).map((n) => {
-          const group = n.node.id === me?.id ? t_i18n('User') : t_i18n('All');
+          const group = n.node.id === me?.id ? t_i18n('Current User') : t_i18n('All');
           return {
             label: n.node.name,
             value: n.node.id,
             type: n.node.entity_type,
             group,
           };
-        }).sort((a, b) => {
+        });
+        // Add current user if is not in the only first results displayed
+        const isMeDisplayed = newAssignees.find((assignee) => assignee.value === me?.id);
+        if (me && !isMeDisplayed) newAssignees.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('Current User') });
+        newAssignees.sort((a, b) => {
           // Display first the current user
           if (a.value === me?.id) return -1;
           if (b.value === me?.id) return 1;
           // Sort by alphabetic order
           return a.label.localeCompare(b.label);
         });
-        // Add current user if is not in the only first results displayed
-        const isMeDisplayed = newAssignees.find((assignee) => assignee.value === me?.id);
-        if (me && !isMeDisplayed) newAssignees.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('User') });
         setAssignees(newAssignees);
       });
   };

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectAssigneeField.tsx
@@ -113,6 +113,9 @@ const ObjectAssigneeField: FunctionComponent<ObjectAssigneeFieldProps> = ({
           // Sort by alphabetic order
           return a.label.localeCompare(b.label);
         });
+        // Add current user if is not in the only first results displayed
+        const isMeDisplayed = newAssignees.find((assignee) => assignee.value === me?.id);
+        if (me && !isMeDisplayed) newAssignees.unshift({ label: me.name, value: me.id, type: 'User' });
         setAssignees(newAssignees);
       });
   };

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
@@ -95,23 +95,24 @@ const ObjectParticipantField: FunctionComponent<ObjectParticipantFieldProps> = (
         const newParticipants = (
           (data as ObjectParticipantFieldMembersSearchQuery$data)?.members?.edges ?? []
         ).map((n) => {
-          const group = n.node.id === me?.id ? t_i18n('User') : t_i18n('All');
+          const group = n.node.id === me?.id ? t_i18n('Current User') : t_i18n('All');
           return {
             label: n.node.name,
             value: n.node.id,
             type: n.node.entity_type,
             group,
           };
-        }).sort((a, b) => {
+        });
+        // Add current user if is not in the only first results displayed
+        const isMeDisplayed = newParticipants.find((participant) => participant.value === me?.id);
+        if (me && !isMeDisplayed) newParticipants.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('Current User') });
+        newParticipants.sort((a, b) => {
           // Display first the current user
           if (a.value === me?.id) return -1;
           if (b.value === me?.id) return 1;
           // Sort by alphabetic order
           return a.label.localeCompare(b.label);
         });
-        // Add current user if is not in the only first results displayed
-        const isMeDisplayed = newParticipants.find((participant) => participant.value === me?.id);
-        if (me && !isMeDisplayed) newParticipants.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('User') });
         setParticipants(newParticipants);
       });
   };

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 interface OptionParticipant extends Option {
   type: string;
+  group: string;
 }
 interface ObjectParticipantFieldProps {
   name: string;
@@ -93,11 +94,15 @@ const ObjectParticipantField: FunctionComponent<ObjectParticipantFieldProps> = (
       .then((data) => {
         const newParticipants = (
           (data as ObjectParticipantFieldMembersSearchQuery$data)?.members?.edges ?? []
-        ).map((n) => ({
-          label: n.node.name,
-          value: n.node.id,
-          type: n.node.entity_type,
-        })).sort((a, b) => {
+        ).map((n) => {
+          const group = n.node.id === me?.id ? t_i18n('User') : t_i18n('All');
+          return {
+            label: n.node.name,
+            value: n.node.id,
+            type: n.node.entity_type,
+            group,
+          };
+        }).sort((a, b) => {
           // Display first the current user
           if (a.value === me?.id) return -1;
           if (b.value === me?.id) return 1;
@@ -106,7 +111,7 @@ const ObjectParticipantField: FunctionComponent<ObjectParticipantFieldProps> = (
         });
         // Add current user if is not in the only first results displayed
         const isMeDisplayed = newParticipants.find((participant) => participant.value === me?.id);
-        if (me && !isMeDisplayed) newParticipants.unshift({ label: me.name, value: me.id, type: 'User' });
+        if (me && !isMeDisplayed) newParticipants.unshift({ label: me.name, value: me.id, type: 'User', group: t_i18n('User') });
         setParticipants(newParticipants);
       });
   };
@@ -118,6 +123,7 @@ const ObjectParticipantField: FunctionComponent<ObjectParticipantFieldProps> = (
       required={required}
       disabled={disabled}
       multiple={true}
+      groupBy={(option: OptionParticipant) => option.group}
       textfieldprops={{
         variant: 'standard',
         label: label ?? t_i18n('Participant(s)'),

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectParticipantField.tsx
@@ -104,6 +104,9 @@ const ObjectParticipantField: FunctionComponent<ObjectParticipantFieldProps> = (
           // Sort by alphabetic order
           return a.label.localeCompare(b.label);
         });
+        // Add current user if is not in the only first results displayed
+        const isMeDisplayed = newParticipants.find((participant) => participant.value === me?.id);
+        if (me && !isMeDisplayed) newParticipants.unshift({ label: me.name, value: me.id, type: 'User' });
         setParticipants(newParticipants);
       });
   };


### PR DESCRIPTION
### Proposed changes

* add current user first in assignee/participant field

### Related issues

* #4333 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- fix for the 2 cases : If the user is in the only 10 first results returned by the query AND if is not returned
