### PR TITLE
[frontend]Massive relationships creation screen is not respecting default radius (#8425)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/bulk/BulkSelectRawLineData.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/bulk/BulkSelectRawLineData.tsx
@@ -131,6 +131,7 @@ const BulkSelectRawLineData : FunctionComponent<BulkSelectRawLineDataProps> = ({
       </Box>
       <Box sx={{ minWidth: `${matchHeaderWidth}px` }}>
         <Chip
+          style={{ borderRadius: '4px' }}
           label={getRelationMatchStatus()}
           color={getChipColor()}
         />

--- a/opencti-platform/opencti-front/src/private/components/common/bulk/EntityRelationshipCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/bulk/EntityRelationshipCard.tsx
@@ -18,7 +18,7 @@ const EntityRelationshipCard : FunctionComponent<EntityRelationshipCardProps> = 
       <div style={{
         width: 180,
         height: 80,
-        borderRadius: 10,
+        borderRadius: 4,
         top: 10,
         right: 10,
         border: `1px solid ${itemColor(entityType)}`,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* border radius updated on left panel with the selected entity
* same for relation compatibility information chip

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/8425
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
