### PR TITLE
[frontend] fix startDate and endDate default values in public dashboard widgets (#8901)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiAreaChart.tsx
@@ -73,8 +73,8 @@ const PublicStixCoreObjectsMultiAreaChartComponent = ({
 const PublicStixCoreObjectsMultiAreaChart = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -84,8 +84,8 @@ const PublicStixCoreObjectsMultiAreaChart = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiHeatMap.tsx
@@ -79,8 +79,8 @@ const PublicStixCoreObjectsMultiHeatMapComponent = ({
 const PublicStixCoreObjectsMultiHeatMap = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -90,8 +90,8 @@ const PublicStixCoreObjectsMultiHeatMap = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiLineChart.tsx
@@ -72,8 +72,8 @@ const PublicStixCoreObjectsMultiLineChartComponent = ({
 const PublicStixCoreObjectsMultiLineChart = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -83,8 +83,8 @@ const PublicStixCoreObjectsMultiLineChart = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsMultiVerticalBars.tsx
@@ -73,8 +73,8 @@ const PublicStixCoreObjectsMultiVerticalBarsComponent = ({
 const PublicStixCoreObjectsMultiVerticalBars = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -84,8 +84,8 @@ const PublicStixCoreObjectsMultiVerticalBars = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiAreaChart.tsx
@@ -73,8 +73,8 @@ const PublicStixRelationshipsMultiAreaChartComponent = ({
 const PublicStixRelationshipsMultiAreaChart = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -84,8 +84,8 @@ const PublicStixRelationshipsMultiAreaChart = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiHeatMap.tsx
@@ -79,8 +79,8 @@ const PublicStixRelationshipsMultiHeatMapComponent = ({
 const PublicStixRelationshipsMultiHeatMap = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -90,8 +90,8 @@ const PublicStixRelationshipsMultiHeatMap = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiLineChart.tsx
@@ -72,8 +72,8 @@ const PublicStixRelationshipsMultiLineChartComponent = ({
 const PublicStixRelationshipsMultiLineChart = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -83,8 +83,8 @@ const PublicStixRelationshipsMultiLineChart = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsMultiVerticalBars.tsx
@@ -73,8 +73,8 @@ const PublicStixRelationshipsMultiVerticalBarsComponent = ({
 const PublicStixRelationshipsMultiVerticalBars = ({
   uriKey,
   widget,
-  startDate = monthsAgo(12),
-  endDate = now(),
+  startDate,
+  endDate,
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
@@ -84,8 +84,8 @@ const PublicStixRelationshipsMultiVerticalBars = ({
     {
       uriKey,
       widgetId: id,
-      startDate,
-      endDate,
+      startDate: startDate ?? monthsAgo(12),
+      endDate: endDate ?? now(),
     },
   );
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* default startDate and endDate values when sending API request in required widgets 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8901 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
