### PR TITLE
[backend] secure organization deletion (#8838)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -79,6 +79,7 @@ import { BackgroundTaskScope } from '../generated/graphql';
 import { ENTITY_TYPE_INTERNAL_FILE } from '../schema/internalObject';
 import { deleteFile } from '../database/file-storage';
 import { checkUserIsAdminOnDashboard } from '../modules/publicDashboard/publicDashboard-utils';
+import { organizationDelete } from '../modules/organization/organization-domain';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 
 // Task manager responsible to execute long manual tasks
@@ -237,6 +238,9 @@ const executeDelete = async (context, user, element, scope) => {
   }
   if (scope === BackgroundTaskScope.Import) {
     await deleteFile(context, user, element.id);
+  } else if (element.entity_type === ENTITY_TYPE_IDENTITY_ORGANIZATION) {
+    // call organizationDelete which will ensure protections (for platform organization & members)
+    await organizationDelete(context, user, element.internal_id);
   } else {
     await deleteElementById(context, user, element.internal_id, element.entity_type);
   }

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
@@ -148,7 +148,7 @@ export const organizationDelete = async (context: AuthContext, user: AuthUser, o
   }
   if (organization.authorized_authorities && organization.authorized_authorities.length > 0) {
     if (isUserHasCapability(user, SETTINGS_SET_ACCESSES)) {
-      throw FunctionalError('Cannot delete the organization that has an administrator.');
+      throw FunctionalError('Cannot delete an organization that has an administrator.');
     }
     // no information leakage about the organization administrators or members
     throw FunctionalError('Cannot delete the organization.');
@@ -156,7 +156,7 @@ export const organizationDelete = async (context: AuthContext, user: AuthUser, o
   const members = await organizationMembersPaginated(context, user, organization.id, { first: 1, indices: [READ_INDEX_INTERNAL_OBJECTS] });
   if (members.pageInfo.globalCount > 0) {
     if (isUserHasCapability(user, SETTINGS_SET_ACCESSES)) {
-      throw FunctionalError('Cannot delete the organization that has members.');
+      throw FunctionalError('Cannot delete an organization that has members.');
     }
     // no information leakage about the organization administrators or members
     throw FunctionalError('Cannot delete the organization.');

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization-resolver.ts
@@ -10,6 +10,7 @@ import {
   findGrantableGroups,
   organizationAdminAdd,
   organizationAdminRemove,
+  organizationDelete,
   organizationMembersPaginated,
   organizationSectorsPaginated,
   parentOrganizationsPaginated
@@ -17,7 +18,6 @@ import {
 import {
   stixDomainObjectAddRelation,
   stixDomainObjectCleanContext,
-  stixDomainObjectDelete,
   stixDomainObjectDeleteRelation,
   stixDomainObjectEditContext,
   stixDomainObjectEditField
@@ -46,7 +46,7 @@ const organizationResolvers: Resolvers = {
   },
   Mutation: {
     organizationAdd: (_, { input }, context) => addOrganization(context, context.user, input),
-    organizationDelete: (_, { id }, context) => stixDomainObjectDelete(context, context.user, id),
+    organizationDelete: (_, { id }, context) => organizationDelete(context, context.user, id),
     organizationFieldPatch: (_, { id, input, commitMessage, references }, context) => {
       return stixDomainObjectEditField(context, context.user, id, input, { commitMessage, references });
     },

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-sharing-test.ts
@@ -12,7 +12,7 @@ import {
   testContext,
   USER_EDITOR
 } from '../../utils/testQuery';
-import { adminQueryWithSuccess, enableCEAndUnSetOrganization, enableEEAndSetOrganization, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
+import { adminQueryWithSuccess, enableCEAndUnSetOrganization, enableEEAndSetOrganization, queryAsUserIsExpectedError, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
 import { findById } from '../../../src/domain/report';
 import { execChildPython } from '../../../src/python/pythonBridge';
 import { taskHandler } from '../../../src/manager/taskManager';
@@ -84,6 +84,18 @@ describe('Organization sharing standard behavior for container', () => {
   });
   it('should platform organization sharing and EE activated', async () => {
     await enableEEAndSetOrganization(PLATFORM_ORGANIZATION);
+  });
+  it('should not delete organization if platform organization', async () => {
+    const DELETE_QUERY = gql`
+      mutation organizationDelete($id: ID!) {
+        organizationDelete(id: $id)
+      }
+    `;
+    // Delete the organization should fail with error
+    await queryAsUserIsExpectedError(USER_EDITOR.client, {
+      query: DELETE_QUERY,
+      variables: { id: PLATFORM_ORGANIZATION.id },
+    }, 'Cannot delete the platform organization.', 'FUNCTIONAL_ERROR');
   });
   it('should user from different organization not access the report', async () => {
     const queryResult = await queryAsUserWithSuccess(USER_EDITOR.client, {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
@@ -252,6 +252,6 @@ describe('Organization resolver standard behavior', () => {
     await queryAsUserIsExpectedError(USER_SECURITY.client, {
       query: DELETE_QUERY,
       variables: { id: TEST_ORGANIZATION.id },
-    }, 'Cannot delete the organization that has members.', 'FUNCTIONAL_ERROR');
+    }, 'Cannot delete an organization that has members.', 'FUNCTIONAL_ERROR');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/retentionManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/retentionManager-test.ts
@@ -325,6 +325,6 @@ describe('Retention Manager tests ', () => {
   });
   it('should not delete organization with members', async () => {
     await expect(() => deleteElement(context, 'knowledge', TEST_ORGANIZATION.id, ENTITY_TYPE_IDENTITY_ORGANIZATION))
-      .rejects.toThrowError('Cannot delete the organization that has members.');
+      .rejects.toThrowError('Cannot delete an organization that has members.');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/retentionManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/retentionManager-test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import gql from 'graphql-tag';
 import { Readable } from 'stream';
-import { ADMIN_USER, queryAsAdmin, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, queryAsAdmin, TEST_ORGANIZATION, testContext } from '../../utils/testQuery';
 import { utcDate } from '../../../src/utils/format';
 import { deleteElement, getElementsToDelete } from '../../../src/manager/retentionManager';
 import { allFilesForPaths } from '../../../src/modules/internal/document/document-domain';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../src/modules/organization/organization-types';
 import { uploadToStorage } from '../../../src/database/file-storage-helper';
 import { elLoadById, elRawUpdateByQuery } from '../../../src/database/engine';
 import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../../../src/database/utils';
@@ -321,5 +322,9 @@ describe('Retention Manager tests ', () => {
     await deleteElement(context, 'knowledge', report1Id, ENTITY_TYPE_CONTAINER_REPORT); // should delete report1
     const report1deleted = await elLoadById(testContext, ADMIN_USER, report1Id);
     expect(report1deleted).toBeUndefined();
+  });
+  it('should not delete organization with members', async () => {
+    await expect(() => deleteElement(context, 'knowledge', TEST_ORGANIZATION.id, ENTITY_TYPE_IDENTITY_ORGANIZATION))
+      .rejects.toThrowError('Cannot delete the organization that has members.');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -82,8 +82,12 @@ export const queryAsUserIsExpectedError = async (client: AxiosInstance, request:
   logApp.info('queryAsUserIsExpectedError=> queryResult:', queryResult);
   expect(queryResult.errors, 'error is expected.').toBeDefined();
   expect(queryResult.errors?.length, `1 error is expected, but got ${queryResult.errors?.length} errors`).toBe(1);
-  expect(queryResult.errors[0].message, `error message: ${errorMessage} is expected, but got ${queryResult.errors[0].message}`).toBe(errorMessage);
-  expect(queryResult.errors[0].extensions.code, `error is expected but got ${queryResult.errors[0].name}`).toBe(errorName);
+  if (errorMessage) {
+    expect(queryResult.errors[0].message, `error message: ${errorMessage} is expected, but got ${queryResult.errors[0].message}`).toBe(errorMessage);
+  }
+  if (errorName) {
+    expect(queryResult.errors[0].extensions.code, `error is expected but got ${queryResult.errors[0].name}`).toBe(errorName);
+  }
 };
 
 /**

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -74,12 +74,15 @@ export const queryAsUserIsExpectedForbidden = async (client: AxiosInstance, requ
  * Execute the query as some User (see testQuery.ts), and verify that error is thrown.
  * @param client
  * @param request
+ * @param errorMessage
+ * @param errorName
  */
-export const queryAsUserIsExpectedError = async (client: AxiosInstance, request: any, message?: string, errorName?: string) => {
+export const queryAsUserIsExpectedError = async (client: AxiosInstance, request: any, errorMessage?: string, errorName?: string) => {
   const queryResult = await executeInternalQuery(client, print(request.query), request.variables);
   logApp.info('queryAsUserIsExpectedError=> queryResult:', queryResult);
   expect(queryResult.errors, 'error is expected.').toBeDefined();
-  expect(queryResult.errors?.length, message ?? `error is expected, but got ${queryResult.errors?.length} errors`).toBe(1);
+  expect(queryResult.errors?.length, `1 error is expected, but got ${queryResult.errors?.length} errors`).toBe(1);
+  expect(queryResult.errors[0].message, `error message: ${errorMessage} is expected, but got ${queryResult.errors[0].message}`).toBe(errorMessage);
   expect(queryResult.errors[0].extensions.code, `error is expected but got ${queryResult.errors[0].name}`).toBe(errorName);
 };
 

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -71,6 +71,19 @@ export const queryAsUserIsExpectedForbidden = async (client: AxiosInstance, requ
 };
 
 /**
+ * Execute the query as some User (see testQuery.ts), and verify that error is thrown.
+ * @param client
+ * @param request
+ */
+export const queryAsUserIsExpectedError = async (client: AxiosInstance, request: any, message?: string, errorName?: string) => {
+  const queryResult = await executeInternalQuery(client, print(request.query), request.variables);
+  logApp.info('queryAsUserIsExpectedError=> queryResult:', queryResult);
+  expect(queryResult.errors, 'error is expected.').toBeDefined();
+  expect(queryResult.errors?.length, message ?? `error is expected, but got ${queryResult.errors?.length} errors`).toBe(1);
+  expect(queryResult.errors[0].extensions.code, `error is expected but got ${queryResult.errors[0].name}`).toBe(errorName);
+};
+
+/**
  * Call a graphQL request with no authentication / no login and verify that access is forbidden.
  * @param request
  */


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add protections to prevent organization deletion if it's a platform organization, if it has an administrator, if it has members
* call organizationDelete in retention manager (however it doesn't delete permanently, it will go in trash => I don't think it's an issue, since organization delete can be quite destructive, so it's better we keep it in trash in case)
* add tests

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8838 

To test : organization can't be deleted if it is used as platform organization, or it has at least one member (user part of the organization), or has an organization admin (org admin is also a member, but the error message is different). Otherwise the deletion should work. Also error message is different for users depending on their capability : if user has set access, the message will explain the reason (members or orga admin reason).

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
