### PR TITLE
[frontend] Refacto of data tables dimensions computation (#8808)

### DIFF
--- a/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
+++ b/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
@@ -25,7 +25,11 @@ const Breadcrumbs: FunctionComponent<BreadcrumbsProps> = ({ elements, isSensitiv
   );
 
   return (
-    <div data-testid="navigation" style={{ marginBottom: theme.spacing(2), display: 'flex' }}>
+    <div
+      id="page-breadcrumb"
+      data-testid="navigation"
+      style={{ marginBottom: theme.spacing(2), display: 'flex' }}
+    >
       {elements.map((element, index) => {
         if (element.current) {
           return (

--- a/opencti-platform/opencti-front/src/components/ItemOperations.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOperations.tsx
@@ -1,7 +1,7 @@
 import Chip from '@mui/material/Chip';
 import React, { FunctionComponent } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
-import useTheme from '@mui/styles/useTheme';
+import { useTheme } from '@mui/styles';
 import type { Theme } from './Theme';
 
 const useStyles = makeStyles(() => ({

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
@@ -1,6 +1,6 @@
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
-import React, { CSSProperties, forwardRef, ReactNode } from 'react';
+import React, { CSSProperties, ReactNode } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -10,7 +10,6 @@ const useStyles = makeStyles({
     minHeight: 110,
     height: '100%',
     margin: '4px 0 0 0',
-    padding: '0 0 10px 0',
     borderRadius: 4,
   },
 });
@@ -23,17 +22,17 @@ interface WidgetContainerProps {
   withoutTitle?: boolean
 }
 
-const WidgetContainer = forwardRef<HTMLDivElement, WidgetContainerProps>(({
+const WidgetContainer = ({
   children,
   height,
   title,
   variant,
   withoutTitle = false,
-}, ref) => {
+}: WidgetContainerProps) => {
   const classes = useStyles();
 
   return (
-    <div ref={ref} style={{ height: height || '100%' }}>
+    <div style={{ height: height || '100%' }}>
       {!withoutTitle && (
         <Typography
           variant={variant === 'inEntity' ? 'h3' : 'h4'}
@@ -57,8 +56,6 @@ const WidgetContainer = forwardRef<HTMLDivElement, WidgetContainerProps>(({
       )}
     </div>
   );
-});
-
-WidgetContainer.displayName = 'WidgetContainer';
+};
 
 export default WidgetContainer;

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -11,7 +11,6 @@ import { DataTableProps } from './dataTableTypes';
 import useAuth from '../../utils/hooks/useAuth';
 import { useDataTable, useLineData } from './dataTableHooks';
 import DataTableComponent from './components/DataTableComponent';
-import { SELECT_COLUMN_SIZE } from './components/DataTableHeader';
 import { UsePreloadedPaginationFragment } from '../../utils/hooks/usePreloadedPaginationFragment';
 import { FilterIconButtonProps } from '../FilterIconButton';
 import { isNotEmptyField } from '../../utils/utils';
@@ -95,7 +94,6 @@ const DataTableInternalFilters = ({
           availableEntityTypes={availableEntityTypes}
           additionalFilterKeys={additionalFilterKeys}
           entityTypes={computedEntityTypes}
-          paginationOptions={paginationOptions}
         />
       )}
     </>
@@ -135,7 +133,7 @@ const DataTableInternalToolbar = ({
     <div
       style={{
         background: theme.palette.background.accent,
-        width: `calc(( var(--header-table-size) - ${SELECT_COLUMN_SIZE} ) * 1px)`,
+        flex: 1,
       }}
     >
       <DataTableToolBar

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTablePagination.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTablePagination.tsx
@@ -24,7 +24,6 @@ const DataTablePagination = ({
 
   const {
     resetColumns,
-    useDataTableColumnsLocalStorage,
     useDataTablePaginationLocalStorage: {
       viewStorage: {
         pageSize,
@@ -57,10 +56,7 @@ const DataTablePagination = ({
     }
   }, [page, pageSize]);
 
-  const [_, setLocalStorageColumns] = useDataTableColumnsLocalStorage;
-
   const resetTable = () => {
-    setLocalStorageColumns({});
     resetColumns();
     helpers.handleAddProperty('pageSize', '25');
   };

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -1,54 +1,36 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import { createStyles } from '@mui/styles';
-import { Theme as MuiTheme } from '@mui/material/styles/createTheme';
+import React, { CSSProperties, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as R from 'ramda';
 import DataTableHeaders from './DataTableHeaders';
-import { ColumnSizeVars, DataTableBodyProps, DataTableLineProps, DataTableVariant, LocalStorageColumns } from '../dataTableTypes';
+import { DataTableBodyProps, DataTableLineProps, DataTableVariant } from '../dataTableTypes';
 import DataTableLine, { DataTableLinesDummy } from './DataTableLine';
-import { SELECT_COLUMN_SIZE } from './DataTableHeader';
-import { throttle } from '../../../utils/utils';
 import { useDataTableContext } from './DataTableContext';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<MuiTheme, { columnSizeVars: ColumnSizeVars }>(() => createStyles({
-  tableContainer: ({ columnSizeVars }) => ({
-    ...columnSizeVars,
-    height: 'calc(var(--table-height) * 1px)',
-    overflowY: 'visible',
-  }),
-  linesContainer: {
-    height: 'calc(var(--table-height, 100%) * 1px - 50px)',
-    width: 'calc(var(--col-table-size, 100%) * 1px)', // 10px is approx. the scrollbar size to prevent alignment issues
-    overflowY: 'auto',
-    overflowX: 'hidden',
-  },
-}));
-
 const DataTableBody = ({
-  columns,
   settingsMessagesBannerHeight = 0,
   hasFilterComponent,
   dataTableToolBarComponent,
   pageStart,
   pageSize,
-  setReset,
-  reset = false,
   hideHeaders = false,
 }: DataTableBodyProps) => {
   const {
     rootRef,
-    setColumns,
-    useDataTableColumnsLocalStorage,
     variant,
-    useDataTable,
     resolvePath,
-    useDataTableToggle,
-    actions,
+    useDataTable: {
+      data: queryData,
+      isLoading,
+      loadMore,
+      hasMore,
+    },
+    useDataTableToggle: {
+      selectedElements,
+      onToggleEntity,
+    },
+    useDataTablePaginationLocalStorage: {
+      viewStorage: { filters },
+    },
   } = useDataTableContext();
-
-  const { data: queryData, isLoading, loadMore, hasMore } = useDataTable;
 
   const resolvedData = useMemo(() => {
     if (!queryData) {
@@ -64,115 +46,8 @@ const DataTableBody = ({
   }, [resolvedData]);
 
   // TABLE HANDLING
-  const [resize, setResize] = useState(false);
-  const resizeObserver = useRef(new ResizeObserver(throttle(() => {
-    setResize(true);
-  }, 200)));
-  const [computeState, setComputeState] = useState<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const [localStorageColumns, setLocalStorageColumns] = useDataTableColumnsLocalStorage;
-
-  const startsWithSelect = columns.at(0)?.id === 'select';
-  const endsWithNavigate = columns.at(-1)?.id === 'navigate';
-
-  let storedSize = (endsWithNavigate || actions) ? SELECT_COLUMN_SIZE : 0;
-  if (startsWithSelect) {
-    storedSize += SELECT_COLUMN_SIZE;
-  }
-
-  // This is intended to improve performance by memoizing the column sizes
-  const columnSizeVars: ColumnSizeVars = React.useMemo(() => {
-    const localColumns: LocalStorageColumns = {};
-    const colSizes: { [key: string]: number } = {
-      '--header-select-size': SELECT_COLUMN_SIZE,
-      '--col-select-size': SELECT_COLUMN_SIZE,
-      '--header-navigate-size': SELECT_COLUMN_SIZE,
-      '--col-navigate-size': SELECT_COLUMN_SIZE,
-    };
-    const currentRefContainer = containerRef.current;
-    if (!computeState && !currentRefContainer) {
-      return colSizes;
-    }
-    // From there, currentRefContainer is not null
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const clientWidth = currentRefContainer!.clientWidth - storedSize - 10; // Scrollbar size to prevent alignment issues
-    for (let i = startsWithSelect ? 1 : 0; i < columns.length - (endsWithNavigate ? 1 : 0); i += 1) {
-      const column = reset ? columns[i] : { ...columns[i], ...localStorageColumns[columns[i].id] };
-      const shouldCompute = (!column.size || resize || !localStorageColumns[columns[i].id]?.size) && (column.percentWidth && Boolean(computeState));
-      let size = column.size ?? 200;
-
-      // We must compute px size for columns
-      if (shouldCompute || reset) {
-        size = column.percentWidth * (clientWidth / 100);
-        column.size = size;
-      }
-      localColumns[column.id] = { size };
-      colSizes[`--header-${column.id}-size`] = size;
-      colSizes[`--col-${column.id}-size`] = size;
-    }
-    if (Object.keys(localColumns).length > 0) {
-      setResize(false);
-    }
-    if (Object.entries(localColumns).some(([id, { size }]) => localStorageColumns[id]?.size !== size)) {
-      setLocalStorageColumns(localColumns);
-      setColumns((curr) => {
-        return curr.map((col) => {
-          if (localColumns[col.id]) {
-            return { ...col, size: localColumns[col.id].size };
-          }
-          return col;
-        });
-      });
-    }
-    const columnsSize = Object.values(localColumns).reduce((acc, { size }) => acc + size, 0);
-    const tableSize = columnsSize + storedSize;
-
-    // Dirty fix for tables with mismatch size
-    // Will be remove when rework by Landry
-    if (tableSize < clientWidth) {
-      setResize(true);
-    }
-
-    if (columnsSize > clientWidth) {
-      currentRefContainer!.style.overflowX = 'auto';
-      currentRefContainer!.style.overflowY = 'hidden';
-    } else {
-      currentRefContainer!.style.overflow = 'hidden';
-    }
-    colSizes['--header-table-size'] = tableSize + 10;
-    colSizes['--col-table-size'] = tableSize + 10;
-    if (variant === DataTableVariant.widget) {
-      if (!rootRef) {
-        throw Error('Invalid configuration for widget list');
-      }
-      colSizes['--table-height'] = rootRef.offsetHeight;
-    } else if (rootRef) {
-      colSizes['--table-height'] = rootRef.offsetHeight - 42; // SIZE OF CONTAINER - Nb Elements - Line Size
-    } else {
-      const rootSize = (document.getElementById('root')?.offsetHeight ?? 0) - settingsMessagesBannerHeight;
-      const filterRemoval = (hasFilterComponent && document.getElementById('filter-container')?.children.length) ? 230 : 200;
-      const tabsRemoval = document.getElementById('tabs-container')?.children.length ? 50 : 0;
-      colSizes['--table-height'] = rootSize - filterRemoval - tabsRemoval;
-    }
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
-
-    setReset(false);
-    return colSizes;
-  }, [
-    resize,
-    computeState,
-    columns,
-    localStorageColumns,
-    document.getElementById('filter-container'),
-    rootRef,
-  ]);
-  const classes = useStyles({ columnSizeVars });
-
-  const {
-    selectedElements,
-    onToggleEntity,
-  } = useDataTableToggle;
   const onToggleShiftEntity: DataTableLineProps['onToggleShiftEntity'] = (currentIndex, currentEntity, event) => {
     if (selectedElements && !R.isEmpty(selectedElements)) {
       // Find the indexes of the first and last selected entities
@@ -204,70 +79,59 @@ const DataTableBody = ({
     return onToggleEntity(currentEntity, event);
   };
 
+  const [tableHeight, setTableHeight] = useState(0);
   useLayoutEffect(() => {
-    const handleResize = () => setResize(true);
-    const handleStorage = ({ key }: StorageEvent) => setTimeout(() => {
-      if (key === 'navOpen') {
-        setResize(true);
-      }
-    }, 200);
+    const hasFilters = (filters?.filters ?? []).length > 0;
+    let filtersHeight = hasFilterComponent ? 54 : 0;
+    if (hasFilterComponent && hasFilters) filtersHeight += 48;
 
-    window.addEventListener('resize', handleResize);
-    window.addEventListener('storage', handleStorage);
-    if (rootRef) resizeObserver.current.observe(rootRef);
-    let observer: MutationObserver | undefined;
-    const elementToObserve = document.getElementById('filter-container');
-    if (elementToObserve) {
-      observer = new MutationObserver(() => setResize(true));
-      observer.observe(elementToObserve, { childList: true });
+    if (variant === DataTableVariant.widget) {
+      if (!rootRef) throw Error('Invalid configuration for widget list');
+      setTableHeight(rootRef.offsetHeight);
+    } else if (rootRef) {
+      setTableHeight(rootRef.offsetHeight - filtersHeight);
+    } else {
+      // TODO: this computation should be avoided because too many risk of changes.
+      // Instead use the rootRef props. Example in:
+      // - StixCoreRelationshipCreationFromEntity.tsx
+      // - IndicatorObservables.jsx
+      const rootHeight = (document.getElementById('root')?.offsetHeight ?? 0) - settingsMessagesBannerHeight;
+      const headerHeight = 64;
+      const breadcrumbHeight = document.getElementById('page-breadcrumb') ? 38 : 0;
+      const mainPadding = 24;
+      const tabsHeight = document.getElementById('tabs-container')?.children.length ? 72 : 0;
+      setTableHeight(rootHeight - headerHeight - breadcrumbHeight - mainPadding - filtersHeight - tabsHeight);
     }
+  }, [setTableHeight, settingsMessagesBannerHeight, rootRef, filters]);
 
-    return () => {
-      window.removeEventListener('resize', handleResize);
-      window.removeEventListener('storage', handleStorage);
-      resizeObserver.current.disconnect();
-      if (hasFilterComponent && observer) {
-        observer.disconnect();
-      }
-    };
-  }, []);
-  const effectiveColumns = useMemo(() => columns
-    .map((col) => ({ ...col, size: localStorageColumns[col.id]?.size })), [columns, localStorageColumns, reset]);
+  const containerStyle: CSSProperties = {
+    overflow: 'auto',
+    maxHeight: `${tableHeight}px`,
+  };
+
+  const containerLinesStyle: CSSProperties = {
+    position: 'relative',
+  };
 
   return (
-    <div
-      ref={containerRef}
-      className={classes.tableContainer}
-      style={{ ...columnSizeVars }}
-    >
-      {!hideHeaders && (
-        <DataTableHeaders
-          containerRef={containerRef}
-          effectiveColumns={effectiveColumns}
-          dataTableToolBarComponent={dataTableToolBarComponent}
-        />
-      )}
-      <div
-        ref={(node) => setComputeState(node)}
-        className={classes.linesContainer}
-      >
-        {computeState && (
-          <>
-            {/* If we have perf issues we should find a way to memoize this */}
-            {resolvedData.map((row: { id: string }, index: number) => {
-              return (
-                <DataTableLine
-                  key={row.id}
-                  row={row}
-                  effectiveColumns={effectiveColumns}
-                  index={index}
-                  onToggleShiftEntity={onToggleShiftEntity}
-                />
-              );
-            })}
-            {isLoading && <DataTableLinesDummy number={Math.max(pageSize, 25)} />}
-          </>
+    <div style={containerStyle} ref={containerRef}>
+      <div style={containerLinesStyle}>
+        {!hideHeaders && (
+          <DataTableHeaders dataTableToolBarComponent={dataTableToolBarComponent} />
         )}
+
+        {/* If we have perf issues we should find a way to memoize this */}
+        {resolvedData.map((row: { id: string }, index: number) => {
+          return (
+            <DataTableLine
+              key={row.id}
+              row={row}
+              index={index}
+              onToggleShiftEntity={onToggleShiftEntity}
+            />
+          );
+        })}
+        {isLoading && <DataTableLinesDummy number={Math.max(pageSize, 25)} />}
       </div>
     </div>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -133,12 +133,12 @@ const DataTableBody = ({
         ? Math.round(tableWidth * (col.percentWidth / 100))
         : SELECT_COLUMN_SIZE;
       return acc + width;
-    }, actions ? SELECT_COLUMN_SIZE + 9 : 9)
+    }, actions ? SELECT_COLUMN_SIZE + 9 : 9) // 9 is for scrollbar.
   ), [columns, tableWidth]);
 
   const containerLinesStyle: CSSProperties = {
     overflow: 'hidden auto',
-    maxHeight: `calc(${tableHeight}px - ${hideHeaders ? 0 : 42}px)`,
+    maxHeight: `calc(${tableHeight}px - ${hideHeaders ? 0 : SELECT_COLUMN_SIZE}px)`,
     width: rowWidth,
   };
 

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -128,12 +128,12 @@ const DataTableBody = ({
   }, [setTableHeight, settingsMessagesBannerHeight, rootRef, filters]);
 
   const rowWidth = useMemo(() => (
-    columns.reduce((acc, col) => {
+    Math.floor(columns.reduce((acc, col) => {
       const width = col.percentWidth
-        ? Math.round(tableWidth * (col.percentWidth / 100))
+        ? tableWidth * (col.percentWidth / 100)
         : SELECT_COLUMN_SIZE;
       return acc + width;
-    }, actions ? SELECT_COLUMN_SIZE + 9 : 9) // 9 is for scrollbar.
+    }, actions ? SELECT_COLUMN_SIZE + 9 : 9)) // 9 is for scrollbar.
   ), [columns, tableWidth]);
 
   const containerLinesStyle: CSSProperties = {
@@ -148,9 +148,11 @@ const DataTableBody = ({
 
   return (
     <>
-      {!hideHeaders && (
-        <DataTableHeaders dataTableToolBarComponent={dataTableToolBarComponent} />
-      )}
+      <div style={{ width: rowWidth }}>
+        {!hideHeaders && (
+          <DataTableHeaders dataTableToolBarComponent={dataTableToolBarComponent} />
+        )}
+      </div>
 
       <div style={containerLinesStyle}>
         {/* If we have perf issues we should find a way to memoize this */}

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles<MuiTheme, { column: DataTableColumn }>((theme) => c
     flex: '0 0 auto',
     position: 'relative',
     display: 'flex',
-    width: ({ column }) => `${column.percentWidth}%`,
     fontWeight: 'bold',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -80,6 +79,7 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
     onSort,
     variant,
     formatter: { t_i18n },
+    tableWidthState: [tableWidth],
   } = useDataTableContext();
 
   // To avoid spamming sorting (and calling API)
@@ -96,9 +96,14 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
   };
 
   const hasColumnMenu = column.isSortable || (availableFilterKeys ?? []).includes(column.id);
+  const cellWidth = Math.round(tableWidth * (column.percentWidth / 100));
 
   return (
-    <div key={column.id} className={classes.headerContainer}>
+    <div
+      key={column.id}
+      className={classes.headerContainer}
+      style={{ width: cellWidth }}
+    >
       <div className={classes.label} onClick={throttleSortColumn}>
         <Tooltip title={t_i18n(column.label)}>
           {t_i18n(column.label).toUpperCase()}

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -1,44 +1,41 @@
 import React, { CSSProperties } from 'react';
-import { Skeleton, Checkbox, IconButton, Box, SxProps } from '@mui/material';
+import { Skeleton, Checkbox, IconButton } from '@mui/material';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
-import makeStyles from '@mui/styles/makeStyles';
-import { createStyles, useTheme } from '@mui/styles';
+import { useTheme } from '@mui/styles';
 import { useNavigate } from 'react-router-dom';
 import type { DataTableCellProps, DataTableLineProps } from '../dataTableTypes';
-import { DataTableColumn, DataTableVariant } from '../dataTableTypes';
+import { DataTableVariant } from '../dataTableTypes';
 import type { Theme } from '../../Theme';
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import { SELECT_COLUMN_SIZE } from './DataTableHeader';
 import { useDataTableContext } from './DataTableContext';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme, { cell?: DataTableColumn, clickable?: boolean }>((theme) => createStyles({
-  cellContainer: ({ cell }) => ({
-    display: 'flex',
-    width: `${cell?.percentWidth}%`,
-    height: theme.spacing(6),
-    alignItems: 'center',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    flex: '0 0 auto',
-  }),
-}));
+const cellContainerStyle = (theme: Theme) => ({
+  display: 'flex',
+  height: theme.spacing(6),
+  alignItems: 'center',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  flex: '0 0 auto',
+});
 
 const DataTableLineDummy = () => {
-  const { columns } = useDataTableContext();
-  const columnStyle = (c: typeof columns[0]) => ({
-    paddingLeft: '4px',
-    paddingRight: '8px',
-    flex: '0 0 auto',
-    width: c.percentWidth ? `${c.percentWidth}%` : `${SELECT_COLUMN_SIZE}px`,
-  });
-
+  const { columns, tableWidthState: [tableWidth] } = useDataTableContext();
   return (
     <div style={{ display: 'flex' }}>
       {columns.map((column) => (
-        <div key={column.id} style={columnStyle(column)}>
+        <div
+          key={column.id}
+          style={{
+            paddingLeft: '4px',
+            paddingRight: '8px',
+            flex: '0 0 auto',
+            width: column.percentWidth
+              ? Math.round(tableWidth * (column.percentWidth / 100))
+              : SELECT_COLUMN_SIZE,
+          }}
+        >
           <Skeleton variant="text" height={35} />
         </div>
       ))}
@@ -46,28 +43,18 @@ const DataTableLineDummy = () => {
   );
 };
 
-export const DataTableLinesDummy = ({ number = 10 }: { number?: number }) => {
-  const { columns, actions } = useDataTableContext();
-  const startsWithSelect = columns.at(0)?.id === 'select';
-  const endsWithNavigate = columns.at(-1)?.id === 'navigate';
-
-  let offset = 0;
-  if (startsWithSelect) offset += SELECT_COLUMN_SIZE;
-  if (endsWithNavigate || actions) offset += SELECT_COLUMN_SIZE;
-
-  return (
-    <div style={{ paddingRight: offset }}>
-      {Array(Math.min(number, 25)).fill(0).map((_, idx) => (<DataTableLineDummy key={idx} />))}
-    </div>
-  );
-};
+export const DataTableLinesDummy = ({ number = 10 }: { number?: number }) => <>
+  {Array(Math.min(number, 25)).fill(0).map((_, idx) => (
+    <DataTableLineDummy key={idx} />
+  ))}
+</>;
 
 const DataTableCell = ({
   cell,
   data,
 }: DataTableCellProps) => {
-  const classes = useStyles({ cell });
-  const { useDataCellHelpers } = useDataTableContext();
+  const theme = useTheme<Theme>();
+  const { useDataCellHelpers, tableWidthState: [tableWidth] } = useDataTableContext();
   const helpers = useDataCellHelpers(cell);
 
   const cellStyle: CSSProperties = {
@@ -81,7 +68,13 @@ const DataTableCell = ({
   };
 
   return (
-    <div key={`${cell.id}_${data.id}`} className={classes.cellContainer}>
+    <div
+      key={`${cell.id}_${data.id}`}
+      style={{
+        ...cellContainerStyle(theme),
+        width: Math.round(tableWidth * (cell.percentWidth / 100)),
+      }}
+    >
       <div style={cellStyle}>
         {cell.render?.(data, helpers) ?? (<div>-</div>)}
       </div>
@@ -96,22 +89,30 @@ const DataTableLine = ({
 }: DataTableLineProps) => {
   const navigate = useNavigate();
   const theme = useTheme<Theme>();
-  const classes = useStyles({ });
 
   const {
     columns,
     useLineData,
-    useDataTableToggle,
     useComputeLink,
     actions,
     disableNavigation,
     onLineClick,
     selectOnLineClick,
     variant,
+    startsWithAction,
+    endsWithAction,
+    endsWithNavigate,
+    useDataTableToggle: {
+      selectAll,
+      deSelectedElements,
+      selectedElements,
+      onToggleEntity,
+    },
     useDataTablePaginationLocalStorage: {
       viewStorage: { redirectionMode },
     },
   } = useDataTableContext();
+
   const data = useLineData(row);
 
   let link = useComputeLink(data);
@@ -121,16 +122,6 @@ const DataTableLine = ({
 
   const navigable = !disableNavigation && !onLineClick && !selectOnLineClick;
   const clickable = !!(navigable || selectOnLineClick || onLineClick);
-
-  const {
-    selectAll,
-    deSelectedElements,
-    selectedElements,
-    onToggleEntity,
-  } = useDataTableToggle;
-
-  const startsWithSelect = columns.at(0)?.id === 'select';
-  const endsWithNavigate = columns.at(-1)?.id === 'navigate';
 
   const handleSelectLine = (event: React.MouseEvent) => {
     if (event.shiftKey) {
@@ -163,93 +154,75 @@ const DataTableLine = ({
     }
   };
 
-  let offset = 0;
-  if (startsWithSelect) offset += SELECT_COLUMN_SIZE;
-  if (endsWithNavigate || actions) offset += SELECT_COLUMN_SIZE;
-
   const linkStyle: CSSProperties = {
     display: 'flex',
     color: 'inherit',
-  };
-
-  const containerStyle: SxProps = {
+    borderBottom: `1px solid ${theme.palette.divider}`,
     cursor: clickable ? 'pointer' : 'unset',
-    paddingRight: `${offset}px`,
-    '& a > div': {
-      borderBottom: `1px solid ${theme.palette.divider}`,
-    },
-    '& a:hover > div': clickable ? {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
-    } : {},
   };
 
   return (
-    <Box
-      key={row.id}
-      sx={containerStyle}
+    <a
+      style={linkStyle}
+      href={navigable ? link : undefined}
       // We need both to handle accessibility and widget.
       onMouseDown={variant === DataTableVariant.widget ? handleNavigate : undefined}
       onClick={variant !== DataTableVariant.widget ? handleRowClick : undefined}
       data-testid={getMainRepresentative(data)}
     >
-      <a
-        style={linkStyle}
-        href={navigable ? link : undefined}
-      >
-        {startsWithSelect && (
-          <div
-            key={`select_${data.id}`}
-            className={classes.cellContainer}
-            style={{ width: SELECT_COLUMN_SIZE }}
-          >
-            <Checkbox
-              onClick={handleSelectLine}
-              sx={{
-                marginRight: 1,
-                flex: '0 0 auto',
-                '&:hover': {
-                  background: 'transparent',
-                },
-              }}
-              checked={
-                (selectAll
-                  && !((data.id || 'id') in (deSelectedElements || {})))
-                || (data.id || 'id') in (selectedElements || {})
-              }
-            />
-          </div>
-        )}
-
-        {columns.slice(startsWithSelect ? 1 : 0, (actions || disableNavigation) ? undefined : -1).map((column) => (
-          <DataTableCell
-            key={column.id}
-            cell={column}
-            data={data}
-          />
-        ))}
-
-        {(actions || endsWithNavigate) && (
-          <div
-            key={`navigate_${data.id}`}
-            className={classes.cellContainer}
-            style={{
-              width: SELECT_COLUMN_SIZE,
-              overflow: 'initial',
+      {startsWithAction && (
+        <div
+          key={`select_${data.id}`}
+          style={{
+            ...cellContainerStyle(theme),
+            width: SELECT_COLUMN_SIZE,
+          }}
+        >
+          <Checkbox
+            onClick={handleSelectLine}
+            sx={{
+              marginRight: 1,
+              flex: '0 0 auto',
+              paddingLeft: 0,
+              '&:hover': {
+                background: 'transparent',
+              },
             }}
-          >
-            {actions && actions(data)}
-            {endsWithNavigate && (
-              <IconButton onClick={() => navigate(link)}>
-                <KeyboardArrowRightOutlined />
-              </IconButton>
-            )}
-          </div>
-        )}
-      </a>
-    </Box>
+            checked={
+                  (selectAll
+                    && !((data.id || 'id') in (deSelectedElements || {})))
+                  || (data.id || 'id') in (selectedElements || {})
+                }
+          />
+        </div>
+      )}
+
+      {columns.slice(startsWithAction ? 1 : 0, (actions || disableNavigation) ? undefined : -1).map((column) => (
+        <DataTableCell
+          key={column.id}
+          cell={column}
+          data={data}
+        />
+      ))}
+
+      {endsWithAction && (
+        <div
+          key={`navigate_${data.id}`}
+          style={{
+            ...cellContainerStyle(theme),
+            width: SELECT_COLUMN_SIZE,
+            overflow: 'initial',
+          }}
+        >
+          {actions && actions(data)}
+          {endsWithNavigate && (
+            <IconButton onClick={() => navigate(link)}>
+              <KeyboardArrowRightOutlined />
+            </IconButton>
+          )}
+        </div>
+      )}
+    </a>
   );
 };
 

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -21,6 +21,7 @@ const cellContainerStyle = (theme: Theme) => ({
 });
 
 const DataTableLineDummy = () => {
+  const theme = useTheme<Theme>();
   const { columns, tableWidthState: [tableWidth] } = useDataTableContext();
   return (
     <div style={{ display: 'flex' }}>
@@ -28,8 +29,8 @@ const DataTableLineDummy = () => {
         <div
           key={column.id}
           style={{
-            paddingLeft: '4px',
-            paddingRight: '8px',
+            paddingLeft: theme.spacing(0.5),
+            paddingRight: theme.spacing(1),
             flex: '0 0 auto',
             width: column.percentWidth
               ? Math.round(tableWidth * (column.percentWidth / 100))
@@ -59,11 +60,11 @@ const DataTableCell = ({
 
   const cellStyle: CSSProperties = {
     display: 'flex',
-    paddingLeft: '8px',
-    paddingRight: '8px',
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
     width: '100%',
     alignItems: 'center',
-    gap: '3px',
+    gap: theme.spacing(0.5),
     fontSize: '13px',
   };
 

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -7,9 +7,7 @@ import type { LocalStorage } from '../../utils/hooks/useLocalStorageModel';
 import { NumberOfElements, PaginationLocalStorage, UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 import { FilterGroup } from '../../utils/filters/filtersHelpers-types';
 
-export type ColumnSizeVars = Record<string, number>;
-
-export type LocalStorageColumn = { size: number, visible?: boolean, index?: number };
+export type LocalStorageColumn = { percentWidth: number, visible?: boolean, index?: number };
 export type LocalStorageColumns = Record<string, LocalStorageColumn>;
 
 export enum DataTableVariant {
@@ -30,7 +28,6 @@ export interface DataTableColumn {
   id: string
   isSortable?: boolean
   label?: string
-  size?: number
   percentWidth: number
   render?: (v: any, helpers?: any, draftVersion?: boolean) => React.ReactNode
   visible?: boolean
@@ -44,7 +41,6 @@ export interface DataTableContextProps {
   storageKey: string
   columns: DataTableColumns
   availableFilterKeys?: string[] | undefined;
-  effectiveColumns: DataTableColumns
   initialValues: DataTableProps['initialValues']
   setColumns: Dispatch<SetStateAction<DataTableColumns>>
   resolvePath: (data: any) => any
@@ -138,14 +134,11 @@ export interface DataTableProps {
 }
 
 export interface DataTableBodyProps {
-  columns: DataTableColumns
   hasFilterComponent: boolean
   dataTableToolBarComponent?: ReactNode
   settingsMessagesBannerHeight?: DataTableProps['settingsMessagesBannerHeight']
   pageSize: number
   pageStart: number
-  reset: boolean,
-  setReset: Dispatch<SetStateAction<boolean>>
   hideHeaders: DataTableProps['hideHeaders']
 }
 
@@ -155,7 +148,6 @@ export interface DataTableDisplayFiltersProps {
   availableRelationFilterTypes?: Record<string, string[]> | undefined
   availableFilterKeys?: string[] | undefined;
   availableEntityTypes?: string[]
-  paginationOptions: any
 }
 
 export interface DataTableFiltersProps {
@@ -171,8 +163,6 @@ export interface DataTableFiltersProps {
 }
 
 export interface DataTableHeadersProps {
-  containerRef?: MutableRefObject<HTMLDivElement | null>
-  effectiveColumns: DataTableColumns
   dataTableToolBarComponent: ReactNode
 }
 
@@ -180,7 +170,6 @@ export interface DataTableHeaderProps {
   column: DataTableColumn
   setAnchorEl: Dispatch<SetStateAction<PopoverProps['anchorEl']>>
   setActiveColumn: Dispatch<SetStateAction<DataTableColumn | undefined>>
-  setLocalStorageColumns: Dispatch<SetStateAction<LocalStorageColumns>>
   containerRef?: MutableRefObject<HTMLDivElement | null>
   sortBy: boolean
   orderAsc: boolean
@@ -189,7 +178,6 @@ export interface DataTableHeaderProps {
 
 export interface DataTableLineProps {
   row: any
-  effectiveColumns: DataTableColumns
   index: number
   onToggleShiftEntity: (currentIndex: number, currentEntity: { id: string }, event?: React.MouseEvent) => void
 }

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -67,6 +67,10 @@ export interface DataTableContextProps {
   onLineClick: DataTableProps['onLineClick']
   page: number
   setPage:Dispatch<SetStateAction<number>>
+  tableWidthState: [number, Dispatch<SetStateAction<number>>]
+  startsWithAction: boolean
+  endsWithAction: boolean
+  endsWithNavigate: boolean
 }
 
 export interface DataTableProps {
@@ -140,6 +144,7 @@ export interface DataTableBodyProps {
   pageSize: number
   pageStart: number
   hideHeaders: DataTableProps['hideHeaders']
+  tableRef: MutableRefObject<HTMLDivElement | null>
 }
 
 export interface DataTableDisplayFiltersProps {

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -82,7 +82,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-const Truncate = ({ children }: { children: ReactNode }) => (
+export const Truncate = ({ children }: { children: ReactNode }) => (
   <div style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}>
     {children}
   </div>
@@ -862,7 +862,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
               marginRight: 5,
             }}
           />
-          {truncate(x_opencti_color, size * MAGICAL_SIZE)}
+          <Truncate>{x_opencti_color}</Truncate>
         </>
       </Tooltip>
     ),

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -91,7 +91,7 @@ export const Truncate = ({ children }: { children: ReactNode }) => (
 export const defaultRender: NonNullable<DataTableColumn['render']> = (data, displayDraftChip = false) => {
   return (
     <Tooltip title={data}>
-      <div style={{ maxWidth: '100%' }}>
+      <div style={{ maxWidth: '100%', display: 'flex' }}>
         <Truncate>{data}</Truncate>
         {displayDraftChip && (<DraftChip/>)}
       </div>
@@ -849,7 +849,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Color',
     percentWidth: 15,
     isSortable: true,
-    render: ({ x_opencti_color }, { column: { size } }) => (
+    render: ({ x_opencti_color }) => (
       <Tooltip title={x_opencti_color}>
         <>
           <div

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -10,7 +10,7 @@ import type { DataTableColumn } from './dataTableTypes';
 import { DataTableProps, DataTableVariant } from './dataTableTypes';
 import ItemMarkings from '../ItemMarkings';
 import ItemStatus from '../ItemStatus';
-import { emptyFilled, truncate } from '../../utils/String';
+import { emptyFilled } from '../../utils/String';
 import ItemPriority from '../ItemPriority';
 import { isNotEmptyField } from '../../utils/utils';
 import RatingField from '../fields/RatingField';
@@ -25,26 +25,12 @@ import ItemSeverity from '../ItemSeverity';
 import { APP_BASE_PATH } from '../../relay/environment';
 import ItemOperations from '../ItemOperations';
 
-export const MAGICAL_SIZE = 0.113;
-
 const chipStyle = {
   fontSize: '12px',
   lineHeight: '12px',
   height: '20px',
   marginRight: '7px',
   borderRadius: '10px',
-};
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type TextInTooltip = (val?: string, helpers?: any) => ReactNode;
-export const textInTooltip: TextInTooltip = (val, helpers) => {
-  const value = val ?? '-';
-  const { column: { size } } = helpers;
-  return (
-    <Tooltip title={value}>
-      <div>{truncate(value, size * MAGICAL_SIZE, false)}</div>
-    </Tooltip>
-  );
 };
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -96,13 +82,21 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-const defaultRender: DataTableColumn['render'] = (data, { column: { size } }, displayDraftChip = false) => {
-  return (<Tooltip title={data}>
-    <div>
-      {truncate(data, size * MAGICAL_SIZE)}
-      {displayDraftChip && (<DraftChip/>)}
-    </div>
-  </Tooltip>);
+const Truncate = ({ children }: { children: ReactNode }) => (
+  <div style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+    {children}
+  </div>
+);
+
+export const defaultRender: NonNullable<DataTableColumn['render']> = (data, displayDraftChip = false) => {
+  return (
+    <Tooltip title={data}>
+      <div style={{ maxWidth: '100%' }}>
+        <Truncate>{data}</Truncate>
+        {displayDraftChip && (<DraftChip/>)}
+      </div>
+    </Tooltip>
+  );
 };
 
 const defaultColumns: DataTableProps['dataColumns'] = {
@@ -159,8 +153,8 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Abstract',
     percentWidth: 25,
     isSortable: true,
-    render: ({ attribute_abstract, content, draftVersion }, helpers) => {
-      return defaultRender(attribute_abstract || content, helpers, draftVersion);
+    render: ({ attribute_abstract, content, draftVersion }) => {
+      return defaultRender(attribute_abstract || content, draftVersion);
     },
   },
   attribute_count: {
@@ -168,16 +162,16 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Nb.',
     percentWidth: 4,
     isSortable: true,
-    render: ({ attribute_count }, helpers) => defaultRender(String(attribute_count), helpers),
+    render: ({ attribute_count }) => defaultRender(String(attribute_count)),
   },
   channel_types: {
     id: 'channel_types',
     label: 'Types',
     percentWidth: 20,
     isSortable: true,
-    render: ({ channel_types }, helpers) => {
+    render: ({ channel_types }) => {
       const value = channel_types ? channel_types.join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   color: {
@@ -185,7 +179,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Color',
     percentWidth: 25,
     isSortable: true,
-    render: ({ color }, { column: { size } }) => (
+    render: ({ color }) => (
       <Tooltip title={color}>
         <>
           <div
@@ -198,7 +192,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
               marginRight: 5,
             }}
           />
-          {truncate(color, size * MAGICAL_SIZE)}
+          <Truncate>{color}</Truncate>
         </>
       </Tooltip>
     ),
@@ -234,14 +228,14 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Original creation date',
     percentWidth: 15,
     isSortable: true,
-    render: ({ created }, helpers) => defaultRender(helpers.fd(created), helpers),
+    render: ({ created }, helpers) => defaultRender(helpers.fd(created)),
   },
   created_at: {
     id: 'created_at',
     label: 'Platform creation date',
     percentWidth: 15,
     isSortable: true,
-    render: ({ created_at }, helpers) => defaultRender(helpers.fd(created_at), helpers),
+    render: ({ created_at }, helpers) => defaultRender(helpers.fd(created_at)),
   },
   createdBy: {
     id: 'createdBy',
@@ -253,9 +247,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     id: 'creator',
     label: 'Creators',
     percentWidth: 12,
-    render: ({ creators }, helpers) => {
+    render: ({ creators }) => {
       const value = isNotEmptyField(creators) ? creators.map((c: { name: string }) => c.name).join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   entity_type: {
@@ -284,9 +278,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Types',
     percentWidth: 20,
     isSortable: true,
-    render: ({ event_types }, helpers) => {
+    render: ({ event_types }) => {
       const value = event_types ? event_types.join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   external_id: {
@@ -294,7 +288,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'External ID',
     percentWidth: 10,
     isSortable: true,
-    render: ({ external_id }, helpers) => defaultRender(external_id, helpers),
+    render: ({ external_id }) => defaultRender(external_id),
   },
   first_observed: {
     id: 'first_observed',
@@ -317,7 +311,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     isSortable: false,
     render: ({ from }, helpers) => {
       const value = from ? getMainRepresentative(from) : helpers.t_i18n('Restricted');
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   incident_type: {
@@ -393,15 +387,11 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Kill chain phase',
     percentWidth: 15,
     isSortable: false,
-    render: ({ killChainPhases }, { column: { size } }) => {
+    render: ({ killChainPhases }) => {
       const formattedKillChainPhase = (killChainPhases && killChainPhases.length > 0)
         ? `[${killChainPhases[0].kill_chain_name}] ${killChainPhases[0].phase_name}`
         : '-';
-      return (
-        <Tooltip title={formattedKillChainPhase}>
-          <div>{truncate(formattedKillChainPhase, size * MAGICAL_SIZE)}</div>
-        </Tooltip>
-      );
+      return defaultRender(formattedKillChainPhase);
     },
   },
   kill_chain_name: {
@@ -409,7 +399,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Kill chain name',
     percentWidth: 40,
     isSortable: true,
-    render: ({ kill_chain_name }, helpers) => defaultRender(kill_chain_name, helpers),
+    render: ({ kill_chain_name }) => defaultRender(kill_chain_name),
   },
   last_observed: {
     id: 'last_observed',
@@ -430,9 +420,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Malware types',
     percentWidth: 15,
     isSortable: true,
-    render: ({ malware_types }, helpers) => {
+    render: ({ malware_types }) => {
       const value = malware_types ? malware_types.join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   modified: {
@@ -447,9 +437,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Name',
     percentWidth: 25,
     isSortable: true,
-    render: (data, helpers) => {
+    render: (data) => {
       const displayDraftChip = !!data.draftVersion;
-      return defaultRender(getMainRepresentative(data), helpers, displayDraftChip);
+      return defaultRender(getMainRepresentative(data), displayDraftChip);
     },
   },
   note_types: {
@@ -487,9 +477,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Assignees',
     percentWidth: 10,
     isSortable: false,
-    render: ({ objectAssignee }, helpers) => {
+    render: ({ objectAssignee }) => {
       const value = isNotEmptyField(objectAssignee) ? objectAssignee.map((c: { name: string }) => c.name).join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   objectLabel: {
@@ -527,7 +517,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     percentWidth: 20,
     isSortable: false,
     // Please check the String.jsx->renderObservableValue. It should have the same behavior and will replace it at the end.
-    render: (observable, helpers) => {
+    render: (observable) => {
       const theme = useTheme<Theme>();
       switch (observable.entity_type) {
         case 'IPv4-Addr':
@@ -546,16 +536,16 @@ const defaultColumns: DataTableProps['dataColumns'] = {
                     />
                   </Tooltip>
                   <div>
-                    {defaultRender(observable.observable_value, helpers, observable.draftVersion)}
+                    {defaultRender(observable.observable_value, observable.draftVersion)}
                   </div>
                 </div>
               );
             }
           }
-          return defaultRender(observable.observable_value, helpers, observable.draftVersion);
+          return defaultRender(observable.observable_value, observable.draftVersion);
         }
         default:
-          return defaultRender(observable.observable_value, helpers, observable.draftVersion);
+          return defaultRender(observable.observable_value, observable.draftVersion);
       }
     },
   },
@@ -576,7 +566,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Owner',
     percentWidth: 12,
     isSortable: true,
-    render: ({ owner }, h) => textInTooltip(owner.name, h),
+    render: ({ owner }) => defaultRender(owner.name),
   },
   pattern_type: {
     id: 'pattern_type',
@@ -590,7 +580,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Phase name',
     percentWidth: 35,
     isSortable: true,
-    render: ({ phase_name }, helpers) => defaultRender(phase_name, helpers),
+    render: ({ phase_name }) => defaultRender(phase_name),
   },
   primary_motivation: {
     id: 'primary_motivation',
@@ -622,7 +612,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Product',
     percentWidth: 15,
     isSortable: true,
-    render: ({ product }, helpers) => defaultRender(product, helpers),
+    render: ({ product }) => defaultRender(product),
   },
   published: {
     id: 'published',
@@ -706,16 +696,16 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Result name',
     percentWidth: 15,
     isSortable: true,
-    render: ({ result_name, draftVersion }, helpers) => defaultRender(result_name, helpers, draftVersion),
+    render: ({ result_name, draftVersion }) => defaultRender(result_name, draftVersion),
   },
   secondary_motivations: {
     id: 'secondary_motivations',
     label: 'Secondary motivations',
     percentWidth: 10,
     isSortable: false,
-    render: ({ secondary_motivations }, helpers) => {
+    render: ({ secondary_motivations }) => {
       const value = secondary_motivations ? secondary_motivations.join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   severity: {
@@ -748,7 +738,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Source name',
     percentWidth: 15,
     isSortable: true,
-    render: ({ source_name, draftVersion }, helpers) => defaultRender(source_name, helpers, draftVersion),
+    render: ({ source_name, draftVersion }) => defaultRender(source_name, draftVersion),
   },
   start_time: {
     id: 'start_time',
@@ -801,9 +791,9 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Types',
     percentWidth: 20,
     isSortable: true,
-    render: ({ threat_actor_types }, helpers) => {
+    render: ({ threat_actor_types }) => {
       const value = threat_actor_types ? threat_actor_types.join(', ') : '-';
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   toName: {
@@ -813,7 +803,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     isSortable: false,
     render: ({ to }, helpers) => {
       const value = to ? getMainRepresentative(to) : helpers.t_i18n('Restricted');
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   updated_at: {
@@ -828,23 +818,23 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'URL',
     percentWidth: 45,
     isSortable: true,
-    render: ({ url }, helpers) => defaultRender(url, helpers),
+    render: ({ url }) => defaultRender(url),
   },
   user_email: {
     id: 'user_email',
     label: 'Email',
     percentWidth: 50,
     isSortable: false,
-    render: ({ user_email }, helpers) => defaultRender(user_email, helpers),
+    render: ({ user_email }) => defaultRender(user_email),
   },
   value: {
     id: 'value',
     label: 'Value',
     percentWidth: 22,
     isSortable: false,
-    render: (node, helpers) => {
+    render: (node) => {
       const value = getMainRepresentative(node);
-      return defaultRender(value, helpers);
+      return defaultRender(value);
     },
   },
   x_mitre_id: {
@@ -882,7 +872,7 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Order',
     percentWidth: 10,
     isSortable: true,
-    render: ({ x_opencti_order }, helpers) => defaultRender(x_opencti_order.toString(), helpers),
+    render: ({ x_opencti_order }) => defaultRender(x_opencti_order.toString()),
   },
   x_opencti_negative: {
     id: 'x_opencti_negative',
@@ -960,12 +950,15 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'File name',
     percentWidth: 12,
     isSortable: false,
-    render: (data, { column: { size } }) => {
+    render: (data) => {
       const file = (data.importFiles?.edges && data.importFiles.edges.length > 0)
         ? data.importFiles.edges[0]?.node
         : { name: 'N/A', metaData: { mimetype: 'N/A' }, size: 0 };
-      return (<Tooltip title={file?.name}><>{truncate(file?.name, size * MAGICAL_SIZE)}</>
-      </Tooltip>);
+      return (
+        <Tooltip title='ntm'>
+          <Truncate>{file?.name}</Truncate>
+        </Tooltip>
+      );
     },
   },
   file_mime_type: {
@@ -973,12 +966,15 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     label: 'Mime/Type',
     percentWidth: 8,
     isSortable: false,
-    render: (data, { column: { size } }) => {
+    render: (data) => {
       const file = (data.importFiles?.edges && data.importFiles.edges.length > 0)
         ? data.importFiles.edges[0]?.node
         : { name: 'N/A', metaData: { mimetype: 'N/A' }, size: 0 };
-      return (<Tooltip title={file?.metaData?.mimetype}><>{truncate(file?.metaData?.mimetype, size * MAGICAL_SIZE)}</>
-      </Tooltip>);
+      return (
+        <Tooltip title={file?.metaData?.mimetype}>
+          <Truncate>{file?.metaData.mimetype}</Truncate>
+        </Tooltip>
+      );
     },
   },
   file_size: {

--- a/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
@@ -3,7 +3,6 @@ import useHelper from 'src/utils/hooks/useHelper';
 import { graphql } from 'react-relay';
 import { ReportsLinesPaginationQuery, ReportsLinesPaginationQuery$variables } from '@components/analyses/__generated__/ReportsLinesPaginationQuery.graphql';
 import { ReportsLines_data$data } from '@components/analyses/__generated__/ReportsLines_data.graphql';
-import IndicatorObservablePopover from '@components/observations/indicators/IndicatorObservablePopover';
 import ReportCreation from './reports/ReportCreation';
 import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
@@ -225,12 +224,6 @@ const Reports: FunctionComponent = () => {
             <Security needs={[KNOWLEDGE_KNUPDATE]}>
               <ReportCreation paginationOptions={queryPaginationOptions} />
             </Security>
-          )}
-          actions={(observable) => (
-            <IndicatorObservablePopover
-              indicatorId={observable.id}
-              observableId={observable.id}
-            />
           )}
         />
       )}

--- a/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
@@ -3,6 +3,7 @@ import useHelper from 'src/utils/hooks/useHelper';
 import { graphql } from 'react-relay';
 import { ReportsLinesPaginationQuery, ReportsLinesPaginationQuery$variables } from '@components/analyses/__generated__/ReportsLinesPaginationQuery.graphql';
 import { ReportsLines_data$data } from '@components/analyses/__generated__/ReportsLines_data.graphql';
+import IndicatorObservablePopover from '@components/observations/indicators/IndicatorObservablePopover';
 import ReportCreation from './reports/ReportCreation';
 import Security from '../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
@@ -224,6 +225,12 @@ const Reports: FunctionComponent = () => {
             <Security needs={[KNOWLEDGE_KNUPDATE]}>
               <ReportCreation paginationOptions={queryPaginationOptions} />
             </Security>
+          )}
+          actions={(observable) => (
+            <IndicatorObservablePopover
+              indicatorId={observable.id}
+              observableId={observable.id}
+            />
           )}
         />
       )}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
@@ -250,41 +250,42 @@ const StixCoreObjectsList = ({
       height={height}
       title={parameters.title ?? title ?? t_i18n('Entities list')}
       variant={variant}
-      ref={rootRef}
     >
-      <QueryRenderer
-        query={stixCoreObjectsListQuery}
-        variables={{
-          types: dataSelectionTypes,
-          first: selection.number ?? 10,
-          orderBy: sortBy,
-          orderMode: selection.sort_mode ?? 'asc',
-          filters,
-        }}
-        render={({ props }) => {
-          if (
-            props
+      <div ref={rootRef} style={{ height: '100%' }}>
+        <QueryRenderer
+          query={stixCoreObjectsListQuery}
+          variables={{
+            types: dataSelectionTypes,
+            first: selection.number ?? 10,
+            orderBy: sortBy,
+            orderMode: selection.sort_mode ?? 'asc',
+            filters,
+          }}
+          render={({ props }) => {
+            if (
+              props
             && props.stixCoreObjects
             && props.stixCoreObjects.edges.length > 0
-          ) {
-            const data = props.stixCoreObjects.edges;
-            return (
-              <WidgetListCoreObjects
-                data={data}
-                dateAttribute={dateAttribute}
-                rootRef={rootRef.current ?? undefined}
-                widgetId={widgetId}
-                pageSize={selection.number ?? 10}
-                sortBy={sortBy}
-              />
-            );
-          }
-          if (props) {
-            return <WidgetNoData />;
-          }
-          return <Loader variant={LoaderVariant.inElement} />;
-        }}
-      />
+            ) {
+              const data = props.stixCoreObjects.edges;
+              return (
+                <WidgetListCoreObjects
+                  data={data}
+                  dateAttribute={dateAttribute}
+                  rootRef={rootRef.current ?? undefined}
+                  widgetId={widgetId}
+                  pageSize={selection.number ?? 10}
+                  sortBy={sortBy}
+                />
+              );
+            }
+            if (props) {
+              return <WidgetNoData />;
+            }
+            return <Loader variant={LoaderVariant.inElement} />;
+          }}
+        />
+      </div>
     </WidgetContainer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -60,9 +60,8 @@ const useStyles = makeStyles<Theme>(() => ({
     zIndex: 1001,
   },
   container: {
-    width: '100%',
-    height: '100%',
-    maxHeight: '100%',
+    flex: '1 0 0',
+    overflow: 'hidden',
   },
 }));
 
@@ -783,7 +782,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
             {({ platformModuleHelpers }) => (
               <>
                 {queryRef && (
-                  <div style={{ height: '98%' }} ref={setTableRootRef}>
+                  <div style={{ height: '100%' }} ref={setTableRootRef}>
                     <DataTable
                       disableToolBar
                       disableSelectAll

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
@@ -28,10 +28,6 @@ const styles = (theme) => ({
     }),
     padding: 0,
   },
-  createButton: {
-    float: 'left',
-    marginTop: -15,
-  },
   title: {
     float: 'left',
   },
@@ -93,7 +89,6 @@ class IndicatorAddObservables extends Component {
           color="primary"
           aria-label="Add"
           onClick={this.handleOpen.bind(this)}
-          classes={{ root: classes.createButton }}
           size="large"
         >
           <Add fontSize="small" />

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservablePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservablePopover.jsx
@@ -64,24 +64,33 @@ class IndicatorObservablePopover extends Component {
   }
 
   handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
     event.stopPropagation();
+    event.preventDefault();
+    this.setState({ anchorEl: event.currentTarget });
   }
 
-  handleClose() {
+  handleClose(event) {
+    event.stopPropagation();
+    event.preventDefault();
     this.setState({ anchorEl: null });
   }
 
-  handleOpenDelete() {
+  handleOpenDelete(event) {
+    event.stopPropagation();
+    event.preventDefault();
     this.setState({ displayDelete: true });
-    this.handleClose();
+    this.handleClose(event);
   }
 
-  handleCloseDelete() {
+  handleCloseDelete(event) {
+    event.stopPropagation();
+    event.preventDefault();
     this.setState({ deleting: false, displayDelete: false });
   }
 
-  submitDelete() {
+  submitDelete(event) {
+    event.stopPropagation();
+    event.preventDefault();
     this.setState({ deleting: true });
     commitMutation({
       mutation: indicatorObservablePopoverDeletionMutation,
@@ -92,7 +101,7 @@ class IndicatorObservablePopover extends Component {
       },
       updater: (store) => deleteNodeFromEdge(store, 'observables', this.props.indicatorId, this.props.observableId, { first: 100 }),
       onCompleted: () => {
-        this.handleCloseDelete();
+        this.handleCloseDelete(event);
         if (this.props.onDelete) {
           this.props.onDelete();
         }
@@ -108,7 +117,6 @@ class IndicatorObservablePopover extends Component {
           onClick={this.handleOpen.bind(this)}
           aria-haspopup="true"
           style={{ marginTop: 3 }}
-          size="large"
           color="primary"
         >
           <MoreVert />

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservables.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservables.jsx
@@ -23,46 +23,49 @@ const IndicatorObservablesComponent = ({ indicator }) => {
   const observablesGlobalCount = indicator.observables.pageInfo.globalCount;
 
   return (
-    <div style={{ marginTop: 20, height: 300 }} ref={(r) => setRef(r)}>
-      <Typography variant="h3" gutterBottom={true} style={{ float: 'left' }}>
-        {t_i18n('Based on')}
-      </Typography>
-      <Security needs={[KNOWLEDGE_KNUPDATE]}>
-        <IndicatorAddObservables
-          indicator={indicator}
-          indicatorObservables={indicator.observables.edges}
-        />
-      </Security>
-      <div className="clearfix" />
-      <DataTableWithoutFragment
-        dataColumns={{
-          entity_type: {
-            percentWidth: 20,
-            isSortable: false,
-          },
-          observable_value: {
-            percentWidth: 55,
-            isSortable: false,
-          },
-          created_at: {
-            percentWidth: 25,
-            isSortable: false,
-          },
-        }}
-        data={observables}
-        globalCount={observablesGlobalCount}
-        rootRef={ref}
-        storageKey={`indicator-observables-${indicator.id}`}
-        variant={DataTableVariant.inline}
-        hideHeaders
-        actions={(observable) => (
-          <IndicatorObservablePopover
-            indicatorId={indicator.id}
-            observableId={observable.id}
-            onDelete={() => onDelete(observable.id)}
+    <div style={{ marginTop: 20, height: 300, display: 'flex', flexFlow: 'column' }} >
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Typography variant="h3" style={{ marginBottom: 0 }}>
+          {t_i18n('Based on')}
+        </Typography>
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <IndicatorAddObservables
+            indicator={indicator}
+            indicatorObservables={indicator.observables.edges}
           />
-        )}
-      />
+        </Security>
+      </div>
+      <div style={{ overflow: 'hidden', flex: 1 }} ref={(r) => setRef(r)}>
+        <DataTableWithoutFragment
+          dataColumns={{
+            entity_type: {
+              percentWidth: 20,
+              isSortable: false,
+            },
+            observable_value: {
+              percentWidth: 55,
+              isSortable: false,
+            },
+            created_at: {
+              percentWidth: 25,
+              isSortable: false,
+            },
+          }}
+          data={observables}
+          globalCount={observablesGlobalCount}
+          rootRef={ref}
+          storageKey={`indicator-observables-${indicator.id}`}
+          variant={DataTableVariant.inline}
+          hideHeaders
+          actions={(observable) => (
+            <IndicatorObservablePopover
+              indicatorId={indicator.id}
+              observableId={observable.id}
+              onDelete={() => onDelete(observable.id)}
+            />
+          )}
+        />
+      </div>
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
@@ -122,7 +122,7 @@ const MarkingDefinitions = () => {
     const { isSensitive } = useSensitiveModifications('markings', standard_id);
     return (
       <Tooltip title={definition_type}>
-        <div>
+        <div style={{ display: 'flex' }}>
           <Truncate>{definition_type}</Truncate>
           {isSensitive && <DangerZoneChip />}
         </div>

--- a/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
@@ -16,9 +16,8 @@ import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { useBuildEntityTypeBasedFilterContext } from '../../../utils/filters/filtersUtils';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
-import { truncate } from '../../../utils/String';
 import useSensitiveModifications from '../../../utils/hooks/useSensitiveModifications';
-import { MAGICAL_SIZE } from '../../../components/dataGrid/dataTableUtils';
+import { Truncate } from '../../../components/dataGrid/dataTableUtils';
 import type { DataTableColumn } from '../../../components/dataGrid/dataTableTypes';
 
 const LOCAL_STORAGE_KEY = 'MarkingDefinitions';
@@ -118,14 +117,13 @@ const MarkingDefinitions = () => {
 
   const definitionTypeRender: DataTableColumn['render'] = (
     data: MarkingDefinitionsLine_node$data,
-    { column: { size } },
   ) => {
     const { standard_id, definition_type } = data;
     const { isSensitive } = useSensitiveModifications('markings', standard_id);
     return (
       <Tooltip title={definition_type}>
         <div>
-          {truncate(definition_type, size * MAGICAL_SIZE)}
+          <Truncate>{definition_type}</Truncate>
           {isSensitive && <DangerZoneChip />}
         </div>
       </Tooltip>

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -156,7 +156,7 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
                 keyword={searchTerm}
                 sx={{
                   marginTop: 2,
-                  marginBottom: 1,
+                  marginBottom: 2,
                 }}
               />
             </GroupEditionUsers>

--- a/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
 import { AttackPatternsLinesPaginationQuery, AttackPatternsLinesPaginationQuery$variables } from '@components/techniques/__generated__/AttackPatternsLinesPaginationQuery.graphql';
-import Tooltip from '@mui/material/Tooltip';
 import { AttackPatternsLines_data$data } from '@components/techniques/__generated__/AttackPatternsLines_data.graphql';
 import AttackPatternCreation from './attack_patterns/AttackPatternCreation';
 import Security from '../../../utils/Security';
@@ -13,9 +12,9 @@ import { useFormatter } from '../../../components/i18n';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
-import { truncate } from '../../../utils/String';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
 import useHelper from '../../../utils/hooks/useHelper';
+import { defaultRender } from '../../../components/dataGrid/dataTableUtils';
 
 const LOCAL_STORAGE_KEY = 'attackPattern';
 
@@ -129,7 +128,7 @@ const AttackPatterns = () => {
     x_mitre_id: {},
     name: {
       percentWidth: 30,
-      render: ({ name }, { column: { size } }) => (<Tooltip title={name}>{truncate(name, size * 0.113)}</Tooltip>),
+      render: ({ name }) => defaultRender(name),
     },
     objectLabel: {},
     created: {},

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.jsx
@@ -26,6 +26,7 @@ import handleExportJson from './workspaceExportHandler';
 import WorkspaceDuplicationDialog from './WorkspaceDuplicationDialog';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
 import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
+import stopEvent from '../../../utils/domEvent';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -61,23 +62,42 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
   const [displayDuplicate, setDisplayDuplicate] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [duplicating, setDuplicating] = useState(false);
-  const handleOpen = (event) => setAnchorEl(event.currentTarget);
-  const handleClose = () => setAnchorEl(null);
-  const handleOpenDelete = () => {
-    setDisplayDelete(true);
-    handleClose();
+
+  const handleOpen = (event) => {
+    stopEvent(event);
+    setAnchorEl(event.currentTarget);
   };
-  const handleCloseDelete = () => setDisplayDelete(false);
-  const handleCloseDuplicate = () => {
+
+  const handleClose = (event) => {
+    stopEvent(event);
+    setAnchorEl(null);
+  };
+
+  const handleOpenDelete = (event) => {
+    setDisplayDelete(true);
+    handleClose(event);
+  };
+
+  const handleCloseDelete = (event) => {
+    stopEvent(event);
+    setDisplayDelete(false);
+  };
+
+  const handleCloseDuplicate = (event) => {
+    if (event) stopEvent(event);
     setDisplayDuplicate(false);
   };
+
   const [commit] = useApiMutation(WorkspacePopoverDeletionMutation);
+
   const updater = (store) => {
     if (paginationOptions) {
       insertNode(store, 'Pagination_workspaces', paginationOptions, 'workspaceDuplicate');
     }
   };
-  const submitDelete = () => {
+
+  const submitDelete = (event) => {
+    stopEvent(event);
     setDeleting(true);
     commit({
       variables: { id },
@@ -88,9 +108,9 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
       },
       onCompleted: () => {
         setDeleting(false);
-        handleClose();
+        handleClose(event);
         if (paginationOptions) {
-          handleCloseDelete();
+          handleCloseDelete(event);
         } else {
           navigate(`/dashboard/workspaces/${type}s`);
         }
@@ -98,22 +118,26 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
     });
   };
 
-  const handleOpenEdit = () => {
+  const handleOpenEdit = (event) => {
     setDisplayEdit(true);
-    handleClose();
+    handleClose(event);
   };
-  const handleDashboardDuplication = () => {
+
+  const handleDashboardDuplication = (event) => {
     setDisplayDuplicate(true);
-    handleClose();
+    handleClose(event);
   };
 
   const handleCloseEdit = () => setDisplayEdit(false);
+
   const { canManage, canEdit } = useGetCurrentUserAccessRight(workspace.currentUserAccessRight);
   if (!canEdit && workspace.type !== 'dashboard') {
     return <></>;
   }
 
-  const goToPublicDashboards = () => {
+  const goToPublicDashboards = (event) => {
+    stopEvent(event);
+
     const filter = {
       mode: 'and',
       filterGroups: [],
@@ -130,18 +154,25 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
   // -- Creation public dashboard --
   const [displayCreate, setDisplayCreate] = useState(false);
 
-  const handleOpenCreation = () => {
+  const handleOpenCreation = (event) => {
     setDisplayCreate(true);
-    handleClose();
+    handleClose(event);
   };
-  const handleCloseCreate = () => setDisplayCreate(false);
+
+  const handleCloseCreate = () => {
+    setDisplayCreate(false);
+  };
+
+  const handleExport = (event) => {
+    stopEvent(event);
+    handleExportJson(workspace);
+  };
 
   return (
     <div className={classes.container}>
       <IconButton
         onClick={handleOpen}
         aria-haspopup="true"
-        size="large"
         style={{ marginTop: 3 }}
         color="primary"
         aria-label={t_i18n('Workspace popover of actions')}
@@ -158,13 +189,13 @@ const WorkspacePopover = ({ workspace, paginationOptions }) => {
               <MenuItem onClick={handleDashboardDuplication}>{t_i18n('Duplicate')}</MenuItem>
             </Security>
             <Security needs={[EXPLORE_EXUPDATE]} hasAccess={canEdit}>
-              <MenuItem onClick={() => handleExportJson(workspace)}>{t_i18n('Export')}</MenuItem>
+              <MenuItem onClick={handleExport}>{t_i18n('Export')}</MenuItem>
             </Security>
             <Security needs={[EXPLORE_EXUPDATE_EXDELETE]} hasAccess={canManage}>
               <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
             </Security>
             <Box>
-              <MenuItem onClick={() => goToPublicDashboards()}>
+              <MenuItem onClick={goToPublicDashboards}>
                 {t_i18n('View associated public dashboards')}
               </MenuItem>
               <Security needs={[EXPLORE_EXUPDATE_PUBLISH]} hasAccess={canManage}>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/Workspaces.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/Workspaces.tsx
@@ -16,7 +16,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import { useFormatter } from '../../../components/i18n';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
-import { textInTooltip } from '../../../components/dataGrid/dataTableUtils';
+import { defaultRender } from '../../../components/dataGrid/dataTableUtils';
 
 interface WorkspacesProps {
   type: string;
@@ -83,7 +83,6 @@ const Workspaces: FunctionComponent<WorkspacesProps> = ({
       name: {
         id: 'name',
         percentWidth: 33,
-        render: ({ name }, h) => textInTooltip(name, h),
       },
       tags: {
         id: 'tags',
@@ -91,7 +90,7 @@ const Workspaces: FunctionComponent<WorkspacesProps> = ({
       creator: {
         id: 'creator',
         isSortable: true,
-        render: ({ owner }, h) => textInTooltip(owner.name, h),
+        render: ({ owner }) => defaultRender(owner.name),
       },
       created_at: {
         id: 'created_at',

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboards.tsx
@@ -10,7 +10,7 @@ import useQueryLoading from '../../../../../utils/hooks/useQueryLoading';
 import { usePaginationLocalStorage } from '../../../../../utils/hooks/useLocalStorage';
 import ItemBoolean from '../../../../../components/ItemBoolean';
 import { DataTableProps } from '../../../../../components/dataGrid/dataTableTypes';
-import { textInTooltip } from '../../../../../components/dataGrid/dataTableUtils';
+import { defaultRender } from '../../../../../components/dataGrid/dataTableUtils';
 import Security from '../../../../../utils/Security';
 import { EXPLORE_EXUPDATE_PUBLISH } from '../../../../../utils/hooks/useGranted';
 import useHelper from '../../../../../utils/hooks/useHelper';
@@ -141,14 +141,14 @@ const PublicDashboards = () => {
       percentWidth: 18,
       label: 'URI key',
       isSortable: true,
-      render: ({ uri_key }, h) => textInTooltip(uri_key, h),
+      render: ({ uri_key }) => defaultRender(uri_key),
     },
     dashboard: {
       id: 'dashboard',
       percentWidth: 18,
       label: 'Dashboard',
       isSortable: false,
-      render: ({ dashboard }, h) => textInTooltip(dashboard.name, h),
+      render: ({ dashboard }) => defaultRender(dashboard.name),
     },
     enabled: {
       id: 'enabled',
@@ -167,7 +167,7 @@ const PublicDashboards = () => {
       percentWidth: 15,
       label: 'Shared by',
       isSortable: true,
-      render: ({ owner }, h) => textInTooltip(owner.name, h),
+      render: ({ owner }) => defaultRender(owner.name),
     },
     allowed_markings: {
       id: 'allowed_markings',

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
@@ -264,20 +264,21 @@ const PublicStixCoreObjectsList = ({
     <WidgetContainer
       title={parameters?.title ?? title ?? t_i18n('Entities number')}
       variant="inLine"
-      ref={rootRef}
     >
-      {queryRef ? (
-        <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
-          <PublicStixCoreObjectsListComponent
-            queryRef={queryRef}
-            dateAttribute={dateAttribute}
-            rootRef={rootRef.current ?? undefined}
-            widgetId={id}
-          />
-        </React.Suspense>
-      ) : (
-        <Loader variant={LoaderVariant.inElement} />
-      )}
+      <div ref={rootRef} style={{ height: '100%' }}>
+        {queryRef ? (
+          <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
+            <PublicStixCoreObjectsListComponent
+              queryRef={queryRef}
+              dateAttribute={dateAttribute}
+              rootRef={rootRef.current ?? undefined}
+              widgetId={id}
+            />
+          </React.Suspense>
+        ) : (
+          <Loader variant={LoaderVariant.inElement} />
+        )}
+      </div>
     </WidgetContainer>
   );
 };

--- a/opencti-platform/opencti-front/src/utils/domEvent.ts
+++ b/opencti-platform/opencti-front/src/utils/domEvent.ts
@@ -1,0 +1,8 @@
+import { UIEvent } from 'react';
+
+const stopEvent = (event: UIEvent) => {
+  event.stopPropagation();
+  event.preventDefault();
+};
+
+export default stopEvent;

--- a/opencti-platform/opencti-front/src/utils/resizeObservers.ts
+++ b/opencti-platform/opencti-front/src/utils/resizeObservers.ts
@@ -1,0 +1,21 @@
+/**
+ * Observe a DOM element and call the callback function each time
+ * the element has been resized.
+ *
+ * Don't forget to stop observing when not needed anymore.
+ * const observer = callbackResizeObserver(...);
+ * observer.disconnect();
+ *
+ * @param target The element to observe.
+ * @param callback The callback to execute on resize.
+ * @returns The observer.
+ */
+const callbackResizeObserver = (target: Element, callback: (entry: Element) => void) => {
+  const observer = new ResizeObserver((entries) => {
+    entries.forEach((entry) => callback(entry.target));
+  });
+  observer.observe(target);
+  return observer;
+};
+
+export default callbackResizeObserver;

--- a/opencti-platform/opencti-front/tests_e2e/model/MalwareAnalyses.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/MalwareAnalyses.pageModel.ts
@@ -20,11 +20,12 @@ export default class MalwareAnalysesPage {
     await leftBarPage.open();
     await leftBarPage.clickOnMenu('Analyses', 'Malware analyses');
   }
+
   getPage() {
     return this.page.getByTestId('malware-analyses-page');
   }
 
   getItemFromList(name: string) {
-    return this.page.getByLabel(name);
+    return this.getPage().getByText(name);
   }
 }

--- a/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
@@ -22,7 +22,7 @@ const navigateMalwareAnalyses = async (page: Page) => {
   await malwareAnalysesPage.navigateFromMenu();
 
   await expect(malwareAnalysesPage.getPage()).toBeVisible();
-  await expect(page.getByText(malwareAnalysesNameFromInitData)).toBeVisible();
+  await expect(malwareAnalysesPage.getItemFromList(malwareAnalysesNameFromInitData)).toBeVisible();
   await malwareAnalysesPage.getItemFromList(malwareAnalysesNameFromInitData).click();
 
   const malwareAnalysesDetailsPage = new MalwareAnalysesDetailsPage(page);


### PR DESCRIPTION
### Proposed changes

* Refactor how dimensions of DataTables are computed.
  * For width: use CSS with flexboxes instead of JS
  * For height: keep JS
* Remove some code not useful anymore

### Related issues

* #8808 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
