### PR TITLE
[frontend] Change the color of the 'create' button in Observable  (#8910)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -874,7 +874,7 @@ const StixCyberObservableCreation = ({
                         </Button>
                         <Button
                           variant={contextual ? 'text' : 'contained'}
-                          color="primary"
+                          color="secondary"
                           onClick={submitForm}
                           disabled={isSubmitting}
                           classes={{ root: classes.button }}


### PR DESCRIPTION
### Proposed changes

* The design of the ‘create’ button on an observable must be the same as that of the other create buttons. The colour must be changed.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/8910 