### PR TITLE
[frontend] fix unable to expand indicators based on file (#8831)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -564,6 +564,10 @@ const investigationGraphStixRelationshipsQuery = graphql`
             }
             ... on StixFile {
               observableName: name
+              hashes {
+                algorithm
+                hash
+              }
             }
             ... on StixMetaObject {
               created
@@ -769,6 +773,10 @@ const investigationGraphStixRelationshipsQuery = graphql`
             }
             ... on StixFile {
               observableName: name
+              hashes {
+                algorithm
+                hash
+              }
             }
             ... on StixMetaObject {
               created


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add missing Hashes for `StixFile` in `InvestigationGraphStixRelationshipsQuery` 


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/8831
* fixes also https://github.com/OpenCTI-Platform/opencti/issues/8908


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
