### PR TITLE
[frontend] use inline for header loader variant (#8279)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEdition.tsx
@@ -25,7 +25,7 @@ const CaseIncidentEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) 
     <>
       {queryRef && (
         <React.Suspense
-          fallback={<Loader variant={LoaderVariant.inElement} />}
+          fallback={<Loader variant={LoaderVariant.inline} />}
         >
           <CaseIncidentEditionContainer
             queryRef={queryRef}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEdition.tsx
@@ -25,7 +25,7 @@ const CaseRfiEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
     <>
       {queryRef && (
         <React.Suspense
-          fallback={<Loader variant={LoaderVariant.inElement} />}
+          fallback={<Loader variant={LoaderVariant.inline} />}
         >
           <CaseRfiEditionContainer
             queryRef={queryRef}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEdition.tsx
@@ -25,7 +25,7 @@ const CaseRftEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
     <>
       {queryRef && (
         <React.Suspense
-          fallback={<Loader variant={LoaderVariant.inElement} />}
+          fallback={<Loader variant={LoaderVariant.inline} />}
         >
           <CaseRftEditionContainer
             queryRef={queryRef}

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEdition.tsx
@@ -25,7 +25,7 @@ const FeedbackEdition: FunctionComponent<{ feedbackId: string }> = ({ feedbackId
     <>
       {queryRef && (
         <React.Suspense
-          fallback={<Loader variant={LoaderVariant.inElement} />}
+          fallback={<Loader variant={LoaderVariant.inline} />}
         >
           <FeedbackEditionContainer
             queryRef={queryRef}

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskEdition.tsx
@@ -25,7 +25,7 @@ const TaskEdition: FunctionComponent<{ caseId: string }> = ({ caseId }) => {
     <>
       {queryRef && (
         <React.Suspense
-          fallback={<Loader variant={LoaderVariant.inElement} />}
+          fallback={<Loader variant={LoaderVariant.inline} />}
         >
           <TasksEditionContainer
             queryRef={queryRef}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEdition.tsx
@@ -31,7 +31,7 @@ const ThreatActorIndividualEdition = ({
   return (
     <>
       {queryRef && (
-        <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
+        <React.Suspense fallback={<Loader variant={LoaderVariant.inline} />}>
           <ThreatActorIndividualEditionContainer
             queryRef={queryRef}
             handleClose={handleClose}


### PR DESCRIPTION
### Proposed changes

* use inline for header loader variant

### Related issues

* close #8279 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### screenshoot

Previously : 
![image](https://github.com/user-attachments/assets/b9986d87-11a5-4ebd-bf34-38abf876e562)

Now : 
![image](https://github.com/user-attachments/assets/003742d7-5b17-40de-98f4-3c121ffb2b48)
