### PR TITLE
[frontend] Add support for dynamic configurable required fields to Events

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
@@ -26,7 +26,7 @@ import { isEmptyField } from '../../../../utils/utils';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import type { Theme } from '../../../../components/Theme';
 import { Option } from '../../common/form/ReferenceField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -106,16 +106,17 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
     undefined,
     { successMessage: `${t_i18n('entity_Incident')} ${t_i18n('successfully created')}` },
   );
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INCIDENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     confidence: Yup.number().nullable(),
     incident_type: Yup.string().nullable(),
     severity: Yup.string().nullable(),
     source: Yup.string().nullable(),
     description: Yup.string().nullable(),
-  };
-  const incidentValidator = useSchemaCreationValidation(
-    INCIDENT_TYPE,
+  }, mandatoryAttributes);
+  const incidentValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const onSubmit: FormikConfig<IncidentAddInput>['onSubmit'] = (
@@ -181,6 +182,8 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
     <Formik<IncidentAddInput>
       initialValues={initialValues}
       validationSchema={incidentValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -191,6 +194,7 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Incident']}
           />
@@ -202,6 +206,7 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
             label={t_i18n('Incident type')}
             type="incident-type-ov"
             name="incident_type"
+            required={(mandatoryAttributes.includes('incident_type'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
@@ -210,6 +215,7 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
             label={t_i18n('Severity')}
             type="incident-severity-ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
@@ -218,6 +224,7 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -228,35 +235,42 @@ export const IncidentCreationForm: FunctionComponent<IncidentCreationProps> = ({
             variant="standard"
             name="source"
             label={t_i18n('Source')}
+            required={(mandatoryAttributes.includes('source'))}
             fullWidth={true}
             style={fieldSpacingContainerStyle}
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -20,7 +20,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import { Option } from '../../common/form/ReferenceField';
 import { IncidentEditionOverview_incident$key } from './__generated__/IncidentEditionOverview_incident.graphql';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import { GenericContext } from '../../common/model/GenericContextModel';
@@ -138,6 +138,8 @@ const incidentEditionOverviewFragment = graphql`
   }
 `;
 
+const INCIDENT_TYPE = 'Incident';
+
 interface IncidentEditionOverviewProps {
   incidentRef: IncidentEditionOverview_incident$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -163,16 +165,17 @@ IncidentEditionOverviewProps
   const theme = useTheme<Theme>();
 
   const incident = useFragment(incidentEditionOverviewFragment, incidentRef);
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INCIDENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     incident_type: Yup.string().nullable(),
     severity: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     x_opencti_workflow_id: Yup.object(),
     references: Yup.array(),
-  };
-  const incidentValidator = useSchemaEditionValidation('Incident', basicShape);
+  }, mandatoryAttributes);
+  const incidentValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
   const queries = {
     fieldPatch: incidentMutationFieldPatch,
     relationAdd: incidentMutationRelationAdd,
@@ -254,6 +257,8 @@ IncidentEditionOverviewProps
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={incidentValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -271,6 +276,7 @@ IncidentEditionOverviewProps
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             disabled={isInferred}
             onFocus={editor.changeFocus}
@@ -292,6 +298,7 @@ IncidentEditionOverviewProps
             label={t_i18n('Incident type')}
             type="incident-type-ov"
             name="incident_type"
+            required={(mandatoryAttributes.includes('incident_type'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
@@ -304,6 +311,7 @@ IncidentEditionOverviewProps
             label={t_i18n('Severity')}
             type="incident-severity-ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
@@ -316,6 +324,7 @@ IncidentEditionOverviewProps
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             disabled={isInferred}
@@ -329,6 +338,7 @@ IncidentEditionOverviewProps
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectAssignee" />
@@ -337,6 +347,7 @@ IncidentEditionOverviewProps
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
             onChange={editor.changeParticipant}
           />
@@ -358,6 +369,7 @@ IncidentEditionOverviewProps
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -367,6 +379,7 @@ IncidentEditionOverviewProps
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             disabled={isInferred}
             helpertext={

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataCreation.tsx
@@ -22,7 +22,7 @@ import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import type { Theme } from '../../../../components/Theme';
 import { Option } from '../../common/form/ReferenceField';
 import { ObservedDataCreationMutation, ObservedDataCreationMutation$variables } from './__generated__/ObservedDataCreationMutation.graphql';
@@ -99,19 +99,18 @@ ObservedDataFormProps
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const basicShape = {
+  const { mandatoryAttributes } = useIsMandatoryAttribute(OBSERVED_DATA_TYPE);
+  const basicShape = yupShapeConditionalRequired({
     objects: Yup.array(),
     first_observed: Yup.date()
-      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
-      .required(t_i18n('This field is required')),
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     last_observed: Yup.date()
-      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
-      .required(t_i18n('This field is required')),
-    number_observed: Yup.number().required(t_i18n('This field is required')),
+      .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
+    number_observed: Yup.number(),
     confidence: Yup.number().nullable(),
-  };
-  const observedDataValidator = useSchemaCreationValidation(
-    OBSERVED_DATA_TYPE,
+  }, mandatoryAttributes);
+  const observedDataValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const [commit] = useApiMutation<ObservedDataCreationMutation>(
@@ -173,6 +172,8 @@ ObservedDataFormProps
     <Formik<ObservedDataAddInput>
       initialValues={initialValues}
       validationSchema={observedDataValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -181,6 +182,7 @@ ObservedDataFormProps
           <StixCoreObjectsField
             name="objects"
             style={fieldSpacingContainerStyle}
+            required={(mandatoryAttributes.includes('objects'))}
             setFieldValue={setFieldValue}
             values={values.objects}
           />
@@ -189,6 +191,7 @@ ObservedDataFormProps
             name="first_observed"
             textFieldProps={{
               label: t_i18n('First observed'),
+              required: (mandatoryAttributes.includes('first_observed')),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -199,6 +202,7 @@ ObservedDataFormProps
             name="last_observed"
             textFieldProps={{
               label: t_i18n('Last observed'),
+              required: (mandatoryAttributes.includes('last_observed')),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -210,6 +214,7 @@ ObservedDataFormProps
             name="number_observed"
             type="number"
             label={t_i18n('Number observed')}
+            required={(mandatoryAttributes.includes('number_observed'))}
             fullWidth={true}
             style={fieldSpacingContainerStyle}
           />
@@ -219,22 +224,26 @@ ObservedDataFormProps
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.js
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.js
@@ -16,7 +16,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import SwitchField from '../../../../components/fields/SwitchField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
@@ -102,8 +102,9 @@ const StixSightingRelationshipCreationForm = ({
 }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
-  const basicShape = {
-    attribute_count: Yup.number().required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(STIX_SIGHTING_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    attribute_count: Yup.number(),
     confidence: Yup.number().nullable(),
     first_seen: Yup.date()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
@@ -114,8 +115,8 @@ const StixSightingRelationshipCreationForm = ({
       .nullable(),
     description: Yup.string().nullable(),
     x_opencti_negative: Yup.boolean().nullable(),
-  };
-  const stixSightingRelationshipValidator = useSchemaCreationValidation(STIX_SIGHTING_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const stixSightingRelationshipValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const fromEntity = fromEntities[0];
   const toEntity = toEntities[0];
@@ -155,6 +156,8 @@ const StixSightingRelationshipCreationForm = ({
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={stixSightingRelationshipValidator}
+      validateOnBlur={false}
+      validateOnChange={false}
       onSubmit={onSubmit}
       onReset={handleClose}
     >
@@ -252,6 +255,7 @@ const StixSightingRelationshipCreationForm = ({
               component={TextField}
               variant="standard"
               name="attribute_count"
+              required={(mandatoryAttributes.includes('attribute_count'))}
               label={t_i18n('Count')}
               fullWidth={true}
               type="number"
@@ -266,6 +270,7 @@ const StixSightingRelationshipCreationForm = ({
               name="first_seen"
               textFieldProps={{
                 label: t_i18n('First seen'),
+                required: (mandatoryAttributes.includes('first_seen')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { marginTop: 20 },
@@ -276,6 +281,7 @@ const StixSightingRelationshipCreationForm = ({
               name="last_seen"
               textFieldProps={{
                 label: t_i18n('Last seen'),
+                required: (mandatoryAttributes.includes('last_seen')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { marginTop: 20 },
@@ -285,6 +291,7 @@ const StixSightingRelationshipCreationForm = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -292,11 +299,13 @@ const StixSightingRelationshipCreationForm = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
@@ -309,6 +318,7 @@ const StixSightingRelationshipCreationForm = ({
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -230,6 +230,8 @@ const StixSightingRelationshipEditionOverviewComponent: FunctionComponent<Omit<S
     description: Yup.string().nullable(),
     x_opencti_negative: Yup.boolean(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const stixSightingRelationshipValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
@@ -110,7 +110,7 @@ const stixDomainObjectsAttributes: { [k: string]: Array<AttributeDefinition> } =
     { name: 'first_observed', label: 'First observed', type: 'date', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'last_observed', label: 'Last observed', type: 'date', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'number_observed', label: 'Number observed', type: 'numeric', precision: 'integer', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
-    { name: 'content', label: 'Content', type: 'string', format: 'short', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'content', label: 'Content', type: 'string', format: 'short', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'content_mapping', label: 'Content mapping', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ],
   [ENTITY_TYPE_CONTAINER_OPINION]: [


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Events' section of the platform, to include creating and editing the following entity types:

* Incidents
* Observed Data
* Sightings

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

* The customization menu for 'Observed Data' includes a 'Content' field, but there is no 'Content' field in either the create or edit form, so requiring this field makes it impossible to submit the form.

* Incident and Observed Data creation forms include the field objectLabel but the edit forms do not. This field is not in the 'Customization' menu. Adding it would break the edit forms.
