### PR TITLE
[frontend] Add support for dynamic configurable required fields to Entities

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -18,7 +18,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { EventCreationMutation, EventCreationMutation$variables } from './__generated__/EventCreationMutation.graphql';
@@ -93,8 +93,9 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(EVENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),
@@ -105,8 +106,8 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .min(Yup.ref('start_time'), 'The end date can\'t be before start date')
       .nullable(),
-  };
-  const eventValidator = useSchemaCreationValidation(EVENT_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const eventValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<EventCreationMutation>(
     eventMutation,
@@ -188,6 +189,8 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
     <Formik<EventAddInput>
       initialValues={initialValues}
       validationSchema={eventValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -224,6 +227,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Event']}
             />
@@ -231,6 +235,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               label={t_i18n('Event types')}
               type="event-type-ov"
               name="event_types"
+              required={(mandatoryAttributes.includes('event_types'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple
               onChange={setFieldValue}
@@ -239,6 +244,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows={4}
@@ -249,6 +255,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               name="start_time"
               textFieldProps={{
                 label: t_i18n('Start date'),
+                required: (mandatoryAttributes.includes('start_time')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -259,6 +266,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               name="stop_time"
               textFieldProps={{
                 label: t_i18n('End date'),
+                required: (mandatoryAttributes.includes('stop_time')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -270,22 +278,26 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -96,6 +96,7 @@ const EventEditionOverviewComponent = (props) => {
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const eventValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';
@@ -89,17 +89,16 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
-  };
-  const individualValidator = useSchemaCreationValidation(INDIVIDUAL_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const individualValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<IndividualCreationMutation>(
     individualMutation,
@@ -181,6 +180,8 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
     <Formik<IndividualAddInput>
       initialValues={initialValues}
       validationSchema={individualValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -224,6 +225,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['User']}
             />
@@ -231,6 +233,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -244,28 +247,33 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               label={t_i18n('Reliability')}
               type="reliability_ov"
               name="x_opencti_reliability"
+              required={(mandatoryAttributes.includes('x_opencti_reliability'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple={false}
               onChange={setFieldValue}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -100,6 +100,7 @@ const IndividualEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const individualValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { OrganizationCreationMutation, OrganizationCreationMutation$variables } from './__generated__/OrganizationCreationMutation.graphql';
@@ -90,10 +90,9 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ORGANIZATION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),
@@ -101,8 +100,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       .nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
-  };
-  const organizationValidator = useSchemaCreationValidation(ORGANIZATION_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const organizationValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<OrganizationCreationMutation>(
     organizationMutation,
@@ -185,6 +184,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
   return <Formik<OrganizationAddInput>
     initialValues={initialValues}
     validationSchema={organizationValidator}
+    validateOnChange={false}
+    validateOnBlur={false}
     onSubmit={onSubmit}
     onReset={onReset}
          >
@@ -228,6 +229,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Organization']}
           />
@@ -235,6 +237,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -249,6 +252,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             label={t_i18n('Organization type')}
             type="organization_type_ov"
             name="x_opencti_organization_type"
+            required={(mandatoryAttributes.includes('x_opencti_organization_type'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
@@ -257,28 +261,33 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -18,7 +18,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import StatusField from '../../common/form/StatusField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
@@ -81,6 +81,8 @@ const organizationMutationRelationDelete = graphql`
   }
 `;
 
+const ORGANIZATION_TYPE = 'Organization';
+
 type OrganizationGenericData = OrganizationEditionOverview_organization$data & GenericData;
 
 interface OrganizationEditionOverviewComponentProps {
@@ -107,8 +109,9 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ORGANIZATION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
@@ -116,8 +119,8 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const organizationValidator = useSchemaEditionValidation('Organization', basicShape);
+  }, mandatoryAttributes);
+  const organizationValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: organizationMutationFieldPatch,
@@ -193,6 +196,8 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={organizationValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -210,6 +215,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -221,6 +227,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -258,6 +265,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             label={t_i18n('Organization type')}
             type="organization_type_ov"
             name="x_opencti_organization_type"
+            required={(mandatoryAttributes.includes('x_opencti_organization_type'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -270,6 +278,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -293,6 +302,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -302,6 +312,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -119,6 +119,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const organizationValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -15,7 +15,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { SectorCreationMutation, SectorCreationMutation$variables } from './__generated__/SectorCreationMutation.graphql';
@@ -108,15 +108,13 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
-    description: Yup.string()
-      .nullable(),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SECTOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
+    description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const sectorValidator = useSchemaCreationValidation(SECTOR_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const sectorValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<SectorCreationMutation>(
     sectorMutation,
@@ -199,6 +197,8 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
     <Formik<SectorAddInput>
       initialValues={initialValues}
       validationSchema={sectorValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -242,6 +242,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Sector']}
             />
@@ -249,6 +250,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -260,22 +262,26 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -14,7 +14,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -80,19 +80,22 @@ const sectorMutationRelationDelete = graphql`
   }
 `;
 
+const SECTOR_TYPE = 'Sector';
+
 const SectorEditionOverviewComponent = (props) => {
   const { sector, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SECTOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const sectorValidator = useSchemaEditionValidation('Sector', basicShape);
+  }, mandatoryAttributes);
+  const sectorValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: sectorMutationFieldPatch,
@@ -173,6 +176,8 @@ const SectorEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={sectorValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -190,6 +195,7 @@ const SectorEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -201,6 +207,7 @@ const SectorEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -234,6 +241,7 @@ const SectorEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -243,6 +251,7 @@ const SectorEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -94,6 +94,7 @@ const SectorEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const sectorValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';
@@ -89,17 +89,15 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
-    description: Yup.string()
-      .nullable(),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SYSTEM_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
+    description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
-  };
-  const systemValidator = useSchemaCreationValidation(SYSTEM_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const systemValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<SystemCreationMutation>(
     systemMutation,
@@ -184,6 +182,8 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
     <Formik<SystemAddInput>
       initialValues={initialValues}
       validationSchema={systemValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -227,6 +227,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['User']}
             />
@@ -234,6 +235,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -247,28 +249,33 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               label={t_i18n('Reliability')}
               type="reliability_ov"
               name="x_opencti_reliability"
+              required={(mandatoryAttributes.includes('x_opencti_reliability'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple={false}
               onChange={setFieldValue}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -15,7 +15,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import StatusField from '../../common/form/StatusField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -81,21 +81,24 @@ const systemMutationRelationDelete = graphql`
   }
 `;
 
+const SYSTEM_TYPE = 'System';
+
 const SystemEditionOverviewComponent = (props) => {
   const { system, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SYSTEM_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const systemValidator = useSchemaEditionValidation('System', basicShape);
+  }, mandatoryAttributes);
+  const systemValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: systemMutationFieldPatch,
@@ -176,6 +179,8 @@ const SystemEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={systemValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -194,6 +199,7 @@ const SystemEditionOverviewComponent = (props) => {
             name="name"
             disabled={external}
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -205,6 +211,7 @@ const SystemEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -228,6 +235,7 @@ const SystemEditionOverviewComponent = (props) => {
             variant="standard"
             name="contact_information"
             label={t_i18n('Contact information')}
+            required={(mandatoryAttributes.includes('contact_information'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -242,6 +250,7 @@ const SystemEditionOverviewComponent = (props) => {
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -265,6 +274,7 @@ const SystemEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -274,6 +284,7 @@ const SystemEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -97,6 +97,7 @@ const SystemEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const systemValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Entities' section of the platform, to include creating and editing the following entity types:

* Sectors
* Events
* Organizations
* Systems
* Individuals

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


* The `Individual`, `Organization` , and `Systems` creation/edit forms have the requirable field `x_opencti_reliability` which is not in the 'Customization' menu.

* The `Organization` and `System` edit forms include the field `Contact Information` but the creation forms do not. This field is not in the 'Customization' menu for either entity. Adding it would break the creation forms.

* All creation forms include the field `objectLabel` but the edit forms do not. This field is not in the 'Customization' menu. Adding it would break the edit forms.