### PR TITLE
[backend] enable danger zone in default settings (#8284)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -126,7 +126,7 @@
     "created_by_based": false
   },
   "protected_sensitive_config": {
-    "enabled": false,
+    "enabled": true,
     "markings": {
       "enabled": true,
       "protected_definitions": ["TLP:CLEAR", "TLP:GREEN", "TLP:AMBER", "TLP:AMBER+STRICT", "TLP:RED", "PAP:CLEAR", "PAP:GREEN", "PAP:AMBER", "PAP:RED"]


### PR DESCRIPTION
Enabling the danger zones in the `default.json` configuration file.