### PR TITLE
[backend] existing roles without danger zone capa are considered NOT …

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1323,7 +1323,7 @@ export const isSensitiveChangesAllowed = (userId, roles) => {
   if (userId === OPENCTI_ADMIN_UUID) {
     return true;
   }
-  return roles.some((role) => role.can_manage_sensitive_config === true);
+  return roles.some(({ can_manage_sensitive_config }) => can_manage_sensitive_config);
 };
 
 export const buildCompleteUser = async (context, client) => {

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1323,7 +1323,7 @@ export const isSensitiveChangesAllowed = (userId, roles) => {
   if (userId === OPENCTI_ADMIN_UUID) {
     return true;
   }
-  return roles.some((role) => role.can_manage_sensitive_config !== false);
+  return roles.some((role) => role.can_manage_sensitive_config === true);
 };
 
 export const buildCompleteUser = async (context, client) => {


### PR DESCRIPTION
Relates to #8284

Change of behavior:

We want the danger zone "capa" to be granted only explicitly to enforce danger zone protection on every platform and force users to setup access thoughtfully.

=> Existing roles are not migrated and a flag to `undefined` means false.