### PR TITLE
[frontend] Popover arsenal menu support for FAB_REPLACEMENT feature flag

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const ChannelDeletionDeleteMutation = graphql`
+  mutation ChannelDeletionDeleteMutation($id: ID!) {
+    channelDelete(id: $id)
+  }
+`;
+
+const ChannelDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Channel') },
+  });
+  const [commit] = useApiMutation(
+    ChannelDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/channels');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this channel?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ChannelDeletion;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionContainer.jsx
@@ -10,7 +10,6 @@ const ChannelEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { handleClose, channel, open, controlledDial } = props;
   const { editContext } = channel;
 

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -19,6 +19,8 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import ChannelDeletion from './ChannelDeletion';
 
 const channelMutationFieldPatch = graphql`
   mutation ChannelEditionOverviewFieldPatchMutation(
@@ -79,7 +81,8 @@ const channelMutationRelationDelete = graphql`
 const ChannelEditionOverviewComponent = (props) => {
   const { channel, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     channel_types: Yup.array().nullable(),
@@ -251,21 +254,28 @@ const ChannelEditionOverviewComponent = (props) => {
             name="objectMarking"
             style={fieldSpacingContainerStyle}
             helpertext={
-              <SubscriptionFocus context={context} fieldname="objectMarking"/>
+              <SubscriptionFocus context={context} fieldname="objectMarking" />
             }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={channel.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <ChannelDeletion
+                  id={channel.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={channel.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelPopover.jsx
@@ -1,25 +1,24 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import ToggleButton from '@mui/material/ToggleButton';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import inject18n from '../../../../components/i18n';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
 import { channelEditionQuery } from './ChannelEdition';
 import ChannelEditionContainer from './ChannelEditionContainer';
-import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import Transition from '../../../../components/Transition';
+import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 
 const ChannelPopoverDeletionMutation = graphql`
   mutation ChannelPopoverDeletionMutation($id: ID!) {
@@ -27,125 +26,88 @@ const ChannelPopoverDeletionMutation = graphql`
   }
 `;
 
-class ChannelPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const ChannelPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: ChannelPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/arsenal/channels');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/channels');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          </Security>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
           keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this channel?')}
+              {t_i18n('Do you want to delete this channel?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -157,8 +119,8 @@ class ChannelPopover extends Component {
               return (
                 <ChannelEditionContainer
                   channel={props.channel}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -167,14 +129,6 @@ class ChannelPopover extends Component {
         />
       </>
     );
-  }
-}
-
-ChannelPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(ChannelPopover);
+export default ChannelPopover;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -145,6 +145,7 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
                   <ChannelEdition channelId={channel.id} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -139,7 +139,7 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
             <StixDomainObjectHeader
               entityType="Channel"
               stixDomainObject={channel}
-              PopoverComponent={<ChannelPopover />}
+              PopoverComponent={<ChannelPopover id={channel.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <ChannelEdition channelId={channel.id} />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const MalwareDeletionDeleteMutation = graphql`
+  mutation MalwareDeletionDeleteMutation($id: ID!) {
+    malwareEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const MalwareDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Malware') },
+  });
+  const [commit] = useApiMutation(
+    MalwareDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/malwares');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this malware?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default MalwareDeletion;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionContainer.jsx
@@ -10,12 +10,9 @@ import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings
 
 const MalwareEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
-
   const { handleClose, malware } = props;
   const { editContext } = malware;
-
   const [currentTab, setCurrentTab] = useState(0);
-
   const handleChangeTab = (event, value) => setCurrentTab(value);
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -22,6 +22,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import SwitchField from '../../../../components/fields/SwitchField';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import MalwareDeletion from './MalwareDeletion';
 
 const malwareMutationFieldPatch = graphql`
   mutation MalwareEditionOverviewFieldPatchMutation(
@@ -85,6 +87,8 @@ export const malwareMutationRelationDelete = graphql`
 const MalwareEditionOverviewComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
   const basicShape = {
@@ -203,7 +207,7 @@ const MalwareEditionOverviewComponent = (props) => {
             askAi={true}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <OpenVocabField
             label={t_i18n('Malware types')}
@@ -227,7 +231,7 @@ const MalwareEditionOverviewComponent = (props) => {
             onChange={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="is_family" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -250,7 +254,7 @@ const MalwareEditionOverviewComponent = (props) => {
             askAi={true}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <KillChainPhasesField
             name="killChainPhases"
@@ -258,19 +262,19 @@ const MalwareEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="killChainPhases" />
-              }
+            }
             onChange={editor.changeKillChainPhases}
           />
           {malware.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Malware"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={<SubscriptionFocus context={context} fieldName="x_opencti_workflow_id"/>}
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Malware"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={<SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />}
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -278,26 +282,33 @@ const MalwareEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
             name="objectMarking"
             style={fieldSpacingContainerStyle}
-            helpertext={<SubscriptionFocus context={context} fieldname="objectMarking"/>}
+            helpertext={<SubscriptionFocus context={context} fieldname="objectMarking" />}
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={malware.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <MalwareDeletion
+                  id={malware.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={malware.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwarePopover.jsx
@@ -1,26 +1,25 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import ToggleButton from '@mui/material/ToggleButton';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { malwareEditionQuery } from './MalwareEdition';
 import MalwareEditionContainer from './MalwareEditionContainer';
-import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import Transition from '../../../../components/Transition';
-import withRouter from '../../../../utils/compat_router/withRouter';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import Drawer from '../../common/drawer/Drawer';
 
 const MalwarePopoverDeletionMutation = graphql`
   mutation MalwarePopoverDeletionMutation($id: ID!) {
@@ -30,134 +29,95 @@ const MalwarePopoverDeletionMutation = graphql`
   }
 `;
 
-class MalwarePopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const MalwarePopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: MalwarePopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/arsenal/malwares');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/malwares');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
           <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-              {t('Update')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
           keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this malware?')}
+              {t_i18n('Do you want to delete this malware?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
         <Drawer
-          title={t('Update a malware')}
-          open={this.state.displayEdit}
-          onClose={this.handleCloseEdit.bind(this)}
+          title={t_i18n('Update a malware')}
+          open={displayEdit}
+          onClose={handleCloseEdit}
         >
           <QueryRenderer
             query={malwareEditionQuery}
@@ -167,7 +127,8 @@ class MalwarePopover extends Component {
                 return (
                   <MalwareEditionContainer
                     malware={props.malware}
-                    handleClose={this.handleCloseEdit.bind(this)}
+                    handleClose={handleCloseEdit}
+                    open={displayEdit}
                   />
                 );
               }
@@ -177,14 +138,6 @@ class MalwarePopover extends Component {
         </Drawer>
       </>
     );
-  }
-}
-
-MalwarePopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(MalwarePopover);
+export default MalwarePopover;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -146,7 +146,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
             <StixDomainObjectHeader
               entityType="Malware"
               stixDomainObject={malware}
-              PopoverComponent={<MalwarePopover />}
+              PopoverComponent={<MalwarePopover id={malware.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <MalwareEdition

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -155,6 +155,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
                   />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -146,6 +146,7 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
                   <ToolEdition toolId={tool.id} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -140,7 +140,7 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
             <StixDomainObjectHeader
               entityType="Tool"
               stixDomainObject={tool}
-              PopoverComponent={<ToolPopover />}
+              PopoverComponent={<ToolPopover id={tool.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <ToolEdition toolId={tool.id} />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const ToolDeletionDeleteMutation = graphql`
+  mutation ToolDeletionDeleteMutation($id: ID!) {
+    toolEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const ToolDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Tool') },
+  });
+  const [commit] = useApiMutation(
+    ToolDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/tools');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this tool?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ToolDeletion;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionContainer.jsx
@@ -10,7 +10,6 @@ const ToolEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { handleClose, tool, open, controlledDial } = props;
   const { editContext } = tool;
 

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.jsx
@@ -20,6 +20,8 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import ToolDeletion from './ToolDeletion';
 
 const toolMutationFieldPatch = graphql`
   mutation ToolEditionOverviewFieldPatchMutation(
@@ -83,7 +85,8 @@ const toolMutationRelationDelete = graphql`
 const ToolEditionOverviewComponent = (props) => {
   const { tool, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -201,7 +204,7 @@ const ToolEditionOverviewComponent = (props) => {
             askAi={true}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <Field
             component={MarkdownField}
@@ -216,7 +219,7 @@ const ToolEditionOverviewComponent = (props) => {
             askAi={true}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -232,21 +235,21 @@ const ToolEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="killChainPhases" />
-              }
+            }
             onChange={editor.changeKillChainPhases}
           />
           {tool.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Tool"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Tool"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -254,7 +257,7 @@ const ToolEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -262,7 +265,7 @@ const ToolEditionOverviewComponent = (props) => {
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
@@ -278,16 +281,23 @@ const ToolEditionOverviewComponent = (props) => {
             multiple={true}
             editContext={context}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={tool.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <ToolDeletion
+                  id={tool.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={tool.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -145,6 +145,7 @@ const RootVulnerability = ({ queryRef, vulnerabilityId }: RootVulnerabilityProps
                   <VulnerabilityEdition vulnerabilityId={vulnerabilityId} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const VulnerabilityDeletionDeleteMutation = graphql`
+  mutation VulnerabilityDeletionDeleteMutation($id: ID!) {
+    vulnerabilityEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const VulnerabilityDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Vulnerability') },
+  });
+  const [commit] = useApiMutation(
+    VulnerabilityDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/vulnerabilities');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this vulnerability?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default VulnerabilityDeletion;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionContainer.jsx
@@ -13,7 +13,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 const VulnerabilityEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
-  const FABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
   const { handleClose, vulnerability, open, controlledDial } = props;
   const { editContext } = vulnerability;
@@ -26,9 +26,9 @@ const VulnerabilityEditionContainer = (props) => {
       title={t_i18n('Update a vulnerability')}
       open={open}
       onClose={handleClose}
-      variant={!FABReplaced && open == null ? DrawerVariant.update : undefined}
+      variant={!isFABReplaced && open == null ? DrawerVariant.update : undefined}
       context={editContext}
-      controlledDial={FABReplaced ? controlledDial : undefined}
+      controlledDial={isFABReplaced ? controlledDial : undefined}
     >
       <>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -41,20 +41,20 @@ const VulnerabilityEditionContainer = (props) => {
           </Tabs>
         </Box>
         {currentTab === 0 && (
-        <VulnerabilityEditionOverview
-          vulnerability={vulnerability}
-          enableReferences={useIsEnforceReference('Vulnerability')}
-          context={editContext}
-          handleClose={handleClose}
-        />
+          <VulnerabilityEditionOverview
+            vulnerability={vulnerability}
+            enableReferences={useIsEnforceReference('Vulnerability')}
+            context={editContext}
+            handleClose={handleClose}
+          />
         )}
         {currentTab === 1 && (
-        <VulnerabilityEditionDetails
-          vulnerability={vulnerability}
-          enableReferences={useIsEnforceReference('Vulnerability')}
-          context={editContext}
-          handleClose={handleClose}
-        />
+          <VulnerabilityEditionDetails
+            vulnerability={vulnerability}
+            enableReferences={useIsEnforceReference('Vulnerability')}
+            context={editContext}
+            handleClose={handleClose}
+          />
         )}
       </>
     </Drawer>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -19,6 +19,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import VulnerabilityDeletion from './VulnerabilityDeletion';
 
 const vulnerabilityMutationFieldPatch = graphql`
   mutation VulnerabilityEditionOverviewFieldPatchMutation(
@@ -85,6 +87,8 @@ export const vulnerabilityMutationRelationDelete = graphql`
 const VulnerabilityEditionOverviewComponent = (props) => {
   const { vulnerability, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
   const basicShape = {
@@ -200,7 +204,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <Field
             component={MarkdownField}
@@ -214,7 +218,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -225,17 +229,17 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             variant="edit"
           />
           {vulnerability.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Vulnerability"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Vulnerability"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -243,7 +247,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -251,20 +255,27 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={vulnerability.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <VulnerabilityDeletion
+                  id={vulnerability.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={vulnerability.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityPopover.jsx
@@ -1,25 +1,24 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
+import ToggleButton from '@mui/material/ToggleButton';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import ToggleButton from '@mui/material/ToggleButton';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import inject18n from '../../../../components/i18n';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { vulnerabilityEditionQuery } from './VulnerabilityEdition';
 import VulnerabilityEditionContainer from './VulnerabilityEditionContainer';
-import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import Transition from '../../../../components/Transition';
-import withRouter from '../../../../utils/compat_router/withRouter';
+import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 
 const VulnerabilityPopoverDeletionMutation = graphql`
   mutation VulnerabilityPopoverDeletionMutation($id: ID!) {
@@ -29,125 +28,88 @@ const VulnerabilityPopoverDeletionMutation = graphql`
   }
 `;
 
-class VulnerabilityPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const VulnerabilityPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: VulnerabilityPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/arsenal/vulnerabilities');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/arsenal/vulnerabilities');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          </Security>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
           keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this vulnerability?')}
+              {t_i18n('Do you want to delete this vulnerability?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -159,8 +121,8 @@ class VulnerabilityPopover extends Component {
               return (
                 <VulnerabilityEditionContainer
                   vulnerability={props.vulnerability}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -169,13 +131,6 @@ class VulnerabilityPopover extends Component {
         />
       </>
     );
-  }
-}
-
-VulnerabilityPopover.propTypes = {
-  id: PropTypes.string,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(VulnerabilityPopover);
+export default VulnerabilityPopover;


### PR DESCRIPTION
### Proposed changes
These changes apply to the Arsenal menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

- Remove the ... popover icon.
- Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
- Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues

- This work is complementary to the FAB replacement PRs that have been merged of:
     - https://github.com/OpenCTI-Platform/opencti/pull/8106
     - https://github.com/OpenCTI-Platform/opencti/pull/8121
     - https://github.com/OpenCTI-Platform/opencti/pull/8199
- Addresses the behavior seen for areas this capability has not merged against brought up in Issue popover should not be visible if update button is  #8704

### Checklist

- [x]  I consider the submitted work as finished
- [x]  I tested the code for its functionality
- [ ]  I wrote test cases for the relevant uses case (coverage and e2e)
- [ ]  I added/update the relevant documentation (either on github or on notion)
- [x]  Where necessary I refactored code to improve the overall quality