### PR TITLE
[frontend] Popover threats menu support for FAB_REPLACEMENT feature flag

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { RelayError } from '../../../../relay/relayTypes';
+import { MESSAGING$ } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const CampaignDeletionDeleteMutation = graphql`
+  mutation CampaignDeletionDeleteMutation($id: ID!) {
+    campaignEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+const CampaignDeletion = ({ id }: { id: string }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Campaign') },
+  });
+  const [commit] = useApiMutation(
+    CampaignDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/campaigns');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this campaign?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default CampaignDeletion;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -19,6 +19,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import CampaignDeletion from './CampaignDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionOverviewFieldPatchMutation(
@@ -87,6 +89,8 @@ const CampaignEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme();
 
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     confidence: Yup.number().nullable(),
@@ -254,16 +258,24 @@ const CampaignEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={campaign.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <CampaignDeletion
+                  id={campaign.id}
+                />
+              : <div />
+            }
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={campaign.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignPopover.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -12,14 +11,14 @@ import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
 import ToggleButton from '@mui/material/ToggleButton';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { campaignEditionQuery } from './CampaignEdition';
 import CampaignEditionContainer from './CampaignEditionContainer';
 import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const CampaignPopoverDeletionMutation = graphql`
   mutation CampaignPopoverDeletionMutation($id: ID!) {
@@ -29,127 +28,85 @@ const CampaignPopoverDeletionMutation = graphql`
   }
 `;
 
-class CampaignPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const CampaignPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: CampaignPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/threats/campaigns');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/campaigns');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-              {t('Update')}
-            </MenuItem>
-          </Security>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this campaign?')}
+              {t_i18n('Do you want to delete this campaign?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -161,8 +118,8 @@ class CampaignPopover extends Component {
               return (
                 <CampaignEditionContainer
                   campaign={props.campaign}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -171,13 +128,6 @@ class CampaignPopover extends Component {
         />
       </>
     );
-  }
-}
-
-CampaignPopover.propTypes = {
-  id: PropTypes.string,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(CampaignPopover);
+export default CampaignPopover;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -143,7 +143,7 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
             <StixDomainObjectHeader
               entityType="Campaign"
               stixDomainObject={campaign}
-              PopoverComponent={<CampaignPopover />}
+              PopoverComponent={<CampaignPopover id={campaign.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <CampaignEdition campaignId={campaign.id} />

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -149,6 +149,7 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
                   <CampaignEdition campaignId={campaign.id} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { RelayError } from '../../../../relay/relayTypes';
+import { MESSAGING$ } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const IntrusionSetDeletionDeleteMutation = graphql`
+  mutation IntrusionSetDeletionDeleteMutation($id: ID!) {
+    intrusionSetEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+const CampaignDeletion = ({ id }: { id: string }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Intrusion-Set') },
+  });
+  const [commit] = useApiMutation(
+    IntrusionSetDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/intrusion_sets');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this intrusion set?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default CampaignDeletion;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -19,6 +19,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import IntrusionSetDeletion from './IntrusionSetDeletion';
 
 const intrusionSetMutationFieldPatch = graphql`
   mutation IntrusionSetEditionOverviewFieldPatchMutation(
@@ -85,6 +87,8 @@ export const intrusionSetMutationRelationDelete = graphql`
 const IntrusionSetEditionOverviewComponent = (props) => {
   const { intrusionSet, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
   const basicShape = {
@@ -263,16 +267,24 @@ const IntrusionSetEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={intrusionSet.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <IntrusionSetDeletion
+                  id={intrusionSet.id}
+                />
+              : <div />
+            }
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={intrusionSet.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetPopover.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -12,14 +11,14 @@ import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
 import ToggleButton from '@mui/material/ToggleButton';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
 import { QueryRenderer, commitMutation } from '../../../../relay/environment';
 import { intrusionSetEditionQuery } from './IntrusionSetEdition';
 import IntrusionSetEditionContainer from './IntrusionSetEditionContainer';
 import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const IntrusionSetPopoverDeletionMutation = graphql`
   mutation IntrusionSetPopoverDeletionMutation($id: ID!) {
@@ -29,127 +28,85 @@ const IntrusionSetPopoverDeletionMutation = graphql`
   }
 `;
 
-class IntrusionSetPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const IntrusionSetPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: IntrusionSetPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/threats/intrusion_sets');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/intrusion_sets');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-              {t('Update')}
-            </MenuItem>
-          </Security>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this intrusion set?')}
+              {t_i18n('Do you want to delete this intrusion set?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -161,8 +118,8 @@ class IntrusionSetPopover extends Component {
               return (
                 <IntrusionSetEditionContainer
                   intrusionSet={props.intrusionSet}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -171,13 +128,6 @@ class IntrusionSetPopover extends Component {
         />
       </>
     );
-  }
-}
-
-IntrusionSetPopover.propTypes = {
-  id: PropTypes.string,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(IntrusionSetPopover);
+export default IntrusionSetPopover;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -155,6 +155,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
                   <IntrusionSetEdition intrusionSetId={intrusionSet.id} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
               enableAskAi={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -149,7 +149,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
             <StixDomainObjectHeader
               entityType="Intrusion-Set"
               stixDomainObject={intrusionSet}
-              PopoverComponent={<IntrusionSetPopover />}
+              PopoverComponent={<IntrusionSetPopover id={intrusionSet.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <IntrusionSetEdition intrusionSetId={intrusionSet.id} />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -147,7 +147,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
             <StixDomainObjectHeader
               entityType="Threat-Actor-Group"
               stixDomainObject={threatActorGroup}
-              PopoverComponent={<ThreatActorGroupPopover />}
+              PopoverComponent={<ThreatActorGroupPopover id={threatActorGroup.id} />}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <ThreatActorGroupEdition threatActorGroupId={threatActorGroup.id} />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -153,6 +153,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                   <ThreatActorGroupEdition threatActorGroupId={threatActorGroup.id} />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { RelayError } from '../../../../relay/relayTypes';
+import { MESSAGING$ } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const ThreatActorGroupDeletionDeleteMutation = graphql`
+  mutation ThreatActorGroupDeletionDeleteMutation($id: ID!) {
+    threatActorGroupEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+const ThreatActorGroupDeletion = ({ id }: { id: string }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Threat-Actor-Group') },
+  });
+  const [commit] = useApiMutation(
+    ThreatActorGroupDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/threat_actors_group');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this threat actor group?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ThreatActorGroupDeletion;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -20,6 +20,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import ThreatActorGroupDeletion from './ThreatActorGroupDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ThreatActorGroupMutationFieldPatch = graphql`
   mutation ThreatActorGroupEditionOverviewFieldPatchMutation(
@@ -86,6 +88,8 @@ export const ThreatActorGroupMutationRelationDelete = graphql`
 const ThreatActorGroupEditionOverviewComponent = (props) => {
   const { threatActorGroup, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
   const basicShape = {
@@ -279,16 +283,24 @@ const ThreatActorGroupEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={threatActorGroup.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <ThreatActorGroupDeletion
+                  id={threatActorGroup.id}
+                />
+              : <div />
+            }
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={threatActorGroup.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupPopover.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,15 +10,15 @@ import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
 import ToggleButton from '@mui/material/ToggleButton';
-import withRouter from '../../../../utils/compat_router/withRouter';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import inject18n from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { ThreatActorGroupEditionQuery } from './ThreatActorGroupEdition';
 import ThreatActorGroupEditionContainer from './ThreatActorGroupEditionContainer';
 import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const ThreatActorGroupPopoverDeletionMutation = graphql`
   mutation ThreatActorGroupPopoverDeletionMutation($id: ID!) {
@@ -29,133 +28,85 @@ const ThreatActorGroupPopoverDeletionMutation = graphql`
   }
 `;
 
-class ThreatActorGroupPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      displayEnrichment: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const ThreatActorGroupPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const [displayEnrichment, setDisplayEnrichment] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseEnrichment = () => {
+    setDisplayEnrichment(false);
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: ThreatActorGroupPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
-      config: [
-        {
-          type: 'NODE_DELETE',
-          deletedIDFieldName: 'id',
-        },
-      ],
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/threats/threat_actors_group');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/threat_actors_group');
       },
     });
-  }
-
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  handleOpenEnrichment() {
-    this.setState({ displayEnrichment: true });
-    this.handleClose();
-  }
-
-  handleCloseEnrichment() {
-    this.setState({ displayEnrichment: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
+  const handleOpenEnrichment = () => {
+    setDisplayEnrichment(true);
+    handleClose();
+  };
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-              {t('Update')}
-            </MenuItem>
-          </Security>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={this.handleOpenEnrichment.bind(this)}>
-              {t('Enrich')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
           </Security>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={this.state.displayEnrichment} handleClose={this.handleCloseEnrichment.bind(this)} />
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <Dialog
-          open={this.state.displayDelete}
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this threat actor group?')}
+              {t_i18n('Do you want to delete this threat actor group?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -167,8 +118,8 @@ class ThreatActorGroupPopover extends Component {
               return (
                 <ThreatActorGroupEditionContainer
                   threatActorGroup={props.threatActorGroup}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -177,14 +128,6 @@ class ThreatActorGroupPopover extends Component {
         />
       </>
     );
-  }
-}
-
-ThreatActorGroupPopover.propTypes = {
-  id: PropTypes.string,
-  paginationOptions: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(ThreatActorGroupPopover);
+export default ThreatActorGroupPopover;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -167,6 +167,7 @@ const RootThreatActorIndividualComponent = ({
                   />
                 </Security>
               )}
+              enableEnricher={isFABReplaced}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import Transition from '../../../../components/Transition';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { RelayError } from '../../../../relay/relayTypes';
+import { MESSAGING$ } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+
+const ThreatActorIndividualDeletionDeleteMutation = graphql`
+  mutation ThreatActorIndividualDeletionDeleteMutation($id: ID!) {
+    threatActorIndividualDelete(id: $id)
+  }
+`;
+
+const ThreatActorIndividualDeletion = ({ id }: { id: string }) => {
+  const { t_i18n } = useFormatter();
+  const navigate = useNavigate();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Threat-Actor-Individual') },
+  });
+  const [commit] = useApiMutation(
+    ThreatActorIndividualDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/threats/threat_actors_individual');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this threat actor individual?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default ThreatActorIndividualDeletion;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -23,6 +23,8 @@ import { Option } from '../../common/form/ReferenceField';
 import { ThreatActorIndividualEditionOverview_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionOverview_ThreatActorIndividual.graphql';
 import { GenericContext } from '../../common/model/GenericContextModel';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import ThreatActorIndividualDeletion from './ThreatActorIndividualDeletion';
 import type { Theme } from '../../../../components/Theme';
 
 const ThreatActorIndividualMutationFieldPatch = graphql`
@@ -142,6 +144,8 @@ ThreatActorIndividualEditionOverviewProps
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
 
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const threatActorIndividual = useFragment(
     threatActorIndividualEditionOverviewFragment,
     threatActorIndividualRef,
@@ -189,7 +193,7 @@ ThreatActorIndividualEditionOverviewProps
         id: threatActorIndividual.id,
         input: inputValues,
         commitMessage:
-            commitMessage && commitMessage.length > 0 ? commitMessage : null,
+          commitMessage && commitMessage.length > 0 ? commitMessage : null,
         references: commitReferences,
       },
       onCompleted: () => {
@@ -333,16 +337,24 @@ ThreatActorIndividualEditionOverviewProps
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={threatActorIndividual.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <ThreatActorIndividualDeletion
+                  id={threatActorIndividual.id}
+                />
+              : <div />
+            }
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={threatActorIndividual.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualPopover.tsx
@@ -21,6 +21,7 @@ import Transition from '../../../../components/Transition';
 import ThreatActorIndividualEditionContainer, { ThreatActorIndividualEditionQuery } from './ThreatActorIndividualEditionContainer';
 import { ThreatActorIndividualEditionContainerQuery } from './__generated__/ThreatActorIndividualEditionContainerQuery.graphql';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const ThreatActorIndividualPopoverDeletionMutation = graphql`
   mutation ThreatActorIndividualPopoverDeletionMutation($id: ID!) {
@@ -33,6 +34,8 @@ const ThreatActorIndividualPopover = ({ id }: { id: string }) => {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<PopoverProps['anchorEl']>(null);
   const [displayEdit, setDisplayEdit] = useState<boolean>(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [displayEnrichment, setDisplayEnrichment] = useState<boolean>(false);
   const [commit] = useApiMutation(ThreatActorIndividualPopoverDeletionMutation);
   const queryRef = useQueryLoading<ThreatActorIndividualEditionContainerQuery>(
@@ -86,49 +89,51 @@ const ThreatActorIndividualPopover = ({ id }: { id: string }) => {
       },
     });
   };
-  return (
-    <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <Security needs={[KNOWLEDGE_KNUPDATE]}>
-          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        </Security>
-        <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-          <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
-        </Security>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
-      <Dialog
-        open={displayDelete}
-        PaperProps={{ elevation: 1 }}
-        keepMounted={true}
-        TransitionComponent={Transition}
-        onClose={handleCloseDelete}
-      >
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to delete this threat actor individual?')}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete} disabled={deleting}>
-            {t_i18n('Cancel')}
-          </Button>
-          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-            {t_i18n('Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {queryRef && (
+  return isFABReplaced
+    ? (<></>)
+    : (
+      <>
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          </Security>
+          <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
+            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
+          </Security>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
+        <Dialog
+          open={displayDelete}
+          PaperProps={{ elevation: 1 }}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          onClose={handleCloseDelete}
+        >
+          <DialogContent>
+            <DialogContentText>
+              {t_i18n('Do you want to delete this threat actor individual?')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
+            </Button>
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+        {queryRef && (
         <React.Suspense fallback={<div />}>
           <ThreatActorIndividualEditionContainer
             queryRef={queryRef}
@@ -136,9 +141,9 @@ const ThreatActorIndividualPopover = ({ id }: { id: string }) => {
             open={displayEdit}
           />
         </React.Suspense>
-      )}
-    </>
-  );
+        )}
+      </>
+    );
 };
 
 export default ThreatActorIndividualPopover;


### PR DESCRIPTION
### Proposed changes
These changes apply to the Threats menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

- Remove the ... popover icon.
- Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
- Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues

- This work is complementary to the FAB replacement PRs that have been merged of:
     - https://github.com/OpenCTI-Platform/opencti/pull/8106
     - https://github.com/OpenCTI-Platform/opencti/pull/8121
     - https://github.com/OpenCTI-Platform/opencti/pull/8199
- Addresses the behavior seen for areas this capability has not merged against brought up in Issue popover should not be visible if update button is  #8704

### Checklist

- [x]  I consider the submitted work as finished
- [x]  I tested the code for its functionality
- [ ]  I wrote test cases for the relevant uses case (coverage and e2e)
- [ ]  I added/update the relevant documentation (either on github or on notion)
- [x]  Where necessary I refactored code to improve the overall quality