### PR TITLE
[frontend] Popover entities menu support for FAB_REPLACEMENT feature flag

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichment.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichment.jsx
@@ -14,7 +14,7 @@ const StixCoreObjectEnrichment = (props) => {
   const { t, stixCoreObjectId, handleClose, open } = props;
   // otherwise, a button + internal state allow to open and close
   const [openDrawer, setOpenDrawer] = useState(false);
-
+  const [search, setSearch] = useState('');
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
@@ -23,11 +23,12 @@ const StixCoreObjectEnrichment = (props) => {
   };
   const handleCloseEnrichment = () => {
     setOpenDrawer(false);
+    setSearch('');
   };
 
   return (
     <>
-      {(isFABReplaced || !handleClose) && (
+      {isFABReplaced && (
         <Tooltip title={t('Enrichment')}>
           <ToggleButton
             onClick={handleOpenEnrichment}
@@ -37,33 +38,72 @@ const StixCoreObjectEnrichment = (props) => {
           >
             <CloudRefreshOutline fontSize="small" color="primary" />
           </ToggleButton>
-        </Tooltip>
-      )}
-      <Drawer
-        open={open || openDrawer}
-        onClose={handleClose || handleCloseEnrichment}
-        title={t('Enrichment connectors')}
-      >
-        <QueryRenderer
-          query={stixCoreObjectEnrichmentLinesQuery}
-          variables={{ id: stixCoreObjectId }}
-          render={({ props: queryProps }) => {
-            if (
-              queryProps
+        </Tooltip>)}
+      {isFABReplaced && (
+        <Drawer
+          open={openDrawer}
+          onClose={() => { setOpenDrawer(false); setSearch(''); }}
+          title={t('Enrichment connectors')}
+        >
+          <QueryRenderer
+            query={stixCoreObjectEnrichmentLinesQuery}
+            variables={{ id: stixCoreObjectId }}
+            render={({ props: queryProps }) => {
+              if (
+                queryProps
                 && queryProps.stixCoreObject
                 && queryProps.connectorsForImport
-            ) {
-              return (
-                <StixCoreObjectEnrichmentLines
-                  stixCoreObject={queryProps.stixCoreObject}
-                  connectorsForImport={queryProps.connectorsForImport}
-                />
-              );
-            }
-            return <div />;
-          }}
-        />
-      </Drawer>
+              ) {
+                return (
+                  <StixCoreObjectEnrichmentLines
+                    stixCoreObject={queryProps.stixCoreObject}
+                    connectorsForImport={queryProps.connectorsForImport}
+                    search={search}
+                  />
+                );
+              }
+              return <div />;
+            }}
+          />
+        </Drawer>)}
+      {!isFABReplaced && !handleClose
+        && <Tooltip title={t('Enrichment')}>
+          <ToggleButton
+            onClick={handleOpenEnrichment}
+            value="enrich"
+            size="small"
+            style={{ marginRight: 3 }}
+          >
+            <CloudRefreshOutline fontSize="small" color="primary" />
+          </ToggleButton>
+        </Tooltip>
+      }
+      {!isFABReplaced && (
+        <Drawer
+          open={open || handleOpenEnrichment}
+          onClose={handleClose || handleCloseEnrichment}
+          title={t('Enrichment connectors')}
+        >
+          <QueryRenderer
+            query={stixCoreObjectEnrichmentLinesQuery}
+            variables={{ id: stixCoreObjectId }}
+            render={({ props: queryProps }) => {
+              if (
+                queryProps
+                && queryProps.stixCoreObject
+                && queryProps.connectorsForImport
+              ) {
+                return (
+                  <StixCoreObjectEnrichmentLines
+                    stixCoreObject={queryProps.stixCoreObject}
+                    connectorsForImport={queryProps.connectorsForImport}
+                  />
+                );
+              }
+              return <div />;
+            }}
+          />
+        </Drawer>)}
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const EventDeletionDeleteMutation = graphql`
+  mutation EventDeletionDeleteMutation($id: ID!) {
+    eventDelete(id: $id)
+  }
+`;
+
+const EventDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Event') },
+  });
+  const [commit] = useApiMutation(
+    EventDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/events');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this event?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default EventDeletion;

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -21,6 +21,8 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import EventDeletion from './EventDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const eventMutationFieldPatch = graphql`
   mutation EventEditionOverviewFieldPatchMutation(
@@ -77,7 +79,8 @@ const eventMutationRelationDelete = graphql`
 const EventEditionOverviewComponent = (props) => {
   const { event, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -195,7 +198,7 @@ const EventEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <OpenVocabField
             label={t_i18n('Event types')}
@@ -221,7 +224,7 @@ const EventEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <Field
             component={DateTimePickerField}
@@ -234,7 +237,7 @@ const EventEditionOverviewComponent = (props) => {
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="start_date"/>
+                <SubscriptionFocus context={context} fieldName="start_date" />
               ),
             }}
           />
@@ -249,7 +252,7 @@ const EventEditionOverviewComponent = (props) => {
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="end_date"/>
+                <SubscriptionFocus context={context} fieldName="end_date" />
               ),
             }}
           />
@@ -262,17 +265,17 @@ const EventEditionOverviewComponent = (props) => {
             variant="edit"
           />
           {event.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Event"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Event"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -280,7 +283,7 @@ const EventEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -288,20 +291,27 @@ const EventEditionOverviewComponent = (props) => {
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={event.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <EventDeletion
+                  id={event.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={event.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { eventEditionQuery } from './EventEdition';
 import EventEditionContainer from './EventEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const EventPopoverDeletionMutation = graphql`
   mutation EventPopoverDeletionMutation($id: ID!) {
@@ -26,109 +25,74 @@ const EventPopoverDeletionMutation = graphql`
   }
 `;
 
-class EventPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const EventPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: EventPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/entities/events');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/events');
       },
     });
-  }
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
 
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this event?')}
+              {t_i18n('Do you want to delete this event?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -140,8 +104,8 @@ class EventPopover extends Component {
               return (
                 <EventEditionContainer
                   event={props.event}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -150,13 +114,6 @@ class EventPopover extends Component {
         />
       </>
     );
-  }
-}
-
-EventPopover.propTypes = {
-  id: PropTypes.string,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(EventPopover);
+export default EventPopover;

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -137,7 +137,7 @@ const RootEvent = ({ eventId, queryRef }: RootEventProps) => {
               entityType="Event"
               stixDomainObject={event}
               enableQuickSubscription={true}
-              PopoverComponent={<EventPopover />}
+              PopoverComponent={<EventPopover id={event.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <EventEdition eventId={event.id} />

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const IndividualDeletionDeleteMutation = graphql`
+  mutation IndividualDeletionDeleteMutation($id: ID!) {
+    individualEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const IndividualDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Individual') },
+  });
+  const [commit] = useApiMutation(
+    IndividualDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/individuals');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this individual?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default IndividualDeletion;

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -19,6 +19,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import IndividualDeletion from './IndividualDeletion';
 
 const individualMutationFieldPatch = graphql`
   mutation IndividualEditionOverviewFieldPatchMutation(
@@ -85,7 +87,8 @@ const individualMutationRelationDelete = graphql`
 const IndividualEditionOverviewComponent = (props) => {
   const { individual, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -280,16 +283,23 @@ const IndividualEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={individual.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <IndividualDeletion
+                  id={individual.id}
+                />
+              : <div />}
+            {enableReferences && (
+            <CommitMessage
+              submitForm={submitForm}
+              disabled={isSubmitting || !isValid || !dirty}
+              setFieldValue={setFieldValue}
+              open={false}
+              values={values.references}
+              id={individual.id}
+            />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { individualEditionQuery } from './IndividualEdition';
 import IndividualEditionContainer from './IndividualEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const IndividualPopoverDeletionMutation = graphql`
   mutation IndividualPopoverDeletionMutation($id: ID!) {
@@ -28,110 +27,74 @@ const IndividualPopoverDeletionMutation = graphql`
   }
 `;
 
-class IndividualPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const IndividualPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: IndividualPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/entities/individuals');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/individuals');
       },
     });
-  }
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
 
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id, disabled } = this.props;
-    return (
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
-          disabled={disabled}
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this individual?')}
+              {t_i18n('Do you want to delete this individual?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -143,8 +106,8 @@ class IndividualPopover extends Component {
               return (
                 <IndividualEditionContainer
                   individual={props.individual}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -153,15 +116,6 @@ class IndividualPopover extends Component {
         />
       </>
     );
-  }
-}
-
-IndividualPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
-  disabled: PropTypes.bool,
 };
 
-export default compose(inject18n, withRouter)(IndividualPopover);
+export default IndividualPopover;

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -172,7 +172,7 @@ const RootIndividual = ({ individualId, queryRef }: RootIndividualProps) => {
               stixDomainObject={individual}
               isOpenctiAlias={true}
               enableQuickSubscription={true}
-              PopoverComponent={<IndividualPopover />}
+              PopoverComponent={<IndividualPopover id={individual.id}/>}
               EditComponent={!individual.isUser && isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <IndividualEdition individualId={individual.id} />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const OrganizationDeletionDeleteMutation = graphql`
+  mutation OrganizationDeletionDeleteMutation($id: ID!) {
+    organizationDelete(id: $id)
+  }
+`;
+
+const OrganizationDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Organization') },
+  });
+  const [commit] = useApiMutation(
+    OrganizationDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/organizations');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this organization?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default OrganizationDeletion;

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -23,6 +23,8 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import OrganizationDeletion from './OrganizationDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const organizationMutationFieldPatch = graphql`
   mutation OrganizationEditionOverviewFieldPatchMutation(
@@ -103,7 +105,8 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -212,7 +215,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <Field
             component={MarkdownField}
@@ -226,7 +229,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -249,7 +252,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="contact_information" />
-              }
+            }
           />
           <OpenVocabField
             label={t_i18n('Organization type')}
@@ -276,17 +279,17 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             containerStyle={fieldSpacingContainerStyle}
           />
           {organization.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Organization"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Organization"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -294,7 +297,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -302,20 +305,27 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={organization.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <OrganizationDeletion
+                  id={organization.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={organization.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { organizationEditionQuery } from './OrganizationEdition';
 import OrganizationEditionContainer from './OrganizationEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const OrganizationPopoverDeletionMutation = graphql`
   mutation OrganizationPopoverDeletionMutation($id: ID!) {
@@ -26,109 +25,74 @@ const OrganizationPopoverDeletionMutation = graphql`
   }
 `;
 
-class OrganizationPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const OrganizationPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: OrganizationPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/entities/organizations');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/organizations');
       },
     });
-  }
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
 
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this organization?')}
+              {t_i18n('Do you want to delete this organization?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -140,8 +104,8 @@ class OrganizationPopover extends Component {
               return (
                 <OrganizationEditionContainer
                   organization={props.organization}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -150,14 +114,6 @@ class OrganizationPopover extends Component {
         />
       </>
     );
-  }
-}
-
-OrganizationPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(OrganizationPopover);
+export default OrganizationPopover;

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -171,7 +171,7 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
               stixDomainObject={organization}
               isOpenctiAlias={true}
               enableQuickSubscription={true}
-              PopoverComponent={<OrganizationPopover />}
+              PopoverComponent={<OrganizationPopover id={organization.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <OrganizationEdition organizationId={organization.id} />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -141,7 +141,7 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
               stixDomainObject={sector}
               isOpenctiAlias={true}
               enableQuickSubscription={true}
-              PopoverComponent={<SectorPopover />}
+              PopoverComponent={<SectorPopover id={sector.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <SectorEdition sectorId={sector.id} />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const SectorDeletionDeleteMutation = graphql`
+  mutation SectorDeletionDeleteMutation($id: ID!) {
+    sectorEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const SectorDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Sector') },
+  });
+  const [commit] = useApiMutation(
+    SectorDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/sectors');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this sector?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default SectorDeletion;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -18,6 +18,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import SectorDeletion from './SectorDeletion';
 
 const sectorMutationFieldPatch = graphql`
   mutation SectorEditionOverviewFieldPatchMutation(
@@ -81,7 +83,8 @@ const sectorMutationRelationDelete = graphql`
 const SectorEditionOverviewComponent = (props) => {
   const { sector, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -192,7 +195,7 @@ const SectorEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <Field
             component={MarkdownField}
@@ -206,7 +209,7 @@ const SectorEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -217,17 +220,17 @@ const SectorEditionOverviewComponent = (props) => {
             variant="edit"
           />
           {sector.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="Sector"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="Sector"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -235,7 +238,7 @@ const SectorEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -243,20 +246,27 @@ const SectorEditionOverviewComponent = (props) => {
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={sector.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <SectorDeletion
+                  id={sector.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={sector.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { sectorEditionQuery } from './SectorEdition';
 import SectorEditionContainer from './SectorEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const SectorPopoverDeletionMutation = graphql`
   mutation SectorPopoverDeletionMutation($id: ID!) {
@@ -28,109 +27,74 @@ const SectorPopoverDeletionMutation = graphql`
   }
 `;
 
-class SectorPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const SectorPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: SectorPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/entities/sectors');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/sectors');
       },
     });
-  }
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
 
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id } = this.props;
-    return (
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
           value="popover"
           size="small"
-
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this sector?')}
+              {t_i18n('Do you want to delete this sector?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -143,8 +107,8 @@ class SectorPopover extends Component {
               return (
                 <SectorEditionContainer
                   sector={props.sector}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -153,14 +117,6 @@ class SectorPopover extends Component {
         />
       </>
     );
-  }
-}
-
-SectorPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
 };
 
-export default compose(inject18n, withRouter)(SectorPopover);
+export default SectorPopover;

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -166,7 +166,7 @@ const RootSystem = ({ systemId, queryRef }: RootSystemProps) => {
               isOpenctiAlias={true}
               enableQuickSubscription={true}
               enableEnricher={true}
-              PopoverComponent={<SystemPopover />}
+              PopoverComponent={<SystemPopover id={system.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <SystemEdition systemId={system.id} />

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const SystemDeletionDeleteMutation = graphql`
+  mutation SystemDeletionDeleteMutation($id: ID!) {
+    systemEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const SystemDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_System') },
+  });
+  const [commit] = useApiMutation(
+    SystemDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/systems');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this system?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default SystemDeletion;

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -19,6 +19,8 @@ import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySet
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import SystemDeletion from './SystemDeletion';
 
 const systemMutationFieldPatch = graphql`
   mutation SystemEditionOverviewFieldPatchMutation(
@@ -82,7 +84,8 @@ const systemMutationRelationDelete = graphql`
 const SystemEditionOverviewComponent = (props) => {
   const { system, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -196,7 +199,7 @@ const SystemEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="name" />
-              }
+            }
           />
           <Field
             component={MarkdownField}
@@ -210,7 +213,7 @@ const SystemEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="description" />
-              }
+            }
           />
           <ConfidenceField
             onFocus={editor.changeFocus}
@@ -233,7 +236,7 @@ const SystemEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             helperText={
               <SubscriptionFocus context={context} fieldName="contact_information" />
-              }
+            }
           />
           <OpenVocabField
             label={t_i18n('Reliability')}
@@ -248,17 +251,17 @@ const SystemEditionOverviewComponent = (props) => {
             containerStyle={fieldSpacingContainerStyle}
           />
           {system.workflowEnabled && (
-          <StatusField
-            name="x_opencti_workflow_id"
-            type="System"
-            onFocus={editor.changeFocus}
-            onChange={handleSubmitField}
-            setFieldValue={setFieldValue}
-            style={{ marginTop: 20 }}
-            helpertext={
-              <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
-                }
-          />
+            <StatusField
+              name="x_opencti_workflow_id"
+              type="System"
+              onFocus={editor.changeFocus}
+              onChange={handleSubmitField}
+              setFieldValue={setFieldValue}
+              style={{ marginTop: 20 }}
+              helpertext={
+                <SubscriptionFocus context={context} fieldName="x_opencti_workflow_id" />
+              }
+            />
           )}
           <CreatedByField
             name="createdBy"
@@ -266,7 +269,7 @@ const SystemEditionOverviewComponent = (props) => {
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
-              }
+            }
             onChange={editor.changeCreated}
           />
           <ObjectMarkingField
@@ -274,20 +277,27 @@ const SystemEditionOverviewComponent = (props) => {
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />
-              }
+            }
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-          <CommitMessage
-            submitForm={submitForm}
-            disabled={isSubmitting || !isValid || !dirty}
-            setFieldValue={setFieldValue}
-            open={false}
-            values={values.references}
-            id={system.id}
-          />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <SystemDeletion
+                  id={system.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={system.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemPopover.jsx
@@ -1,6 +1,4 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
@@ -11,14 +9,15 @@ import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
 import ToggleButton from '@mui/material/ToggleButton';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useNavigate } from 'react-router-dom';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { systemEditionQuery } from './SystemEdition';
 import SystemEditionContainer from './SystemEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
+import useHelper from '../../../../utils/hooks/useHelper';
+import { useFormatter } from '../../../../components/i18n';
 
 const SystemPopoverDeletionMutation = graphql`
   mutation SystemPopoverDeletionMutation($id: ID!) {
@@ -28,109 +27,74 @@ const SystemPopoverDeletionMutation = graphql`
   }
 `;
 
-class SystemPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      displayEdit: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+const SystemPopover = ({ id }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEdit, setDisplayEdit] = useState(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
+  const handleCloseDelete = () => setDisplayDelete(false);
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: SystemPopoverDeletionMutation,
-      variables: {
-        id: this.props.id,
-      },
+      variables: { id },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleClose();
-        this.props.navigate('/dashboard/entities/systems');
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/entities/systems');
       },
     });
-  }
+  };
+  const handleOpenEdit = () => {
+    setDisplayEdit(true);
+    handleClose();
+  };
+  const handleCloseEdit = () => setDisplayEdit(false);
 
-  handleOpenEdit() {
-    this.setState({ displayEdit: true });
-    this.handleClose();
-  }
-
-  handleCloseEdit() {
-    this.setState({ displayEdit: false });
-  }
-
-  render() {
-    const { t, id, disabled } = this.props;
-    return (
+  return isFABReplaced
+    ? (<></>)
+    : (
       <>
         <ToggleButton
-          disabled={disabled}
           value="popover"
           size="small"
-          onClick={this.handleOpen.bind(this)}
+          onClick={handleOpen}
         >
           <MoreVert fontSize="small" color="primary" />
         </ToggleButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenEdit.bind(this)}>
-            {t('Update')}
-          </MenuItem>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-              {t('Delete')}
-            </MenuItem>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
         <Dialog
+          open={displayDelete}
           PaperProps={{ elevation: 1 }}
-          open={this.state.displayDelete}
-          keepMounted={true}
           TransitionComponent={Transition}
-          onClose={this.handleCloseDelete.bind(this)}
+          onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t('Do you want to delete this system?')}
+              {t_i18n('Do you want to delete this system?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
             </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Delete')}
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -142,8 +106,8 @@ class SystemPopover extends Component {
               return (
                 <SystemEditionContainer
                   system={props.system}
-                  handleClose={this.handleCloseEdit.bind(this)}
-                  open={this.state.displayEdit}
+                  handleClose={handleCloseEdit}
+                  open={displayEdit}
                 />
               );
             }
@@ -152,15 +116,6 @@ class SystemPopover extends Component {
         />
       </>
     );
-  }
-}
-
-SystemPopover.propTypes = {
-  id: PropTypes.string,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  navigate: PropTypes.func,
-  disabled: PropTypes.bool,
 };
 
-export default compose(inject18n, withRouter)(SystemPopover);
+export default SystemPopover;


### PR DESCRIPTION
### Proposed changes
These changes apply to the Entities menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

- Remove the ... popover icon.
- Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
- Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues

- This work is complementary to the FAB replacement PRs that have been merged of:
     - https://github.com/OpenCTI-Platform/opencti/pull/8106
     - https://github.com/OpenCTI-Platform/opencti/pull/8121
     - https://github.com/OpenCTI-Platform/opencti/pull/8199
- Addresses the behavior seen for areas this capability has not merged against brought up in Issue popover should not be visible if update button is  #8704

### Checklist

- [x]  I consider the submitted work as finished
- [x]  I tested the code for its functionality
- [ ]  I wrote test cases for the relevant uses case (coverage and e2e)
- [ ]  I added/update the relevant documentation (either on github or on notion)
- [x]  Where necessary I refactored code to improve the overall quality