### PR TITLE
[backend] modify rss http getter to a simple fetch (#8736)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -121,6 +121,7 @@ interface RssItem {
   'content:encoded': { _: string }
   category: { _: string } | { _: string }[]
   pubDate: { _: string }
+  'dc:date': { _: string }
   lastBuildDate: { _: string }
   updated: { _: string }
 }
@@ -154,7 +155,7 @@ const rssItemV2Convert = (turndownService: TurndownService, channel: RssElement,
     link: isNotEmptyField(item.link) ? ((item.link as { _: string })._ ?? '').trim() : '',
     content: turndownService.turndown(item['content:encoded']?._ ?? item.content?._ ?? ''),
     labels: R.uniq(asArray(item.category).filter((c) => isNotEmptyField(c)).map((c) => (c as { _: string })._.trim())),
-    pubDate: utcDate(sanitizeForMomentParsing(item.pubDate?._ ?? pubDate?._ ?? FROM_START_STR)),
+    pubDate: utcDate(sanitizeForMomentParsing(item.pubDate?._ ?? item['dc:date']?._ ?? pubDate?._ ?? FROM_START_STR)),
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -104,7 +104,7 @@ const pushBundleToConnectorQueue = async (context: AuthContext, ingestion: Basic
 // endregion
 
 // region Rss ingestion
-type Getter = (uri: string) => Promise<object>;
+type Getter = (uri: string) => Promise<string>;
 
 interface RssElement {
   pubDate: { _: string }
@@ -159,14 +159,9 @@ const rssItemV2Convert = (turndownService: TurndownService, channel: RssElement,
 };
 
 const rssHttpGetter = (): Getter => {
-  const httpClientOptions: GetHttpClient = {
-    responseType: 'text',
-    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0' }
-  };
-  const httpClient = getHttpClient(httpClientOptions);
   return async (uri: string) => {
-    const { data } = await httpClient.get(uri);
-    return data;
+    const fetchResponse = await fetch(uri);
+    return fetchResponse.text();
   };
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* instead of using httpClient, use simple fetch to get RSS data

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8736 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
In the related issue, all linked feeds are now fetched without any 403 errors.
However, the https://cybersecurity.att.com/site/blog-all-rss feed isn't ingested properly, because items in this feed don't have any pubDate metadata, they only have a dc:date. Not sure if we want to modify the RSS parser to use dc:date if no pubDate exist in the item?
