### PR TITLE
Popover observations menu support for FAB_REPLACEMENT feature flag 

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDeletion.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const IndicatorDeletionDeleteMutation = graphql`
+  mutation IndicatorDeletionDeleteMutation($id: ID!) {
+    indicatorDelete(id: $id)
+  }
+`;
+
+const IndicatorDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Indicator') },
+  });
+  const [commit] = useApiMutation(
+    IndicatorDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => {};
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/observations/indicators');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this indicator?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default IndicatorDeletion;

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionContainer.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
+import useHelper from '../../../../utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
 import IndicatorEditionOverview from './IndicatorEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import Drawer, { DrawerVariant } from '../../common/drawer/Drawer';
-import useHelper from '../../../../utils/hooks/useHelper';
 
 const IndicatorEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { handleClose, indicator, open, controlledDial } = props;
   const { editContext } = indicator;
 

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -24,6 +24,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import IndicatorDeletion from './IndicatorDeletion';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const indicatorMutationFieldPatch = graphql`
   mutation IndicatorEditionOverviewFieldPatchMutation(
@@ -82,7 +84,8 @@ const IndicatorEditionOverviewComponent = ({
   enableReferences,
 }) => {
   const { t_i18n } = useFormatter();
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     indicator_types: Yup.array(),
@@ -284,7 +287,7 @@ const IndicatorEditionOverviewComponent = ({
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="valid_from"/>
+                <SubscriptionFocus context={context} fieldName="valid_from" />
               ),
             }}
           />
@@ -299,7 +302,7 @@ const IndicatorEditionOverviewComponent = ({
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="valid_until"/>
+                <SubscriptionFocus context={context} fieldName="valid_until" />
               ),
             }}
           />
@@ -405,16 +408,22 @@ const IndicatorEditionOverviewComponent = ({
               />
             }
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={indicator.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <IndicatorDeletion id={indicator.id} />
+              : <div />
+            }
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={indicator.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -109,7 +109,7 @@ const RootIndicator = ({ indicatorId, queryRef }: RootIndicatorProps) => {
           <StixDomainObjectHeader
             entityType="Indicator"
             stixDomainObject={indicator}
-            PopoverComponent={<IndicatorPopover/>}
+            PopoverComponent={<IndicatorPopover id={indicator.id}/>}
             EditComponent={isFABReplaced && (
               <Security needs={[KNOWLEDGE_KNUPDATE]}>
                 <IndicatorEdition indicatorId={indicator.id} />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDeletion.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const InfrastructureDeletionDeleteMutation = graphql`
+  mutation InfrastructureDeletionDeleteMutation($id: ID!) {
+    infrastructureEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+const InfrastructureDeletion = ({ id }: { id: string }) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Infrastructure') },
+  });
+  const [commit] = useApiMutation(
+    InfrastructureDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate('/dashboard/observations/infrastructures');
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this intrusion set?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default InfrastructureDeletion;

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionContainer.tsx
@@ -36,7 +36,6 @@ const InfrastructureEditionContainer: FunctionComponent<InfrastructureEditionCon
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-
   const { infrastructure } = usePreloadedQuery(infrastructureEditionContainerQuery, queryRef);
 
   if (infrastructure) {

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -25,6 +25,8 @@ import { InfrastructureEditionOverview_infrastructure$key } from './__generated_
 import { Option } from '../../common/form/ReferenceField';
 import { GenericContext } from '../../common/model/GenericContextModel';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
+import InfrastructureDeletion from './InfrastructureDeletion';
 
 const infrastructureMutationFieldPatch = graphql`
   mutation InfrastructureEditionOverviewFieldPatchMutation(
@@ -158,7 +160,8 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
 }) => {
   const { t_i18n } = useFormatter();
   const infrastructure = useFragment(infrastructureEditionOverviewFragment, infrastructureData);
-
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -313,7 +316,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="first_seen"/>
+                <SubscriptionFocus context={context} fieldName="first_seen" />
               ),
             }}
           />
@@ -328,7 +331,7 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
               fullWidth: true,
               style: { marginTop: 20 },
               helperText: (
-                <SubscriptionFocus context={context} fieldName="last_seen"/>
+                <SubscriptionFocus context={context} fieldName="last_seen" />
               ),
             }}
           />
@@ -392,16 +395,23 @@ const InfrastructureEditionOverviewComponent: FunctionComponent<InfrastructureEd
             setFieldValue={setFieldValue}
             onChange={editor.changeMarking}
           />
-          {enableReferences && (
-            <CommitMessage
-              submitForm={submitForm}
-              disabled={isSubmitting || !isValid || !dirty}
-              setFieldValue={setFieldValue}
-              open={false}
-              values={values.references}
-              id={infrastructure.id}
-            />
-          )}
+          <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+            {isFABReplaced
+              ? <InfrastructureDeletion
+                  id={infrastructure.id}
+                />
+              : <div />}
+            {enableReferences && (
+              <CommitMessage
+                submitForm={submitForm}
+                disabled={isSubmitting || !isValid || !dirty}
+                setFieldValue={setFieldValue}
+                open={false}
+                values={values.references}
+                id={infrastructure.id}
+              />
+            )}
+          </div>
         </Form>
       )}
     </Formik>

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructurePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructurePopover.tsx
@@ -18,6 +18,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import InfrastructureEditionContainer, { infrastructureEditionContainerQuery } from './InfrastructureEditionContainer';
 import Transition from '../../../../components/Transition';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const InfrastructurePopoverDeletionMutation = graphql`
   mutation InfrastructurePopoverDeletionMutation($id: ID!) {
@@ -33,6 +34,8 @@ const InfrastructurePopover = ({ id }: { id: string }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [displayDelete, setDisplayDelete] = useState<boolean>(false);
   const [displayEdit, setDisplayEdit] = useState<boolean>(false);
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [deleting, setDeleting] = useState<boolean>(false);
   const [commit] = useApiMutation(InfrastructurePopoverDeletionMutation);
   const queryRef = useQueryLoading<InfrastructureEditionContainerQuery>(
@@ -65,53 +68,55 @@ const InfrastructurePopover = ({ id }: { id: string }) => {
     setDisplayEdit(true);
     handleClose();
   };
-  return (
-    <>
-      <ToggleButton
-        value="popover"
-        size="small"
-        onClick={handleOpen}
-      >
-        <MoreVert fontSize="small" color="primary" />
-      </ToggleButton>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-        <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
-        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
-        </Security>
-      </Menu>
-      <Dialog
-        open={displayDelete}
-        PaperProps={{ elevation: 1 }}
-        keepMounted={true}
-        TransitionComponent={Transition}
-        onClose={handleCloseDelete}
-      >
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to delete this intrusion set?')}
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCloseDelete} disabled={deleting}>
-            {t_i18n('Cancel')}
-          </Button>
-          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
-            {t_i18n('Delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
-      {queryRef && (
-        <React.Suspense fallback={<div />}>
-          <InfrastructureEditionContainer
-            queryRef={queryRef}
-            handleClose={handleClose}
-            open={displayEdit}
-          />
-        </React.Suspense>
-      )}
-    </>
-  );
+  return isFABReplaced
+    ? (<></>)
+    : (
+      <>
+        <ToggleButton
+          value="popover"
+          size="small"
+          onClick={handleOpen}
+        >
+          <MoreVert fontSize="small" color="primary" />
+        </ToggleButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
+          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+            <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          </Security>
+        </Menu>
+        <Dialog
+          open={displayDelete}
+          PaperProps={{ elevation: 1 }}
+          keepMounted={true}
+          TransitionComponent={Transition}
+          onClose={handleCloseDelete}
+        >
+          <DialogContent>
+            <DialogContentText>
+              {t_i18n('Do you want to delete this intrusion set?')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDelete} disabled={deleting}>
+              {t_i18n('Cancel')}
+            </Button>
+            <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+              {t_i18n('Delete')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+        {queryRef && (
+          <React.Suspense fallback={<div />}>
+            <InfrastructureEditionContainer
+              queryRef={queryRef}
+              handleClose={handleClose}
+              open={displayEdit}
+            />
+          </React.Suspense>
+        )}
+      </>
+    );
 };
 
 export default InfrastructurePopover;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDeletion.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import { graphql } from 'react-relay';
+import { useFormatter } from '../../../../components/i18n';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
+import Transition from '../../../../components/Transition';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDeletion from '../../../../utils/hooks/useDeletion';
+import { MESSAGING$ } from '../../../../relay/environment';
+import { RelayError } from '../../../../relay/relayTypes';
+
+const StixCyberObservableDeletionDeleteMutation = graphql`
+  mutation StixCyberObservableDeletionDeleteMutation($id: ID!) {
+    stixCyberObservableEdit(id: $id) {
+        delete
+      }
+    }
+  `;
+
+const StixCyberObservableDeletion = (
+  { id }: { id: string },
+) => {
+  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
+  const deleteSuccessMessage = t_i18n('', {
+    id: '... successfully deleted',
+    values: { entity_type: t_i18n('entity_Observable') },
+  });
+  const [commit] = useApiMutation(
+    StixCyberObservableDeletionDeleteMutation,
+    undefined,
+    { successMessage: deleteSuccessMessage },
+  );
+  const isArtifactInURL = window.location.href.includes('artifact');
+  const handleClose = () => { };
+  const {
+    deleting,
+    handleOpenDelete,
+    displayDelete,
+    handleCloseDelete,
+    setDeleting,
+  } = useDeletion({ handleClose });
+  const submitDelete = () => {
+    setDeleting(true);
+    commit({
+      variables: {
+        id,
+      },
+      onCompleted: () => {
+        setDeleting(false);
+        handleClose();
+        navigate(`/dashboard/observations/${isArtifactInURL ? 'artifacts' : 'observables'}`);
+      },
+      onError: (error) => {
+        const { errors } = (error as unknown as RelayError).res;
+        MESSAGING$.notifyError(errors.at(0)?.message);
+      },
+    });
+  };
+  return (
+    <>
+      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+        <Button
+          color="error"
+          variant="contained"
+          onClick={handleOpenDelete}
+          disabled={deleting}
+          sx={{ marginTop: 2 }}
+        >
+          {t_i18n('Delete')}
+        </Button>
+      </Security>
+      <Dialog
+        open={displayDelete}
+        PaperProps={{ elevation: 1 }}
+        TransitionComponent={Transition}
+        onClose={handleCloseDelete}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to delete this observable?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDelete} disabled={deleting}>
+            {t_i18n('Cancel')}
+          </Button>
+          <Button color="secondary" onClick={submitDelete} disabled={deleting}>
+            {t_i18n('Delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default StixCyberObservableDeletion;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
@@ -55,12 +55,12 @@ const StixCyberObservableEditionContainer = (props) => {
         <div className="clearfix" />
       </div>
       <div className={classes.container}>
-          <StixCyberObservableEditionOverview
-            stixCyberObservable={stixCyberObservable}
-            enableReferences={useIsEnforceReference('Stix-Cyber-Observable')}
-            context={editContext}
-            handleClose={handleClose}
-          />
+        <StixCyberObservableEditionOverview
+          stixCyberObservable={stixCyberObservable}
+          enableReferences={useIsEnforceReference('Stix-Cyber-Observable')}
+          context={editContext}
+          handleClose={handleClose}
+        />
       </div>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionContainer.jsx
@@ -33,7 +33,6 @@ const useStyles = makeStyles((theme) => ({
 const StixCyberObservableEditionContainer = (props) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-
   const { handleClose, stixCyberObservable } = props;
   const { editContext } = stixCyberObservable;
 
@@ -56,17 +55,16 @@ const StixCyberObservableEditionContainer = (props) => {
         <div className="clearfix" />
       </div>
       <div className={classes.container}>
-        <StixCyberObservableEditionOverview
-          stixCyberObservable={stixCyberObservable}
-          enableReferences={useIsEnforceReference('Stix-Cyber-Observable')}
-          context={editContext}
-          handleClose={handleClose}
-        />
+          <StixCyberObservableEditionOverview
+            stixCyberObservable={stixCyberObservable}
+            enableReferences={useIsEnforceReference('Stix-Cyber-Observable')}
+            context={editContext}
+            handleClose={handleClose}
+          />
       </div>
     </div>
   );
 };
-
 const StixCyberObservableEditionFragment = createFragmentContainer(
   StixCyberObservableEditionContainer,
   {
@@ -82,5 +80,4 @@ const StixCyberObservableEditionFragment = createFragmentContainer(
     `,
   },
 );
-
 export default StixCyberObservableEditionFragment;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -18,10 +18,12 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ArtifactField from '../../common/form/ArtifactField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { useFormatter } from '../../../../components/i18n';
+import useHelper from '../../../../utils/hooks/useHelper';
 import useVocabularyCategory from '../../../../utils/hooks/useVocabularyCategory';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertMarkings } from '../../../../utils/edition';
 import useAttributes from '../../../../utils/hooks/useAttributes';
+import StixCyberObservableDeletion from './StixCyberObservableDeletion';
 
 const stixCyberObservableMutationFieldPatch = graphql`
   mutation StixCyberObservableEditionOverviewFieldPatchMutation(
@@ -95,6 +97,8 @@ const StixCyberObservableEditionOverviewComponent = ({
 }) => {
   const navigate = useNavigate();
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const { isVocabularyField, fieldToCategory } = useVocabularyCategory();
   const { booleanAttributes, dateAttributes, ignoredAttributes, multipleAttributes, numberAttributes } = useAttributes();
   const onSubmit = (values, { setSubmitting }) => {
@@ -494,7 +498,7 @@ const StixCyberObservableEditionOverviewComponent = ({
                             artifact
                               ? {
                                 label:
-                                    artifact.observable_value ?? artifact.id,
+                                  artifact.observable_value ?? artifact.id,
                                 value: artifact.id,
                               }
                               : undefined
@@ -547,6 +551,11 @@ const StixCyberObservableEditionOverviewComponent = ({
                     setFieldValue={setFieldValue}
                     onChange={handleChangeObjectMarking}
                   />
+                  {isFABReplaced && (
+                    <StixCyberObservableDeletion
+                      id={stixCyberObservable.id}
+                    />
+                  )}
                 </Form>
               )}
             </Formik>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -4,12 +4,14 @@ import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
 import StixCoreObjectContainer from '../../common/stix_core_objects/StixCoreObjectContainer';
 import StixCyberObservablePopover from './StixCyberObservablePopover';
+import StixCyberObservablePopoverFABReplaced from './StixCyberObservablePopoverFABReplaced';
 import { truncate } from '../../../../utils/String';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
 import StixCoreObjectSharing from '../../common/stix_core_objects/StixCoreObjectSharing';
 import useGranted, { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import StixCyberObservableEdition from './StixCyberObservableEdition';
 import Security from '../../../../utils/Security';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -31,6 +33,8 @@ const StixCyberObservableHeaderComponent = ({
   isArtifact,
   disableSharing,
 }) => {
+  const { isFeatureEnable } = useHelper();
+  const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const classes = useStyles();
   const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
   const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]);
@@ -57,10 +61,16 @@ const StixCyberObservableHeaderComponent = ({
           {isKnowledgeEnricher && (
             <StixCoreObjectEnrichment stixCoreObjectId={stixCyberObservable.id} />
           )}
-          <StixCyberObservablePopover
+          {isFABReplaced && (<StixCyberObservablePopoverFABReplaced
             stixCyberObservableId={stixCyberObservable.id}
             isArtifact={isArtifact}
-          />
+                             />
+          )}
+          {!isFABReplaced && (<StixCyberObservablePopover
+            stixCyberObservableId={stixCyberObservable.id}
+            isArtifact={isArtifact}
+                              />
+          )}
           <Security needs={[KNOWLEDGE_KNUPDATE]}>
             <StixCyberObservableEdition
               stixCyberObservableId={stixCyberObservable.id}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablePopoverFABReplaced.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablePopoverFABReplaced.jsx
@@ -2,39 +2,40 @@ import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
-import ToggleButton from '@mui/material/ToggleButton';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
+import ToggleButton from '@mui/material/ToggleButton';
 import { useNavigate } from 'react-router-dom';
+import Drawer from '@mui/material/Drawer';
 import StixCoreObjectEnrollPlaybook from '../../common/stix_core_objects/StixCoreObjectEnrollPlaybook';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import { indicatorEditionQuery } from './IndicatorEdition';
-import IndicatorEditionContainer from './IndicatorEditionContainer';
+import { QueryRenderer, commitMutation } from '../../../../relay/environment';
+import { stixCyberObservableEditionQuery } from './StixCyberObservableEdition';
+import StixCyberObservableEditionContainer from './StixCyberObservableEditionContainer';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import Transition from '../../../../components/Transition';
 import useHelper from '../../../../utils/hooks/useHelper';
 import { useFormatter } from '../../../../components/i18n';
-import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
 
-const IndicatorPopoverDeletionMutation = graphql`
-  mutation IndicatorPopoverDeletionMutation($id: ID!) {
-    indicatorDelete(id: $id)
+const StixCyberObservablePopoverFABReplacedDeletionMutation = graphql`
+  mutation StixCyberObservablePopoverFABReplacedDeletionMutation($id: ID!) {
+    stixCyberObservableEdit(id: $id) {
+      delete
+    }
   }
 `;
 
-const IndicatorPopover = ({ id }) => {
+const StixCyberObservablePopoverFABReplaced = ({ id }) => {
   const navigate = useNavigate();
   const { t_i18n } = useFormatter();
   const [anchorEl, setAnchorEl] = useState(null);
-  const [displayEnroll, setDisplayEnroll] = useState(false);
   const [displayDelete, setDisplayDelete] = useState(false);
+  const [displayEnroll, setDisplayEnroll] = useState(false);
   const [displayEdit, setDisplayEdit] = useState(false);
-  const [displayEnrichment, setDisplayEnrichment] = useState(false);
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const [deleting, setDeleting] = useState(false);
@@ -48,12 +49,12 @@ const IndicatorPopover = ({ id }) => {
   const submitDelete = () => {
     setDeleting(true);
     commitMutation({
-      mutation: IndicatorPopoverDeletionMutation,
+      mutation: StixCyberObservablePopoverFABReplacedDeletionMutation,
       variables: { id },
       onCompleted: () => {
         setDeleting(false);
         handleClose();
-        navigate('/dashboard/observations/indicators');
+        navigate('/dashboard/observations/observables');
       },
     });
   };
@@ -62,19 +63,12 @@ const IndicatorPopover = ({ id }) => {
     handleClose();
   };
   const handleCloseEdit = () => setDisplayEdit(false);
-  const handleOpenEnrichment = () => {
-    setDisplayEnrichment(true);
-    handleClose();
-  };
   const handleOpenEnroll = () => {
     setDisplayEnroll(true);
     handleClose();
   };
   const handleCloseEnroll = () => {
     setDisplayEnroll(false);
-  };
-  const handleCloseEnrichment = () => {
-    setDisplayEnrichment(false);
   };
   return isFABReplaced
     ? (<></>)
@@ -90,9 +84,6 @@ const IndicatorPopover = ({ id }) => {
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
           <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
           <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
-            <MenuItem onClick={handleOpenEnrichment}>{t_i18n('Enrich')}</MenuItem>
-          </Security>
-          <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
             <MenuItem onClick={handleOpenEnroll}>
               {t_i18n('Enroll in playbook')}
             </MenuItem>
@@ -101,17 +92,17 @@ const IndicatorPopover = ({ id }) => {
             <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
           </Security>
         </Menu>
-        <StixCoreObjectEnrichment stixCoreObjectId={id} open={displayEnrichment} handleClose={handleCloseEnrichment} />
         <StixCoreObjectEnrollPlaybook stixCoreObjectId={id} open={displayEnroll} handleClose={handleCloseEnroll} />
         <Dialog
           open={displayDelete}
           PaperProps={{ elevation: 1 }}
+          keepMounted={true}
           TransitionComponent={Transition}
           onClose={handleCloseDelete}
         >
           <DialogContent>
             <DialogContentText>
-              {t_i18n('Do you want to delete this indicator?')}
+              {t_i18n('Do you want to delete this observable?')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>
@@ -123,24 +114,30 @@ const IndicatorPopover = ({ id }) => {
             </Button>
           </DialogActions>
         </Dialog>
-        <QueryRenderer
-          query={indicatorEditionQuery}
-          variables={{ id }}
-          render={({ props }) => {
-            if (props) {
-              return (
-                <IndicatorEditionContainer
-                  indicator={props.indicator}
-                  handleClose={handleCloseEdit}
-                  open={displayEdit}
-                />
-              );
-            }
-            return <div />;
-          }}
-        />
+        <Drawer
+          title={t_i18n('Update an observable')}
+          open={displayEdit}
+          onClose={handleCloseEdit}
+        >
+          <QueryRenderer
+            query={stixCyberObservableEditionQuery}
+            variables={{ id }}
+            render={({ props }) => {
+              if (props) {
+                return (
+                  <StixCyberObservableEditionContainer
+                    stixCyberObservable={props.stixCyberObservable}
+                    handleClose={handleCloseEdit}
+                    open={displayEdit}
+                  />
+                );
+              }
+              return <div />;
+            }}
+          />
+        </Drawer>
       </>
     );
 };
 
-export default IndicatorPopover;
+export default StixCyberObservablePopoverFABReplaced;


### PR DESCRIPTION
### Proposed changes
These changes apply to the Observations menu items in support of the popover removal as part of the FAB_REPLACEMENT feature flag.

* Remove the ... popover icon.
* Move the "Delete" from this popover into the Drawer for the item, have the button be on the bottom left of the drawer in red
* Float the Enrich option to the top row and use the default cloud enrichment icon

### Related issues
* This work is complementary to the FAB replacement PRs that have been merged of:
* [Popover Removal - Analyses (Updated) #8106](https://github.com/OpenCTI-Platform/opencti/pull/8106)
* [Popover Removal - Cases #8121](https://github.com/OpenCTI-Platform/opencti/pull/8121)
* [Popover Removal - Locations #8199](https://github.com/OpenCTI-Platform/opencti/pull/8199)
* Addresses the behavior seen for areas this capability has not merged against brought up in Issue popover should not be visible if update button is  [popover should not be visible if update button is  #8704](https://github.com/OpenCTI-Platform/opencti/issues/8704)

### Checklist
 * [x]   I consider the submitted work as finished
 * [x]   I tested the code for its functionality
 * [ ]   I wrote test cases for the relevant uses case (coverage and e2e)
 * [ ]   I added/update the relevant documentation (either on github or on notion)
 * [x]   Where necessary I refactored code to improve the overall quality

