### PR TITLE
[frontend] Add support for dynamic configurable required fields to Cases

### DIFF
--- a/opencti-platform/opencti-front/src/components/SimpleMarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/SimpleMarkdownField.jsx
@@ -11,6 +11,7 @@ const MarkdownField = (props) => {
   const {
     form: { setFieldValue, setFieldTouched },
     field: { name },
+    required = false,
     onFocus,
     onSubmit,
     onSelect,
@@ -59,7 +60,11 @@ const MarkdownField = (props) => {
       onBlur={internalOnBlur}
       onFocus={internalOnFocus}
     >
-      <InputLabel shrink={true}>
+      <InputLabel
+        shrink={true}
+        required={required}
+        error={!!meta.error}
+      >
         {label}
       </InputLabel>
       <ReactMde

--- a/opencti-platform/opencti-front/src/components/fields/MarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/fields/MarkdownField.jsx
@@ -59,7 +59,7 @@ const MarkdownField = (props) => {
       <InputLabel
         shrink={true}
         required={required}
-        error={meta.error}
+        error={!!meta.error}
       >
         {label}
       </InputLabel>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -19,7 +19,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import CaseTemplateField from '../../common/form/CaseTemplateField';
 import ConfidenceField from '../../common/form/ConfidenceField';
@@ -122,15 +122,17 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
   const isEnterpriseEdition = useEnterpriseEdition();
-
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    CASE_INCIDENT_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
     authorized_members: Yup.array().nullable(),
-  };
-  const caseIncidentValidator = useSchemaCreationValidation(
-    CASE_INCIDENT_TYPE,
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const [commit] = useApiMutation<CaseIncidentCreationCaseMutation>(
@@ -222,17 +224,20 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   return (
     <Formik<FormikCaseIncidentAddInput>
       initialValues={initialValues}
-      validationSchema={caseIncidentValidator}
+      validationSchema={validator}
       onSubmit={onSubmit}
+      validateOnChange={true}
+      validateOnBlur={true}
       onReset={onClose}
     >
-      {({ submitForm, handleReset, isSubmitting, setFieldValue, values }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue, values, errors }) => (
         <Form>
           <Field
             component={TextField}
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Case-Incident']}
             askAi={true}
@@ -242,6 +247,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             name="created"
             textFieldProps={{
               label: t_i18n('Incident date'),
+              required: mandatoryAttributes.includes('created'),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -251,6 +257,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             label={t_i18n('Severity')}
             type="case_severity_ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -258,6 +265,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             label={t_i18n('Priority')}
             type="case_priority_ov"
             name="priority"
+            required={(mandatoryAttributes.includes('priority'))}
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -265,6 +273,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             label={t_i18n('Incident type')}
             type="incident_response_types_ov"
             name="response_types"
+            required={(mandatoryAttributes.includes('response_types'))}
             multiple
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
@@ -281,6 +290,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('priority'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -291,6 +301,8 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             component={RichTextField}
             name="content"
             label={t_i18n('Content')}
+            required={(mandatoryAttributes.includes('content'))}
+            meta={{ error: errors.content }}
             fullWidth={true}
             askAi={true}
             style={{
@@ -301,30 +313,36 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -12,7 +12,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
@@ -166,6 +166,8 @@ interface CaseIncidentEditionFormValues {
   references: ExternalReferencesValues | undefined
 }
 
+const CASE_INCIDENT_TYPE = 'Case-Incident';
+
 const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverviewProps> = ({
   caseRef,
   context,
@@ -175,8 +177,10 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
   const { t_i18n } = useFormatter();
   const caseData = useFragment(caseIncidentEditionOverviewFragment, caseRef);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(CASE_INCIDENT_TYPE);
+
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     severity: Yup.string().nullable(),
     priority: Yup.string().nullable(),
     response_types: Yup.array(),
@@ -184,8 +188,12 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
     x_opencti_workflow_id: Yup.object().nullable(),
     rating: Yup.number().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const caseIncidentValidator = useSchemaEditionValidation('Case-Incident', basicShape);
+    objectAssignee: Yup.array().nullable(),
+    objectParticipant: Yup.array().nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: caseIncidentMutationFieldPatch,
@@ -193,7 +201,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
     relationDelete: caseIncidentMutationRelationDelete,
     editionFocus: caseIncidentEditionOverviewFocus,
   };
-  const editor = useFormEditor(caseData as GenericData, enableReferences, queries, caseIncidentValidator);
+  const editor = useFormEditor(caseData as GenericData, enableReferences, queries, validator);
 
   const onSubmit: FormikConfig<CaseIncidentEditionFormValues>['onSubmit'] = (values, { setSubmitting }) => {
     const { message, references, ...otherValues } = values;
@@ -227,7 +235,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
       if (['x_opencti_workflow_id'].includes(name)) {
         finalValue = (value as Option).value;
       }
-      caseIncidentValidator
+      validator
         .validateAt(name, { [name]: value })
         .then(() => {
           editor.fieldPatch({
@@ -248,7 +256,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
     severity: caseData.severity,
     response_types: caseData.response_types ?? [],
     confidence: caseData.confidence,
-    createdBy: convertCreatedBy(caseData),
+    createdBy: convertCreatedBy(caseData) as Option,
     objectMarking: convertMarkings(caseData),
     objectAssignee: convertAssignees(caseData),
     objectParticipant: convertParticipants(caseData),
@@ -263,7 +271,9 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
     <Formik
       enableReinitialize={true}
       initialValues={initialValues as never}
-      validationSchema={caseIncidentValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -281,6 +291,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={editor.changeField}
@@ -296,6 +307,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             onSubmit={editor.changeField}
             textFieldProps={{
               label: t_i18n('Incident date'),
+              required: (mandatoryAttributes.includes('created')),
               variant: 'standard',
               fullWidth: true,
               helperText: (
@@ -309,6 +321,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             label={t_i18n('Case severity')}
             type="case_severity_ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
             variant="edit"
@@ -320,6 +333,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             label={t_i18n('Case priority')}
             type="case_priority_ov"
             name="priority"
+            required={(mandatoryAttributes.includes('priority'))}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
             variant="edit"
@@ -331,6 +345,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             label={t_i18n('Response type')}
             type="incident_response_types_ov"
             name="response_types"
+            required={(mandatoryAttributes.includes('response_types'))}
             onSubmit={handleSubmitField}
             onChange={setFieldValue}
             variant="edit"
@@ -350,6 +365,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -361,8 +377,10 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
               <SubscriptionFocus context={context} fieldName="description" />
             }
           />
+
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectAssignee" />
@@ -371,6 +389,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
             onChange={editor.changeParticipant}
           />
@@ -392,6 +411,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -401,6 +421,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -19,7 +19,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import CaseTemplateField from '../../common/form/CaseTemplateField';
 import ConfidenceField from '../../common/form/ConfidenceField';
@@ -121,14 +121,16 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
   const isEnterpriseEdition = useEnterpriseEdition();
-
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    CASE_RFI_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     authorized_members: Yup.array().nullable(),
-  };
-  const caseRfiValidator = useSchemaCreationValidation(
-    CASE_RFI_TYPE,
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const [commit] = useApiMutation<CaseRfiCreationCaseMutation>(
@@ -217,17 +219,20 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   return (
     <Formik<FormikCaseRfiAddInput>
       initialValues={initialValues}
-      validationSchema={caseRfiValidator}
+      validationSchema={validator}
       onSubmit={onSubmit}
+      validateOnChange={true}
+      validateOnBlur={true}
       onReset={onClose}
     >
-      {({ submitForm, handleReset, isSubmitting, setFieldValue, values }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue, values, errors }) => (
         <Form>
           <Field
             component={TextField}
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Case-Rfi']}
             askAi={true}
@@ -237,6 +242,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             name="created"
             textFieldProps={{
               label: t_i18n('Request For Information Date'),
+              required: (mandatoryAttributes.includes('created')),
               variant: 'standard',
               fullWidth: true,
               style: { ...fieldSpacingContainerStyle },
@@ -246,6 +252,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             label={t_i18n('Request for information type')}
             type="request_for_information_types_ov"
             name="information_types"
+            required={(mandatoryAttributes.includes('information_types'))}
             multiple
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
@@ -254,6 +261,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             label={t_i18n('Severity')}
             type="case_severity_ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -261,6 +269,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             label={t_i18n('Priority')}
             type="case_priority_ov"
             name="priority"
+            required={(mandatoryAttributes.includes('priority'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -276,6 +285,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -286,6 +296,8 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             component={RichTextField}
             name="content"
             label={t_i18n('Content')}
+            required={(mandatoryAttributes.includes('content'))}
+            meta={{ error: errors.content }}
             fullWidth={true}
             askAi={true}
             style={{
@@ -296,30 +308,36 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -19,7 +19,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import CaseTemplateField from '../../common/form/CaseTemplateField';
 import ConfidenceField from '../../common/form/ConfidenceField';
@@ -121,15 +121,17 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
   const isEnterpriseEdition = useEnterpriseEdition();
-
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    CASE_RFT_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
     authorized_members: Yup.array().nullable(),
-  };
-  const caseRftValidator = useSchemaCreationValidation(
-    CASE_RFT_TYPE,
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const [commit] = useApiMutation<CaseRftCreationCaseMutation>(
@@ -219,16 +221,19 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
   return (
     <Formik<FormikCaseRftAddInput>
       initialValues={initialValues}
-      validationSchema={caseRftValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
       onReset={onClose}
     >
-      {({ submitForm, handleReset, isSubmitting, setFieldValue, values }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue, values, errors }) => (
         <Form>
           <Field
             component={TextField}
             variant="standard"
             name="name"
+            required={(mandatoryAttributes.includes('name'))}
             label={t_i18n('Name')}
             fullWidth={true}
             detectDuplicate={['Case-Rft']}
@@ -236,6 +241,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
           <Field
             component={DateTimePickerField}
             name="created"
+            required={(mandatoryAttributes.includes('created'))}
             textFieldProps={{
               label: t_i18n('Request For Takedown Date'),
               variant: 'standard',
@@ -247,6 +253,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             label={t_i18n('Request for takedown type')}
             type="request_for_takedown_types_ov"
             name="takedown_types"
+            required={(mandatoryAttributes.includes('takedown_types'))}
             multiple
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
@@ -255,6 +262,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             label={t_i18n('Severity')}
             type="case_severity_ov"
             name="severity"
+            required={(mandatoryAttributes.includes('severity'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -262,6 +270,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             label={t_i18n('Priority')}
             type="case_priority_ov"
             name="priority"
+            required={(mandatoryAttributes.includes('priority'))}
             onChange={(name, value) => setFieldValue(name, value)}
             containerStyle={fieldSpacingContainerStyle}
           />
@@ -277,6 +286,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -286,6 +296,8 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             component={RichTextField}
             name="content"
             label={t_i18n('Content')}
+            required={(mandatoryAttributes.includes('content'))}
+            meta={{ error: errors.content }}
             fullWidth={true}
             style={{
               ...fieldSpacingContainerStyle,
@@ -295,30 +307,36 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackCreation.tsx
@@ -15,7 +15,7 @@ import ConfidenceField from '../../common/form/ConfidenceField';
 import { Option } from '../../common/form/ReferenceField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import useGranted, { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { FeedbackCreationMutation$variables } from './__generated__/FeedbackCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -70,12 +70,15 @@ const FeedbackCreation: FunctionComponent<{
   );
   const userIsKnowledgeEditor = useGranted([KNOWLEDGE_KNUPDATE]);
 
-  const basicShape = {
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    FEEDBACK_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
     description: Yup.string().nullable(),
     confidence: Yup.number(),
-    rating: Yup.number(),
-  };
-  const feedbackValidator = useSchemaCreationValidation(FEEDBACK_TYPE, basicShape);
+    rating: Yup.number().min(1).max(5),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const onSubmit: FormikConfig<FormikFeedbackAddInput>['onSubmit'] = (
     values,
@@ -125,8 +128,10 @@ const FeedbackCreation: FunctionComponent<{
     >
       <Formik<FormikFeedbackAddInput>
         initialValues={initialValues}
-        validationSchema={feedbackValidator}
+        validationSchema={validator}
         onSubmit={onSubmit}
+        validateOnChange={true}
+        validateOnBlur={true}
         onReset={handleCloseDrawer}
       >
         {({
@@ -139,8 +144,10 @@ const FeedbackCreation: FunctionComponent<{
           <Form>
             <Field
               component={SimpleMarkdownField}
+              askAI={false}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -151,15 +158,21 @@ const FeedbackCreation: FunctionComponent<{
             />
             <RatingField
               label={t_i18n('Rating')}
+              readOnly={false}
+              required={(mandatoryAttributes.includes('rating'))}
               rating={values.rating}
               size="small"
               handleOnChange={(newValue) => {
-                setFieldValue('rating', newValue);
+                // Cannot remove the rating, always required and not customizable, and can only be 1-5 in value
+                if (newValue != null && newValue >= 1 && newValue <= 5) {
+                  setFieldValue('rating', newValue);
+                }
               }}
               style={fieldSpacingContainerStyle}
             />
             <StixCoreObjectsField
               name="objects"
+              required={(mandatoryAttributes.includes('objects'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objects}
@@ -167,6 +180,7 @@ const FeedbackCreation: FunctionComponent<{
             <CustomFileUploader setFieldValue={setFieldValue} />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={{ marginTop: userIsKnowledgeEditor ? 20 : 10 }}
               setFieldValue={setFieldValue}
               values={values.objectLabel}

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
@@ -13,7 +13,7 @@ import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
@@ -43,6 +43,7 @@ const caseTaskAddMutation = graphql`
   }
 `;
 
+const TASK_TYPE = 'Task';
 interface FormikCaseTaskAddInput {
   name: string;
   due_date?: Date | null;
@@ -69,8 +70,11 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
   const { t_i18n } = useFormatter();
   const classes = useStyles();
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    TASK_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     due_date: Yup.date().nullable(),
     objectLabel: Yup.array(),
@@ -78,8 +82,8 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
     objectAssignee: Yup.array(),
     objectParticipant: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const taskValidator = useSchemaEditionValidation('Task', basicShape);
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const [addTask] = useApiMutation(
     caseTaskAddMutation,
@@ -130,7 +134,9 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
       }}
       onSubmit={onSubmit}
       onReset={onClose}
-      validationSchema={taskValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
     >
       {({ isSubmitting, handleReset, submitForm, setFieldValue }) => (
         <Form>
@@ -140,6 +146,7 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth
           />
           <Field
@@ -153,18 +160,22 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
           />
           <ObjectAssigneeField
             name="objectAssignee"
+            required={(mandatoryAttributes.includes('objectAssignee'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectParticipantField
             name="objectParticipant"
+            required={(mandatoryAttributes.includes('objectParticipant'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
@@ -172,6 +183,7 @@ const CaseTaskCreation: FunctionComponent<CaseTaskCreationProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth
             multiline
             rows="4"

--- a/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.ts
@@ -32,6 +32,7 @@ const FEEDBACK_DEFINITION: ModuleDefinition<StoreEntityFeedback, StixFeedback> =
     { key: 'mostRecentHistory', width: 6, label: 'Most recent history' },
   ],
   attributes: [
+    { name: 'content', label: 'Content', type: 'string', format: 'short', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'rating', label: 'Rating', type: 'numeric', precision: 'integer', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { ...authorizedMembers, editDefault: true },
     { ...authorizedMembersActivationDate },

--- a/opencti-platform/opencti-graphql/src/modules/task/task.ts
+++ b/opencti-platform/opencti-graphql/src/modules/task/task.ts
@@ -1,7 +1,7 @@
 import { ENTITY_TYPE_CONTAINER } from '../../schema/general';
 import { NAME_FIELD, normalizeName } from '../../schema/identifier';
 import { type ModuleDefinition, registerDefinition } from '../../schema/module';
-import { objectAssignee, objectOrganization, objectParticipant } from '../../schema/stixRefRelationship';
+import { createdBy, objectAssignee, objectOrganization, objectParticipant } from '../../schema/stixRefRelationship';
 import convertCaseTaskToStix from './task-converter';
 import type { StixTask, StoreEntityTask } from './task-types';
 import { ENTITY_TYPE_CONTAINER_TASK } from './task-types';
@@ -37,6 +37,7 @@ const CASE_TASK_DEFINITION: ModuleDefinition<StoreEntityTask, StixTask> = {
   ],
   relations: [],
   relationsRefs: [
+    { ...createdBy, mandatoryType: 'no' },
     objectOrganization,
     { ...objectAssignee, mandatoryType: 'no' },
     objectParticipant


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This PR builds upon the capabilities from [6972](https://github.com/OpenCTI-Platform/opencti/pull/6972) This PR will add all capabilities from the previous PR to the 'Cases' section of the platform, to include creating and editing the following entity types:

* Case Incidents
* Case RFIs
* Case RFTs
* Feedbacks
* Tasks

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

As stated in [Initial changes to support dynamic configurable required fields via settings](https://github.com/OpenCTI-Platform/opencti/pull/6972) the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case (coverage and e2e) 
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
