### PR TITLE
[frontend] When deleting a connector in ingestion => connectors, interface is redirected to the connector and then to the list (#7828)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -21,7 +21,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import { ConnectorsStatusQuery } from '@components/data/connectors/__generated__/ConnectorsStatusQuery.graphql';
 import { ConnectorsStatus_data$key } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
 import makeStyles from '@mui/styles/makeStyles';
-import { ListItemButton } from '@mui/material';
 import Transition from '../../../../components/Transition';
 import { FIVE_SECONDS } from '../../../../utils/Time';
 import { useFormatter } from '../../../../components/i18n';
@@ -375,7 +374,7 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
             </ListItem>
 
             {sortedConnectors && sortedConnectors.map((connector) => (
-              <ListItemButton
+              <ListItem
                 key={connector.id}
                 classes={{ root: classes.item }}
                 divider={true}
@@ -468,7 +467,7 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
                     </>
                   </Security>
                 </ListItemSecondaryAction>
-              </ListItemButton>
+              </ListItem>
             ))}
           </List>
         </CardContent>


### PR DESCRIPTION
### Proposed changes

* Remove the ListItemButton for a regular ListItem

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7828

