### PR TITLE
[frontend] fix redirect value depending on capability in Data tab

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Root.jsx
@@ -1,7 +1,17 @@
 import React, { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { boundaryWrapper } from '../Error';
-import useGranted, { KNOWLEDGE_KNUPDATE, MODULES, SETTINGS_SETACCESSES, INGESTION, CSVMAPPERS } from '../../../utils/hooks/useGranted';
+import useGranted, {
+  KNOWLEDGE_KNUPDATE,
+  MODULES,
+  SETTINGS_SETACCESSES,
+  INGESTION,
+  CSVMAPPERS,
+  KNOWLEDGE,
+  KNOWLEDGE_KNASKIMPORT,
+  TAXIIAPI,
+  INGESTION_SETINGESTIONS,
+} from '../../../utils/hooks/useGranted';
 import Loader from '../../../components/Loader';
 
 const CsvMappers = lazy(() => import('./CsvMappers'));
@@ -23,6 +33,25 @@ const RootPlaybook = lazy(() => import('./playbooks/Root'));
 const RootImport = lazy(() => import('./import/Root'));
 
 const Root = () => {
+  const isGrantedToKnowledge = useGranted([KNOWLEDGE]);
+  const isGrantedToIngestion = useGranted([MODULES, INGESTION, INGESTION_SETINGESTIONS]);
+  const isGrantedToImport = useGranted([KNOWLEDGE_KNASKIMPORT]);
+  const isGrantedToProcessing = useGranted([KNOWLEDGE_KNUPDATE, SETTINGS_SETACCESSES, CSVMAPPERS]);
+  const isGrantedToSharing = useGranted([TAXIIAPI]);
+
+  let redirect = null;
+  if (isGrantedToKnowledge) {
+    redirect = 'entities';
+  } else if (isGrantedToIngestion) {
+    redirect = 'ingestion';
+  } else if (isGrantedToImport) {
+    redirect = 'import';
+  } else if (isGrantedToProcessing) {
+    redirect = 'processing';
+  } else if (isGrantedToSharing) {
+    redirect = 'sharing';
+  }
+
   const isConnectorReader = useGranted([MODULES]);
 
   return (
@@ -30,7 +59,7 @@ const Root = () => {
       <Routes>
         <Route
           path="/"
-          element={<Navigate to="/dashboard/data/entities" replace={true} />}
+          element={<Navigate to={`/dashboard/data/${redirect}`} replace={true} />}
         />
         <Route
           path="/entities"


### PR DESCRIPTION
[frontend] wip: fix

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add redirect value based on capability: before redirection was only to "Entities" tab, user was kick out of the platform if he/she didn't have knowledge capability.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/8748

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
