### PR TITLE
[backend] Fix for persona_name global search and entity filter/link registration

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1664,6 +1664,7 @@ const BASE_SEARCH_ATTRIBUTES = [
   // Add all other attributes
   'aliases',
   'x_opencti_aliases',
+  'persona_name',
   'roles',
   'objective',
   'content',

--- a/opencti-platform/opencti-graphql/src/modules/relationsRef/stixCyberObservable-registrationRef.ts
+++ b/opencti-platform/opencti-graphql/src/modules/relationsRef/stixCyberObservable-registrationRef.ts
@@ -56,6 +56,7 @@ import {
   ENTITY_MUTEX,
   ENTITY_NETWORK_TRAFFIC,
   ENTITY_PAYMENT_CARD,
+  ENTITY_PERSONA,
   ENTITY_PHONE_NUMBER,
   ENTITY_PROCESS,
   ENTITY_SOFTWARE,
@@ -144,6 +145,7 @@ schemaRelationsRefDefinition.registerRelationsRef(ENTITY_MAC_ADDR, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_MEDIA_CONTENT, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_MUTEX, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_PAYMENT_CARD, []);
+schemaRelationsRefDefinition.registerRelationsRef(ENTITY_PERSONA, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_PHONE_NUMBER, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_SOFTWARE, []);
 schemaRelationsRefDefinition.registerRelationsRef(ENTITY_TEXT, []);


### PR DESCRIPTION

Bugfix PR - Searching for a Persona Observable. Filtering on Entity=Persona or performing a search on a Persona returns 0 results.

Issue #9063 Submitted for this bug


### Proposed changes

* Added persona_name field to engine search fields - Fixed Global Search
* Added missed stixCyberObservable-registrationRef to support filter

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] - N/A - I wrote test cases for the relevant uses case (coverage and e2e)
- [X] - N/A - I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
