### PR TITLE
[frontend] Avoid URI filters repercussion in Knowledge screens (#8511)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
 import useAuth from '../../../../utils/hooks/useAuth';
@@ -27,6 +27,7 @@ const ChannelKnowledgeComponent = ({
     channelKnowledgeFragment,
     channelData,
   );
+  const location = useLocation();
   const link = `/dashboard/arsenal/channels/${channel.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(channel.entity_type, schema);
@@ -65,6 +66,7 @@ const ChannelKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -78,6 +80,7 @@ const ChannelKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -98,6 +101,7 @@ const ChannelKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               isRelationReversed={true}
@@ -117,6 +121,7 @@ const ChannelKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -129,6 +134,7 @@ const ChannelKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -141,6 +147,7 @@ const ChannelKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Campaign']}
@@ -153,6 +160,7 @@ const ChannelKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -165,6 +173,7 @@ const ChannelKnowledgeComponent = ({
           path="/channels"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['amplifies', 'derived-from']}
               stixCoreObjectTypes={['Channel']}
@@ -177,6 +186,7 @@ const ChannelKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses', 'delivers', 'drops']}
               stixCoreObjectTypes={['Malware']}
@@ -189,6 +199,7 @@ const ChannelKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -201,6 +212,7 @@ const ChannelKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={channel.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Incident']}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -31,6 +31,7 @@ const MalwareKnowledgeComponent = ({
     malwareKnowledgeFragment,
     malwareData,
   );
+  const location = useLocation();
   const link = `/dashboard/arsenal/malwares/${malware.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(malware.entity_type, schema);
@@ -69,6 +70,7 @@ const MalwareKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -82,6 +84,7 @@ const MalwareKnowledgeComponent = ({
           path="/related"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -106,6 +109,7 @@ const MalwareKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses']}
               isRelationReversed={true}
@@ -124,6 +128,7 @@ const MalwareKnowledgeComponent = ({
           path="/threat_actors"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses', 'authored-by']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -139,6 +144,7 @@ const MalwareKnowledgeComponent = ({
           path="/intrusion_sets"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses', 'authored-by']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -154,6 +160,7 @@ const MalwareKnowledgeComponent = ({
           path="/campaigns"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Campaign']}
@@ -168,6 +175,7 @@ const MalwareKnowledgeComponent = ({
           path="/variants"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['variant-of']}
               stixCoreObjectTypes={['Malware']}
@@ -203,6 +211,7 @@ const MalwareKnowledgeComponent = ({
           path="/tools"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses', 'downloads', 'drops']}
               stixCoreObjectTypes={['Tool']}
@@ -217,6 +226,7 @@ const MalwareKnowledgeComponent = ({
           path="/vulnerabilities"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['targets', 'exploits']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -231,6 +241,7 @@ const MalwareKnowledgeComponent = ({
           path="/incidents"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Incident']}
@@ -269,6 +280,7 @@ const MalwareKnowledgeComponent = ({
           path="/infrastructures"
           element={(
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={malware.id}
               relationshipTypes={[
                 'beacons-to',

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -27,6 +27,7 @@ const ToolKnowledgeComponent = ({
     ToolKnowledgeFragment,
     toolData,
   );
+  const location = useLocation();
   const link = `/dashboard/arsenal/tools/${tool.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(tool.entity_type, schema);
@@ -65,6 +66,7 @@ const ToolKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -78,6 +80,7 @@ const ToolKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -89,6 +92,7 @@ const ToolKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               isRelationReversed={true}
@@ -108,6 +112,7 @@ const ToolKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -120,6 +125,7 @@ const ToolKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -132,6 +138,7 @@ const ToolKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Campaign']}
@@ -144,6 +151,7 @@ const ToolKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -156,6 +164,7 @@ const ToolKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['delivers', 'drops', 'uses']}
               stixCoreObjectTypes={['Malware']}
@@ -168,6 +177,7 @@ const ToolKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses', 'has', 'targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -180,6 +190,7 @@ const ToolKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={tool.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Incident']}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -26,6 +26,7 @@ const VulnerabilityKnowledgeComponent = ({
     VulnerabilityKnowledgeFragment,
     vulnerabilityData,
   );
+  const location = useLocation();
   const link = `/dashboard/arsenal/vulnerabilities/${vulnerability.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(vulnerability.entity_type, schema);
@@ -63,6 +64,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -76,6 +78,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -96,6 +99,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -107,6 +111,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -119,6 +124,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -131,6 +137,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -143,6 +150,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -179,6 +187,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -191,6 +200,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets', 'exploits']}
               stixCoreObjectTypes={['Malware']}
@@ -203,6 +213,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['targets', 'has']}
               stixCoreObjectTypes={['Tool']}
@@ -215,6 +226,7 @@ const VulnerabilityKnowledgeComponent = ({
           path="/infrastructures"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={vulnerability.id}
               relationshipTypes={['has']}
               stixCoreObjectTypes={['Infrastructure']}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -507,7 +507,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
     openExports = false,
     handleReverseRelation = undefined,
   } = props;
-  const LOCAL_STORAGE_KEY = `${entityId}_stixCoreRelationshipCreationFromEntity`;
+  const LOCAL_STORAGE_KEY = `stixCoreRelationshipCreationFromEntity-${entityId}-${targetStixDomainObjectTypes?.join('-')}-${targetStixCyberObservableTypes?.join('-')}`;
 
   let isOnlySDOs = false;
   let isOnlySCOs = false;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -489,8 +489,6 @@ export interface TargetEntity {
   name?: string;
 }
 
-const getLocalStorageKey = (entityId: string) => `${entityId}_stixCoreRelationshipCreationFromEntity`;
-
 const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelationshipCreationFromEntityProps> = (props) => {
   const {
     targetEntities: targetEntitiesProps = [],
@@ -509,6 +507,8 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
     openExports = false,
     handleReverseRelation = undefined,
   } = props;
+  const LOCAL_STORAGE_KEY = `${entityId}_stixCoreRelationshipCreationFromEntity`;
+
   let isOnlySDOs = false;
   let isOnlySCOs = false;
   let actualTypeFilterValues = [
@@ -567,7 +567,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
   const containerRef = useRef(null);
 
   const { viewStorage, helpers } = usePaginationLocalStorage<StixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery$variables>(
-    getLocalStorageKey(entityId),
+    LOCAL_STORAGE_KEY,
     {},
     true,
   );
@@ -712,7 +712,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
 
   const {
     selectedElements,
-  } = useEntityToggle(getLocalStorageKey(entityId));
+  } = useEntityToggle(LOCAL_STORAGE_KEY);
 
   useEffect(() => {
     const newTargetEntities: TargetEntity[] = Object.values(selectedElements).map((item) => ({
@@ -800,7 +800,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                       rootRef={tableRootRef ?? undefined}
                       dataColumns={buildColumns(platformModuleHelpers)}
                       resolvePath={(data: StixCoreRelationshipCreationFromEntityStixCoreObjectsLines_data$data) => data.stixCoreObjects?.edges?.map((n) => n?.node)}
-                      storageKey={getLocalStorageKey(entityId)}
+                      storageKey={LOCAL_STORAGE_KEY}
                       lineFragment={stixCoreRelationshipCreationFromEntityStixCoreObjectsLineFragment}
                       initialValues={{}}
                       toolbarFilters={contextFilters}

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
 import useAuth from '../../../../utils/hooks/useAuth';
@@ -24,6 +24,7 @@ const EventKnowledgeComponent = ({
     eventKnowledgeFragment,
     eventData,
   );
+  const location = useLocation();
   const link = `/dashboard/entities/events/${event.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(event.entity_type, schema);
@@ -62,6 +63,7 @@ const EventKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -75,6 +77,7 @@ const EventKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -95,6 +98,7 @@ const EventKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -106,6 +110,7 @@ const EventKnowledgeComponent = ({
           path="/locations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['City', 'Country', 'Region']}
@@ -118,6 +123,7 @@ const EventKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -130,6 +136,7 @@ const EventKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -142,6 +149,7 @@ const EventKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -154,6 +162,7 @@ const EventKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -166,6 +175,7 @@ const EventKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -178,6 +188,7 @@ const EventKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -190,6 +201,7 @@ const EventKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -202,6 +214,7 @@ const EventKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={event.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -26,6 +26,7 @@ const IndividualKnowledgeComponent = ({
     individualKnowledgeFragment,
     individualData,
   );
+  const location = useLocation();
   const link = `/dashboard/entities/individuals/${individual.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(individual.entity_type, schema);
@@ -68,6 +69,7 @@ const IndividualKnowledgeComponent = ({
         path="/all"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={allRelationshipsTypes}
             entityLink={link}
@@ -81,6 +83,7 @@ const IndividualKnowledgeComponent = ({
         path="/threats"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             isRelationReversed
@@ -101,6 +104,7 @@ const IndividualKnowledgeComponent = ({
         path="/related"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['related-to']}
             entityLink={link}
@@ -112,6 +116,7 @@ const IndividualKnowledgeComponent = ({
         path="/organizations"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['part-of']}
             stixCoreObjectTypes={['Organization']}
@@ -124,6 +129,7 @@ const IndividualKnowledgeComponent = ({
         path="/locations"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['located-at']}
             stixCoreObjectTypes={['City', 'Country', 'Region']}
@@ -136,6 +142,7 @@ const IndividualKnowledgeComponent = ({
         path="/threat_actors"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Threat-Actor']}
@@ -148,6 +155,7 @@ const IndividualKnowledgeComponent = ({
         path="/intrusion_sets"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Intrusion-Set']}
@@ -160,6 +168,7 @@ const IndividualKnowledgeComponent = ({
         path="/campaigns"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Campaign']}
@@ -172,6 +181,7 @@ const IndividualKnowledgeComponent = ({
         path="/incidents"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Incident']}
@@ -184,6 +194,7 @@ const IndividualKnowledgeComponent = ({
         path="/malwares"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Malware']}
@@ -196,6 +207,7 @@ const IndividualKnowledgeComponent = ({
         path="/attack_patterns"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Attack-Pattern']}
@@ -208,6 +220,7 @@ const IndividualKnowledgeComponent = ({
         path="/tools"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Tool']}
@@ -220,6 +233,7 @@ const IndividualKnowledgeComponent = ({
         path="/observables"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={individual.id}
             relationshipTypes={['related-to']}
             stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -26,6 +26,7 @@ const OrganizationKnowledgeComponent = ({
     organizationKnowledgeFragment,
     organizationData,
   );
+  const location = useLocation();
   const link = `/dashboard/entities/organizations/${organization.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(organization.entity_type, schema);
@@ -68,6 +69,7 @@ const OrganizationKnowledgeComponent = ({
         path="/all"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={allRelationshipsTypes}
             entityLink={link}
@@ -81,6 +83,7 @@ const OrganizationKnowledgeComponent = ({
         path="/threats"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             isRelationReversed
@@ -101,6 +104,7 @@ const OrganizationKnowledgeComponent = ({
         path="/related"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['related-to']}
             entityLink={link}
@@ -112,6 +116,7 @@ const OrganizationKnowledgeComponent = ({
         path="/organizations"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['part-of', 'derived-from']}
             role="part-of_to"
@@ -125,6 +130,7 @@ const OrganizationKnowledgeComponent = ({
         path="/individuals"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['part-of']}
             stixCoreObjectTypes={['Individual']}
@@ -137,6 +143,7 @@ const OrganizationKnowledgeComponent = ({
         path="/locations"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['located-at']}
             stixCoreObjectTypes={['Location']}
@@ -149,6 +156,7 @@ const OrganizationKnowledgeComponent = ({
         path="/sectors"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['part-of']}
             stixCoreObjectTypes={['Sector']}
@@ -161,6 +169,7 @@ const OrganizationKnowledgeComponent = ({
         path="/used_tools"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['uses']}
             stixCoreObjectTypes={['Tool']}
@@ -173,6 +182,7 @@ const OrganizationKnowledgeComponent = ({
         path="/threat_actors"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets', 'employed-by']}
             stixCoreObjectTypes={['Threat-Actor']}
@@ -185,6 +195,7 @@ const OrganizationKnowledgeComponent = ({
         path="/intrusion_sets"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Intrusion-Set']}
@@ -197,6 +208,7 @@ const OrganizationKnowledgeComponent = ({
         path="/campaigns"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Campaign']}
@@ -209,6 +221,7 @@ const OrganizationKnowledgeComponent = ({
         path="/incidents"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Incident']}
@@ -221,6 +234,7 @@ const OrganizationKnowledgeComponent = ({
         path="/malwares"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Malware']}
@@ -233,6 +247,7 @@ const OrganizationKnowledgeComponent = ({
         path="/attack_patterns"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Attack-Pattern']}
@@ -245,6 +260,7 @@ const OrganizationKnowledgeComponent = ({
         path="/tools"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Tool']}
@@ -257,6 +273,7 @@ const OrganizationKnowledgeComponent = ({
         path="/vulnerabilities"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['related-to']}
             stixCoreObjectTypes={['Vulnerability']}
@@ -269,6 +286,7 @@ const OrganizationKnowledgeComponent = ({
         path="/observables"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={organization.id}
             relationshipTypes={['related-to']}
             stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -24,6 +24,7 @@ const SectorKnowledgeComponent = ({
     sectorKnowledgeFragment,
     sectorData,
   );
+  const location = useLocation();
   const link = `/dashboard/entities/sectors/${sector.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(sector.entity_type, schema);
@@ -61,6 +62,7 @@ const SectorKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -74,6 +76,7 @@ const SectorKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -94,6 +97,7 @@ const SectorKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -105,6 +109,7 @@ const SectorKnowledgeComponent = ({
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['part-of']}
               stixCoreObjectTypes={['Organization']}
@@ -117,6 +122,7 @@ const SectorKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -129,6 +135,7 @@ const SectorKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -141,6 +148,7 @@ const SectorKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -153,6 +161,7 @@ const SectorKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -165,6 +174,7 @@ const SectorKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -177,6 +187,7 @@ const SectorKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -189,6 +200,7 @@ const SectorKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -201,6 +213,7 @@ const SectorKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={sector.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -27,6 +27,7 @@ const SystemKnowledgeComponent = ({
     systemKnowledgeFragment,
     systemData,
   );
+  const location = useLocation();
   const link = `/dashboard/entities/systems/${system.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(system.entity_type, schema);
@@ -70,6 +71,7 @@ const SystemKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -83,6 +85,7 @@ const SystemKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -103,6 +106,7 @@ const SystemKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -114,6 +118,7 @@ const SystemKnowledgeComponent = ({
           path="/systems"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['part-of']}
               stixCoreObjectTypes={['System']}
@@ -126,6 +131,7 @@ const SystemKnowledgeComponent = ({
           path="/locations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['localization']}
               stixCoreObjectTypes={['City', 'Country', 'Region']}
@@ -138,6 +144,7 @@ const SystemKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               stixCoreObjectTypes={['Threat-Actor']}
               entityLink={link}
@@ -149,6 +156,7 @@ const SystemKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               stixCoreObjectTypes={['Intrusion-Set']}
               entityLink={link}
@@ -160,6 +168,7 @@ const SystemKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -172,6 +181,7 @@ const SystemKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -184,6 +194,7 @@ const SystemKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -196,6 +207,7 @@ const SystemKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -208,6 +220,7 @@ const SystemKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -220,6 +233,7 @@ const SystemKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}
@@ -244,6 +258,7 @@ const SystemKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={system.id}
               relationshipTypes={['has']}
               stixCoreObjectTypes={['Vulnerability']}

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectThreatKnowledge from '../../common/stix_domain_objects/StixDomainObjectThreatKnowledge';
@@ -35,6 +35,7 @@ const IncidentKnowledge = ({
     IncidentKnowledgeFragment,
     incidentData,
   );
+  const location = useLocation();
   const link = `/dashboard/events/incidents/${incident.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(incident.entity_type, schema);
@@ -74,6 +75,7 @@ const IncidentKnowledge = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -87,6 +89,7 @@ const IncidentKnowledge = ({
           path="/related"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -100,6 +103,7 @@ const IncidentKnowledge = ({
           path="/attribution"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={[
@@ -140,6 +144,7 @@ const IncidentKnowledge = ({
           path="/malwares"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Malware']}
@@ -154,6 +159,7 @@ const IncidentKnowledge = ({
           path="/narratives"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Narrative']}
@@ -168,6 +174,7 @@ const IncidentKnowledge = ({
           path="/channels"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Channel']}
@@ -182,6 +189,7 @@ const IncidentKnowledge = ({
           path="/tools"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Tool']}
@@ -196,6 +204,7 @@ const IncidentKnowledge = ({
           path="/vulnerabilities"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -210,6 +219,7 @@ const IncidentKnowledge = ({
           path="/observables"
           element={ (
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={incident.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';
@@ -31,6 +31,7 @@ const AdministrativeAreaKnowledge = ({
     administrativeAreaKnowledgeFragment,
     administrativeAreaData,
   );
+  const location = useLocation();
   const link = `/dashboard/locations/administrative_areas/${administrativeArea.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(administrativeArea.entity_type, schema);
@@ -68,6 +69,7 @@ const AdministrativeAreaKnowledge = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -81,6 +83,7 @@ const AdministrativeAreaKnowledge = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -101,6 +104,7 @@ const AdministrativeAreaKnowledge = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -128,6 +132,7 @@ const AdministrativeAreaKnowledge = ({
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Organization']}
@@ -140,6 +145,7 @@ const AdministrativeAreaKnowledge = ({
           path="/regions"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Region']}
@@ -152,6 +158,7 @@ const AdministrativeAreaKnowledge = ({
           path="/countries"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Country']}
@@ -164,6 +171,7 @@ const AdministrativeAreaKnowledge = ({
           path="/cities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['City']}
@@ -176,6 +184,7 @@ const AdministrativeAreaKnowledge = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -188,6 +197,7 @@ const AdministrativeAreaKnowledge = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets', 'originates-from']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -200,6 +210,7 @@ const AdministrativeAreaKnowledge = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -212,6 +223,7 @@ const AdministrativeAreaKnowledge = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -224,6 +236,7 @@ const AdministrativeAreaKnowledge = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -236,6 +249,7 @@ const AdministrativeAreaKnowledge = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -248,6 +262,7 @@ const AdministrativeAreaKnowledge = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -260,6 +275,7 @@ const AdministrativeAreaKnowledge = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={administrativeArea.id}
               relationshipTypes={['related-to', 'located-at']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';
@@ -27,6 +27,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
     cityKnowledgeFragment,
     cityData,
   );
+  const location = useLocation();
   const link = `/dashboard/locations/cities/${city.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(city.entity_type, schema);
@@ -64,6 +65,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -77,6 +79,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -97,6 +100,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -125,6 +129,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Organization']}
@@ -137,6 +142,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/areas"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Administrative-Area']}
@@ -149,6 +155,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/countries"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Country']}
@@ -162,6 +169,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/regions"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Region']}
@@ -175,6 +183,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -187,6 +196,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -199,6 +209,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -211,6 +222,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -223,6 +235,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -235,6 +248,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -247,6 +261,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -259,6 +274,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={city.id}
               relationshipTypes={['related-to', 'located-at']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';
@@ -31,6 +31,7 @@ const CountryKnowledgeComponent = ({
     countryKnowledgeFragment,
     countryData,
   );
+  const location = useLocation();
   const link = `/dashboard/locations/countries/${country.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(country.entity_type, schema);
@@ -68,6 +69,7 @@ const CountryKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -81,6 +83,7 @@ const CountryKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -101,6 +104,7 @@ const CountryKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -128,6 +132,7 @@ const CountryKnowledgeComponent = ({
           path="/regions"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Region']}
@@ -140,6 +145,7 @@ const CountryKnowledgeComponent = ({
           path="/areas"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Administrative-Area']}
@@ -152,6 +158,7 @@ const CountryKnowledgeComponent = ({
           path="/cities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['City']}
@@ -164,6 +171,7 @@ const CountryKnowledgeComponent = ({
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Organization']}
@@ -176,6 +184,7 @@ const CountryKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -188,6 +197,7 @@ const CountryKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets', 'originates-from']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -200,6 +210,7 @@ const CountryKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -212,6 +223,7 @@ const CountryKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -224,6 +236,7 @@ const CountryKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -236,6 +249,7 @@ const CountryKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -248,6 +262,7 @@ const CountryKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -260,6 +275,7 @@ const CountryKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={country.id}
               relationshipTypes={['related-to', 'located-at']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -25,6 +25,7 @@ const PositionKnowledgeComponent = ({
     positionKnowledgeFragment,
     positionData,
   );
+  const location = useLocation();
   const link = `/dashboard/locations/positions/${position.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(position.entity_type, schema);
@@ -62,6 +63,7 @@ const PositionKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -75,6 +77,7 @@ const PositionKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -95,6 +98,7 @@ const PositionKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -122,6 +126,7 @@ const PositionKnowledgeComponent = ({
           path="/regions"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Region']}
@@ -134,6 +139,7 @@ const PositionKnowledgeComponent = ({
           path="/countries"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Country']}
@@ -146,6 +152,7 @@ const PositionKnowledgeComponent = ({
           path="/areas"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Administrative-Area']}
@@ -158,6 +165,7 @@ const PositionKnowledgeComponent = ({
           path="/cities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['City']}
@@ -170,6 +178,7 @@ const PositionKnowledgeComponent = ({
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Organization']}
@@ -182,6 +191,7 @@ const PositionKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -194,6 +204,7 @@ const PositionKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -206,6 +217,7 @@ const PositionKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -218,6 +230,7 @@ const PositionKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -230,6 +243,7 @@ const PositionKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -242,6 +256,7 @@ const PositionKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -254,6 +269,7 @@ const PositionKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -266,6 +282,7 @@ const PositionKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={position.id}
               relationshipTypes={['related-to', 'located-at']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';
@@ -30,6 +30,7 @@ const RegionKnowledgeComponent = ({
     regionKnowledgeFragment,
     regionData,
   );
+  const location = useLocation();
   const link = `/dashboard/locations/regions/${region.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(region.entity_type, schema);
@@ -67,6 +68,7 @@ const RegionKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -80,6 +82,7 @@ const RegionKnowledgeComponent = ({
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               isRelationReversed
@@ -100,6 +103,7 @@ const RegionKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -127,6 +131,7 @@ const RegionKnowledgeComponent = ({
           path="/regions"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Region']}
@@ -139,6 +144,7 @@ const RegionKnowledgeComponent = ({
           path="/countries"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Country']}
@@ -151,6 +157,7 @@ const RegionKnowledgeComponent = ({
           path="/areas"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Administrative-Area']}
@@ -163,6 +170,7 @@ const RegionKnowledgeComponent = ({
           path="/cities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['City']}
@@ -175,6 +183,7 @@ const RegionKnowledgeComponent = ({
           path="/organizations"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['located-at']}
               stixCoreObjectTypes={['Organization']}
@@ -187,6 +196,7 @@ const RegionKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -199,6 +209,7 @@ const RegionKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -211,6 +222,7 @@ const RegionKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Campaign']}
@@ -223,6 +235,7 @@ const RegionKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Incident']}
@@ -235,6 +248,7 @@ const RegionKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Malware']}
@@ -247,6 +261,7 @@ const RegionKnowledgeComponent = ({
           path="/attack_patterns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Attack-Pattern']}
@@ -259,6 +274,7 @@ const RegionKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Tool']}
@@ -271,6 +287,7 @@ const RegionKnowledgeComponent = ({
           path="/observables"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={region.id}
               relationshipTypes={['related-to', 'located-at']}
               stixCoreObjectTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import StixCoreObjectKnowledgeBar from '@components/common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
@@ -34,6 +34,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
     infrastructureKnowledgeFragment,
     infrastructure,
   );
+  const location = useLocation();
   const link = `/dashboard/observations/infrastructures/${infrastructureData.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(infrastructureData.entity_type, schema);
@@ -91,6 +92,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -104,6 +106,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -133,6 +136,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/infrastructures"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={[
                 'communicates-with',
@@ -175,6 +179,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/observed_data"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Observed-Data']}
               relationshipTypes={['consists-of']}
@@ -189,6 +194,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/threats"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={['compromises', 'uses']}
               entityLink={link}
@@ -208,6 +214,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Threat-Actor']}
               relationshipTypes={['compromises', 'uses']}
@@ -222,6 +229,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Intrusion-Set']}
               relationshipTypes={['compromises', 'uses']}
@@ -236,6 +244,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Campaign']}
               relationshipTypes={['compromises', 'uses']}
@@ -250,6 +259,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Malware']}
               relationshipTypes={['controls', 'delivers', 'hosts', 'uses']}
@@ -264,6 +274,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               stixCoreObjectTypes={['Tool']}
               relationshipTypes={['hosts', 'uses']}
@@ -278,6 +289,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={['has']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -313,6 +325,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={infrastructureData.id}
               relationshipTypes={['uses', 'compromises']}
               stixCoreObjectTypes={['Incident']}

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -28,6 +28,7 @@ const AttackPatternKnowledgeComponent = ({
     AttackPatternKnowledgeFragment,
     attackPatternData,
   );
+  const location = useLocation();
   const link = `/dashboard/techniques/attack_patterns/${attackPattern.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(attackPattern.entity_type, schema);
@@ -59,6 +60,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -72,6 +74,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -108,6 +111,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -120,6 +124,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -132,6 +137,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Campaign']}
@@ -145,6 +151,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Incident']}
@@ -181,6 +188,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Malware']}
@@ -193,6 +201,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Tool']}
@@ -205,6 +214,7 @@ const AttackPatternKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={attackPattern.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -26,6 +26,7 @@ const NarrativeKnowledgeComponent = ({
     NarrativeKnowledgeFragment,
     narrativeData,
   );
+  const location = useLocation();
   const link = `/dashboard/techniques/narratives/${narrative.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(narrative.entity_type, schema);
@@ -63,6 +64,7 @@ const NarrativeKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={allRelationshipsTypes}
               defaultStartTime={narrative.startTime}
@@ -76,6 +78,7 @@ const NarrativeKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -103,6 +106,7 @@ const NarrativeKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -115,6 +119,7 @@ const NarrativeKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -127,6 +132,7 @@ const NarrativeKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Campaign']}
@@ -139,6 +145,7 @@ const NarrativeKnowledgeComponent = ({
           path="/channels"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Channel']}
@@ -151,6 +158,7 @@ const NarrativeKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={narrative.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Incident']}

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -31,6 +31,7 @@ const CampaignKnowledgeComponent = ({
     CampaignKnowledgeFragment,
     campaignData,
   );
+  const location = useLocation();
   const link = `/dashboard/threats/campaigns/${campaign.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(campaign.entity_type, schema);
@@ -69,6 +70,7 @@ const CampaignKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -82,6 +84,7 @@ const CampaignKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['related-to']}
               stixCoreObjectTypes={[
@@ -111,6 +114,7 @@ const CampaignKnowledgeComponent = ({
           path="/attribution"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['attributed-to', 'participates-in']}
               stixCoreObjectTypes={['Threat-Actor', 'Intrusion-Set']}
@@ -146,6 +150,7 @@ const CampaignKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Malware']}
@@ -160,6 +165,7 @@ const CampaignKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Tool']}
@@ -174,6 +180,7 @@ const CampaignKnowledgeComponent = ({
           path="/channels"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Channel']}
@@ -188,6 +195,7 @@ const CampaignKnowledgeComponent = ({
           path="/narratives"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Narrative']}
@@ -202,6 +210,7 @@ const CampaignKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -216,6 +225,7 @@ const CampaignKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Incident']}
@@ -254,6 +264,7 @@ const CampaignKnowledgeComponent = ({
           path="/infrastructures"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={campaign.id}
               relationshipTypes={['uses', 'compromises']}
               stixCoreObjectTypes={['Infrastructure']}

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
@@ -31,6 +31,7 @@ const IntrusionSetKnowledgeComponent = ({
     IntrusionSetKnowledgeFragment,
     intrusionSetData,
   );
+  const location = useLocation();
   const link = `/dashboard/threats/intrusion_sets/${intrusionSet.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(intrusionSet.entity_type, schema);
@@ -70,6 +71,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -83,6 +85,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['related-to']}
               entityLink={link}
@@ -96,6 +99,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/attribution"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -121,6 +125,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Campaign']}
@@ -145,6 +150,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['uses', 'authored-by']}
               stixCoreObjectTypes={['Malware']}
@@ -160,6 +166,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Tool']}
@@ -174,6 +181,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/channels"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Channel']}
@@ -188,6 +196,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/narratives"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Narrative']}
@@ -202,6 +211,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -216,6 +226,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Incident']}
@@ -254,6 +265,7 @@ const IntrusionSetKnowledgeComponent = ({
           path="/infrastructures"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={intrusionSet.id}
               relationshipTypes={['uses', 'compromises']}
               stixCoreObjectTypes={['Infrastructure']}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
@@ -32,6 +32,7 @@ const ThreatActorGroupKnowledgeComponent = ({
     threatActorGroupKnowledgeFragment,
     threatActorGroupData,
   );
+  const location = useLocation();
   const link = `/dashboard/threats/threat_actors_group/${threatActorGroup.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(threatActorGroup.entity_type, schema);
@@ -70,6 +71,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/all"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={allRelationshipsTypes}
               entityLink={link}
@@ -83,6 +85,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/related"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={relatedRelationshipTypes}
               entityLink={link}
@@ -107,6 +110,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/threat_actors"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['part-of', 'cooperates-with', 'employed-by', 'derived-from']}
               stixCoreObjectTypes={['Threat-Actor']}
@@ -121,6 +125,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/intrusion_sets"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Intrusion-Set']}
@@ -135,6 +140,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/campaigns"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['attributed-to', 'participates-in']}
               stixCoreObjectTypes={['Campaign']}
@@ -159,6 +165,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/malwares"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['uses', 'authored-by']}
               stixCoreObjectTypes={['Malware']}
@@ -173,6 +180,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/channels"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Channel']}
@@ -186,6 +194,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/narratives"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Narrative']}
@@ -199,6 +208,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/tools"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['uses']}
               stixCoreObjectTypes={['Tool']}
@@ -212,6 +222,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/vulnerabilities"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['targets']}
               stixCoreObjectTypes={['Vulnerability']}
@@ -225,6 +236,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/incidents"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['attributed-to']}
               stixCoreObjectTypes={['Incident']}
@@ -263,6 +275,7 @@ const ThreatActorGroupKnowledgeComponent = ({
           path="/infrastructures"
           element={
             <EntityStixCoreRelationships
+              key={location.pathname}
               entityId={threatActorGroup.id}
               relationshipTypes={['uses', 'compromises']}
               stixCoreObjectTypes={['Infrastructure']}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -40,6 +40,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
     threatActorIndividualKnowledgeFragment,
     threatActorIndividualData,
   );
+  const location = useLocation();
   const link = `/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(threatActorIndividual.entity_type, schema);
@@ -77,6 +78,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/all"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={allRelationshipsTypes}
             entityLink={link}
@@ -90,6 +92,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/related"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={relatedRelationshipTypes}
             entityLink={link}
@@ -114,6 +117,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/threat_actors"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={[
               'part-of',
@@ -135,6 +139,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/intrusion_sets"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['attributed-to']}
             stixCoreObjectTypes={['Intrusion-Set']}
@@ -149,6 +154,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/campaigns"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['attributed-to', 'participates-in']}
             stixCoreObjectTypes={['Campaign']}
@@ -173,6 +179,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/malwares"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['uses', 'authored-by']}
             stixCoreObjectTypes={['Malware']}
@@ -187,6 +194,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/channels"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['uses']}
             stixCoreObjectTypes={['Channel']}
@@ -200,6 +208,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/narratives"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['uses']}
             stixCoreObjectTypes={['Narrative']}
@@ -213,6 +222,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/tools"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['uses']}
             stixCoreObjectTypes={['Tool']}
@@ -226,6 +236,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/vulnerabilities"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['targets']}
             stixCoreObjectTypes={['Vulnerability']}
@@ -239,6 +250,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/countries"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['resides-in', 'citizen-of', 'national-of']}
             stixCoreObjectTypes={['Country']}
@@ -252,6 +264,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/organizations"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['employed-by', 'impersonates']}
             stixCoreObjectTypes={['Organization']}
@@ -265,6 +278,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/incidents"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['attributed-to']}
             stixCoreObjectTypes={['Incident']}
@@ -303,6 +317,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         path="/infrastructures"
         element={
           <EntityStixCoreRelationships
+            key={location.pathname}
             entityId={threatActorIndividual.id}
             relationshipTypes={['uses', 'compromises']}
             stixCoreObjectTypes={['Infrastructure']}


### PR DESCRIPTION
### Proposed changes
Avoid filters repercussion in several screens:
- Filters in knowledge screens of an entity (the different entity types tabs in Knowledge)
- Local storage keys should be independant in the different screens of the Knowledge tab of an entity 

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8511
