### PR TITLE
[frontend] fix display of danger zone in roles (#8284)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
@@ -33,7 +33,7 @@ const CapabilitiesList: FunctionComponent<CapabilitiesListProps> = ({
 
   return (
     <List>
-      {(isSensitive && role.can_manage_sensitive_config !== false) && (
+      {(isSensitive && role.can_manage_sensitive_config) && (
         <ListItem
           key="sensitive"
           dense={true}

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -162,7 +162,7 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
             <ListItemSecondaryAction>
               <Checkbox
                 onChange={(event) => handleSensitiveToggle(event)}
-                checked={role.can_manage_sensitive_config !== false} // beware: undefined value means access is granted
+                checked={!!role.can_manage_sensitive_config}
                 style={{ color: theme.palette.dangerZone.main }}
                 disabled={false}
               />


### PR DESCRIPTION
Display not aligned with behavior

linked to #8284 