### PR TITLE
[frontend] fix missing base path in publicdashboard link

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceShareList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceShareList.tsx
@@ -10,10 +10,10 @@ import { ContentCopy, Delete, DoNotDisturbAlt, Done, ReportGmailerrorred } from 
 import { useTheme } from '@mui/styles';
 import { useFormatter } from '../../../components/i18n';
 import type { Theme } from '../../../components/Theme';
-import { copyToClipboard } from '../../../utils/utils';
 import ItemMarkings from '../../../components/ItemMarkings';
 import ItemBoolean from '../../../components/ItemBoolean';
 import useAuth from '../../../utils/hooks/useAuth';
+import { copyPublicLinkUrl } from '../../../utils/dashboard';
 
 export const workspaceShareListQuery = graphql`
   query WorkspaceShareListQuery($filters: FilterGroup) {
@@ -56,13 +56,6 @@ const WorkspaceShareList = ({ queryRef, onDelete, onToggleEnabled }: WorkspaceSh
   const dashboards = publicDashboards?.edges
     .map((edge) => edge.node)
     .sort((a, b) => a.created_at.localeCompare(b.created_at));
-
-  const copyLinkUrl = (uriKey: string) => {
-    copyToClipboard(
-      t_i18n,
-      `${window.location.origin}/public/dashboard/${uriKey.toLowerCase()}`,
-    );
-  };
 
   if (!dashboards || dashboards.length === 0) {
     return <p>{t_i18n('No public dashboard created yet')}</p>;
@@ -114,7 +107,7 @@ const WorkspaceShareList = ({ queryRef, onDelete, onToggleEnabled }: WorkspaceSh
                       aria-label="Label"
                       size="small"
                       value="copy-link"
-                      onClick={() => copyLinkUrl(dashboard.uri_key)}
+                      onClick={() => copyPublicLinkUrl(t_i18n, dashboard.uri_key)}
                     >
                       <ContentCopy fontSize="small" color="primary" />
                     </ToggleButton>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import { PublicDashboardsListQuery$variables } from '@components/workspaces/dashboards/public_dashboards/__generated__/PublicDashboardsListQuery.graphql';
 import { useFormatter } from '../../../../../components/i18n';
-import { copyToClipboard } from '../../../../../utils/utils';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 import useDeletion from '../../../../../utils/hooks/useDeletion';
 import DeleteDialog from '../../../../../components/DeleteDialog';
@@ -14,6 +13,7 @@ import { EXPLORE_EXUPDATE_PUBLISH } from '../../../../../utils/hooks/useGranted'
 import Security from '../../../../../utils/Security';
 import { useGetCurrentUserAccessRight } from '../../../../../utils/authorizedMembers';
 import { deleteNode } from '../../../../../utils/store';
+import { copyPublicLinkUrl } from '../../../../../utils/dashboard';
 
 interface PublicDashboardLineActionsProps {
   publicDashboard: PublicDashboards_PublicDashboard$data
@@ -47,10 +47,7 @@ const PublicDashboardLineActions = ({ publicDashboard, paginationOptions }: Publ
   const { canManage } = useGetCurrentUserAccessRight(publicDashboard.dashboard.currentUserAccessRight);
 
   const copyLinkUrl = () => {
-    copyToClipboard(
-      t_i18n,
-      `${window.location.origin}/public/dashboard/${publicDashboard.uri_key.toLowerCase()}`,
-    );
+    copyPublicLinkUrl(t_i18n, publicDashboard.uri_key);
     setAnchor(undefined);
   };
 

--- a/opencti-platform/opencti-front/src/utils/dashboard.ts
+++ b/opencti-platform/opencti-front/src/utils/dashboard.ts
@@ -1,4 +1,6 @@
 import { FilterGroup } from './filters/filtersHelpers-types';
+import { copyToClipboard } from './utils';
+import { APP_BASE_PATH } from '../relay/environment';
 
 export interface DashboardWidgetDataSelection {
   label?: string
@@ -19,3 +21,10 @@ export interface DashboardWidgetParameters {
   legend?: boolean
   distributed?: boolean
 }
+
+export const copyPublicLinkUrl = (t: (text: string) => string, uriKey: string) => {
+  copyToClipboard(
+    t,
+    `${window.location.origin}${APP_BASE_PATH}/public/dashboard/${uriKey.toLowerCase()}`,
+  );
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add `BASE_PATH` in publicdashboard link

To test:
* add  `base_path` in your `development.json` :  `"app": {
    "base_path": "something",
`
* run `yarn build` In your frontend and then in your backend
* start your backend
* open your localhost => you should see the base path in the url


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/7973
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
