### PR TITLE
[frontend] Restrict entity type filter values in Relationship creation list (#9073)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -793,6 +793,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                       toolbarFilters={contextFilters}
                       preloadedPaginationProps={preloadedPaginationProps}
                       entityTypes={virtualEntityTypes}
+                      availableEntityTypes={virtualEntityTypes}
                       additionalHeaderButtons={[(
                         <BulkRelationDialogContainer
                           targetObjectTypes={[...targetStixDomainObjectTypes, ...targetStixCyberObservableTypes]}


### PR DESCRIPTION
### Proposed changes
In relationship creation list (of Knowledge tab of an entity),
- the entity type filter should be available only if there is more than one entity type targeted
- and the possible values for the entity type filter should only be the possible type for the screen

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9073