### PR TITLE
[frontend] use context to prefill the dynamic entity mapping column

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+
+interface CsvMapperContextProps {
+  dynamicMappingColumn: string | null;
+  setDynamicMappingColumn: (index: string) => void;
+}
+
+interface CsvMapperProviderProps {
+  children: ReactNode;
+}
+
+const CsvMapperContext = createContext<CsvMapperContextProps | undefined>(undefined);
+export const CsvMapperProvider: React.FC<CsvMapperProviderProps> = ({ children }) => {
+  const [dynamicMappingColumn, setDynamicMappingColumn] = useState<string>('');
+  return (
+    <CsvMapperContext.Provider value={{ dynamicMappingColumn, setDynamicMappingColumn }}>
+      {children}
+    </CsvMapperContext.Provider>
+  );
+};
+export const useCsvMapperContext = () => {
+  const context = useContext(CsvMapperContext);
+  if (!context) {
+    throw new Error('useCsvMapperContext must be used within a CsvMapperProvider');
+  }
+  return context;
+};

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperContext.tsx
@@ -11,7 +11,7 @@ interface CsvMapperProviderProps {
 
 const CsvMapperContext = createContext<CsvMapperContextProps | undefined>(undefined);
 export const CsvMapperProvider: React.FC<CsvMapperProviderProps> = ({ children }) => {
-  const [dynamicMappingColumn, setDynamicMappingColumn] = useState<string>('');
+  const [dynamicMappingColumn, setDynamicMappingColumn] = useState<string | null>(null);
   return (
     <CsvMapperContext.Provider value={{ dynamicMappingColumn, setDynamicMappingColumn }}>
       {children}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -14,6 +14,7 @@ import { CsvMapperFormData } from '@components/data/csvMapper/CsvMapper';
 import classNames from 'classnames';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { formDataToCsvMapper } from '@components/data/csvMapper/CsvMapperUtils';
+import { CsvMapperProvider } from '@components/data/csvMapper/CsvMapperContext';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -160,7 +161,7 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
     setHasError(Object.values(errors).filter((v) => v).length > 0);
   };
   return (
-    <>
+    <CsvMapperProvider>
       <Formik<CsvMapperFormData>
         enableReinitialize
         initialValues={csvMapper}
@@ -351,7 +352,7 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
           );
         }}
       </Formik>
-    </>
+    </CsvMapperProvider>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
@@ -30,7 +30,7 @@ CsvMapperConditionalEntityMappingProps
 
   const handleColumnSelect = async (column: string | null) => {
     await setFieldValue(`${representationName}.column_based.column_reference`, column);
-    if (!dynamicMappingColumn && column) {
+    if (column) {
       setDynamicMappingColumn(column);
     }
   };
@@ -88,9 +88,10 @@ CsvMapperConditionalEntityMappingProps
         autoHighlight
         options={columnOptions}
         disabled={!columnBased?.enabled}
-        value={columnBased?.enabled
-          ? columnBased?.column_reference
-          : null
+        value={
+          columnBased?.enabled
+            ? columnBased?.column_reference
+            : null
           }
         onChange={(_, val) => handleColumnSelect(val)}
         sx={{ width: '100%' }}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
@@ -62,8 +62,7 @@ CsvMapperConditionalEntityMappingProps
       display: 'grid',
       gridTemplateColumns: '1.3fr 1fr 1fr 1fr',
       alignItems: 'center',
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(3),
+      marginTop: `${theme.spacing(3)} 0 `,
       gap: theme.spacing(1),
     }}
     >

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
@@ -50,7 +50,6 @@ CsvMapperConditionalEntityMappingProps
     if (val === 'false') {
       await setFieldValue(`${representationName}.column_based.column_reference`, null);
       await setFieldValue(`${representationName}.column_based.operator`, null);
-      await setFieldValue(`${representationName}.column_based.value`, null);
     } else {
       await setFieldValue(`${representationName}.column_based.column_reference`, dynamicMappingColumn ?? null);
       await setFieldValue(`${representationName}.column_based.operator`, 'eq');
@@ -156,6 +155,7 @@ CsvMapperConditionalEntityMappingProps
           component={TextField}
           label={t_i18n('Value')}
           name={`${representationName}.column_based.value`}
+          value={columnBased?.enabled ? columnBased.value : ''}
           variant='standard'
           style={{ width: '100%' }}
           disabled={!representation.column_based?.enabled}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import MuiTextField from '@mui/material/TextField';
 import MUIAutocomplete from '@mui/material/Autocomplete';
 import { Field, FieldProps } from 'formik';
@@ -6,6 +6,7 @@ import { CsvMapperColumnBasedFormData, CsvMapperRepresentationFormData } from '@
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import { alphabet } from '@components/data/csvMapper/representations/attributes/AttributeUtils';
+import { useCsvMapperContext } from '@components/data/csvMapper/CsvMapperContext';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
 import SwitchField from '../../../../../components/fields/SwitchField';
@@ -21,14 +22,27 @@ CsvMapperConditionalEntityMappingProps
   const { t_i18n } = useFormatter();
   const columnOptions = alphabet(26);
   const operatorOptions = [
-    { label: t_i18n('Equal'), value: ('eq') },
+    { label: t_i18n('Equal'), value: 'eq' },
     { label: t_i18n('Not equal'), value: 'not_eq' }];
   const { setFieldValue } = form;
   const columnBased = representation.column_based;
+  const { dynamicMappingColumn, setDynamicMappingColumn } = useCsvMapperContext();
 
   const handleColumnSelect = async (column: string | null) => {
     await setFieldValue(`${representationName}.column_based.column_reference`, column);
+    if (!dynamicMappingColumn && column) {
+      setDynamicMappingColumn(column);
+    }
   };
+
+  useEffect(() => {
+    if (!columnBased?.column_reference && dynamicMappingColumn) {
+      handleColumnSelect(dynamicMappingColumn);
+    }
+    if (!columnBased?.operator && columnBased?.enabled) {
+      setFieldValue(`${representationName}.column_based.operator`, 'eq');
+    }
+  }, [columnBased?.operator, columnBased?.column_reference]);
 
   const handleOperatorSelect = async (operator: { label: string, value: string } | null) => {
     await setFieldValue(`${representationName}.column_based.operator`, operator?.value);
@@ -74,10 +88,9 @@ CsvMapperConditionalEntityMappingProps
         autoHighlight
         options={columnOptions}
         disabled={!columnBased?.enabled}
-        value={
-          columnBased?.enabled
-            ? columnBased?.column_reference
-            : null
+        value={columnBased?.enabled
+          ? columnBased?.column_reference
+          : null
           }
         onChange={(_, val) => handleColumnSelect(val)}
         sx={{ width: '100%' }}
@@ -109,11 +122,10 @@ CsvMapperConditionalEntityMappingProps
         disabled={!columnBased?.enabled}
         value={
           columnBased?.enabled
-            ? (operatorOptions.find((opt) => (opt.value === columnBased?.operator)) ?? undefined)
+            ? operatorOptions.find((opt) => opt.value === (columnBased?.operator || 'eq'))
             : null
           }
         onChange={(_, val) => handleOperatorSelect(val)}
-        defaultValue={operatorOptions.find((opt) => opt.value === 'eq')}
         sx={{ width: '100%' }}
         renderInput={(params) => (
           <MuiTextField
@@ -121,16 +133,6 @@ CsvMapperConditionalEntityMappingProps
             label={t_i18n('Operator')}
             variant="outlined"
             size="small"
-            InputProps={{
-              ...params.InputProps,
-              sx: {
-                '& fieldset': {
-                  borderColor: (!columnBased?.operator)
-                    ? 'rgb(244, 67, 54)'
-                    : '',
-                },
-              },
-            }}
           />
         )}
       />

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx
@@ -36,13 +36,13 @@ CsvMapperConditionalEntityMappingProps
   };
 
   useEffect(() => {
-    if (!columnBased?.column_reference && dynamicMappingColumn) {
+    if (!columnBased?.column_reference && dynamicMappingColumn && columnBased?.enabled) {
       handleColumnSelect(dynamicMappingColumn);
     }
     if (!columnBased?.operator && columnBased?.enabled) {
       setFieldValue(`${representationName}.column_based.operator`, 'eq');
     }
-  }, [columnBased?.operator, columnBased?.column_reference]);
+  }, [dynamicMappingColumn, columnBased?.enabled]);
 
   const handleOperatorSelect = async (operator: { label: string, value: string } | null) => {
     await setFieldValue(`${representationName}.column_based.operator`, operator?.value);
@@ -90,7 +90,7 @@ CsvMapperConditionalEntityMappingProps
         disabled={!columnBased?.enabled}
         value={
           columnBased?.enabled
-            ? columnBased?.column_reference
+            ? columnBased.column_reference
             : null
           }
         onChange={(_, val) => handleColumnSelect(val)}
@@ -117,13 +117,14 @@ CsvMapperConditionalEntityMappingProps
       <MUIAutocomplete<{ label: string, value: string }>
         selectOnFocus
         openOnFocus
+        autoComplete
         autoSelect={false}
         autoHighlight
         options={operatorOptions}
         disabled={!columnBased?.enabled}
         value={
           columnBased?.enabled
-            ? operatorOptions.find((opt) => opt.value === (columnBased?.operator || 'eq'))
+            ? operatorOptions.find((opt) => opt.value === (columnBased?.operator))
             : null
           }
         onChange={(_, val) => handleOperatorSelect(val)}
@@ -134,6 +135,16 @@ CsvMapperConditionalEntityMappingProps
             label={t_i18n('Operator')}
             variant="outlined"
             size="small"
+            InputProps={{
+              ...params.InputProps,
+              sx: {
+                '& fieldset': {
+                  borderColor: (!columnBased?.operator)
+                    ? 'rgb(244, 67, 54)'
+                    : '',
+                },
+              },
+            }}
           />
         )}
       />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add CsvMapperContext to pass the dynamicMappingColumn to the others representation
* add onToggleDynamicMapping to set  the dynamicMappingColumn
* add useState to modify the value of the dynamicMappingColumn

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* 7400

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
