### PR TITLE
[frontend] fix the green dot after setting a default value for an attribute ref

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeRefForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeRefForm.tsx
@@ -232,7 +232,7 @@ CsvMapperRepresentationAttributeRefFormProps
       </div>
       <div>
         {schemaAttribute.editDefault && (
-          <CsvMapperRepresentationDialogOption>
+          <CsvMapperRepresentationDialogOption configuration={value}>
             <CsvMapperRepresentationAttributeOptions
               schemaAttribute={schemaAttribute}
               attributeName={name}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add configuration={value} missing when the component is called

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7400 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
When we set a default value, we see a green dot appear! However, it doesn't work for the ref attribute (in this case, the author).:
![image](https://github.com/user-attachments/assets/2d01e308-5f57-47a0-a5a2-1932b2a0d4b3)

