### PR TITLE
[frontend] fix refresh delay after adding relationships (#7830)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -457,7 +457,7 @@ interface StixCoreRelationshipCreationFromEntityProps {
   targetStixCyberObservableTypes?: string[];
   defaultStartTime: string;
   defaultStopTime: string;
-  paginationOptions: Record<string, any>;
+  paginationOptions: Record<string, unknown>;
   connectionKey?: string;
   paddingRight: number;
   variant?: string;
@@ -626,7 +626,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
             // we need to filter them to prevent getConnection to fail
             const { count: _, ...options } = paginationOptions;
 
-            if (userProxy && options) {
+            if (userProxy) {
               conn = ConnectionHandler.getConnection(
                 userProxy,
                 connKey,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -449,10 +449,6 @@ const stixCoreRelationshipCreationFromEntityToMutation = graphql`
   }
 `;
 
-type ExtendedPaginationOptions = PaginationOptions & {
-  [key: string]: string | number;
-};
-
 interface StixCoreRelationshipCreationFromEntityProps {
   entityId: string;
   allowedRelationshipTypes?: string[];
@@ -461,7 +457,7 @@ interface StixCoreRelationshipCreationFromEntityProps {
   targetStixCyberObservableTypes?: string[];
   defaultStartTime: string;
   defaultStopTime: string;
-  paginationOptions: ExtendedPaginationOptions;
+  paginationOptions: Record<string, any>;
   connectionKey?: string;
   paddingRight: number;
   variant?: string;
@@ -630,7 +626,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
             // we need to filter them to prevent getConnection to fail
             const { count: _, ...options } = paginationOptions;
 
-            if (userProxy && paginationOptions) {
+            if (userProxy && options) {
               conn = ConnectionHandler.getConnection(
                 userProxy,
                 connKey,
@@ -644,6 +640,8 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
             ) {
               const newEdge = payload.setLinkedRecord(createdNode, 'node');
               ConnectionHandler.insertEdgeBefore(conn, newEdge);
+
+              helpers.handleSetNumberOfElements({ });
             }
           }
         },

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -621,13 +621,16 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
               ? payload.getLinkedRecord(isRelationReversed ? 'from' : 'to')
               : payload;
             const connKey = connectionKey || 'Pagination_stixCoreRelationships';
-            // When using connectionKey we use less props of PaginationOptions, we need to filter them
             let conn;
+            // When using connectionKey we use less props of PaginationOptions (ex: count),
+            // we need to filter them to prevent getConnection to fail
+            const { count: _, ...options } = paginationOptions;
+
             if (userProxy && paginationOptions) {
               conn = ConnectionHandler.getConnection(
                 userProxy,
                 connKey,
-                paginationOptions,
+                options,
               );
             }
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -449,6 +449,10 @@ const stixCoreRelationshipCreationFromEntityToMutation = graphql`
   }
 `;
 
+type ExtendedPaginationOptions = PaginationOptions & {
+  [key: string]: string | number;
+};
+
 interface StixCoreRelationshipCreationFromEntityProps {
   entityId: string;
   allowedRelationshipTypes?: string[];
@@ -457,7 +461,7 @@ interface StixCoreRelationshipCreationFromEntityProps {
   targetStixCyberObservableTypes?: string[];
   defaultStartTime: string;
   defaultStopTime: string;
-  paginationOptions: unknown;
+  paginationOptions: ExtendedPaginationOptions;
   connectionKey?: string;
   paddingRight: number;
   variant?: string;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
@@ -144,7 +144,7 @@ const EntityStixCoreRelationshipsRelationshipsView: FunctionComponent<EntityStix
     orderBy: (sortBy && (sortBy in dataColumns) && dataColumns[sortBy].isSortable) ? sortBy : 'relationship_type',
     orderMode: orderAsc ? 'asc' : 'desc',
     filters: contextFilters,
-  } as object;
+  };
 
   const {
     selectedElements,

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntitiesLines.jsx
@@ -24,9 +24,21 @@ class IndicatorEntitiesLines extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    // Compute the new count based on the current data
+    const globalCount = (this.props.data.stixCoreRelationships?.edges || []).length;
+
+    const updatedProps = {
+      data: {
+        stixCoreRelationships: {
+          pageInfo: {
+            globalCount,
+          },
+        },
+      },
+    };
     setNumberOfElements(
       prevProps,
-      this.props,
+      updatedProps,
       'stixCoreRelationships',
       this.props.setNumberOfElements.bind(this),
     );


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix refresh delay after adding relationships in Observations / indicators / Knowledge
* also fix table counter refresh

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close  https://github.com/OpenCTI-Platform/opencti/issues/7830

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

* It was a **relay** issue, we have to mind what we send in query filters, especially with **count** and **cursor**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
