### PR TITLE
[frontend] Add support for dynamic configurable required fields to Techniques

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
@@ -67,6 +67,7 @@ class KillChainPhasesField extends Component {
         required={required}
         multiple={true}
         disabled={disabled}
+        required={required}
         textfieldprops={{
           variant: 'standard',
           label: t('Kill chain phases'),

--- a/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/KillChainPhasesField.jsx
@@ -67,7 +67,6 @@ class KillChainPhasesField extends Component {
         required={required}
         multiple={true}
         disabled={disabled}
-        required={required}
         textfieldprops={{
           variant: 'standard',
           label: t('Kill chain phases'),

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
@@ -22,7 +22,7 @@ import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import type { Theme } from '../../../../components/Theme';
 import { Option } from '../../common/form/ReferenceField';
@@ -119,15 +119,14 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ATTACK_PATTERN_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     x_mitre_id: Yup.string().nullable(),
-  };
-  const attackPatternValidator = useSchemaCreationValidation(
-    ATTACK_PATTERN_TYPE,
-    basicShape,
-  );
+  }, mandatoryAttributes);
+
+  const attackPatternValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<AttackPatternCreationMutation>(
     attackPatternMutation,
@@ -137,11 +136,7 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
 
   const onSubmit: FormikConfig<AttackPatternAddInput>['onSubmit'] = (
     values,
-    {
-      setSubmitting,
-      setErrors,
-      resetForm,
-    },
+    { setSubmitting, setErrors, resetForm },
   ) => {
     const input: AttackPatternCreationMutation$variables['input'] = {
       name: values.name,
@@ -196,6 +191,8 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
     <Formik<AttackPatternAddInput>
       initialValues={initialValues}
       validationSchema={attackPatternValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -205,6 +202,7 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Attack-Pattern']}
           />
@@ -212,6 +210,7 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
             component={TextField}
             name="x_mitre_id"
             label={t_i18n('External ID')}
+            required={(mandatoryAttributes.includes('x_mitre_id'))}
             fullWidth={true}
             style={fieldSpacingContainerStyle}
           />
@@ -219,6 +218,7 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -230,26 +230,31 @@ export const AttackPatternCreationForm: FunctionComponent<AttackPatternFormProps
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}
@@ -308,7 +313,7 @@ const AttackPatternCreation = ({
   );
   const CreateAttackPatternControlledDialContextual = CreateAttackPatternControlledDial({
     onOpen: handleOpen,
-    onClose: () => {},
+    onClose: () => { },
   });
   const renderClassic = () => (
     <Drawer

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -16,7 +16,7 @@ import StatusField from '../../common/form/StatusField';
 import { convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatus } from '../../../../utils/edition';
 import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -85,24 +85,24 @@ export const attackPatternMutationRelationDelete = graphql`
   }
 `;
 
+const ATTACK_PATTERN_TYPE = 'Attack-Pattern';
+
 const AttackPatternEditionOverviewComponent = (props) => {
   const { attackPattern, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ATTACK_PATTERN_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     x_mitre_id: Yup.string().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
     confidence: Yup.number().nullable(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const attackPatternValidator = useSchemaEditionValidation(
-    'Attack-Pattern',
-    basicShape,
-  );
+  }, mandatoryAttributes);
+  const attackPatternValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: attackPatternMutationFieldPatch,
@@ -188,6 +188,8 @@ const AttackPatternEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={{ ...initialValues, references: [] }}
       validationSchema={attackPatternValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -204,6 +206,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -215,6 +218,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
             component={TextField}
             name="x_mitre_id"
             label={t_i18n('External ID')}
+            required={(mandatoryAttributes.includes('x_mitre_id'))}
             fullWidth={true}
             style={{ marginTop: 20 }}
             onFocus={editor.changeFocus}
@@ -227,6 +231,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -248,6 +253,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
           <KillChainPhasesField
             name="killChainPhases"
             style={fieldSpacingContainerStyle}
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus
@@ -275,6 +281,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -284,6 +291,7 @@ const AttackPatternEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -101,6 +101,9 @@ const AttackPatternEditionOverviewComponent = (props) => {
     references: Yup.array(),
     confidence: Yup.number().nullable(),
     x_opencti_workflow_id: Yup.object(),
+    killChainPhases: Yup.array().nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const attackPatternValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
@@ -151,6 +154,9 @@ const AttackPatternEditionOverviewComponent = (props) => {
       let finalValue = value;
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
+      }
+      if (name === 'killChainPhases') {
+        finalValue = (value.value ?? []).map(({ value_translate }) => value_translate);
       }
       attackPatternValidator
         .validateAt(name, { [name]: value })

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
@@ -200,7 +200,7 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
         setFieldValue,
         values,
       }) => (
-        <Form style={{ margin: '20px 0 20px 0' }}>
+        <Form>
           <Field
             component={TextField}
             name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
@@ -25,7 +25,7 @@ import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import type { Theme } from '../../../../components/Theme';
 import { Option } from '../../common/form/ReferenceField';
@@ -111,16 +111,15 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(COURSE_OF_ACTION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const courseOfActionValidator = useSchemaCreationValidation(
-    COURSE_OF_ACTION_TYPE,
+  }, mandatoryAttributes);
+  const courseOfActionValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -189,6 +188,8 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
     <Formik<CourseOfActionAddInput>
       initialValues={initialValues}
       validationSchema={courseOfActionValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -199,11 +200,12 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
         setFieldValue,
         values,
       }) => (
-        <Form>
+        <Form style={{ margin: '20px 0 20px 0' }}>
           <Field
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Course-Of-Action']}
           />
@@ -211,6 +213,7 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -222,22 +225,26 @@ export const CourseOfActionCreationForm: FunctionComponent<CourseOfActionFormPro
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}
@@ -293,7 +300,7 @@ const CourseOfActionCreation: FunctionComponent<CourseOfActionFormProps> = ({
   );
   const CreateCourseOfActionControlledDialContextual = CreateCourseOfActionControlledDial({
     onOpen: handleOpen,
-    onClose: () => {},
+    onClose: () => { },
   });
   const renderClassic = () => {
     return (

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -14,7 +14,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import StatusField from '../../common/form/StatusField';
 import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -83,13 +83,16 @@ const courseOfActionMutationRelationDelete = graphql`
   }
 `;
 
+const COURSE_OF_ACTION_TYPE = 'Course-Of-Action';
+
 const CourseOfActionEditionOverviewComponent = (props) => {
   const { courseOfAction, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(COURSE_OF_ACTION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_threat_hunting: Yup.string().nullable(),
@@ -97,12 +100,8 @@ const CourseOfActionEditionOverviewComponent = (props) => {
     x_mitre_id: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const courseOfActionValidator = useSchemaEditionValidation(
-    'Course-Of-Action',
-    basicShape,
-  );
-
+  }, mandatoryAttributes);
+  const courseOfActionValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {
     fieldPatch: courseOfActionMutationFieldPatch,
     relationAdd: courseOfActionMutationRelationAdd,
@@ -197,6 +196,8 @@ const CourseOfActionEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={courseOfActionValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -207,12 +208,13 @@ const CourseOfActionEditionOverviewComponent = (props) => {
         isValid,
         dirty,
       }) => (
-        <Form>
+        <Form style={{ margin: '20px 0 20px 0' }}>
           <AlertConfidenceForEntity entity={courseOfAction} />
           <Field
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -224,6 +226,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             component={TextField}
             name="x_mitre_id"
             label={t_i18n('External ID')}
+            required={(mandatoryAttributes.includes('x_mitre_id'))}
             fullWidth={true}
             style={{ marginTop: 20 }}
             onFocus={editor.changeFocus}
@@ -236,6 +239,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -258,6 +262,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="x_opencti_threat_hunting"
             label={t_i18n('Threat hunting techniques')}
+            required={(mandatoryAttributes.includes('x_opencti_threat_hunting'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -275,6 +280,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             component={TextField}
             name="x_opencti_log_sources"
             label={t_i18n('Log sources (1 / line)')}
+            required={(mandatoryAttributes.includes('x_opencti_log_sources'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -307,6 +313,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
           <CreatedByField
             name="createdBy"
             style={fieldSpacingContainerStyle}
+            required={(mandatoryAttributes.includes('createdBy'))}
             setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="createdBy" />
@@ -315,6 +322,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -100,6 +100,8 @@ const CourseOfActionEditionOverviewComponent = (props) => {
     x_mitre_id: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const courseOfActionValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {
@@ -188,7 +190,6 @@ const CourseOfActionEditionOverviewComponent = (props) => {
       'objectMarking',
       'confidence',
       'x_opencti_workflow_id',
-      'x_mitre_id',
     ]),
   )(courseOfAction);
   return (

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -209,7 +209,7 @@ const CourseOfActionEditionOverviewComponent = (props) => {
         isValid,
         dirty,
       }) => (
-        <Form style={{ margin: '20px 0 20px 0' }}>
+        <Form>
           <AlertConfidenceForEntity entity={courseOfAction} />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
@@ -22,7 +22,7 @@ import { insertNode } from '../../../../utils/store';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { Option } from '../../common/form/ReferenceField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import { DataComponentCreationMutation, DataComponentCreationMutation$variables } from './__generated__/DataComponentCreationMutation.graphql';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -92,17 +92,16 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DATA_COMPONENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number()
       .nullable(),
-  };
-  const dataComponentValidator = useSchemaCreationValidation(
-    DATA_COMPONENT_TYPE,
+  }, mandatoryAttributes);
+  const dataComponentValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -187,6 +186,8 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
     <Formik<DataComponentAddInput>
       initialValues={initialValues}
       validationSchema={dataComponentValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -224,11 +225,12 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form>
+          <Form style={{ margin: '20px 0 20px 0' }}>
             <Field
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Data-Component']}
             />
@@ -240,6 +242,7 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -248,22 +251,26 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
             <CreatedByField
               name="createdBy"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('createdBy'))}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectLabel'))}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectMarking'))}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('externalReferences'))}
               setFieldValue={setFieldValue}
               values={values.externalReferences}
             />

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
@@ -225,7 +225,7 @@ export const DataComponentCreationForm: FunctionComponent<DataComponentFormProps
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form style={{ margin: '20px 0 20px 0' }}>
+          <Form>
             <Field
               component={BulkTextField}
               name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -155,6 +155,8 @@ DataComponentEditionOverviewComponentProps
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const dataComponentValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -253,7 +253,7 @@ DataComponentEditionOverviewComponentProps
         isValid,
         dirty,
       }) => (
-        <Form style={{ margin: '20px 0 20px 0' }}>
+        <Form>
           <AlertConfidenceForEntity entity={dataComponent} />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -25,7 +25,7 @@ import { Option } from '../../common/form/ReferenceField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { DataSourceCreationMutation, DataSourceCreationMutation$variables } from './__generated__/DataSourceCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -103,13 +103,14 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DATA_SOURCE_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const dataSourceValidator = useSchemaCreationValidation(
-    DATA_SOURCE_TYPE,
+  }, mandatoryAttributes);
+  const dataSourceValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -191,6 +192,8 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
     <Formik<DataSourceAddInput>
       initialValues={initialValues}
       validationSchema={dataSourceValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -221,11 +224,12 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form>
+          <Form style={{ margin: '20px 0 20px 0' }}>
             <Field
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Data-Source']}
             />
@@ -237,6 +241,7 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -245,22 +250,26 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
             <CreatedByField
               name="createdBy"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('createdBy'))}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectLabel'))}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectMarking'))}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('externalReferences'))}
               setFieldValue={setFieldValue}
               values={values.externalReferences}
             />
@@ -278,6 +287,7 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
               label={t_i18n('Platforms')}
               type="platforms_ov"
               name="x_mitre_platforms"
+              required={(mandatoryAttributes.includes('x_mitre_platforms'))}
               onChange={(name, value) => setFieldValue(name, value)}
               containerStyle={fieldSpacingContainerStyle}
               multiple={true}
@@ -286,6 +296,7 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
               label={t_i18n('Layers')}
               type="collection_layers_ov"
               name="collection_layers"
+              required={(mandatoryAttributes.includes('collection_layers'))}
               onChange={(name, value) => setFieldValue(name, value)}
               containerStyle={fieldSpacingContainerStyle}
               multiple={true}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -224,7 +224,7 @@ export const DataSourceCreationForm: FunctionComponent<DataSourceFormProps> = ({
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form style={{ margin: '20px 0 20px 0' }}>
+          <Form>
             <Field
               component={BulkTextField}
               name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -263,7 +263,7 @@ DataSourceEditionOverviewProps
         isValid,
         dirty,
       }) => (
-        <Form style={{ margin: '20px 0 20px 0' }}>
+        <Form>
           <AlertConfidenceForEntity entity={dataSource} />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -163,6 +163,8 @@ DataSourceEditionOverviewProps
     collection_layers: Yup.array().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const dataSourceValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -19,7 +19,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { NarrativeCreationMutation, NarrativeCreationMutation$variables } from './__generated__/NarrativeCreationMutation.graphql';
@@ -115,12 +115,13 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(NARRATIVE_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
-  };
-  const narrativeValidator = useSchemaCreationValidation(
-    NARRATIVE_TYPE,
+  }, mandatoryAttributes);
+  const narrativeValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -201,6 +202,8 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
     <Formik<NarrativeAddInput>
       initialValues={initialValues}
       validationSchema={narrativeValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -231,11 +234,12 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form>
+          <Form style={{ margin: '20px 0 20px 0' }}>
             <Field
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Narrative']}
             />
@@ -243,6 +247,7 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -254,22 +259,26 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -234,7 +234,7 @@ export const NarrativeCreationForm: FunctionComponent<NarrativeFormProps> = ({
           >
             <BulkResult variablesToString={(v) => v.input.name} />
           </ProgressBar>
-          <Form style={{ margin: '20px 0 20px 0' }}>
+          <Form>
             <Field
               component={BulkTextField}
               name="name"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -195,7 +195,7 @@ const NarrativeEditionOverviewComponent = (props) => {
         isValid,
         dirty,
       }) => (
-        <Form style={{ margin: '20px 0 20px 0' }}>
+        <Form>
           <AlertConfidenceForEntity entity={narrative} />
           <Field
             component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -94,6 +94,8 @@ const NarrativeEditionOverviewComponent = (props) => {
     references: Yup.array(),
     confidence: Yup.number().nullable(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const narrativeValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 


### PR DESCRIPTION
### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Techniques' section of the platform, to include creating and editing the following entity types:

* Attack patterns
* Narratives
* Courses of action
* Data components
* Data sources

### Related issues
* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

* In Course of Action the fields 'x_mitre_id', 'x_opencti_threat_hunting', and 'x_opencti_log_sources' are only present on the Edit form and not the Create form or the Customization fields.
* The 'KillChainPhase' field is not showing a '*' even though it is required and turns red on submit. May be an issue with the field itself.
