### PR TITLE
[backend] Fix distribution widget by creator error (#9117)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -519,18 +519,18 @@ const convertAggregateDistributions = async (context, user, limit, orderingFunct
   const data = R.take(limit, R.sortWith([orderingFunction(R.prop('value'))])(distribution));
   // resolve all of them with system user
   const allResolveLabels = await elFindByIds(context, SYSTEM_USER, data.map((d) => d.label), { toMap: true });
+  // filter out unresolved data (like the SYSTEM user for instance)
+  const filteredData = data.filter((n) => isNotEmptyField(allResolveLabels[n.label.toLowerCase()]));
   // entities not granted shall be sent as "restricted" with limited information
   const grantedIds = [];
-  for (let i = 0; i < data.length; i += 1) {
-    const resolved = allResolveLabels[data[i].label.toLowerCase()];
+  for (let i = 0; i < filteredData.length; i += 1) {
+    const resolved = allResolveLabels[filteredData[i].label.toLowerCase()];
     const canAccess = await isUserCanAccessStoreElement(context, user, resolved);
     if (canAccess) {
-      grantedIds.push(data[i].label.toLowerCase());
+      grantedIds.push(filteredData[i].label.toLowerCase());
     }
   }
-  return data
-    // filter out unresolved data (like the SYSTEM user for instance)
-    .filter((n) => isNotEmptyField(allResolveLabels[n.label.toLowerCase()]))
+  return filteredData
     .map((n) => {
       const element = allResolveLabels[n.label.toLowerCase()];
       if (grantedIds.includes(n.label.toLowerCase())) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* filter out unresolved data (like the SYSTEM user) before testing user access on element

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
Check the issue for repro steps
* #9117

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I think we might need to fix this issue differently at some point. Right now it will display the same data as for admin users, but it's missing all the data created by system users which I think we should display.

Sorry I didn't write any integration test for this, it would take a lot of time since audit logs resolver test doesn't even exist, and I would need to fill the database with data created by internal users (currently everything is created with admin)
