### PR TITLE
[frontend] clamp confidence input values between 0 and 100 (#6715)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3085,6 +3085,7 @@
   "The value must be less than or equal to 100": "Der Wert muss kleiner als oder gleich 100 sein",
   "The value must not be empty": "Der Wert darf nicht leer sein",
   "The value must not be empty.": "Der Wert darf nicht leer sein.",
+  "The value should be between 0 and 100": "Der Wert sollte zwischen 0 und 100 liegen",
   "The values do not match": "Die Werte stimmen nicht überein",
   "The values must be different.": "Die Werte müssen unterschiedlich sein.",
   "The variable name should not contain spaces": "Der Variablenname sollte keine Leerzeichen enthalten",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3083,6 +3083,7 @@
   "The value must be greater than or equal to 0": "The value must be greater than or equal to 0",
   "The value must be greater than or equal to 1": "The value must be greater than or equal to 1",
   "The value must be less than or equal to 100": "The value must be less than or equal to 100",
+  "The value should be between 0 and 100": "The value should be between 0 and 100",
   "The value must not be empty": "The value must not be empty",
   "The value must not be empty.": "The value must not be empty.",
   "The values do not match": "The values do not match",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3083,6 +3083,7 @@
   "The value must be greater than or equal to 0": "El valor debe ser mayor o igual a 0",
   "The value must be greater than or equal to 1": "El valor debe ser mayor o igual a 1",
   "The value must be less than or equal to 100": "El valor debe ser menor o igual a 100",
+  "The value should be between 0 and 100": "El valor debe estar comprendido entre 0 y 100",
   "The value must not be empty": "El valor no debe estar vacío",
   "The value must not be empty.": "El valor no debe estar vacío.",
   "The values do not match": "Los valores no coinciden",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3085,6 +3085,7 @@
   "The value must be less than or equal to 100": "La valeur doit être inférieure ou égale à 100",
   "The value must not be empty": "La valeur ne doit pas être vide",
   "The value must not be empty.": "La valeur ne doit pas être vide.",
+  "The value should be between 0 and 100": "La valeur doit être comprise entre 0 et 100",
   "The values do not match": "Les valeurs ne correspondent pas",
   "The values must be different.": "Les valeurs doivent être différentes.",
   "The variable name should not contain spaces": "Le nom de la variable ne doit pas contenir d'espaces",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3083,6 +3083,7 @@
   "The value must be greater than or equal to 0": "値は 0 以上である必要があります",
   "The value must be greater than or equal to 1": "値は 1 以上である必要があります",
   "The value must be less than or equal to 100": "値は 100 以下である必要があります",
+  "The value should be between 0 and 100": "値は0から100の間でなければならない。",
   "The value must not be empty": "値は空であってはならない",
   "The value must not be empty.": "値は空であってはならない。",
   "The values do not match": "値が一致しません",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3083,6 +3083,7 @@
   "The value must be greater than or equal to 0": "값은 0 이상이어야 합니다",
   "The value must be greater than or equal to 1": "값은 1보다 크거나 같아야 합니다",
   "The value must be less than or equal to 100": "값은 100 이하이어야 합니다",
+  "The value should be between 0 and 100": "값은 0에서 100 사이여야 합니다",
   "The value must not be empty": "값이 비어 있지 않아야 합니다",
   "The value must not be empty.": "값이 비어 있지 않아야 합니다.",
   "The values do not match": "값이 일치하지 않습니다",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3085,6 +3085,7 @@
   "The value must be less than or equal to 100": "该值必须小于或等于 100",
   "The value must not be empty": "值不能为空",
   "The value must not be empty.": "值不能为空。",
+  "The value should be between 0 and 100": "数值应介于 0 和 100 之间",
   "The values do not match": "该值不匹配",
   "The values must be different.": "数值必须不同。",
   "The variable name should not contain spaces": "变量名不应包含空格",

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -142,7 +142,10 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
         return !valid_from || !value || value > valid_from;
       }),
     x_mitre_platforms: Yup.array().nullable(),
-    x_opencti_score: Yup.number().nullable(),
+    x_opencti_score: Yup.number()
+      .nullable()
+      .min(0, t_i18n('The value must be greater than or equal to 0'))
+      .max(100, t_i18n('The value must be less than or equal to 100')),
     description: Yup.string().nullable(),
     x_opencti_detection: Yup.boolean().nullable(),
     createObservables: Yup.boolean().nullable(),

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -105,7 +105,10 @@ const IndicatorEditionOverviewComponent = ({
         return !valid_from || !value || value > valid_from;
       }),
     x_mitre_platforms: Yup.array().nullable(),
-    x_opencti_score: Yup.number().nullable(),
+    x_opencti_score: Yup.number()
+      .nullable()
+      .min(0, t_i18n('The value must be greater than or equal to 0'))
+      .max(100, t_i18n('The value must be less than or equal to 100')),
     description: Yup.string().nullable(),
     x_opencti_detection: Yup.boolean(),
     references: Yup.array(),

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -267,12 +267,6 @@ const SCO_DEFAULT_FIELD = [
   { type: 'X509-Certificate', field: 'hashes_MD5' },
 ];
 
-const stixCyberObservableValidation = () => Yup.object().shape({
-  x_opencti_score: Yup.number().nullable(),
-  x_opencti_description: Yup.string().nullable(),
-  createIndicator: Yup.boolean(),
-});
-
 const StixCyberObservableCreation = ({
   contextual,
   open,
@@ -606,6 +600,15 @@ const StixCyberObservableCreation = ({
                 initialValues[attribute.value] = '';
               }
             }
+
+            const stixCyberObservableValidation = () => Yup.object().shape({
+              x_opencti_score: Yup.number()
+                .nullable()
+                .min(0, t_i18n('The value must be greater than or equal to 0'))
+                .max(100, t_i18n('The value must be less than or equal to 100')),
+              x_opencti_description: Yup.string().nullable(),
+              createIndicator: Yup.boolean(),
+            });
 
             const stixCyberObservableValidationFinal = Yup.object().shape({
               ...stixCyberObservableValidation,

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -241,9 +241,9 @@ const StixCyberObservableEditionOverviewComponent = ({
 
   const stixCyberObservableValidation = Yup.object().shape({
     x_opencti_score: Yup.number()
-      .min(0, 'Score must be between 0 and 100')
-      .max(100, 'Score must be between 0 and 100')
-      .nullable(),
+      .nullable()
+      .min(0, t_i18n('The value must be greater than or equal to 0'))
+      .max(100, t_i18n('The value must be less than or equal to 100')),
   });
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
+import * as R from 'ramda';
 import { assoc, difference, filter, fromPairs, head, includes, map, pick, pipe } from 'ramda';
 import { useNavigate } from 'react-router-dom';
-import * as R from 'ramda';
+import * as Yup from 'yup';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
@@ -237,6 +238,14 @@ const StixCyberObservableEditionOverviewComponent = ({
       }
     }
   };
+
+  const stixCyberObservableValidation = Yup.object().shape({
+    x_opencti_score: Yup.number()
+      .min(0, 'Score must be between 0 and 100')
+      .max(100, 'Score must be between 0 and 100')
+      .nullable(),
+  });
+
   return (
     <QueryRenderer
       query={stixCyberObservablesLinesAttributesQuery}
@@ -298,6 +307,7 @@ const StixCyberObservableEditionOverviewComponent = ({
             <Formik
               enableReinitialize={true}
               initialValues={initialValues}
+              validationSchema={stixCyberObservableValidation}
               onSubmit={onSubmit}
             >
               {({ setFieldValue }) => (

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -258,6 +258,10 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   const { formattedPattern } = await validateIndicatorPattern(context, user, indicator.pattern_type, indicator.pattern);
 
   const indicatorBaseScore = indicator.x_opencti_score ?? 50;
+  if (indicatorBaseScore < 0 || indicatorBaseScore > 100) {
+    throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
+  }
+
   const isDecayActivated = await isModuleActivated('INDICATOR_DECAY_MANAGER');
   // find default decay rule (even if decay is not activated, it is used to compute default validFrom and validUntil)
   const decayRule = await findDecayRuleForIndicator(context, observableType);

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -347,8 +347,11 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   }
   const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
   if (scoreEditInput) {
+    const newScore = scoreEditInput.value[0];
+    if (newScore < 0 || newScore > 100) {
+      throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
+    }
     if (indicator.decay_applied_rule && !scoreEditInput.value.includes(indicator.decay_base_score)) {
-      const newScore = scoreEditInput.value[0];
       const updateDate = utcDate();
       finalInput.push({ key: 'decay_base_score', value: [newScore] });
       finalInput.push({ key: 'decay_base_score_date', value: [updateDate.toISOString()] });

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
@@ -220,7 +220,7 @@ input IndicatorAddInput {
   confidence: Int
   revoked: Boolean
   lang: String
-  x_opencti_score: Int
+  x_opencti_score: Int @constraint(min: 0, max: 100)
   x_opencti_detection: Boolean
   x_opencti_main_observable_type: String
   x_mitre_platforms: [String!]

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -119,7 +119,7 @@ describe('Indicator resolver standard behavior', () => {
   let indicatorStixId = 'indicator--f6ad652c-166a-43e6-98b8-8ff078e2349f';
   const indicatorForTestName = 'Indicator in indicator-test';
 
-  it('should not create indicator with score value outside of 0 and 100', async () => {
+  it('should not create indicator with score value higher than 100', async () => {
     // Create the indicator
     const INDICATOR_TO_CREATE = {
       input: {
@@ -247,7 +247,7 @@ describe('Indicator resolver standard behavior', () => {
       expect(indicatorCreatedEarlier).toBeDefined();
     }
   });
-  it('should not update indicator with score value outside of 0 and 100', async () => {
+  it('should not update indicator with score negative value and value higher than 100', async () => {
     const queryResulAbove100 = await adminQuery({
       query: UPDATE_QUERY,
       variables: { id: firstIndicatorInternalId, input: { key: 'x_opencti_score', value: ['142'] } },

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -130,7 +130,7 @@ describe('Indicator resolver standard behavior', () => {
         x_opencti_score: 142,
       },
     };
-    const indicator = await queryAsAdminWithSuccess({
+    const indicator = await queryAsAdmin({
       query: CREATE_QUERY,
       variables: INDICATOR_TO_CREATE,
     });

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -80,13 +80,13 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
       expect(updateEventsByTypes['report'].length).toBe(19);
-      expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
+      expect(updateEventsByTypes['ipv4-addr'].length).toBe(5);
       expect(updateEventsByTypes['tool'].length).toBe(9);
       expect(updateEventsByTypes['sighting'].length).toBe(4);
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(196);
+      expect(updateEvents.length).toBe(198);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1202;
+export const RAW_EVENTS_SIZE = 1201;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1201;
+export const RAW_EVENTS_SIZE = 1202;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1201;
+export const RAW_EVENTS_SIZE = 1203;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* clamp confidence input field values between 0 and 100 🗜️ 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close [When an indicator score is set to 1000000, the object does not load properly and the system hangs](https://github.com/OpenCTI-Platform/opencti/issues/6715)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
