### PR TITLE
[frontend] Add support for dynamic configurable required fields to Locations

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
@@ -18,7 +18,7 @@ import { AdministrativeAreasLinesPaginationQuery$variables } from './__generated
 import { AdministrativeAreaCreationMutation, AdministrativeAreaCreationMutation$variables } from './__generated__/AdministrativeAreaCreationMutation.graphql';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -92,8 +92,9 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ADMINISTRATIVE_AREA_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -102,11 +103,8 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
     longitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
-  };
-  const administrativeAreaValidator = useSchemaCreationValidation(
-    ADMINISTRATIVE_AREA_TYPE,
-    basicShape,
-  );
+  }, mandatoryAttributes);
+  const administrativeAreaValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<AdministrativeAreaCreationMutation>(
     administrativeAreaMutation,
@@ -189,6 +187,8 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
     <Formik<AdministrativeAreaAddInput>
       initialValues={initialValues}
       validationSchema={administrativeAreaValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -225,6 +225,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Administrative-Area']}
             />
@@ -232,6 +233,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows={4}
@@ -246,6 +248,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
               variant="standard"
               name="latitude"
               label={t_i18n('Latitude')}
+              required={(mandatoryAttributes.includes('latitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -254,6 +257,7 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
               variant="standard"
               name="longitude"
               label={t_i18n('Longitude')}
+              required={(mandatoryAttributes.includes('longitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -261,23 +265,27 @@ export const AdministrativeAreaCreationForm: FunctionComponent<AdministrativeAre
               name="createdBy"
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
+              required={(mandatoryAttributes.includes('createdBy'))}
             />
             <ObjectLabelField
               name="objectLabel"
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
+              required={(mandatoryAttributes.includes('objectLabel'))}
             />
             <ObjectMarkingField
               name="objectMarking"
               setFieldValue={setFieldValue}
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectMarking'))}
             />
             <ExternalReferencesField
               name="externalReferences"
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}
+              required={(mandatoryAttributes.includes('externalReferences'))}
             />
             <Field
               component={CustomFileUploader}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -17,7 +17,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { useFormatter } from '../../../../components/i18n';
 import { Option } from '../../common/form/ReferenceField';
 import { AdministrativeAreaEditionOverview_administrativeArea$key } from './__generated__/AdministrativeAreaEditionOverview_administrativeArea.graphql';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
@@ -119,6 +119,8 @@ export const administrativeAreaEditionOverviewFragment = graphql`
   }
 `;
 
+const ADMINISTRATIVE_AREA_TYPE = 'Administrative-Area';
+
 interface AdministrativeAreaEditionOverviewProps {
   administrativeAreaRef: AdministrativeAreaEditionOverview_administrativeArea$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -148,8 +150,9 @@ AdministrativeAreaEditionOverviewProps
     administrativeAreaEditionOverviewFragment,
     administrativeAreaRef,
   );
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ADMINISTRATIVE_AREA_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -160,11 +163,9 @@ AdministrativeAreaEditionOverviewProps
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const administrativeAreaValidator = useSchemaEditionValidation(
-    'Administrative-Area',
-    basicShape,
-  );
+  }, mandatoryAttributes);
+  const administrativeAreaValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
+
   const queries = {
     fieldPatch: administrativeAreaMutationFieldPatch,
     relationAdd: administrativeAreaMutationRelationAdd,
@@ -239,6 +240,8 @@ AdministrativeAreaEditionOverviewProps
       enableReinitialize={true}
       initialValues={initialValues as never}
       validationSchema={administrativeAreaValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -256,6 +259,7 @@ AdministrativeAreaEditionOverviewProps
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -267,6 +271,7 @@ AdministrativeAreaEditionOverviewProps
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -292,6 +297,7 @@ AdministrativeAreaEditionOverviewProps
             name="latitude"
             type="number"
             label={t_i18n('Latitude')}
+            required={(mandatoryAttributes.includes('latitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name: string, value: string) => handleSubmitField(name, (value === '' ? null : value))}
@@ -306,6 +312,7 @@ AdministrativeAreaEditionOverviewProps
             name="longitude"
             type="number"
             label={t_i18n('Longitude')}
+            required={(mandatoryAttributes.includes('longitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name: string, value: string) => handleSubmitField(name, (value === '' ? null : value))}
@@ -331,6 +338,7 @@ AdministrativeAreaEditionOverviewProps
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -340,6 +348,7 @@ AdministrativeAreaEditionOverviewProps
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -163,6 +163,7 @@ AdministrativeAreaEditionOverviewProps
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const administrativeAreaValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
@@ -18,7 +18,7 @@ import { CitiesLinesPaginationQuery$variables } from './__generated__/CitiesLine
 import { CityCreationMutation, CityCreationMutation$variables } from './__generated__/CityCreationMutation.graphql';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { Option } from '../../common/form/ReferenceField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -90,8 +90,9 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(CITY_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -100,8 +101,8 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
     longitude: Yup.number()
       .typeError(t_i18n('This field must be a number'))
       .nullable(),
-  };
-  const cityValidator = useSchemaCreationValidation(CITY_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const cityValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<CityCreationMutation>(
     cityMutation,
@@ -181,6 +182,8 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
     <Formik<CityAddInput>
       initialValues={initialValues}
       validationSchema={cityValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -216,6 +219,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['City']}
             />
@@ -223,6 +227,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows={4}
@@ -236,6 +241,7 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
               component={TextField}
               name="latitude"
               label={t_i18n('Latitude')}
+              required={(mandatoryAttributes.includes('latitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -243,27 +249,32 @@ export const CityCreationForm: FunctionComponent<CityFormProps> = ({
               component={TextField}
               name="longitude"
               label={t_i18n('Longitude')}
+              required={(mandatoryAttributes.includes('longitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -18,7 +18,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import { useFormatter } from '../../../../components/i18n';
 import { Option } from '../../common/form/ReferenceField';
 import { CityEditionOverview_city$key } from './__generated__/CityEditionOverview_city.graphql';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -118,6 +118,8 @@ export const cityEditionOverviewFragment = graphql`
   }
 `;
 
+const CITY_TYPE = 'City';
+
 interface CityEditionOverviewProps {
   cityRef: CityEditionOverview_city$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -141,8 +143,9 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
 }) => {
   const { t_i18n } = useFormatter();
   const city = useFragment(cityEditionOverviewFragment, cityRef);
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(CITY_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -153,8 +156,8 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const cityValidator = useSchemaEditionValidation('City', basicShape);
+  }, mandatoryAttributes);
+  const cityValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {
     fieldPatch: cityMutationFieldPatch,
     relationAdd: cityMutationRelationAdd,
@@ -226,6 +229,8 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
       enableReinitialize={true}
       initialValues={initialValues as never}
       validationSchema={cityValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -243,6 +248,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -254,6 +260,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -279,6 +286,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             name="latitude"
             type="number"
             label={t_i18n('Latitude')}
+            required={(mandatoryAttributes.includes('latitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name: string, value: string) => handleSubmitField(name, (value === '' ? null : value))}
@@ -293,6 +301,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
             name="longitude"
             type="number"
             label={t_i18n('Longitude')}
+            required={(mandatoryAttributes.includes('longitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name: string, value: string) => handleSubmitField(name, (value === '' ? null : value))}
@@ -318,6 +327,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -327,6 +337,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -156,6 +156,7 @@ const CityEditionOverview: FunctionComponent<CityEditionOverviewProps> = ({
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const cityValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
@@ -18,7 +18,7 @@ import { ExternalReferencesField } from '../../common/form/ExternalReferencesFie
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { Option } from '../../common/form/ReferenceField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { CountryCreationMutation, CountryCreationMutation$variables } from './__generated__/CountryCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -87,15 +87,14 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(COUNTRY_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const countryValidator = useSchemaCreationValidation(
-    COUNTRY_TYPE,
-    basicShape,
-  );
+  }, mandatoryAttributes);
+
+  const countryValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<CountryCreationMutation>(
     countryMutation,
@@ -171,6 +170,8 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
     <Formik<CountryAddInput>
       initialValues={initialValues}
       validationSchema={countryValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -207,6 +208,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Country']}
             />
@@ -214,6 +216,7 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -225,22 +228,26 @@ export const CountryCreationForm: FunctionComponent<CountryFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -17,7 +17,7 @@ import { CountryEditionOverview_country$key } from './__generated__/CountryEditi
 import { Option } from '../../common/form/ReferenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { GenericContext } from '../../common/model/GenericContextModel';
@@ -116,6 +116,8 @@ const countryEditionOverviewFragment = graphql`
   }
 `;
 
+const COUNTRY_TYPE = 'Country';
+
 interface CountryEditionOverviewProps {
   countryRef: CountryEditionOverview_country$key;
   context?: readonly (GenericContext | null)[] | null;
@@ -139,14 +141,15 @@ CountryEditionOverviewProps
 > = ({ countryRef, context, enableReferences = false, handleClose }) => {
   const { t_i18n } = useFormatter();
   const country = useFragment(countryEditionOverviewFragment, countryRef);
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(COUNTRY_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const countryValidator = useSchemaEditionValidation('Country', basicShape);
+  }, mandatoryAttributes);
+  const countryValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {
     fieldPatch: countryMutationFieldPatch,
     relationAdd: countryMutationRelationAdd,
@@ -221,6 +224,8 @@ CountryEditionOverviewProps
     <Formik
       enableReinitialize={true}
       initialValues={initialValues as never}
+      validateOnChange={true}
+      validateOnBlur={true}
       validationSchema={countryValidator}
       onSubmit={onSubmit}
     >
@@ -239,6 +244,7 @@ CountryEditionOverviewProps
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -250,6 +256,7 @@ CountryEditionOverviewProps
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -286,6 +293,7 @@ CountryEditionOverviewProps
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -295,6 +303,7 @@ CountryEditionOverviewProps
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -148,6 +148,7 @@ CountryEditionOverviewProps
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const countryValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
@@ -17,7 +17,7 @@ import { ExternalReferencesField } from '../../common/form/ExternalReferencesFie
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { insertNode } from '../../../../utils/store';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { Option } from '../../common/form/ReferenceField';
 import { PositionCreationMutation, PositionCreationMutation$variables } from './__generated__/PositionCreationMutation.graphql';
 import { PositionsLinesPaginationQuery$variables } from './__generated__/PositionsLinesPaginationQuery.graphql';
@@ -92,8 +92,9 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(POSITION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -106,11 +107,9 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
       .nullable()
       .max(1000, t_i18n('The value is too long')),
     postal_code: Yup.string().nullable().max(1000, t_i18n('The value is too long')),
-  };
-  const positionValidator = useSchemaCreationValidation(
-    POSITION_TYPE,
-    basicShape,
-  );
+  }, mandatoryAttributes);
+
+  const positionValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<PositionCreationMutation>(
     positionMutation,
@@ -194,6 +193,8 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
     <Formik<PositionAddInput>
       initialValues={initialValues}
       validationSchema={positionValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -230,6 +231,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Position']}
             />
@@ -237,6 +239,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows={4}
@@ -251,6 +254,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               variant="standard"
               name="latitude"
               label={t_i18n('Latitude')}
+              required={(mandatoryAttributes.includes('latitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -259,6 +263,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               variant="standard"
               name="longitude"
               label={t_i18n('Longitude')}
+              required={(mandatoryAttributes.includes('longitude'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -267,6 +272,7 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               variant="standard"
               name="street_address"
               label={t_i18n('Street address')}
+              required={(mandatoryAttributes.includes('street_address'))}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
@@ -274,28 +280,33 @@ export const PositionCreationForm: FunctionComponent<PositionFormProps> = ({
               component={TextField}
               variant="standard"
               name="postal_code"
+              required={(mandatoryAttributes.includes('postal_code'))}
               label={t_i18n('Postal code')}
               fullWidth={true}
               style={fieldSpacingContainerStyle}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -15,7 +15,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -83,14 +83,17 @@ const positionMutationRelationDelete = graphql`
   }
 `;
 
+const POSITION_TYPE = 'Position';
+
 const PositionEditionOverviewComponent = (props) => {
   const { position, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(POSITION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable().max(5000, t_i18n('The value is too long')),
     confidence: Yup.number().nullable(),
     latitude: Yup.number()
@@ -105,8 +108,8 @@ const PositionEditionOverviewComponent = (props) => {
     postal_code: Yup.string().nullable().max(1000, t_i18n('The value is too long')),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const positionValidator = useSchemaEditionValidation('Position', basicShape);
+  }, mandatoryAttributes);
+  const positionValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {
     fieldPatch: positionMutationFieldPatch,
     relationAdd: positionMutationRelationAdd,
@@ -191,6 +194,8 @@ const PositionEditionOverviewComponent = (props) => {
     <Formik
       enableReinitialize={true}
       initialValues={initialValues}
+      validateOnChange={true}
+      validateOnBlur={true}
       validationSchema={positionValidator}
       onSubmit={onSubmit}
     >
@@ -209,6 +214,7 @@ const PositionEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -220,6 +226,7 @@ const PositionEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -245,6 +252,7 @@ const PositionEditionOverviewComponent = (props) => {
             name="latitude"
             type="number"
             label={t_i18n('Latitude')}
+            required={(mandatoryAttributes.includes('latitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name, value) => handleSubmitField(name, (value === '' ? null : value))}
@@ -259,6 +267,7 @@ const PositionEditionOverviewComponent = (props) => {
             name="longitude"
             type="number"
             label={t_i18n('Longitude')}
+            required={(mandatoryAttributes.includes('longitude'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={(name, value) => handleSubmitField(name, (value === '' ? null : value))}
@@ -272,6 +281,7 @@ const PositionEditionOverviewComponent = (props) => {
             style={{ marginTop: 20 }}
             name="street_address"
             label={t_i18n('Street address')}
+            required={(mandatoryAttributes.includes('street_address'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -285,6 +295,7 @@ const PositionEditionOverviewComponent = (props) => {
             style={{ marginTop: 20 }}
             name="postal_code"
             label={t_i18n('Postal code')}
+            required={(mandatoryAttributes.includes('postal_code'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -310,6 +321,7 @@ const PositionEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -319,6 +331,7 @@ const PositionEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -108,6 +108,7 @@ const PositionEditionOverviewComponent = (props) => {
     postal_code: Yup.string().nullable().max(1000, t_i18n('The value is too long')),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const positionValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
@@ -18,7 +18,7 @@ import { ExternalReferencesField } from '../../common/form/ExternalReferencesFie
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { Option } from '../../common/form/ReferenceField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { RegionCreationMutation, RegionCreationMutation$variables } from './__generated__/RegionCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -87,12 +87,14 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(REGION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const regionValidator = useSchemaCreationValidation(REGION_TYPE, basicShape);
+  }, mandatoryAttributes);
+
+  const regionValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<RegionCreationMutation>(
     regionMutation,
@@ -168,6 +170,8 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
     <Formik<RegionAddInput>
       initialValues={initialValues}
       validationSchema={regionValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -204,6 +208,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Region']}
             />
@@ -211,6 +216,7 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -222,22 +228,26 @@ export const RegionCreationForm: FunctionComponent<RegionFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -148,6 +148,7 @@ RegionEdititionOverviewProps
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const regionValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
   const queries = {


### PR DESCRIPTION
### Proposed changes

This PR builds upon the capabilities from https://github.com/OpenCTI-Platform/opencti/pull/6972. This PR will add all capabilities from the previous PR to the 'Locations' section of the platform, to include creating and editing the following entity types:

* Regions
* Countries
* Administrative areas
* Cities
* Positions

### Related issues
* As stated in https://github.com/OpenCTI-Platform/opencti/pull/6972, the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] (N/A - Existing test cases should work properly) I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

* In Course of Action the fields 'x_mitre_id', 'x_opencti_threat_hunting', and 'x_opencti_log_sources' are only present on the Edit form and not the Create form or the Customization fields.
* The 'Longitude' and 'Latitude' field is not showing as red and without the '*' even though it is required on submit in Positions. May be an issue with the field itself.
* The 'Longitude' and 'Latitude' field is not showing as red and without the '*' even though it is required on submit in Cities. May be an issue with the field itself.
* The 'External References' and 'Labels' field is not showing as red and without the '*' even though it is required on submit. May be an issue with the field itself.
