### PR TITLE
[backend] no longer send x_opencti_files with resolved markings to elastic (#9149)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -390,7 +390,7 @@ export const loadElementsWithDependencies = async (context, user, elements, opts
         }
       });
     }
-    const deps = depsElementsMap.get(element.id);
+    const deps = depsElementsMap.get(element.id) ?? {};
     if (isNotEmptyField(files)) {
       deps.x_opencti_files = files;
     }

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -663,12 +663,17 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
     // Patch the updated_at to force live stream evolution
     const eventFile = storeFileConverter(user, up);
     const files = [...(previous.x_opencti_files ?? []).filter((f) => f.id !== up.id), eventFile];
+    const nonResolvedFiles = files.map((f) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [INPUT_MARKINGS]: markingInput, ...nonResolvedFile } = f;
+      return nonResolvedFile;
+    });
     await elUpdateElement(context, user, {
       _index: previous._index,
       internal_id: internalId,
       entity_type: previous.entity_type, // required for schema validation
       updated_at: now(),
-      x_opencti_files: files
+      x_opencti_files: nonResolvedFiles
     });
     // Stream event generation
     const fileMarkings = R.uniq(R.flatten(files.map((f) => f.file_markings)));
@@ -753,11 +758,16 @@ export const stixCoreObjectImportDelete = async (context, user, fileId) => {
     await deleteFile(context, user, fileId);
     // Patch the updated_at to force live stream evolution
     const files = (previous.x_opencti_files ?? []).filter((f) => f.id !== fileId);
+    const nonResolvedFiles = files.map((f) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [INPUT_MARKINGS]: markingInput, ...nonResolvedFile } = f;
+      return nonResolvedFile;
+    });
     await elUpdateElement(context, user, {
       _index: previous._index,
       internal_id: entityId,
       updated_at: now(),
-      x_opencti_files: files,
+      x_opencti_files: nonResolvedFiles,
       entity_type: previous.entity_type, // required for schema validation
     });
     // Stream event generation


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* deps wasn't properly initialized in loadElementsWithDependencies
* x_opencti_files in stixCoreObject domain were being updated to elastic after markings were resolved, causing a INPUT_MARKINGS trying to be set in the the x_opencti_files of elastic

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9149 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

bug was introduced with this PR https://github.com/OpenCTI-Platform/opencti/pull/9017