### PR TITLE
[frontend] Display filter label according to the entity type context (#9168)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -206,6 +206,9 @@ const DataTable = (props: OCTIDataTableProps) => {
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
 
   const computedEntityTypes = entityTypes ?? (exportContext?.entity_type ? [exportContext.entity_type] : []);
+  const computedSearchContextFinal = searchContextFinal?.entityTypes
+    ? searchContextFinal
+    : { ...searchContextFinal, entityTypes: computedEntityTypes };
   let availableFilterKeys = defaultAvailableFilterKeys ?? [];
   if (availableFilterKeys.length === 0 && isNotEmptyField(computedEntityTypes)) {
     const filterKeysMap = new Map();
@@ -239,7 +242,7 @@ const DataTable = (props: OCTIDataTableProps) => {
           availableRelationshipTypes={availableRelationshipTypes}
           currentView={currentView}
           exportContext={exportContext}
-          searchContextFinal={searchContextFinal}
+          searchContextFinal={computedSearchContextFinal}
         />
       )}
       dataTableToolBarComponent={(


### PR DESCRIPTION
### Proposed changes
Filters definition should be searched according to the correct entity type
If not and if another entity type has a filter with the same key, it can lead to bad labels in the filters list

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9168