### PR TITLE
[frontend] Show all types of containers in overview correlation widget & CTA to correlation graph (#3227)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "Kopieren/Einfügen von Textinhalten",
   "Correlate": "Korrelieren",
   "Correlated cases": "Korrelierte Fälle",
+  "Correlated containers": "Korrelierte Container",
   "Correlated groupings": "Korrelierte Gruppierungen",
   "Correlated intrusion sets": "Korrelierte Intrusion Sets",
   "Correlated reports": "Korrelierte Berichte",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1315,6 +1315,7 @@
   "Global search": "Globale Suche",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "Globale Streams sind für zugelassene Benutzer verfügbar. Live unter /stream/live und raw unter /stream",
   "Global workbenches": "Globale Werkbänke",
+  "Go to correlation graph view": "Zur Ansicht des Korrelationsdiagramms wechseln",
   "Go to dashboard": "Gehe zu Dashboard",
   "Go to investigation": "Zu den Ermittlungen gehen",
   "Go to Original dashboard": "Zum ursprünglichen Dashboard gehen",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "Auf dieser Plattform sind keine Konnektoren aktiviert.",
   "No connectors for this type of entity": "Keine Konnektoren für diese Art von Entität",
   "No containers about this entity.": "Keine Container über diese Entität.",
+  "No correlated containers has been found.": "Es wurden keine entsprechenden Behälter gefunden.",
   "No creators accumulation": "Keine Akkumulation von Erstellern",
   "No data available.": "Keine Daten verfügbar.",
   "No default value set in Settings...": "In den Entitätseinstellungen ist kein Standardwert für dieses Attribut festgelegt. Sie können einen Wert mit der obigen Eingabe angeben. Dieser Wert wird verwendet, wenn die Daten in der CSV-Datei fehlen.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "No connectors are enabled on this platform.",
   "No connectors for this type of entity": "No connectors for this type of entity",
   "No containers about this entity.": "No containers about this entity.",
+  "No correlated containers has been found.": "No correlated containers has been found.",
   "No creators accumulation": "No creators accumulation",
   "No data available.": "No data available.",
   "No default value set in Settings...": "No default value set for this attribute in the entity settings. You can provide one with the input above. This value will be used if the data is missing in the CSV file.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1315,6 +1315,7 @@
   "Global search": "Global search",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "Global streams are available for granted users. Live at /stream/live and raw at /stream",
   "Global workbenches": "Global workbenches",
+  "Go to correlation graph view": "Go to correlation graph view",
   "Go to dashboard": "Go to dashboard",
   "Go to investigation": "Go to investigation",
   "Go to Original dashboard": "Go to Original dashboard",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "Copy/paste text content",
   "Correlate": "Correlate",
   "Correlated cases": "Correlated cases",
+  "Correlated containers": "Correlated containers",
   "Correlated groupings": "Correlated groupings",
   "Correlated intrusion sets": "Correlated intrusion sets",
   "Correlated reports": "Correlated reports",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1315,6 +1315,7 @@
   "Global search": "Búsqueda global",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "Las publicaciones en vivo están permitidas para usuarios autorizados. En tiempo real en /stream/live y en bruto en /stream",
   "Global workbenches": "Bancos de trabajo globales",
+  "Go to correlation graph view": "Ir a la vista del gráfico de correlación",
   "Go to dashboard": "Ir al salpicadero",
   "Go to investigation": "Ir a investigación",
   "Go to Original dashboard": "Ir al panel original",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "Ningún conector se ha habilitado en esta plataforma.",
   "No connectors for this type of entity": "Ningún conector para este tipo de entidad",
   "No containers about this entity.": "No hay contenedores sobre esta entidad.",
+  "No correlated containers has been found.": "No se han encontrado contenedores correlacionados.",
   "No creators accumulation": "Sin acumulación de creadores",
   "No data available.": "No hay datos disponibles.",
   "No default value set in Settings...": "No hay valor por defecto para este atributo en la configuración de la entidad. Puede proporcionar uno con la entrada de arriba. Este valor se utilizará si faltan datos en el archivo CSV.",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "Copiar o pegar contenido textual",
   "Correlate": "Correlar",
   "Correlated cases": "Casos correlacionados",
+  "Correlated containers": "Contenedores correlacionados",
   "Correlated groupings": "Agrupaciones correlacionadas",
   "Correlated intrusion sets": "Conjuntos de intrusión correlacionados",
   "Correlated reports": "Informes correlacionados",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "Aucun connecteur n'est actif sur cette plateforme",
   "No connectors for this type of entity": "Aucun connecteur pour ce type d'entité",
   "No containers about this entity.": "Pas de conteneurs pour cette entité.",
+  "No correlated containers has been found.": "Aucun contenant corrélé n'a été trouvé.",
   "No creators accumulation": "Pas d'accumulation de créateurs",
   "No data available.": "Pas de données disponibles.",
   "No default value set in Settings...": "Aucune valeur par défaut n'a été définie pour cet attribut dans les paramètres de l'entité. Vous pouvez en fournir une en remplissant le champ ci-dessus. Cette valeur sera utilisée si les données sont manquantes dans le fichier CSV.",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1315,6 +1315,7 @@
   "Global search": "Recherche globale",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "Les flux globaux sont disponibles pour les utilisateurs autorisés. Live à /stream/live et raw à /stream",
   "Global workbenches": "Espaces de travail globaux",
+  "Go to correlation graph view": "Passer à l'affichage du graphique de corrélation",
   "Go to dashboard": "Aller au tableau de bord",
   "Go to investigation": "Aller à l'enquête",
   "Go to Original dashboard": "Aller au tableau de bord original",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "Copier/coller du contenu textuel",
   "Correlate": "Corréler",
   "Correlated cases": "Cases connexes",
+  "Correlated containers": "Conteneurs corrélés",
   "Correlated groupings": "Groupements connexes",
   "Correlated intrusion sets": "Modes opératoires connexes",
   "Correlated reports": "Rapports connexes",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "コンテンツのコピー/ペースト",
   "Correlate": "相関",
   "Correlated cases": "関連事例",
+  "Correlated containers": "関連コンテナ",
   "Correlated groupings": "相関のあるグループ化",
   "Correlated intrusion sets": "相関のある侵入セット",
   "Correlated reports": "相関レポート",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1315,6 +1315,7 @@
   "Global search": "グローバル検索",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "グローバルストリームが許可されたユーザーで利用可能です。ライブストリームは/stream/live、生データは/streamから利用してください。",
   "Global workbenches": "グローバルワークベンチ",
+  "Go to correlation graph view": "相関グラフ表示へ",
   "Go to dashboard": "ダッシュボードへ",
   "Go to investigation": "調査に行く",
   "Go to Original dashboard": "オリジナルダッシュボードへ",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "有効なコネクタがありません。",
   "No connectors for this type of entity": "このタイプのエンティティ用のコネクタがありません",
   "No containers about this entity.": "このエンティティに関するコンテナはありません。",
+  "No correlated containers has been found.": "関連する容器は見つかっていない。",
   "No creators accumulation": "クリエーターの蓄積がない",
   "No data available.": "データなし",
   "No default value set in Settings...": "エンティティ設定でこの属性にデフォルト値が設定されていません。上記の入力で指定できます。CSVファイルにデータがない場合、この値が使用されます。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "텍스트 내용 복사/붙여넣기",
   "Correlate": "상관",
   "Correlated cases": "상관된 사례",
+  "Correlated containers": "연관된 컨테이너",
   "Correlated groupings": "상관된 그룹",
   "Correlated intrusion sets": "상관된 침입 세트",
   "Correlated reports": "상관된 보고서",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1315,6 +1315,7 @@
   "Global search": "글로벌 검색",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "글로벌 스트림은 권한이 부여된 사용자에게 제공됩니다. /stream/live에서 실시간, /stream에서 원본",
   "Global workbenches": "글로벌 워크벤치",
+  "Go to correlation graph view": "상관관계 그래프 보기로 이동",
   "Go to dashboard": "대시보드로 이동",
   "Go to investigation": "조사로 이동",
   "Go to Original dashboard": "Original 대시보드로 이동",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "이 플랫폼에서 활성화된 커넥터가 없습니다.",
   "No connectors for this type of entity": "이 유형의 엔터티에 대한 커넥터가 없습니다",
   "No containers about this entity.": "이 엔터티에 대한 컨테이너가 없습니다.",
+  "No correlated containers has been found.": "연관된 컨테이너를 찾지 못했습니다.",
   "No creators accumulation": "크리에이터 누적 없음",
   "No data available.": "사용 가능한 데이터가 없습니다.",
   "No default value set in Settings...": "엔터티 설정에서 이 속성에 대한 기본값이 설정되지 않았습니다. 위의 입력란에 하나를 제공할 수 있습니다. 이 값은 CSV 파일에 데이터가 없을 경우 사용됩니다.",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -443,6 +443,7 @@
   "Copy/paste text content": "复制/粘贴文本内容",
   "Correlate": "关联",
   "Correlated cases": "相关案例",
+  "Correlated containers": "相关容器",
   "Correlated groupings": "相关分组",
   "Correlated intrusion sets": "相关入侵集",
   "Correlated reports": "相关报道",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1315,6 +1315,7 @@
   "Global search": "全局搜索",
   "Global streams are available for granted users. Live at /stream/live and raw at /stream": "授权用户可使用全局流。实时流在 /stream/live，原始流在 /stream",
   "Global workbenches": "全局工作台",
+  "Go to correlation graph view": "转到相关图视图",
   "Go to dashboard": "转到仪表板",
   "Go to investigation": "转到调查",
   "Go to Original dashboard": "转到原始仪表板",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1868,6 +1868,7 @@
   "No connectors are enabled on this platform.": "此平台未启用任何连接器。",
   "No connectors for this type of entity": "此类型的实体没有连接器",
   "No containers about this entity.": "没有关于此实体的容器。",
+  "No correlated containers has been found.": "未找到相关容器。",
   "No creators accumulation": "没有创作者积累",
   "No data available.": "无数据。",
   "No default value set in Settings...": "实体设置中未为此属性设置默认值。您可以通过上面的输入提供一个。如果 CSV 文件中缺少数据，将使用此值。",

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -13,6 +13,8 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'selectOnLineClick'
 | 'filtersComponent'
 | 'pageSize'
+| 'hideHeaders'
+| 'onLineClick'
 | 'variant'> & {
   data: unknown,
   globalCount: number

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -20,6 +20,8 @@ const styles = (theme) => ({
     padding: '15px',
     borderRadius: 4,
     position: 'relative',
+    display: 'flex',
+    flexFlow: 'column',
   },
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -7,21 +7,11 @@ import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import ListItem from '@mui/material/ListItem';
-import { Link, useNavigate } from 'react-router-dom';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import List from '@mui/material/List';
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
+import RelatedContainers from '../../common/containers/RelatedContainers';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
-import { resolveLink } from '../../../../utils/Entity';
 
 const styles = (theme) => ({
   paper: {
@@ -81,41 +71,13 @@ const styles = (theme) => ({
   },
 });
 
-const inlineStyles = {
-  itemAuthor: {
-    width: 80,
-    minWidth: 80,
-    maxWidth: 80,
-    marginRight: 24,
-    marginLeft: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemDate: {
-    width: 80,
-    minWidth: 80,
-    maxWidth: 80,
-    marginRight: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-};
-
 const GroupingDetailsComponent = (props) => {
-  const { t, fsd, classes, grouping } = props;
-  const navigate = useNavigate();
-  const [expanded, setExpanded] = useState(false);
+  const { t, classes, grouping } = props;
   const [height, setHeight] = useState(0);
   const ref = useRef(null);
   useEffect(() => {
     setHeight(ref.current.clientHeight);
   });
-  const expandable = grouping.relatedContainers.edges.length > 5;
-  const relatedContainers = grouping.relatedContainers.edges
-    .filter((relatedContainerEdge) => relatedContainerEdge.node.id !== grouping.id)
-    .slice(0, expanded ? 200 : 5);
 
   const entitiesDistributionDataSelection = [
     {
@@ -178,76 +140,11 @@ const GroupingDetailsComponent = (props) => {
             />
           </Grid>
         </Grid>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Typography variant="h3" gutterBottom={true}>
-            {t('Correlated containers')}
-          </Typography>
-          <IconButton
-            color="primary"
-            aria-label="Go to correlation graph view"
-            onClick={() => navigate(`/dashboard/analyses/groupings/${grouping.id}/knowledge/correlation`)}
-            size="medium"
-            style={{ marginBottom: 4 }}
-          >
-            <OpenInNewOutlined fontSize="small"/>
-          </IconButton>
-        </div>
-        <List>
-          {relatedContainers.length > 0
-            ? relatedContainers.map((relatedContainerEdge) => {
-              const relatedContainer = relatedContainerEdge.node;
-              return (
-                <ListItem
-                  key={grouping.id}
-                  dense={true}
-                  button={true}
-                  classes={{ root: classes.item }}
-                  divider={true}
-                  component={Link}
-                  to={`${resolveLink(relatedContainer.entity_type)}/${relatedContainer.id}`}
-                >
-                  <ListItemIcon>
-                    <ItemIcon type={relatedContainer.entity_type} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <div className={classes.itemText}>
-                        {relatedContainer.name}
-                      </div>
-                  }
-                  />
-                  <div style={inlineStyles.itemAuthor}>
-                    {relatedContainer.createdBy?.name ?? '-'}
-                  </div>
-                  <div style={inlineStyles.itemDate}>
-                    {fsd(relatedContainer.created ?? relatedContainer.published)}
-                  </div>
-                  <div style={{ width: 110, paddingRight: 20 }}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={relatedContainer.objectMarking}
-                      limit={1}
-                    />
-                  </div>
-                </ListItem>
-              );
-            }) : '-'
-          }
-        </List>
-        {expandable && (
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => setExpanded(!expanded)}
-            classes={{ root: classes.buttonExpand }}
-          >
-            {expanded ? (
-              <ExpandLessOutlined fontSize="small" />
-            ) : (
-              <ExpandMoreOutlined fontSize="small" />
-            )}
-          </Button>
-        )}
+        <RelatedContainers
+          relatedContainers={grouping.relatedContainers}
+          containerId={grouping.id}
+          entityType={grouping.entity_type}
+        />
       </Paper>
     </div>
   );
@@ -264,6 +161,7 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
   grouping: graphql`
     fragment GroupingDetails_grouping on Grouping {
       id
+      entity_type
       context
       description
       relatedContainers(

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -204,7 +204,7 @@ const GroupingDetailsComponent = (props) => {
                   classes={{ root: classes.item }}
                   divider={true}
                   component={Link}
-                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
+                  to={`${resolveLink(relatedContainer.entity_type)}/${relatedContainer.id}`}
                 >
                   <ListItemIcon>
                     <ItemIcon type={relatedContainer.entity_type} />
@@ -217,10 +217,10 @@ const GroupingDetailsComponent = (props) => {
                   }
                   />
                   <div style={inlineStyles.itemAuthor}>
-                    {relatedContainer?.createdBy?.name ?? '-'}
+                    {relatedContainer.createdBy?.name ?? '-'}
                   </div>
                   <div style={inlineStyles.itemDate}>
-                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
+                    {fsd(relatedContainer.created ?? relatedContainer.published)}
                   </div>
                   <div style={{ width: 110, paddingRight: 20 }}>
                     <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -171,46 +171,7 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
         types: ["Case", "Report", "Grouping"]
         viaTypes: ["Indicator", "Stix-Cyber-Observable"]
       ) {
-        edges {
-          node {
-            id
-            entity_type
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            ... on Report {
-              name
-              published
-            }
-            ... on Grouping {
-              name
-              created
-            }
-            ... on CaseIncident {
-              name
-              created
-            }
-            ... on CaseRfi {
-              name
-              created
-            }
-            ... on CaseRft {
-              name
-              created
-            }
-          }
-        }
+        ...RelatedContainersFragment_containers_connection
       }
     }
 `,

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -141,7 +141,7 @@ const GroupingDetailsComponent = (props) => {
             />
           </Grid>
         </Grid>
-        <Divider />
+        <Divider style={{ marginTop: 30 }} />
         <RelatedContainers
           relatedContainers={grouping.relatedContainers}
           containerId={grouping.id}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -7,6 +7,7 @@ import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
+import Divider from '@mui/material/Divider';
 import RelatedContainers from '../../common/containers/RelatedContainers';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
@@ -140,6 +141,7 @@ const GroupingDetailsComponent = (props) => {
             />
           </Grid>
         </Grid>
+        <Divider />
         <RelatedContainers
           relatedContainers={grouping.relatedContainers}
           containerId={grouping.id}

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -166,7 +166,7 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
       description
       relatedContainers(
         first: 10
-        orderBy: published
+        orderBy: modified
         orderMode: desc
         types: ["Case", "Report", "Grouping"]
         viaTypes: ["Indicator", "Stix-Cyber-Observable"]

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -277,108 +277,45 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
           node {
             id
             entity_type
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+            createdBy {
+              ... on Identity {
+                id
+                name
+                entity_type
+              }
+            }
             ... on Report {
               name
-              description
               published
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-              }
             }
             ... on Grouping {
               name
-              context
-              description
               created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
-                id
-                definition
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-              }
             }
             ... on CaseIncident {
               name
-              description
               created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-              }
             }
             ... on CaseRfi {
               name
-              description
               created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-              }
             }
             ... on CaseRft {
               name
-              description
               created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-              }
             }
           }
         }
       }
     }
-  `,
+`,
 });
 
 export default R.compose(inject18n, withStyles(styles))(GroupingDetails);

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -171,7 +171,7 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
         types: ["Case", "Report", "Grouping"]
         viaTypes: ["Indicator", "Stix-Cyber-Observable"]
       ) {
-        ...RelatedContainersFragment_containers_connection
+        ...RelatedContainersFragment_container_connection
       }
     }
 `,

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -8,12 +8,13 @@ import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import ListItem from '@mui/material/ListItem';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
-import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
@@ -104,6 +105,7 @@ const inlineStyles = {
 
 const GroupingDetailsComponent = (props) => {
   const { t, fsd, classes, grouping } = props;
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
   const [height, setHeight] = useState(0);
   const ref = useRef(null);
@@ -178,9 +180,20 @@ const GroupingDetailsComponent = (props) => {
             />
           </Grid>
         </Grid>
-        <Typography variant="h3" gutterBottom={true}>
-          {t('Correlated containers')}
-        </Typography>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Typography variant="h3" gutterBottom={true}>
+            {t('Correlated containers')}
+          </Typography>
+          <IconButton
+            color="primary"
+            aria-label="Go to correlation graph view"
+            onClick={() => navigate(`/dashboard/analyses/groupings/${grouping.id}/knowledge/correlation`)}
+            size="medium"
+            style={{ marginBottom: 4 }}
+          >
+            <OpenInNewOutlined fontSize="small"/>
+          </IconButton>
+        </div>
         <List>
           {relatedContainers.length > 0
             ? relatedContainers.map((relatedContainerEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -113,11 +113,9 @@ const GroupingDetailsComponent = (props) => {
     setHeight(ref.current.clientHeight);
   });
   const expandable = grouping.relatedContainers.edges.length > 5;
-  const relatedContainers = R.take(
-    expanded ? 200 : 5,
-    // exclude itself
-    (grouping.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== grouping.id),
-  );
+  const relatedContainers = grouping.relatedContainers.edges
+    .filter((relatedContainerEdge) => relatedContainerEdge.node.id !== grouping.id)
+    .slice(0, expanded ? 200 : 5);
 
   const entitiesDistributionDataSelection = [
     {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -4,23 +4,13 @@ import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import ListItem from '@mui/material/ListItem';
-import { Link, useNavigate } from 'react-router-dom';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import List from '@mui/material/List';
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import Button from '@mui/material/Button';
 import makeStyles from '@mui/styles/makeStyles';
-import IconButton from '@mui/material/IconButton';
+import RelatedContainers from '../../common/containers/RelatedContainers';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
-import { resolveLink } from '../../../../utils/Entity';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -38,68 +28,12 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: 4,
     margin: '0 5px 5px 0',
   },
-  item: {
-    height: 50,
-    minHeight: 50,
-    maxHeight: 50,
-    paddingRight: 0,
-  },
-  itemText: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-  itemAuthor: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    marginLeft: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemDate: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemMarking: {
-    width: 110,
-    paddingRight: 20,
-  },
-  relatedContainers: {
-    paddingTop: 0,
-  },
 }));
 
 const ReportDetailsFragment = graphql`
   fragment ReportDetails_report on Report {
     id
+    entity_type
     published
     report_types
     description
@@ -156,19 +90,13 @@ const ReportDetailsFragment = graphql`
 
 const ReportDetails = ({ report }) => {
   const classes = useStyles();
-  const { t_i18n, fldt, fsd } = useFormatter();
-  const navigate = useNavigate();
-  const [expanded, setExpanded] = useState(false);
+  const { t_i18n, fldt } = useFormatter();
   const [height, setHeight] = useState(0);
   const ref = useRef(null);
   const reportData = useFragment(ReportDetailsFragment, report);
   useEffect(() => {
     setHeight(ref.current.clientHeight);
   });
-  const expandable = reportData.relatedContainers.edges.length > 5;
-  const relatedContainers = reportData.relatedContainers.edges
-    .filter((relatedContainerEdge) => relatedContainerEdge.node.id !== reportData.id)
-    .slice(0, expanded ? 200 : 5);
 
   const entitiesDistributionDataSelection = [
     {
@@ -251,87 +179,11 @@ const ReportDetails = ({ report }) => {
             />
           </Grid>
         </Grid>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Typography variant="h3" gutterBottom={true}>
-            {t_i18n('Correlated containers')}
-          </Typography>
-          <IconButton
-            color="primary"
-            aria-label="Go to correlation graph view"
-            onClick={() => navigate(`/dashboard/analyses/reports/${report.id}/knowledge/correlation`)}
-            size="medium"
-            style={{ marginBottom: 4 }}
-          >
-            <OpenInNewOutlined fontSize="small"/>
-          </IconButton>
-        </div>
-        <List classes={{ root: classes.relatedContainers }}>
-          {relatedContainers.length > 0
-            ? relatedContainers.map((relatedContainerEdge) => {
-              const relatedContainer = relatedContainerEdge.node;
-              return (
-                <ListItem
-                  key={reportData.id}
-                  dense={true}
-                  button={true}
-                  classes={{ root: classes.item }}
-                  divider={true}
-                  component={Link}
-                  to={`${resolveLink(relatedContainer.entity_type)}/${relatedContainer.id}`}
-                >
-                  <ListItemIcon>
-                    <ItemIcon type={relatedContainer.entity_type} />
-                  </ListItemIcon>
-                  <ListItemText
-                    className={classes.itemText}
-                    primary={
-                      <div>
-                        {relatedContainer.name}
-                      </div>
-                    }
-                  />
-                  <ListItemText
-                    className={classes.itemAuthor}
-                    primary={
-                      <div>
-                        {relatedContainer.createdBy?.name ?? '-'}
-                      </div>
-                    }
-                  />
-                  <ListItemText
-                    className={classes.itemDate}
-                    primary={
-                      <div>
-                        {fsd(relatedContainer.created ?? relatedContainer.published)}
-                      </div>
-                    }
-                  />
-                  <div className={classes.itemMarking}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={relatedContainer.objectMarking}
-                      limit={1}
-                    />
-                  </div>
-                </ListItem>
-              );
-            })
-            : '-'}
-        </List>
-        {expandable && (
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => setExpanded(!expanded)}
-            classes={{ root: classes.buttonExpand }}
-          >
-            {expanded ? (
-              <ExpandLessOutlined fontSize="small" />
-            ) : (
-              <ExpandMoreOutlined fontSize="small" />
-            )}
-          </Button>
-        )}
+        <RelatedContainers
+          relatedContainers={reportData.relatedContainers}
+          containerId={reportData.id}
+          entityType={reportData.entity_type}
+        />
       </Paper>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -44,7 +44,7 @@ const ReportDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      ...RelatedContainersFragment_containers_connection
+      ...RelatedContainersFragment_container_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -5,6 +5,7 @@ import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import makeStyles from '@mui/styles/makeStyles';
+import Divider from '@mui/material/Divider';
 import RelatedContainers from '../../common/containers/RelatedContainers';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import { useFormatter } from '../../../../components/i18n';
@@ -140,6 +141,7 @@ const ReportDetails = ({ report }) => {
             />
           </Grid>
         </Grid>
+        <Divider />
         <RelatedContainers
           relatedContainers={reportData.relatedContainers}
           containerId={reportData.id}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -44,46 +44,7 @@ const ReportDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      edges {
-        node {
-          id
-          entity_type
-          objectMarking {
-            id
-            definition_type
-            definition
-            x_opencti_order
-            x_opencti_color
-          }
-          createdBy {
-            ... on Identity {
-              id
-              name
-              entity_type
-            }
-          }
-          ... on Report {
-            name
-            published
-          }
-          ... on Grouping {
-            name
-            created
-          }
-          ... on CaseIncident {
-            name
-            created
-          }
-          ... on CaseRfi {
-            name
-            created
-          }
-          ... on CaseRft {
-            name
-            created
-          }
-        }
-      }
+      ...RelatedContainersFragment_containers_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -141,7 +141,7 @@ const ReportDetails = ({ report }) => {
             />
           </Grid>
         </Grid>
-        <Divider />
+        <Divider style={{ marginTop: 30 }} />
         <RelatedContainers
           relatedContainers={reportData.relatedContainers}
           containerId={reportData.id}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -19,6 +19,8 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(2),
     borderRadius: 4,
     position: 'relative',
+    display: 'flex',
+    flexFlow: 'column',
   },
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -98,123 +98,60 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ReportDetailsFragment = graphql`
-    fragment ReportDetails_report on Report {
-        id
-        published
-        report_types
-        description
-        relatedContainers(
-            first: 10
-            orderBy: published
-            orderMode: desc
-            types: ["Case", "Report", "Grouping"]
-            viaTypes: ["Indicator", "Stix-Cyber-Observable"]
-        ) {
-            edges {
-                node {
-                    id
-                    entity_type
-                    ... on Report {
-                        name
-                        description
-                        published
-                        createdBy {
-                            ... on Identity {
-                                id
-                                name
-                                entity_type
-                            }
-                        }
-                        objectMarking {
-                            id
-                            definition_type
-                            definition
-                            x_opencti_order
-                            x_opencti_color
-                        }
-                    }
-                    ... on Grouping {
-                        name
-                        context
-                        description
-                        created
-                        createdBy {
-                            ... on Identity {
-                                id
-                                name
-                                entity_type
-                            }
-                        }
-                        objectMarking {
-                            id
-                            definition
-                            definition_type
-                            definition
-                            x_opencti_order
-                            x_opencti_color
-                        }
-                    }
-                    ... on CaseIncident {
-                        name
-                        description
-                        created
-                        createdBy {
-                            ... on Identity {
-                                id
-                                name
-                                entity_type
-                            }
-                        }
-                        objectMarking {
-                            id
-                            definition_type
-                            definition
-                            x_opencti_order
-                            x_opencti_color
-                        }
-                    }
-                    ... on CaseRfi {
-                        name
-                        description
-                        created
-                        createdBy {
-                            ... on Identity {
-                                id
-                                name
-                                entity_type
-                            }
-                        }
-                        objectMarking {
-                            id
-                            definition_type
-                            definition
-                            x_opencti_order
-                            x_opencti_color
-                        }
-                    }
-                    ... on CaseRft {
-                        name
-                        description
-                        created
-                        createdBy {
-                            ... on Identity {
-                                id
-                                name
-                                entity_type
-                            }
-                        }
-                        objectMarking {
-                            id
-                            definition_type
-                            definition
-                            x_opencti_order
-                            x_opencti_color
-                        }
-                    }
-                }
+  fragment ReportDetails_report on Report {
+    id
+    published
+    report_types
+    description
+    relatedContainers(
+      first: 10
+      orderBy: published
+      orderMode: desc
+      types: ["Case", "Report", "Grouping"]
+      viaTypes: ["Indicator", "Stix-Cyber-Observable"]
+    ) {
+      edges {
+        node {
+          id
+          entity_type
+          objectMarking {
+            id
+            definition_type
+            definition
+            x_opencti_order
+            x_opencti_color
+          }
+          createdBy {
+            ... on Identity {
+              id
+              name
+              entity_type
             }
+          }
+          ... on Report {
+            name
+            published
+          }
+          ... on Grouping {
+            name
+            created
+          }
+          ... on CaseIncident {
+            name
+            created
+          }
+          ... on CaseRfi {
+            name
+            created
+          }
+          ... on CaseRft {
+            name
+            created
+          }
         }
+      }
     }
+  }
 `;
 
 const ReportDetails = ({ report }) => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -39,7 +39,7 @@ const ReportDetailsFragment = graphql`
     description
     relatedContainers(
       first: 10
-      orderBy: published
+      orderBy: modified
       orderMode: desc
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -5,13 +5,14 @@ import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import ListItem from '@mui/material/ListItem';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
-import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import makeStyles from '@mui/styles/makeStyles';
+import IconButton from '@mui/material/IconButton';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
@@ -140,6 +141,7 @@ const ReportDetailsFragment = graphql`
 const ReportDetails = ({ report }) => {
   const classes = useStyles();
   const { t_i18n, fldt, fsd } = useFormatter();
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
   const [height, setHeight] = useState(0);
   const ref = useRef(null);
@@ -233,9 +235,20 @@ const ReportDetails = ({ report }) => {
             />
           </Grid>
         </Grid>
-        <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated reports')}
-        </Typography>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Typography variant="h3" gutterBottom={true}>
+            {t_i18n('Correlated reports')}
+          </Typography>
+          <IconButton
+            color="primary"
+            aria-label="Go to correlation graph view"
+            onClick={() => navigate(`/dashboard/analyses/reports/${report.id}/knowledge/correlation`)}
+            size="medium"
+            style={{ marginBottom: 4 }}
+          >
+            <OpenInNewOutlined fontSize="small"/>
+          </IconButton>
+        </div>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
             ? relatedContainers.map((relatedContainerEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -340,7 +340,7 @@ const ReportDetails = ({ report }) => {
                   classes={{ root: classes.item }}
                   divider={true}
                   component={Link}
-                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
+                  to={`${resolveLink(relatedContainer.entity_type)}/${relatedContainer.id}`}
                 >
                   <ListItemIcon>
                     <ItemIcon type={relatedContainer.entity_type} />
@@ -365,7 +365,7 @@ const ReportDetails = ({ report }) => {
                     className={classes.itemDate}
                     primary={
                       <div>
-                        {fsd(relatedContainer?.created ?? relatedContainer?.published)}
+                        {fsd(relatedContainer.created ?? relatedContainer.published)}
                       </div>
                     }
                   />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -20,6 +20,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { resolveLink } from '../../../../utils/Entity';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -106,7 +107,7 @@ const ReportDetailsFragment = graphql`
             first: 10
             orderBy: published
             orderMode: desc
-            types: ["Report"]
+            types: ["Case", "Report", "Grouping"]
             viaTypes: ["Indicator", "Stix-Cyber-Observable"]
         ) {
             edges {
@@ -117,6 +118,84 @@ const ReportDetailsFragment = graphql`
                         name
                         description
                         published
+                        createdBy {
+                            ... on Identity {
+                                id
+                                name
+                                entity_type
+                            }
+                        }
+                        objectMarking {
+                            id
+                            definition_type
+                            definition
+                            x_opencti_order
+                            x_opencti_color
+                        }
+                    }
+                    ... on Grouping {
+                        name
+                        context
+                        description
+                        created
+                        createdBy {
+                            ... on Identity {
+                                id
+                                name
+                                entity_type
+                            }
+                        }
+                        objectMarking {
+                            id
+                            definition
+                            definition_type
+                            definition
+                            x_opencti_order
+                            x_opencti_color
+                        }
+                    }
+                    ... on CaseIncident {
+                        name
+                        description
+                        created
+                        createdBy {
+                            ... on Identity {
+                                id
+                                name
+                                entity_type
+                            }
+                        }
+                        objectMarking {
+                            id
+                            definition_type
+                            definition
+                            x_opencti_order
+                            x_opencti_color
+                        }
+                    }
+                    ... on CaseRfi {
+                        name
+                        description
+                        created
+                        createdBy {
+                            ... on Identity {
+                                id
+                                name
+                                entity_type
+                            }
+                        }
+                        objectMarking {
+                            id
+                            definition_type
+                            definition
+                            x_opencti_order
+                            x_opencti_color
+                        }
+                    }
+                    ... on CaseRft {
+                        name
+                        description
+                        created
                         createdBy {
                             ... on Identity {
                                 id
@@ -237,7 +316,7 @@ const ReportDetails = ({ report }) => {
         </Grid>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Typography variant="h3" gutterBottom={true}>
-            {t_i18n('Correlated reports')}
+            {t_i18n('Correlated containers')}
           </Typography>
           <IconButton
             color="primary"
@@ -261,7 +340,7 @@ const ReportDetails = ({ report }) => {
                   classes={{ root: classes.item }}
                   divider={true}
                   component={Link}
-                  to={`/dashboard/analyses/reports/${relatedContainer.id}`}
+                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
                 >
                   <ListItemIcon>
                     <ItemIcon type={relatedContainer.entity_type} />
@@ -286,7 +365,7 @@ const ReportDetails = ({ report }) => {
                     className={classes.itemDate}
                     primary={
                       <div>
-                        {fsd(relatedContainer.published)}
+                        {fsd(relatedContainer?.created ?? relatedContainer?.published)}
                       </div>
                     }
                   />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -6,6 +6,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import RelatedContainers from '@components/common/containers/RelatedContainers';
+import Divider from '@mui/material/Divider';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
@@ -140,6 +141,7 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
             )}
           </Grid>
         </Grid>
+        <Divider />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -62,7 +62,7 @@ const CaseIncidentDetailsFragment = graphql`
     workflowEnabled
     relatedContainers(
       first: 10
-      orderBy: created
+      orderBy: modified
       orderMode: desc
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -9,7 +9,6 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Link, useNavigate } from 'react-router-dom';
@@ -257,7 +256,7 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const responseTypes = data.response_types ?? [];
 
-  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+  const relatedContainers = (data.relatedContainers?.edges ?? [])
     .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
     .slice(0, expanded ? 200 : 5);
 

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -67,46 +67,7 @@ const CaseIncidentDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      edges {
-        node {
-          id
-          entity_type
-          objectMarking {
-            id
-            definition_type
-            definition
-            x_opencti_order
-            x_opencti_color
-          }
-          createdBy {
-            ... on Identity {
-              id
-              name
-              entity_type
-            }
-          }
-          ... on Report {
-            name
-            published
-          }
-          ... on Grouping {
-            name
-            created
-          }
-          ... on CaseIncident {
-            name
-            created
-          }
-          ... on CaseRfi {
-            name
-            created
-          }
-          ... on CaseRft {
-            name
-            created
-          }
-        }
-      }
+      ...RelatedContainersFragment_containers_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
     padding: '15px',
     borderRadius: 4,
     position: 'relative',
+    display: 'flex',
+    flexFlow: 'column',
   },
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -141,7 +141,7 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Divider />
+        <Divider style={{ marginTop: 30 }} />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -1,26 +1,16 @@
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link, useNavigate } from 'react-router-dom';
-import IconButton from '@mui/material/IconButton';
+import RelatedContainers from '@components/common/containers/RelatedContainers';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseIncidentDetails_case$key } from './__generated__/CaseIncidentDetails_case.graphql';
-import { resolveLink } from '../../../../utils/Entity';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -40,70 +30,13 @@ const useStyles = makeStyles<Theme>((theme) => ({
     borderRadius: 4,
     margin: '0 5px 5px 0',
   },
-  item: {
-    height: 50,
-    minHeight: 50,
-    maxHeight: 50,
-    paddingRight: 0,
-  },
-  itemText: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    paddingRight: 10,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-  itemAuthor: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    marginLeft: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemDate: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemMarking: {
-    width: 110,
-    paddingRight: 20,
-  },
-  relatedContainers: {
-    paddingTop: 0,
-  },
 }));
 
 const CaseIncidentDetailsFragment = graphql`
   fragment CaseIncidentDetails_case on CaseIncident {
     id
     name
+    entity_type
     description
     priority
     severity
@@ -185,17 +118,10 @@ interface CaseIncidentDetailsProps {
 const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
   caseIncidentData,
 }) => {
-  const { t_i18n, fsd } = useFormatter();
-  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
   const classes = useStyles();
-  const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseIncidentDetailsFragment, caseIncidentData);
-  const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const responseTypes = data.response_types ?? [];
-
-  const relatedContainers = (data.relatedContainers?.edges ?? [])
-    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
-    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>
@@ -253,76 +179,11 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Typography variant="h3" gutterBottom={true}>
-            {t_i18n('Correlated containers')}
-          </Typography>
-          <IconButton
-            color="primary"
-            aria-label="Go to correlation graph view"
-            onClick={() => navigate(`/dashboard/cases/incidents/${data.id}/knowledge/correlation`)}
-            size="medium"
-            style={{ marginBottom: 4 }}
-          >
-            <OpenInNewOutlined fontSize="small"/>
-          </IconButton>
-        </div>
-        <List classes={{ root: classes.relatedContainers }}>
-          {relatedContainers.length > 0
-            ? relatedContainers.map((relatedContainerEdge) => {
-              const relatedContainer = relatedContainerEdge?.node;
-              return (
-                <ListItem
-                  key={data.id}
-                  dense={true}
-                  button={true}
-                  classes={{ root: classes.item }}
-                  divider={true}
-                  component={Link}
-                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
-                >
-                  <ListItemIcon>
-                    <ItemIcon type={relatedContainer?.entity_type} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <div className={classes.itemText}>
-                        {relatedContainer?.name}
-                      </div>
-                      }
-                  />
-                  <div className={classes.itemAuthor}>
-                    {relatedContainer?.createdBy?.name ?? '-'}
-                  </div>
-                  <div className={classes.itemDate}>
-                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
-                  </div>
-                  <div className={classes.itemMarking}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={relatedContainer?.objectMarking ?? []}
-                      limit={1}
-                    />
-                  </div>
-                </ListItem>
-              );
-            })
-            : '-'}
-        </List>
-        {expandable && (
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => setExpanded(!expanded)}
-            classes={{ root: classes.buttonExpand }}
-          >
-            {expanded ? (
-              <ExpandLessOutlined fontSize="small" />
-            ) : (
-              <ExpandMoreOutlined fontSize="small" />
-            )}
-          </Button>
-        )}
+        <RelatedContainers
+          relatedContainers={data.relatedContainers}
+          containerId={data.id}
+          entityType={data.entity_type}
+        />
       </Paper>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -67,7 +67,7 @@ const CaseIncidentDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      ...RelatedContainersFragment_containers_connection
+      ...RelatedContainersFragment_container_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -138,102 +138,39 @@ const CaseIncidentDetailsFragment = graphql`
         node {
           id
           entity_type
+          objectMarking {
+            id
+            definition_type
+            definition
+            x_opencti_order
+            x_opencti_color
+          }
+          createdBy {
+            ... on Identity {
+              id
+              name
+              entity_type
+            }
+          }
           ... on Report {
             name
-            description
             published
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on Grouping {
             name
-            context
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseIncident {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseRfi {
             name
-            description
             created
-            createdBy {
-                ... on Identity {
-                    id
-                    name
-                    entity_type
-                }
-            }
-            objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-            }
           }
           ... on CaseRft {
             name
-            description
             created
-            createdBy {
-                ... on Identity {
-                    id
-                    name
-                    entity_type
-                }
-            }
-            objectMarking {
-                id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
-            }
           }
         }
       }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -257,11 +257,9 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const responseTypes = data.response_types ?? [];
 
-  const relatedContainers = R.take(
-    expanded ? 200 : 5,
-    // exclude itself
-    (data.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id),
-  );
+  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
+    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -1,4 +1,4 @@
-import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
@@ -12,7 +12,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -249,6 +250,7 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
   caseIncidentData,
 }) => {
   const { t_i18n, fsd } = useFormatter();
+  const navigate = useNavigate();
   const classes = useStyles();
   const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseIncidentDetailsFragment, caseIncidentData);
@@ -317,9 +319,20 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated containers')}
-        </Typography>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Typography variant="h3" gutterBottom={true}>
+            {t_i18n('Correlated containers')}
+          </Typography>
+          <IconButton
+            color="primary"
+            aria-label="Go to correlation graph view"
+            onClick={() => navigate(`/dashboard/cases/incidents/${data.id}/knowledge/correlation`)}
+            size="medium"
+            style={{ marginBottom: 4 }}
+          >
+            <OpenInNewOutlined fontSize="small"/>
+          </IconButton>
+        </div>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
             ? relatedContainers.map((relatedContainerEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -141,7 +141,7 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Divider />
+        <Divider style={{ marginTop: 30 }} />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -1,26 +1,16 @@
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link, useNavigate } from 'react-router-dom';
-import IconButton from '@mui/material/IconButton';
+import RelatedContainers from '@components/common/containers/RelatedContainers';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseRfiDetails_case$key } from './__generated__/CaseRfiDetails_case.graphql';
-import { resolveLink } from '../../../../utils/Entity';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -40,70 +30,13 @@ const useStyles = makeStyles<Theme>((theme) => ({
     borderRadius: 4,
     margin: '0 5px 5px 0',
   },
-  item: {
-    height: 50,
-    minHeight: 50,
-    maxHeight: 50,
-    paddingRight: 0,
-  },
-  itemText: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    paddingRight: 10,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-  itemAuthor: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    marginLeft: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemDate: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemMarking: {
-    width: 110,
-    paddingRight: 20,
-  },
-  relatedContainers: {
-    paddingTop: 0,
-  },
 }));
 
 const CaseRfiDetailsFragment = graphql`
   fragment CaseRfiDetails_case on CaseRfi {
     id
     name
+    entity_type
     description
     created
     modified
@@ -185,17 +118,10 @@ interface CaseRfiDetailsProps {
 const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
   caseRfiData,
 }) => {
-  const { t_i18n, fsd } = useFormatter();
-  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
   const classes = useStyles();
-  const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseRfiDetailsFragment, caseRfiData);
-  const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const informationTypes = data.information_types ?? [];
-
-  const relatedContainers = (data.relatedContainers?.edges ?? [])
-    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
-    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>
@@ -253,78 +179,11 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Typography variant="h3" gutterBottom={true}>
-            {t_i18n('Correlated containers')}
-          </Typography>
-          <IconButton
-            color="primary"
-            aria-label="Go to correlation graph view"
-            onClick={() => navigate(`/dashboard/cases/rfis/${data.id}/knowledge/correlation`)}
-            size="medium"
-            style={{ marginBottom: 4 }}
-          >
-            <OpenInNewOutlined fontSize="small"/>
-          </IconButton>
-        </div>
-        <List classes={{ root: classes.relatedContainers }}>
-          {relatedContainers.length > 0
-            ? relatedContainers.map((relatedContainerEdge) => {
-              const relatedContainer = relatedContainerEdge?.node;
-              return (
-                <ListItem
-                  key={data.id}
-                  dense={true}
-                  button={true}
-                  classes={{ root: classes.item }}
-                  divider={true}
-                  component={Link}
-                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
-                >
-                  <ListItemIcon>
-                    <ItemIcon type={relatedContainer?.entity_type} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <div className={classes.itemText}>
-                        {relatedContainer?.name}
-                      </div>
-                      }
-                  />
-                  <div className={classes.itemAuthor}>
-                    {relatedContainer?.createdBy?.name ?? '-'}
-                  </div>
-                  <div className={classes.itemDate}>
-                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
-                  </div>
-                  <div className={classes.itemMarking}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={
-                          relatedContainer?.objectMarking ?? []
-                        }
-                      limit={1}
-                    />
-                  </div>
-                </ListItem>
-              );
-            })
-            : '-'}
-        </List>
-        {expandable && (
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => setExpanded(!expanded)}
-            classes={{ root: classes.buttonExpand }}
-          >
-            {expanded ? (
-              <ExpandLessOutlined fontSize="small" />
-            ) : (
-              <ExpandMoreOutlined fontSize="small" />
-            )}
-          </Button>
-        )}
+        <RelatedContainers
+          relatedContainers={data.relatedContainers}
+          containerId={data.id}
+          entityType={data.entity_type}
+        />
       </Paper>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -1,4 +1,4 @@
-import { ContentPasteGoOutlined, ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
@@ -9,7 +9,6 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Link, useNavigate } from 'react-router-dom';
@@ -257,7 +256,7 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const informationTypes = data.information_types ?? [];
 
-  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+  const relatedContainers = (data.relatedContainers?.edges ?? [])
     .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
     .slice(0, expanded ? 200 : 5);
 

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -62,7 +62,7 @@ const CaseRfiDetailsFragment = graphql`
     workflowEnabled
     relatedContainers(
       first: 10
-      orderBy: created
+      orderBy: modified
       orderMode: desc
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
     padding: '15px',
     borderRadius: 4,
     position: 'relative',
+    display: 'flex',
+    flexFlow: 'column',
   },
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -67,46 +67,7 @@ const CaseRfiDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      edges {
-        node {
-          id
-          entity_type
-          objectMarking {
-            id
-            definition_type
-            definition
-            x_opencti_order
-            x_opencti_color
-          }
-          createdBy {
-            ... on Identity {
-              id
-              name
-              entity_type
-            }
-          }
-          ... on Report {
-            name
-            published
-          }
-          ... on Grouping {
-            name
-            created
-          }
-          ... on CaseIncident {
-            name
-            created
-          }
-          ... on CaseRfi {
-            name
-            created
-          }
-          ... on CaseRft {
-            name
-            created
-          }
-        }
-      }
+      ...RelatedContainersFragment_containers_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -6,6 +6,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import RelatedContainers from '@components/common/containers/RelatedContainers';
+import Divider from '@mui/material/Divider';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
@@ -140,6 +141,7 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
             )}
           </Grid>
         </Grid>
+        <Divider />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -138,102 +138,39 @@ const CaseRfiDetailsFragment = graphql`
         node {
           id
           entity_type
+          objectMarking {
+            id
+            definition_type
+            definition
+            x_opencti_order
+            x_opencti_color
+          }
+          createdBy {
+            ... on Identity {
+              id
+              name
+              entity_type
+            }
+          }
           ... on Report {
             name
-            description
             published
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on Grouping {
             name
-            context
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseIncident {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseRfi {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseRft {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
         }
       }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -67,7 +67,7 @@ const CaseRfiDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      ...RelatedContainersFragment_containers_connection
+      ...RelatedContainersFragment_container_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -131,70 +131,110 @@ const CaseRfiDetailsFragment = graphql`
       first: 10
       orderBy: created
       orderMode: desc
-      types: ["Case"]
+      types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
       edges {
         node {
           id
           entity_type
-            ... on CaseIncident {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+          ... on Report {
+            name
+            description
+            published
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
-            ... on CaseRfi {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on Grouping {
+            name
+            context
+            description
+            created
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
-            ... on CaseRft {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+            objectMarking {
+              id
+              definition
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseIncident {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseRfi {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
+                id
+                name
+                entity_type
+              }
+            }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseRft {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
+                id
+                name
+                entity_type
+              }
+            }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
         }
       }
     }
@@ -216,10 +256,10 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
   const informationTypes = data.information_types ?? [];
   const relatedContainers = R.take(
     expanded ? 200 : 5,
-    data.relatedContainers?.edges ?? [],
-  ).filter(
-    (relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id,
+    // exclude itself
+    (data.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id),
   );
+
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>
@@ -277,7 +317,7 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
           </Grid>
         </Grid>
         <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated cases')}
+          {t_i18n('Correlated containers')}
         </Typography>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
@@ -304,10 +344,10 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
                       }
                   />
                   <div className={classes.itemAuthor}>
-                    {R.pathOr('', ['createdBy', 'name'], relatedContainer)}
+                    {relatedContainer?.createdBy?.name ?? '-'}
                   </div>
                   <div className={classes.itemDate}>
-                    {fsd(relatedContainer?.created)}
+                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
                   </div>
                   <div className={classes.itemMarking}>
                     <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -256,11 +256,10 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
   const data = useFragment(CaseRfiDetailsFragment, caseRfiData);
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const informationTypes = data.information_types ?? [];
-  const relatedContainers = R.take(
-    expanded ? 200 : 5,
-    // exclude itself
-    (data.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id),
-  );
+
+  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
+    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -1,4 +1,4 @@
-import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import { ContentPasteGoOutlined, ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
@@ -12,7 +12,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -249,6 +250,7 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
   caseRfiData,
 }) => {
   const { t_i18n, fsd } = useFormatter();
+  const navigate = useNavigate();
   const classes = useStyles();
   const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseRfiDetailsFragment, caseRfiData);
@@ -316,9 +318,20 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated containers')}
-        </Typography>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Typography variant="h3" gutterBottom={true}>
+            {t_i18n('Correlated containers')}
+          </Typography>
+          <IconButton
+            color="primary"
+            aria-label="Go to correlation graph view"
+            onClick={() => navigate(`/dashboard/cases/rfis/${data.id}/knowledge/correlation`)}
+            size="medium"
+            style={{ marginBottom: 4 }}
+          >
+            <OpenInNewOutlined fontSize="small"/>
+          </IconButton>
+        </div>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
             ? relatedContainers.map((relatedContainerEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -9,7 +9,6 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Link, useNavigate } from 'react-router-dom';
@@ -257,7 +256,7 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const takedownTypes = data.takedown_types ?? [];
 
-  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+  const relatedContainers = (data.relatedContainers?.edges ?? [])
     .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
     .slice(0, expanded ? 200 : 5);
 

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -67,7 +67,7 @@ const CaseRftDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      ...RelatedContainersFragment_containers_connection
+      ...RelatedContainersFragment_container_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -67,46 +67,7 @@ const CaseRftDetailsFragment = graphql`
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
-      edges {
-        node {
-          id
-          entity_type
-          objectMarking {
-            id
-            definition_type
-            definition
-            x_opencti_order
-            x_opencti_color
-          }
-          createdBy {
-            ... on Identity {
-              id
-              name
-              entity_type
-            }
-          }
-          ... on Report {
-            name
-            published
-          }
-          ... on Grouping {
-            name
-            created
-          }
-          ... on CaseIncident {
-            name
-            created
-          }
-          ... on CaseRfi {
-            name
-            created
-          }
-          ... on CaseRft {
-            name
-            created
-          }
-        }
-      }
+      ...RelatedContainersFragment_containers_connection
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -138,102 +138,39 @@ const CaseRftDetailsFragment = graphql`
         node {
           id
           entity_type
+          objectMarking {
+            id
+            definition_type
+            definition
+            x_opencti_order
+            x_opencti_color
+          }
+          createdBy {
+            ... on Identity {
+              id
+              name
+              entity_type
+            }
+          }
           ... on Report {
             name
-            description
             published
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on Grouping {
             name
-            context
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseIncident {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseRfi {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
           ... on CaseRft {
             name
-            description
             created
-            createdBy {
-              ... on Identity {
-                id
-                name
-                entity_type
-              }
-            }
-            objectMarking {
-              id
-              definition_type
-              definition
-              x_opencti_order
-              x_opencti_color
-            }
           }
         }
       }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -6,6 +6,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import RelatedContainers from '@components/common/containers/RelatedContainers';
+import Divider from '@mui/material/Divider';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
@@ -140,6 +141,7 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
             )}
           </Grid>
         </Grid>
+        <Divider />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -141,7 +141,7 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Divider />
+        <Divider style={{ marginTop: 30 }} />
         <RelatedContainers
           relatedContainers={data.relatedContainers}
           containerId={data.id}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
     padding: '15px',
     borderRadius: 4,
     position: 'relative',
+    display: 'flex',
+    flexFlow: 'column',
   },
   chip: {
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -1,26 +1,16 @@
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link, useNavigate } from 'react-router-dom';
-import IconButton from '@mui/material/IconButton';
+import RelatedContainers from '@components/common/containers/RelatedContainers';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import type { Theme } from '../../../../components/Theme';
 import { CaseRftDetails_case$key } from './__generated__/CaseRftDetails_case.graphql';
-import { resolveLink } from '../../../../utils/Entity';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -40,70 +30,13 @@ const useStyles = makeStyles<Theme>((theme) => ({
     borderRadius: 4,
     margin: '0 5px 5px 0',
   },
-  item: {
-    height: 50,
-    minHeight: 50,
-    maxHeight: 50,
-    paddingRight: 0,
-  },
-  itemText: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    paddingRight: 10,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-  itemAuthor: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    marginLeft: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemDate: {
-    width: 120,
-    minWidth: 120,
-    maxWidth: 120,
-    marginRight: 24,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  itemMarking: {
-    width: 110,
-    paddingRight: 20,
-  },
-  relatedContainers: {
-    paddingTop: 0,
-  },
 }));
 
 const CaseRftDetailsFragment = graphql`
   fragment CaseRftDetails_case on CaseRft {
     id
     name
+    entity_type
     description
     created
     modified
@@ -185,17 +118,10 @@ interface CaseRftDetailsProps {
 const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
   caseRftData,
 }) => {
-  const { t_i18n, fsd } = useFormatter();
-  const navigate = useNavigate();
+  const { t_i18n } = useFormatter();
   const classes = useStyles();
-  const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseRftDetailsFragment, caseRftData);
-  const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const takedownTypes = data.takedown_types ?? [];
-
-  const relatedContainers = (data.relatedContainers?.edges ?? [])
-    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
-    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>
@@ -253,78 +179,11 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <Typography variant="h3" gutterBottom={true}>
-            {t_i18n('Correlated containers')}
-          </Typography>
-          <IconButton
-            color="primary"
-            aria-label="Go to correlation graph view"
-            onClick={() => navigate(`/dashboard/cases/rfts/${data.id}/knowledge/correlation`)}
-            size="medium"
-            style={{ marginBottom: 4 }}
-          >
-            <OpenInNewOutlined fontSize="small"/>
-          </IconButton>
-        </div>
-        <List classes={{ root: classes.relatedContainers }}>
-          {relatedContainers.length > 0
-            ? relatedContainers.map((relatedContainerEdge) => {
-              const relatedContainer = relatedContainerEdge?.node;
-              return (
-                <ListItem
-                  key={data.id}
-                  dense={true}
-                  button={true}
-                  classes={{ root: classes.item }}
-                  divider={true}
-                  component={Link}
-                  to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
-                >
-                  <ListItemIcon>
-                    <ItemIcon type={relatedContainer?.entity_type} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <div className={classes.itemText}>
-                        {relatedContainer?.name}
-                      </div>
-                      }
-                  />
-                  <div className={classes.itemAuthor}>
-                    {relatedContainer?.createdBy?.name ?? '-'}
-                  </div>
-                  <div className={classes.itemDate}>
-                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
-                  </div>
-                  <div className={classes.itemMarking}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={
-                          relatedContainer?.objectMarking ?? []
-                        }
-                      limit={1}
-                    />
-                  </div>
-                </ListItem>
-              );
-            })
-            : '-'}
-        </List>
-        {expandable && (
-          <Button
-            variant="contained"
-            size="small"
-            onClick={() => setExpanded(!expanded)}
-            classes={{ root: classes.buttonExpand }}
-          >
-            {expanded ? (
-              <ExpandLessOutlined fontSize="small" />
-            ) : (
-              <ExpandMoreOutlined fontSize="small" />
-            )}
-          </Button>
-        )}
+        <RelatedContainers
+          relatedContainers={data.relatedContainers}
+          containerId={data.id}
+          entityType={data.entity_type}
+        />
       </Paper>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -62,7 +62,7 @@ const CaseRftDetailsFragment = graphql`
     workflowEnabled
     relatedContainers(
       first: 10
-      orderBy: created
+      orderBy: modified
       orderMode: desc
       types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -1,4 +1,4 @@
-import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
@@ -12,7 +12,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import * as R from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -249,6 +250,7 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
   caseRftData,
 }) => {
   const { t_i18n, fsd } = useFormatter();
+  const navigate = useNavigate();
   const classes = useStyles();
   const [expanded, setExpanded] = useState(false);
   const data = useFragment(CaseRftDetailsFragment, caseRftData);
@@ -317,9 +319,20 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
             )}
           </Grid>
         </Grid>
-        <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated containers')}
-        </Typography>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Typography variant="h3" gutterBottom={true}>
+            {t_i18n('Correlated containers')}
+          </Typography>
+          <IconButton
+            color="primary"
+            aria-label="Go to correlation graph view"
+            onClick={() => navigate(`/dashboard/cases/rfts/${data.id}/knowledge/correlation`)}
+            size="medium"
+            style={{ marginBottom: 4 }}
+          >
+            <OpenInNewOutlined fontSize="small"/>
+          </IconButton>
+        </div>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
             ? relatedContainers.map((relatedContainerEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -257,11 +257,9 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
   const expandable = (data.relatedContainers?.edges ?? []).length > 5;
   const takedownTypes = data.takedown_types ?? [];
 
-  const relatedContainers = R.take(
-    expanded ? 200 : 5,
-    // exclude itself
-    (data.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id),
-  );
+  const relatedContainers = (data?.relatedContainers?.edges ?? [])
+    .filter((relatedContainerEdge) => relatedContainerEdge?.node.id !== data.id)
+    .slice(0, expanded ? 200 : 5);
 
   return (
     <div style={{ height: '100%' }}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -131,70 +131,110 @@ const CaseRftDetailsFragment = graphql`
       first: 10
       orderBy: created
       orderMode: desc
-      types: ["Case"]
+      types: ["Case", "Report", "Grouping"]
       viaTypes: ["Indicator", "Stix-Cyber-Observable"]
     ) {
       edges {
         node {
           id
           entity_type
-            ... on CaseIncident {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+          ... on Report {
+            name
+            description
+            published
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
-            ... on CaseRfi {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on Grouping {
+            name
+            context
+            description
+            created
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
-            ... on CaseRft {
-              name
-              description
-              created
-              createdBy {
-                ... on Identity {
-                  id
-                  name
-                  entity_type
-                }
-              }
-              objectMarking {
+            objectMarking {
+              id
+              definition
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseIncident {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
                 id
-                definition_type
-                definition
-                x_opencti_order
-                x_opencti_color
+                name
+                entity_type
               }
             }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseRfi {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
+                id
+                name
+                entity_type
+              }
+            }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
+          ... on CaseRft {
+            name
+            description
+            created
+            createdBy {
+              ... on Identity {
+                id
+                name
+                entity_type
+              }
+            }
+            objectMarking {
+              id
+              definition_type
+              definition
+              x_opencti_order
+              x_opencti_color
+            }
+          }
         }
       }
     }
@@ -217,9 +257,8 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
 
   const relatedContainers = R.take(
     expanded ? 200 : 5,
-    data.relatedContainers?.edges ?? [],
-  ).filter(
-    (relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id,
+    // exclude itself
+    (data.relatedContainers?.edges ?? []).filter((relatedContainerEdge) => relatedContainerEdge?.node?.id !== data.id),
   );
 
   return (
@@ -279,7 +318,7 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
           </Grid>
         </Grid>
         <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated cases')}
+          {t_i18n('Correlated containers')}
         </Typography>
         <List classes={{ root: classes.relatedContainers }}>
           {relatedContainers.length > 0
@@ -306,10 +345,10 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
                       }
                   />
                   <div className={classes.itemAuthor}>
-                    {relatedContainer?.createdBy?.name ?? ''}
+                    {relatedContainer?.createdBy?.name ?? '-'}
                   </div>
                   <div className={classes.itemDate}>
-                    {fsd(relatedContainer?.created)}
+                    {fsd(relatedContainer?.created ?? relatedContainer?.published)}
                   </div>
                   <div className={classes.itemMarking}>
                     <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -1,21 +1,16 @@
 import React, { useState } from 'react';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Button from '@mui/material/Button';
-import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import { Link, useNavigate } from 'react-router-dom';
+import { OpenInNewOutlined } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/styles';
 import { graphql, useFragment } from 'react-relay';
 import { resolveLink } from '../../../../utils/Entity';
-import ItemIcon from '../../../../components/ItemIcon';
-import ItemMarkings from '../../../../components/ItemMarkings';
 import { useFormatter } from '../../../../components/i18n';
-import type { Theme } from '../../../../components/Theme';
-import { RelatedContainersFragment_container_connection$key } from './__generated__/RelatedContainersFragment_container_connection.graphql';
+import {
+  RelatedContainersFragment_container_connection$key,
+  RelatedContainersFragment_container_connection$data,
+} from './__generated__/RelatedContainersFragment_container_connection.graphql';
+import DataTableWithoutFragment from '../../../../components/dataGrid/DataTableWithoutFragment';
 
 export const RelatedContainersFragment = graphql`
   fragment RelatedContainersFragment_container_connection on ContainerConnection {
@@ -59,8 +54,13 @@ export const RelatedContainersFragment = graphql`
         }
       }
     }
+    pageInfo {
+      globalCount
+    }
   }
 `;
+
+type RelatedContainerNode = NonNullable<NonNullable<RelatedContainersFragment_container_connection$data['edges']>[number]>['node'];
 
 interface RelatedContainersProps {
   relatedContainers: RelatedContainersFragment_container_connection$key | null | undefined;
@@ -73,27 +73,21 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
   containerId,
   entityType,
 }) => {
-  const { t_i18n, fsd } = useFormatter();
-  const theme = useTheme<Theme>();
+  const { t_i18n } = useFormatter();
   const navigate = useNavigate();
-  const [expanded, setExpanded] = useState(false);
   const relatedContainers = useFragment(
     RelatedContainersFragment,
     relatedContainersKey,
   );
+  const [ref, setRef] = useState<HTMLDivElement | undefined>();
 
-  const containersEdges = relatedContainers?.edges ?? [];
-  const expandable = containersEdges.length > 5;
-  const containers = containersEdges
-    .filter((edge) => edge?.node.id !== containerId)
-    .slice(0, expanded ? 200 : 5);
+  const containers = (relatedContainers?.edges ?? []).filter((edge) => edge?.node.id !== containerId).map((edge) => edge?.node);
+  const containersGlobalCount = relatedContainers?.pageInfo?.globalCount ?? 0;
 
   return (
-    <div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <Typography variant="h3" gutterBottom={true}>
-          {t_i18n('Correlated containers')}
-        </Typography>
+    <div style={{ marginTop: 20, height: 400 }} ref={(r) => setRef(r ?? undefined)}>
+      <Typography variant="h3" gutterBottom={true} style={{ }}>
+        {t_i18n('Correlated containers')}
         <IconButton
           color="primary"
           aria-label="Go to correlation graph view"
@@ -103,108 +97,24 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
         >
           <OpenInNewOutlined fontSize="small"/>
         </IconButton>
-      </div>
-      <List sx={{ marginBottom: 1 }}>
-        {containers.length > 0 ? (
-          containers.map((edge) => {
-            const relatedContainer = edge?.node;
-            return (
-              <ListItem
-                key={relatedContainer?.id}
-                button
-                divider
-                component={Link}
-                to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
-                sx={{
-                  '&': {
-                    height: 50,
-                    minHeight: 50,
-                    maxHeight: 50,
-                    paddingRight: 0,
-                  },
-                }}
-              >
-                <ListItemIcon>
-                  <ItemIcon type={relatedContainer?.entity_type}/>
-                </ListItemIcon>
-                <ListItemText primary={
-                  <div style={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    paddingRight: 10,
-                  }}
-                  >
-                    {relatedContainer?.name}
-                  </div>
-                 }
-                />
-                <div style={{
-                  width: 100,
-                  minWidth: 100,
-                  maxWidth: 100,
-                  marginRight: 24,
-                  marginLeft: 24,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-                >{relatedContainer?.createdBy?.name ?? '-'}</div>
-                <div style={{
-                  width: 100,
-                  minWidth: 100,
-                  maxWidth: 100,
-                  marginRight: 24,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-                >{fsd(relatedContainer?.modified)}</div>
-                <div style={{
-                  width: 110,
-                  paddingRight: 20,
-                }}
-                >
-                  <ItemMarkings
-                    variant="inList"
-                    markingDefinitions={relatedContainer?.objectMarking ?? []}
-                    limit={1}
-                  />
-                </div>
-              </ListItem>
-            );
-          })
-        )
-          : '-'}
-      </List>
-      {expandable && (
-        <Button
-          onClick={() => setExpanded(!expanded)}
-          sx={{
-            position: 'absolute',
-            left: 0,
-            bottom: 0,
-            width: '100%',
-            height: 25,
-            color: theme.palette.primary.main,
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .1)'
-                : 'rgba(0, 0, 0, .1)',
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-            '&:hover': {
-              backgroundColor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(255, 255, 255, .2)'
-                  : 'rgba(0, 0, 0, .2)',
-            },
-          }}
-          variant="contained"
-        >
-          {expanded ? <ExpandLessOutlined/> : <ExpandMoreOutlined/>}
-        </Button>
-      )}
+      </Typography>
+      <div className="clearfix"/>
+      <DataTableWithoutFragment
+        dataColumns={{
+          entity_type: { percentWidth: 15 },
+          name: { percentWidth: 40 },
+          createdBy: { percentWidth: 15 },
+          modified: { percentWidth: 15 },
+          objectMarking: { percentWidth: 15 },
+        }}
+        data={containers}
+        globalCount={containersGlobalCount}
+        rootRef={ref}
+        disableNavigation={true}
+        storageKey={`related-containers-${entityType}-${containerId}`}
+        hideHeaders={true}
+        onLineClick={(row: RelatedContainerNode) => navigate(`${resolveLink(row?.entity_type)}/${row?.id}`)}
+      />
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -39,23 +39,23 @@ export const RelatedContainersFragment = graphql`
         }
         ... on Report {
           name
-          published
+          modified
         }
         ... on Grouping {
           name
-          created
+          modified
         }
         ... on CaseIncident {
           name
-          created
+          modified
         }
         ... on CaseRfi {
           name
-          created
+          modified
         }
         ... on CaseRft {
           name
-          created
+          modified
         }
       }
     }
@@ -159,7 +159,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                 }}
-                >{fsd(relatedContainer?.created ?? relatedContainer?.published)}</div>
+                >{fsd(relatedContainer?.modified)}</div>
                 <div style={{
                   width: 110,
                   paddingRight: 20,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -85,7 +85,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
   const containersGlobalCount = relatedContainers?.pageInfo?.globalCount ?? 0;
 
   return (
-    <div style={{ marginTop: 20, height: 400 }} ref={(r) => setRef(r ?? undefined)}>
+    <div style={{ marginTop: 20, height: 300 }} ref={(r) => setRef(r ?? undefined)}>
       <Typography variant="h3" gutterBottom={true} style={{ }}>
         {t_i18n('Correlated containers')}
         <IconButton

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -9,29 +9,67 @@ import { Link, useNavigate } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/styles';
-import { CaseRfiDetails_case$data } from '@components/cases/case_rfis/__generated__/CaseRfiDetails_case.graphql';
-import { CaseRftDetails_case$data } from '@components/cases/case_rfts/__generated__/CaseRftDetails_case.graphql';
-import { CaseIncidentDetails_case$data } from '@components/cases/case_incidents/__generated__/CaseIncidentDetails_case.graphql';
-import { ReportDetails_report$data } from '@components/analyses/reports/__generated__/ReportDetails_report.graphql';
-import { GroupingDetails_grouping$data } from '@components/analyses/groupings/__generated__/GroupingDetails_grouping.graphql';
+import { graphql, useFragment } from 'react-relay';
 import { resolveLink } from '../../../../utils/Entity';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
+import { RelatedContainersFragment$key } from './__generated__/RelatedContainersFragment.graphql';
+
+export const RelatedContainersFragment = graphql`
+  fragment RelatedContainersFragment_containers_connection on ContainerConnection {
+    edges {
+      node {
+        id
+        entity_type
+        objectMarking {
+          id
+          definition_type
+          definition
+          x_opencti_order
+          x_opencti_color
+        }
+        createdBy {
+          ... on Identity {
+            id
+            name
+            entity_type
+          }
+        }
+        ... on Report {
+          name
+          published
+        }
+        ... on Grouping {
+          name
+          created
+        }
+        ... on CaseIncident {
+          name
+          created
+        }
+        ... on CaseRfi {
+          name
+          created
+        }
+        ... on CaseRft {
+          name
+          created
+        }
+      }
+    }
+  }
+`;
 
 interface RelatedContainersProps {
-  relatedContainers: ReportDetails_report$data['relatedContainers']
-  | GroupingDetails_grouping$data['relatedContainers']
-  | CaseIncidentDetails_case$data['relatedContainers']
-  | CaseRftDetails_case$data['relatedContainers']
-  | CaseRfiDetails_case$data['relatedContainers']
+  relatedContainers: RelatedContainersFragment$key | null | undefined;
   containerId: string;
   entityType: string;
 }
 
 const RelatedContainers: React.FC<RelatedContainersProps> = ({
-  relatedContainers,
+  relatedContainers: relatedContainersKey,
   containerId,
   entityType,
 }) => {
@@ -39,6 +77,10 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
   const theme = useTheme<Theme>();
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
+  const relatedContainers = useFragment(
+    RelatedContainersFragment,
+    relatedContainersKey,
+  );
 
   const containersEdges = relatedContainers?.edges ?? [];
   const expandable = containersEdges.length > 5;
@@ -62,7 +104,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
           <OpenInNewOutlined fontSize="small"/>
         </IconButton>
       </div>
-      <List>
+      <List sx={{ marginBottom: 1 }}>
         {containers.length > 0 ? (
           containers.map((edge) => {
             const relatedContainer = edge?.node;

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -15,10 +15,10 @@ import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
-import { RelatedContainersFragment$key } from './__generated__/RelatedContainersFragment.graphql';
+import { RelatedContainersFragment_container_connection$key } from './__generated__/RelatedContainersFragment_container_connection.graphql';
 
 export const RelatedContainersFragment = graphql`
-  fragment RelatedContainersFragment_containers_connection on ContainerConnection {
+  fragment RelatedContainersFragment_container_connection on ContainerConnection {
     edges {
       node {
         id
@@ -63,7 +63,7 @@ export const RelatedContainersFragment = graphql`
 `;
 
 interface RelatedContainersProps {
-  relatedContainers: RelatedContainersFragment$key | null | undefined;
+  relatedContainers: RelatedContainersFragment_container_connection$key | null | undefined;
   containerId: string;
   entityType: string;
 }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -89,7 +89,13 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
   const containersGlobalCount = relatedContainers?.pageInfo?.globalCount ?? 0;
 
   return (
-    <div style={{ marginTop: 20, height: 300 }} ref={(r) => setRef(r ?? undefined)}>
+    <div style={{
+      marginTop: 20,
+      flex: 1,
+      display: 'flex',
+      flexFlow: 'column',
+    }}
+    >
       <Typography variant="h3" gutterBottom={true}>
         {t_i18n('Correlated containers')}
         <Tooltip title={t_i18n('Go to correlation graph view')} placement="top">
@@ -103,9 +109,9 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
           </IconButton>
         </Tooltip>
       </Typography>
-      <div className="clearfix"/>
-      {containersGlobalCount > 0
-        ? <DataTableWithoutFragment
+      <div style={{ height: '100%' }} ref={(r) => setRef(r ?? undefined)}>
+        {containersGlobalCount > 0 ? (
+          <DataTableWithoutFragment
             dataColumns={{
               entity_type: { percentWidth: 15 },
               name: { percentWidth: 40 },
@@ -121,17 +127,20 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
             hideHeaders={true}
             onLineClick={(row: RelatedContainerNode) => navigate(`${resolveLink(row?.entity_type)}/${row?.id}`)}
           />
-        : <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
+        ) : (
+          <div style={{
+            display: 'flex',
+            height: '100%',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
           >
-            {t_i18n('No correlated containers has been found.')}
-          </span>
-        </div>}
+            <span>
+              {t_i18n('No correlated containers has been found.')}
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Button from '@mui/material/Button';
+import { ExpandLessOutlined, ExpandMoreOutlined, OpenInNewOutlined } from '@mui/icons-material';
+import { Link, useNavigate } from 'react-router-dom';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/styles';
+import { CaseRfiDetails_case$data } from '@components/cases/case_rfis/__generated__/CaseRfiDetails_case.graphql';
+import { CaseRftDetails_case$data } from '@components/cases/case_rfts/__generated__/CaseRftDetails_case.graphql';
+import { CaseIncidentDetails_case$data } from '@components/cases/case_incidents/__generated__/CaseIncidentDetails_case.graphql';
+import { ReportDetails_report$data } from '@components/analyses/reports/__generated__/ReportDetails_report.graphql';
+import { GroupingDetails_grouping$data } from '@components/analyses/groupings/__generated__/GroupingDetails_grouping.graphql';
+import { resolveLink } from '../../../../utils/Entity';
+import ItemIcon from '../../../../components/ItemIcon';
+import ItemMarkings from '../../../../components/ItemMarkings';
+import { useFormatter } from '../../../../components/i18n';
+import type { Theme } from '../../../../components/Theme';
+
+interface RelatedContainersProps {
+  relatedContainers: ReportDetails_report$data['relatedContainers']
+  | GroupingDetails_grouping$data['relatedContainers']
+  | CaseIncidentDetails_case$data['relatedContainers']
+  | CaseRftDetails_case$data['relatedContainers']
+  | CaseRfiDetails_case$data['relatedContainers']
+  containerId: string;
+  entityType: string;
+}
+
+const RelatedContainers: React.FC<RelatedContainersProps> = ({
+  relatedContainers,
+  containerId,
+  entityType,
+}) => {
+  const { t_i18n, fsd } = useFormatter();
+  const theme = useTheme<Theme>();
+  const navigate = useNavigate();
+  const [expanded, setExpanded] = useState(false);
+
+  const containersEdges = relatedContainers?.edges ?? [];
+  const expandable = containersEdges.length > 5;
+  const containers = containersEdges
+    .filter((edge) => edge?.node.id !== containerId)
+    .slice(0, expanded ? 200 : 5);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Typography variant="h3" gutterBottom={true}>
+          {t_i18n('Correlated containers')}
+        </Typography>
+        <IconButton
+          color="primary"
+          aria-label="Go to correlation graph view"
+          onClick={() => navigate(`${resolveLink(entityType)}/${containerId}/knowledge/correlation`)}
+          size="medium"
+          style={{ marginBottom: 4 }}
+        >
+          <OpenInNewOutlined fontSize="small"/>
+        </IconButton>
+      </div>
+      <List>
+        {containers.length > 0 ? (
+          containers.map((edge) => {
+            const relatedContainer = edge?.node;
+            return (
+              <ListItem
+                key={relatedContainer?.id}
+                button
+                divider
+                component={Link}
+                to={`${resolveLink(relatedContainer?.entity_type)}/${relatedContainer?.id}`}
+                sx={{
+                  '&': {
+                    height: 50,
+                    minHeight: 50,
+                    maxHeight: 50,
+                    paddingRight: 0,
+                  },
+                }}
+              >
+                <ListItemIcon>
+                  <ItemIcon type={relatedContainer?.entity_type}/>
+                </ListItemIcon>
+                <ListItemText primary={
+                  <div style={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    paddingRight: 10,
+                  }}
+                  >
+                    {relatedContainer?.name}
+                  </div>
+                 }
+                />
+                <div style={{
+                  width: 100,
+                  minWidth: 100,
+                  maxWidth: 100,
+                  marginRight: 24,
+                  marginLeft: 24,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+                >{relatedContainer?.createdBy?.name ?? '-'}</div>
+                <div style={{
+                  width: 100,
+                  minWidth: 100,
+                  maxWidth: 100,
+                  marginRight: 24,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+                >{fsd(relatedContainer?.created ?? relatedContainer?.published)}</div>
+                <div style={{
+                  width: 110,
+                  paddingRight: 20,
+                }}
+                >
+                  <ItemMarkings
+                    variant="inList"
+                    markingDefinitions={relatedContainer?.objectMarking ?? []}
+                    limit={1}
+                  />
+                </div>
+              </ListItem>
+            );
+          })
+        )
+          : '-'}
+      </List>
+      {expandable && (
+        <Button
+          onClick={() => setExpanded(!expanded)}
+          sx={{
+            position: 'absolute',
+            left: 0,
+            bottom: 0,
+            width: '100%',
+            height: 25,
+            color: theme.palette.primary.main,
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .1)'
+                : 'rgba(0, 0, 0, .1)',
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
+            '&:hover': {
+              backgroundColor:
+                theme.palette.mode === 'dark'
+                  ? 'rgba(255, 255, 255, .2)'
+                  : 'rgba(0, 0, 0, .2)',
+            },
+          }}
+          variant="contained"
+        >
+          {expanded ? <ExpandLessOutlined/> : <ExpandMoreOutlined/>}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default RelatedContainers;

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -99,22 +99,34 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
         </IconButton>
       </Typography>
       <div className="clearfix"/>
-      <DataTableWithoutFragment
-        dataColumns={{
-          entity_type: { percentWidth: 15 },
-          name: { percentWidth: 40 },
-          createdBy: { percentWidth: 15 },
-          modified: { percentWidth: 15 },
-          objectMarking: { percentWidth: 15 },
-        }}
-        data={containers}
-        globalCount={containersGlobalCount}
-        rootRef={ref}
-        disableNavigation={true}
-        storageKey={`related-containers-${entityType}-${containerId}`}
-        hideHeaders={true}
-        onLineClick={(row: RelatedContainerNode) => navigate(`${resolveLink(row?.entity_type)}/${row?.id}`)}
-      />
+      {containersGlobalCount > 0
+        ? <DataTableWithoutFragment
+            dataColumns={{
+              entity_type: { percentWidth: 15 },
+              name: { percentWidth: 40 },
+              createdBy: { percentWidth: 15 },
+              modified: { percentWidth: 15 },
+              objectMarking: { percentWidth: 15 },
+            }}
+            data={containers}
+            globalCount={containersGlobalCount}
+            rootRef={ref}
+            disableNavigation={true}
+            storageKey={`related-containers-${entityType}-${containerId}`}
+            hideHeaders={true}
+            onLineClick={(row: RelatedContainerNode) => navigate(`${resolveLink(row?.entity_type)}/${row?.id}`)}
+          />
+        : <div style={{ display: 'table', height: '100%', width: '100%' }}>
+          <span
+            style={{
+              display: 'table-cell',
+              verticalAlign: 'middle',
+              textAlign: 'center',
+            }}
+          >
+            {t_i18n('No correlated containers has been found.')}
+          </span>
+        </div>}
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { OpenInNewOutlined } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import { graphql, useFragment } from 'react-relay';
+import { VectorLink } from 'mdi-material-ui';
+import Tooltip from '@mui/material/Tooltip';
 import { resolveLink } from '../../../../utils/Entity';
 import { useFormatter } from '../../../../components/i18n';
 import {
@@ -88,15 +89,16 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
     <div style={{ marginTop: 20, height: 300 }} ref={(r) => setRef(r ?? undefined)}>
       <Typography variant="h3" gutterBottom={true} style={{ }}>
         {t_i18n('Correlated containers')}
-        <IconButton
-          color="primary"
-          aria-label="Go to correlation graph view"
-          onClick={() => navigate(`${resolveLink(entityType)}/${containerId}/knowledge/correlation`)}
-          size="medium"
-          style={{ marginBottom: 4 }}
-        >
-          <OpenInNewOutlined fontSize="small"/>
-        </IconButton>
+        <Tooltip title={t_i18n('Go to correlation graph view')} placement="top">
+          <IconButton
+            color="primary"
+            component={Link}
+            style={{ marginBottom: 4 }}
+            to={`${resolveLink(entityType)}/${containerId}/knowledge/correlation`}
+          >
+            <VectorLink fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </Typography>
       <div className="clearfix"/>
       {containersGlobalCount > 0

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -90,7 +90,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
 
   return (
     <div style={{ marginTop: 20, height: 300 }} ref={(r) => setRef(r ?? undefined)}>
-      <Typography variant="h3" gutterBottom={true} style={{ }}>
+      <Typography variant="h3" gutterBottom={true}>
         {t_i18n('Correlated containers')}
         <Tooltip title={t_i18n('Go to correlation graph view')} placement="top">
           <IconButton

--- a/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/RelatedContainers.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import { graphql, useFragment } from 'react-relay';
 import { VectorLink } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
+import { useTheme } from '@mui/styles';
 import { resolveLink } from '../../../../utils/Entity';
 import { useFormatter } from '../../../../components/i18n';
 import {
@@ -12,6 +13,7 @@ import {
   RelatedContainersFragment_container_connection$data,
 } from './__generated__/RelatedContainersFragment_container_connection.graphql';
 import DataTableWithoutFragment from '../../../../components/dataGrid/DataTableWithoutFragment';
+import type { Theme } from '../../../../components/Theme';
 
 export const RelatedContainersFragment = graphql`
   fragment RelatedContainersFragment_container_connection on ContainerConnection {
@@ -75,6 +77,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
   entityType,
 }) => {
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const navigate = useNavigate();
   const relatedContainers = useFragment(
     RelatedContainersFragment,
@@ -93,7 +96,7 @@ const RelatedContainers: React.FC<RelatedContainersProps> = ({
           <IconButton
             color="primary"
             component={Link}
-            style={{ marginBottom: 4 }}
+            style={{ marginBottom: theme.spacing(0.5) }}
             to={`${resolveLink(entityType)}/${containerId}/knowledge/correlation`}
           >
             <VectorLink fontSize="small" />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Show all types of containers in overview correlation widget
* Button CTA to correlation graph
![image](https://github.com/user-attachments/assets/3d576a9a-bfa7-4d0d-b969-2417ec1475af)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [Related containers / correlation enhancements #3227](https://github.com/OpenCTI-Platform/opencti/issues/3227)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

To test you have to link the same observable (Ex: URL) to two different containers (Ex: reports/groupings/caseRFI/caseRFT/incidents), then the related containers will show up on overview
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
