### PR TITLE
[frontend] Display the available connectors if the ‘select all’ option is activated  (#9126)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
+import { map, pathOr, pipe } from 'ramda';
 import { Link } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import withTheme from '@mui/styles/withTheme';
@@ -59,7 +60,6 @@ import Grid from '@mui/material/Grid';
 import Avatar from '@mui/material/Avatar';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
-import { map, pathOr, pipe } from 'ramda';
 import { objectParticipantFieldMembersSearchQuery } from '../common/form/ObjectParticipantField';
 import { objectAssigneeFieldMembersSearchQuery } from '../common/form/ObjectAssigneeField';
 import { vocabularyQuery } from '../common/form/OpenVocabField';
@@ -90,12 +90,7 @@ import { hexToRGB } from '../../../utils/Colors';
 import { externalReferencesQueriesSearchQuery } from '../analyses/external_references/ExternalReferencesQueries';
 import StixDomainObjectCreation from '../common/stix_domain_objects/StixDomainObjectCreation';
 import ItemMarkings from '../../../components/ItemMarkings';
-import {
-  findFilterFromKey,
-  getEntityTypeTwoFirstLevelsFilterValues,
-  removeIdAndIncorrectKeysFromFilterGroupObject,
-  serializeFilterGroupForBackend,
-} from '../../../utils/filters/filtersUtils';
+import { getEntityTypeTwoFirstLevelsFilterValues, removeIdAndIncorrectKeysFromFilterGroupObject, serializeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import { isNotEmptyField } from '../../../utils/utils';
 import EETooltip from '../common/entreprise_edition/EETooltip';
@@ -410,35 +405,12 @@ class DataTableToolBar extends Component {
     this.setState({ displayPromote: false });
   }
 
-  handleOpenEnrichment() {
+  handleOpenEnrichment(stixCyberObservableSubTypes, stixDomainObjectSubTypes) {
     // Get enrich type
     let enrichType;
+    const entityTypeFilterValues = getEntityTypeTwoFirstLevelsFilterValues(this.props.filters, stixCyberObservableSubTypes, stixDomainObjectSubTypes);
     if (this.props.selectAll) {
-      enrichType = this.props.type;
-      if (!enrichType) {
-        const filterType = R.head(
-          findFilterFromKey(
-            this.props.filters?.filters ?? [],
-            'entity_type',
-            'eq',
-          )?.values ?? [],
-        );
-        if (filterType === 'Stix-Cyber-Observable' || filterType === 'Stix-Domain-Object') {
-          const allFilters = this.props.filters?.filterGroups ?? [];
-          allFilters.forEach((group) => {
-            const entityTypeFilter = findFilterFromKey(
-              group.filters ?? [],
-              'entity_type',
-              'eq',
-            );
-            if (entityTypeFilter) {
-              enrichType = R.head(entityTypeFilter.values);
-            }
-          });
-        } else {
-          enrichType = filterType;
-        }
-      }
+      enrichType = this.props.type ?? R.head(entityTypeFilterValues);
     } else {
       const selectedElementsList = Object.values(this.props.selectedElements || {});
       const selectedTypes = R.uniq(selectedElementsList
@@ -1826,7 +1798,7 @@ class DataTableToolBar extends Component {
                           <IconButton
                             aria-label="enrichment"
                             disabled={this.state.processing}
-                            onClick={this.handleOpenEnrichment.bind(this)}
+                            onClick={this.handleOpenEnrichment.bind(this, stixCyberObservableSubTypes, stixDomainObjectSubTypes)}
                             color="primary"
                             size="small"
                           >

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -414,14 +414,31 @@ class DataTableToolBar extends Component {
     // Get enrich type
     let enrichType;
     if (this.props.selectAll) {
-      enrichType = this.props.type
-        ?? R.head(
+      enrichType = this.props.type;
+      if (!enrichType) {
+        const filterType = R.head(
           findFilterFromKey(
             this.props.filters?.filters ?? [],
             'entity_type',
             'eq',
           )?.values ?? [],
         );
+        if (filterType === 'Stix-Cyber-Observable' || filterType === 'Stix-Domain-Object') {
+          const allFilters = this.props.filters?.filterGroups ?? [];
+          allFilters.forEach((group) => {
+            const entityTypeFilter = findFilterFromKey(
+              group.filters ?? [],
+              'entity_type',
+              'eq',
+            );
+            if (entityTypeFilter) {
+              enrichType = R.head(entityTypeFilter.values);
+            }
+          });
+        } else {
+          enrichType = filterType;
+        }
+      }
     } else {
       const selectedElementsList = Object.values(this.props.selectedElements || {});
       const selectedTypes = R.uniq(selectedElementsList


### PR DESCRIPTION
### Proposed changes

* Modify entity-type filtering when performing a select-all on SCOs or SDOs.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9126#issuecomment-2495520900