### PR TITLE
[frontend] added configurable required fields to Arsenal

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
@@ -17,7 +17,7 @@ import { ExternalReferencesField } from '../../common/form/ExternalReferencesFie
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { Option } from '../../common/form/ReferenceField';
@@ -90,14 +90,18 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    CHANNEL_TYPE,
+  );
+
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     channel_types: Yup.array().nullable(),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const channelValidator = useSchemaCreationValidation(
-    CHANNEL_TYPE,
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
     basicShape,
   );
 
@@ -177,7 +181,9 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
   return (
     <Formik<ChannelAddInput>
       initialValues={initialValues}
-      validationSchema={channelValidator}
+      validationSchema={validator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -213,6 +219,7 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
               component={BulkTextField}
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Channel', 'Malware']}
             />
@@ -220,6 +227,7 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
               type="channel_types_ov"
               name="channel_types"
               label={t_i18n('Channel type')}
+              required={(mandatoryAttributes.includes('channel_types'))}
               multiple
               containerStyle={fieldSpacingContainerStyle}
               onChange={setFieldValue}
@@ -228,6 +236,7 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -240,22 +249,26 @@ export const ChannelCreationForm: FunctionComponent<ChannelFormProps> = ({
             <CreatedByField
               name="createdBy"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('createdBy'))}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectLabel'))}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectMarking'))}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('externalReferences'))}
               setFieldValue={setFieldValue}
               values={values.externalReferences}
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -16,7 +16,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -62,6 +62,8 @@ const channelMutationRelationAdd = graphql`
   }
 `;
 
+const CHANNEL_TYPE = 'Channel';
+
 const channelMutationRelationDelete = graphql`
   mutation ChannelEditionOverviewRelationDeleteMutation(
     $id: ID!
@@ -83,15 +85,21 @@ const ChannelEditionOverviewComponent = (props) => {
   const { t_i18n } = useFormatter();
   const { isFeatureEnable } = useHelper();
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    CHANNEL_TYPE,
+  );
+
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     channel_types: Yup.array().nullable(),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const channelValidator = useSchemaEditionValidation('Channel', basicShape);
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: channelMutationFieldPatch,
@@ -99,7 +107,7 @@ const ChannelEditionOverviewComponent = (props) => {
     relationDelete: channelMutationRelationDelete,
     editionFocus: channelEditionOverviewFocus,
   };
-  const editor = useFormEditor(channel, enableReferences, queries, channelValidator);
+  const editor = useFormEditor(channel, enableReferences, queries, validator);
 
   const onSubmit = (values, { setSubmitting }) => {
     const commitMessage = values.message;
@@ -138,7 +146,7 @@ const ChannelEditionOverviewComponent = (props) => {
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      channelValidator
+      validator
         .validateAt(name, { [name]: value })
         .then(() => {
           editor.fieldPatch({
@@ -172,7 +180,9 @@ const ChannelEditionOverviewComponent = (props) => {
   return (
     <Formik enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={channelValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -189,6 +199,7 @@ const ChannelEditionOverviewComponent = (props) => {
             component={TextField}
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -200,6 +211,7 @@ const ChannelEditionOverviewComponent = (props) => {
             type="channel_types_ov"
             name="channel_types"
             label={t_i18n('Channel types')}
+            required={(mandatoryAttributes.includes('channel_types'))}
             variant="edit"
             multiple={true}
             containerStyle={fieldSpacingContainerStyle}
@@ -210,6 +222,7 @@ const ChannelEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -243,6 +256,7 @@ const ChannelEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -252,6 +266,7 @@ const ChannelEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
@@ -18,7 +18,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { insertNode } from '../../../../utils/store';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { Option } from '../../common/form/ReferenceField';
 import { MalwareCreationMutation, MalwareCreationMutation$variables } from './__generated__/MalwareCreationMutation.graphql';
@@ -55,7 +55,7 @@ const malwareMutation = graphql`
   }
 `;
 
-const MALWARE_TYPE = 'Malware';
+const OBJECT_TYPE = 'Malware';
 
 interface MalwareAddInput {
   name: string
@@ -99,13 +99,15 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    OBJECT_TYPE,
+  );
+
+  const basicShape = yupShapeConditionalRequired({
     name: Yup.string()
       .trim()
-      .min(2)
-      .required(t_i18n('This field is required')),
-    is_family: Yup.boolean()
-      .required(t_i18n('This field is required')),
+      .min(2),
+    is_family: Yup.boolean(),
     malware_types: Yup.array()
       .nullable(),
     confidence: Yup.number()
@@ -116,8 +118,8 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
       .nullable(),
     implementation_languages: Yup.array()
       .nullable(),
-  };
-  const malwareValidator = useSchemaCreationValidation(MALWARE_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<MalwareCreationMutation>(
     malwareMutation,
@@ -184,7 +186,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
     });
   };
   const initialValues = useDefaultValues<MalwareAddInput>(
-    MALWARE_TYPE,
+    OBJECT_TYPE,
     {
       name: inputValue ?? '',
       malware_types: [],
@@ -205,7 +207,9 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
   return (
     <Formik<MalwareAddInput>
       initialValues={initialValues}
-      validationSchema={malwareValidator}
+      validationSchema={validator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -249,6 +253,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               askAi={true}
               detectDuplicate={[
@@ -263,6 +268,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               label={t_i18n('Malware types')}
               type="malware-type-ov"
               name="malware_types"
+              required={(mandatoryAttributes.includes('malware_types'))}
               multiple
               containerStyle={fieldSpacingContainerStyle}
             />
@@ -271,6 +277,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               type="checkbox"
               name="is_family"
               label={t_i18n('Is family?')}
+              required={(mandatoryAttributes.includes('is_family'))}
               containerstyle={fieldSpacingContainerStyle}
             />
             <ConfidenceField
@@ -281,6 +288,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -291,6 +299,7 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               label={t_i18n('Architecture execution env.')}
               type="processor-architecture-ov"
               name="architecture_execution_envs"
+              required={(mandatoryAttributes.includes('architecture_execution_envs'))}
               containerStyle={fieldSpacingContainerStyle}
               onChange={setFieldValue}
               multiple
@@ -299,32 +308,38 @@ export const MalwareCreationForm: FunctionComponent<MalwareFormProps> = ({
               label={t_i18n('Implementation languages')}
               type="implementation-language-ov"
               name="implementation_languages"
+              required={(mandatoryAttributes.includes('implementation_languages'))}
               containerStyle={fieldSpacingContainerStyle}
               onChange={setFieldValue}
               multiple
             />
             <KillChainPhasesField
               name="killChainPhases"
+              required={(mandatoryAttributes.includes('killChainPhases'))}
               style={fieldSpacingContainerStyle}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionDetails.jsx
@@ -12,7 +12,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -47,12 +47,17 @@ const malwareEditionDetailsFocus = graphql`
   }
 `;
 
+const OBJECT_TYPE = 'Malware';
+
 const MalwareEditionDetailsComponent = (props) => {
   const { malware, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
   const theme = useTheme();
 
-  const basicShape = {
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    OBJECT_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
     first_seen: Yup.date().nullable().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
     last_seen: Yup.date().nullable()
       .min(Yup.ref('first_seen'), "The last seen date can't be before first seen date")
@@ -60,10 +65,10 @@ const MalwareEditionDetailsComponent = (props) => {
     architecture_execution_envs: Yup.array().nullable(),
     implementation_languages: Yup.array().nullable(),
     capabilities: Yup.array().nullable(),
-    references: Yup.array().required(t_i18n('This field is required')),
-  };
-  const malwareValidator = useSchemaEditionValidation(
-    'Malware',
+    references: Yup.array(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(
+    mandatoryAttributes,
     basicShape,
   );
   const queries = {
@@ -76,7 +81,7 @@ const MalwareEditionDetailsComponent = (props) => {
     malware,
     enableReferences,
     queries,
-    malwareValidator,
+    validator,
   );
 
   const [commitEditionDetailsFocus] = useApiMutation(malwareEditionDetailsFocus);
@@ -139,7 +144,7 @@ const MalwareEditionDetailsComponent = (props) => {
     <Formik
       enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={malwareValidator}
+      validationSchema={validator}
       onSubmit={onSubmit}
     >
       {({
@@ -155,6 +160,7 @@ const MalwareEditionDetailsComponent = (props) => {
           <Field
             component={DateTimePickerField}
             name="first_seen"
+            required={(mandatoryAttributes.includes('first_seen'))}
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             textFieldProps={{
@@ -169,6 +175,7 @@ const MalwareEditionDetailsComponent = (props) => {
           <Field
             component={DateTimePickerField}
             name="last_seen"
+            required={(mandatoryAttributes.includes('last_seen'))}
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             textFieldProps={{
@@ -185,6 +192,7 @@ const MalwareEditionDetailsComponent = (props) => {
             label={t_i18n('Architecture execution env.')}
             type="processor-architecture-ov"
             name="architecture_execution_envs"
+            required={(mandatoryAttributes.includes('processor-architecture-ov'))}
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -197,6 +205,7 @@ const MalwareEditionDetailsComponent = (props) => {
             label={t_i18n('Implementation languages')}
             type="implementation-language-ov"
             name="implementation_languages"
+            required={(mandatoryAttributes.includes('implementation-language-ov'))}
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -209,6 +218,7 @@ const MalwareEditionDetailsComponent = (props) => {
             label={t_i18n('Capabilities')}
             type="malware-capabilities-ov"
             name="capabilities"
+            required={(mandatoryAttributes.includes('capabilities'))}
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -18,7 +18,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import SwitchField from '../../../../components/fields/SwitchField';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -70,6 +70,8 @@ export const malwareMutationRelationAdd = graphql`
   }
 `;
 
+const MALWARE_TYPE = 'Malware';
+
 export const malwareMutationRelationDelete = graphql`
   mutation MalwareEditionOverviewRelationDeleteMutation(
     $id: ID!
@@ -91,16 +93,22 @@ const MalwareEditionOverviewComponent = (props) => {
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
-    is_family: Yup.boolean().required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    MALWARE_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
+    is_family: Yup.boolean(),
     malware_types: Yup.array().nullable(),
     confidence: Yup.number().nullable(),
     description: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const malwareValidator = useSchemaEditionValidation('Malware', basicShape);
+    createdBy: Yup.object().nullable(),
+    killChainPhases: Yup.array().nullable(),
+    objectMarking: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: malwareMutationFieldPatch,
@@ -108,7 +116,7 @@ const MalwareEditionOverviewComponent = (props) => {
     relationDelete: malwareMutationRelationDelete,
     editionFocus: malwareEditionOverviewFocus,
   };
-  const editor = useFormEditor(malware, enableReferences, queries, malwareValidator);
+  const editor = useFormEditor(malware, enableReferences, queries, validator);
 
   const onSubmit = (values, { setSubmitting }) => {
     const commitMessage = values.message;
@@ -144,7 +152,10 @@ const MalwareEditionOverviewComponent = (props) => {
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      malwareValidator
+      if (name === 'killChainPhases') {
+        finalValue = (value.value ?? []).map(({ value_translate }) => value_translate);
+      }
+      validator
         .validateAt(name, { [name]: value })
         .then(() => {
           editor.fieldPatch({
@@ -183,7 +194,9 @@ const MalwareEditionOverviewComponent = (props) => {
   return (
     <Formik enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={malwareValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -201,6 +214,7 @@ const MalwareEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -213,6 +227,7 @@ const MalwareEditionOverviewComponent = (props) => {
             label={t_i18n('Malware types')}
             type="malware-type-ov"
             name="malware_types"
+            required={(mandatoryAttributes.includes('malware_types'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -226,6 +241,7 @@ const MalwareEditionOverviewComponent = (props) => {
             type="checkbox"
             name="is_family"
             label={t_i18n('Is family?')}
+            required={(mandatoryAttributes.includes('is_family'))}
             containerstyle={{ marginTop: 20 }}
             onFocus={editor.changeFocus}
             onChange={handleSubmitField}
@@ -245,6 +261,7 @@ const MalwareEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -258,6 +275,7 @@ const MalwareEditionOverviewComponent = (props) => {
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -278,6 +296,7 @@ const MalwareEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -287,6 +306,7 @@ const MalwareEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={<SubscriptionFocus context={context} fieldname="objectMarking" />}
             setFieldValue={setFieldValue}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
@@ -18,7 +18,7 @@ import { ExternalReferencesField } from '../../common/form/ExternalReferencesFie
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { Option } from '../../common/form/ReferenceField';
 import { ToolCreationMutation, ToolCreationMutation$variables } from './__generated__/ToolCreationMutation.graphql';
@@ -94,14 +94,17 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    TOOL_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     tool_types: Yup.array().nullable(),
     tool_version: Yup.string().nullable(),
-  };
-  const toolValidator = useSchemaCreationValidation(TOOL_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<ToolCreationMutation>(
     toolMutation,
@@ -185,7 +188,9 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
   return (
     <Formik<ToolAddInput>
       initialValues={initialValues}
-      validationSchema={toolValidator}
+      validationSchema={validator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -222,6 +227,7 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Tool', 'Malware']}
               askAi={true}
@@ -230,6 +236,7 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -242,21 +249,25 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
             />
             <KillChainPhasesField
               name="killChainPhases"
+              required={(mandatoryAttributes.includes('killChainPhases'))}
               style={fieldSpacingContainerStyle}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
@@ -264,6 +275,7 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
               type="tool_types_ov"
               name="tool_types"
               label={t_i18n('Tool types')}
+              required={(mandatoryAttributes.includes('tool_types'))}
               multiple={true}
               containerStyle={fieldSpacingContainerStyle}
               onChange={setFieldValue}
@@ -272,11 +284,13 @@ export const ToolCreationForm: FunctionComponent<ToolFormProps> = ({
               component={TextField}
               name="tool_version"
               label={t_i18n('Tool Version')}
+              required={(mandatoryAttributes.includes('tool_version'))}
               fullWidth={true}
               style={{ marginTop: 20 }}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolEditionOverview.tsx
@@ -21,7 +21,7 @@ import OpenVocabField from '../../common/form/OpenVocabField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import type { Theme } from '../../../../components/Theme';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -70,6 +70,8 @@ export const toolMutationRelationAdd = graphql`
     }
   }
 `;
+
+const TOOL_TYPE = 'Tool';
 
 export const toolMutationRelationDelete = graphql`
   mutation ToolEditionOverviewRelationDeleteMutation(
@@ -151,15 +153,22 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
 
   const tool = useFragment(toolEditionOverviewFragment, toolRef);
 
-  const toolValidator = useSchemaEditionValidation('Tool', {
-    name: Yup.string().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    TOOL_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     tool_types: Yup.array().nullable(),
     tool_version: Yup.string().nullable(),
     x_opencti_workflow_id: Yup.object().nullable(),
     references: Yup.array().nullable(),
-  });
+    createdBy: Yup.object().nullable(),
+    killChainPhases: Yup.array().nullable(),
+    objectMarking: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: toolMutationFieldPatch,
@@ -172,12 +181,12 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
     tool as GenericData,
     enableReferences,
     queries,
-    toolValidator,
+    validator,
   );
 
   const handleSubmitField = (name: string, value: string[] | string) => {
     if (!enableReferences) {
-      toolValidator
+      validator
         .validateAt(name, { [name]: value })
         .then(() => {
           editor.fieldPatch({
@@ -235,7 +244,9 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
     <Formik<ToolEditionFormValues>
       enableReinitialize={true}
       initialValues={initialValues}
-      validationSchema={toolValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({ submitForm, isSubmitting, setFieldValue, values }) => (
@@ -245,7 +256,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
             component={TextField}
             name="name"
             label={t_i18n('Name')}
-            required
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -255,6 +266,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
             component={TextField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             multiline
             fullWidth
             style={{ marginTop: theme.spacing(2) }}
@@ -272,6 +284,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
           />
           <KillChainPhasesField
             name="killChainPhases"
+            required={(mandatoryAttributes.includes('killChainPhases'))}
             setFieldValue={setFieldValue}
             style={{ marginTop: theme.spacing(2) }}
             helpertext={<SubscriptionFocus context={context} fieldName="killChainPhases" />}
@@ -290,6 +303,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={{ marginTop: theme.spacing(2) }}
             setFieldValue={setFieldValue}
             helpertext={<SubscriptionFocus context={context} fieldName="createdBy" />}
@@ -297,6 +311,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={{ marginTop: theme.spacing(2) }}
             setFieldValue={setFieldValue}
             helpertext={<SubscriptionFocus context={context} fieldName="objectMarking" />}
@@ -306,6 +321,7 @@ const ToolEditionOverview: FunctionComponent<ToolEditionOverviewProps> = ({
             type="tool_types_ov"
             name="tool_types"
             label={t_i18n('Tool types')}
+            required={(mandatoryAttributes.includes('tool_types'))}
             onSubmit={(name, value) => handleSubmitField(name, value as string)}
             onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
@@ -22,7 +22,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import SelectField from '../../../../components/fields/SelectField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { VulnerabilityCreationMutation, VulnerabilityCreationMutation$variables } from './__generated__/VulnerabilityCreationMutation.graphql';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import CustomFileUploader from '../../common/files/CustomFileUploader';
@@ -102,10 +102,12 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
 }) => {
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
-  const basicShape = {
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    VULNERABILITY_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
     name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+      .min(2),
     description: Yup.string()
       .nullable(),
     x_opencti_cvss_base_score: Yup.number().min(0).max(10)
@@ -118,8 +120,8 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
     x_opencti_epss_percentile: Yup.number().min(0).max(1).nullable(),
     confidence: Yup.number()
       .nullable(),
-  };
-  const vulnerabilityValidator = useSchemaCreationValidation(VULNERABILITY_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<VulnerabilityCreationMutation>(
     vulnerabilityMutation,
@@ -213,7 +215,9 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
   return (
     <Formik<VulnerabilityAddInput>
       initialValues={initialValues}
-      validationSchema={vulnerabilityValidator}
+      validationSchema={validator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -257,6 +261,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectduplicate={['Vulnerability']}
               askAi={true}
@@ -265,6 +270,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -275,6 +281,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               component={TextField}
               variant="standard"
               name="x_opencti_cvss_base_score"
+              required={(mandatoryAttributes.includes('x_opencti_base_score'))}
               label={t_i18n('CVSS3 - Score')}
               type="number"
               step="0.1"
@@ -286,6 +293,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               component={SelectField}
               variant="standard"
               name="x_opencti_cvss_base_severity"
+              required={(mandatoryAttributes.includes('x_opencti_base_severity'))}
               label={t_i18n('CVSS3 - Severity')}
               fullWidth={true}
               containerstyle={fieldSpacingContainerStyle}
@@ -301,6 +309,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               variant="standard"
               name="x_opencti_cvss_attack_vector"
               label={t_i18n('CVSS3 - Attack vector')}
+              required={(mandatoryAttributes.includes('x_opencti_attack_vector'))}
               fullWidth={true}
               style={{ marginTop: 20 }}
             />
@@ -321,6 +330,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               variant="standard"
               name="x_opencti_epss_score"
               label={t_i18n('EPSS Score')}
+              required={(mandatoryAttributes.includes('x_opencti_epss_score'))}
               type="number"
               fullWidth={true}
               style={fieldSpacingContainerStyle}
@@ -330,6 +340,7 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
               variant="standard"
               name="x_opencti_epss_percentile"
               label={t_i18n('EPSS Percentile')}
+              required={(mandatoryAttributes.includes('x_opencti_epss_percentile'))}
               type="number"
               fullWidth={true}
               style={fieldSpacingContainerStyle}
@@ -337,21 +348,25 @@ export const VulnerabilityCreationForm: FunctionComponent<VulnerabilityFormProps
             <CreatedByField
               name="createdBy"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('createdBy'))}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectLabel'))}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
               style={fieldSpacingContainerStyle}
+              required={(mandatoryAttributes.includes('objectMarking'))}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -16,7 +16,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -91,14 +91,20 @@ const VulnerabilityEditionOverviewComponent = (props) => {
   const isFABReplaced = isFeatureEnable('FAB_REPLACEMENT');
   const theme = useTheme();
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const VULNERABILITY_TYPE = 'Vulnerability';
+  const { mandatoryAttributes } = useIsMandatoryAttribute(
+    VULNERABILITY_TYPE,
+  );
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const vulnerabilityValidator = useSchemaEditionValidation('Vulnerability', basicShape);
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const validator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: vulnerabilityMutationFieldPatch,
@@ -106,7 +112,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
     relationDelete: vulnerabilityMutationRelationDelete,
     editionFocus: vulnerabilityEditionOverviewFocus,
   };
-  const editor = useFormEditor(vulnerability, enableReferences, queries, vulnerabilityValidator);
+  const editor = useFormEditor(vulnerability, enableReferences, queries, validator);
 
   const onSubmit = (values, { setSubmitting }) => {
     const commitMessage = values.message;
@@ -145,7 +151,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      vulnerabilityValidator
+      validator
         .validateAt(name, { [name]: value })
         .then(() => {
           editor.fieldPatch({
@@ -181,7 +187,9 @@ const VulnerabilityEditionOverviewComponent = (props) => {
     <Formik
       enableReinitialize={true}
       initialValues={{ ...initialValues, references: [] }}
-      validationSchema={vulnerabilityValidator}
+      validationSchema={validator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -199,6 +207,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -210,6 +219,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -243,6 +253,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -252,6 +263,7 @@ const VulnerabilityEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR builds upon the capabilities from [6972](https://github.com/OpenCTI-Platform/opencti/pull/6972). This PR will add all capabilities from the previous PR to the 'Arsenal' section of the platform, to include creating and editing the following entity types: 

* Channels
* Malware
* Tools
* Vulnerabilities

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
As stated in [initial changes to support dynamic configurable required fields via settings](https://github.com/OpenCTI-Platform/opencti/pull/6972) the External-Reference field is not directly supported for this required fields change. Based on communication with the Filigran team - this field will require many complex relationships between mandatory attributes to fully implement.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
