### PR TITLE
[frontend] Filter correlation graphs on common SCOs and indicators by default (#3227)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.graphObjects = R.map((n) => n.node, props.grouping.objects.edges);
+    this.allGraphObjects = R.map((n) => n.node, props.grouping.objects.edges);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),
@@ -282,7 +282,9 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       numberOfSelectedLinks: 0,
       keyword: '',
       navOpen: localStorage.getItem('navOpen') === 'true',
+      queryMode: 'indicators-and-observables',
     };
+    this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
     const filterAdjust = {
       markedBy: [],
       createdBy: [],
@@ -295,7 +297,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       decodeGraphData(props.grouping.x_opencti_graph_data),
       props.t,
       filterAdjust,
-      'groupings',
     );
     this.state.graphData = { ...this.graphData };
   }
@@ -387,6 +388,29 @@ class GroupingKnowledgeCorrelationComponent extends Component {
         },
       },
     });
+  }
+
+  handleToggleQueryMode() {
+    if (this.state.queryMode === 'indicators-and-observables') {
+      this.graphObjects = this.allGraphObjects;
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.grouping.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'all-entities' }, () => this.saveParameters(true));
+    }
+    if (this.state.queryMode === 'all-entities') {
+      this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.grouping.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'indicators-and-observables' }, () => this.saveParameters(true));
+    }
   }
 
   handleToggle3DMode() {
@@ -481,7 +505,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.grouping.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'groupings',
         ),
       },
       () => this.saveParameters(false),
@@ -507,7 +530,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.grouping.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'groupings',
         ),
       },
       () => this.saveParameters(false),
@@ -533,7 +555,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.grouping.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'groupings',
         ),
       },
       () => this.saveParameters(false),
@@ -647,7 +668,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.grouping.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'groupings',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -673,7 +693,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.grouping.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'groupings',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -773,7 +792,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       {},
       this.props.t,
       this.state,
-      'groupings',
     );
     this.setState(
       {
@@ -804,7 +822,6 @@ class GroupingKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.grouping.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'groupings',
         ),
       },
       () => this.saveParameters(false),
@@ -846,6 +863,7 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       selectModeFree,
       selectModeFreeReady,
       navOpen,
+      queryMode,
     } = this.state;
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
@@ -925,6 +943,8 @@ class GroupingKnowledgeCorrelationComponent extends Component {
           return (
             <>
               <GroupingKnowledgeGraphBar
+                handleToggleQueryMode={this.handleToggleQueryMode.bind(this)}
+                currentQueryMode={queryMode}
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}
                 handleToggleTreeMode={this.handleToggleTreeMode.bind(this)}
@@ -1279,12 +1299,65 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 groupings(first: 20) {
                   edges {
                     node {
                       id
                       name
                       context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                cases(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
                       confidence
                       entity_type
                       parent_types
@@ -1387,6 +1460,33 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 groupings(first: 20) {
                   edges {
                     node {
@@ -1404,7 +1504,33 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                cases(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class GroupingKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.allGraphObjects = R.map((n) => n.node, props.grouping.objects.edges);
+    this.allGraphObjects = props.grouping.objects.edges.map((n) => n.node);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -507,15 +507,13 @@ class GroupingKnowledgeGraphBar extends Component {
                           : t('Show all correlated entities')
                       }
                     >
-                      <span>
-                        <IconButton
-                          color={'secondary'}
-                          onClick={handleToggleQueryMode.bind(this)}
-                          size="large"
-                        >
-                          {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                        </IconButton>
-                      </span>
+                      <IconButton
+                        color={'secondary'}
+                        onClick={handleToggleQueryMode.bind(this)}
+                        size="large"
+                      >
+                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                      </IconButton>
                     </Tooltip>
                   )}
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -14,7 +14,9 @@ import {
   FilterAltOffOutlined,
   FilterListOutlined,
   GestureOutlined,
+  HubOutlined,
   LinkOutlined,
+  PolylineOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -333,6 +335,7 @@ class GroupingKnowledgeGraphBar extends Component {
     const {
       t,
       classes,
+      currentQueryMode,
       currentMode3D,
       currentModeTree,
       currentModeFixed,
@@ -341,6 +344,7 @@ class GroupingKnowledgeGraphBar extends Component {
       currentStixCoreObjectsTypes,
       currentSelectRectangleModeFree,
       currentSelectModeFree,
+      handleToggleQueryMode,
       handleToggle3DMode,
       handleToggleTreeMode,
       handleToggleFixedMode,
@@ -495,6 +499,25 @@ class GroupingKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
+                  {handleToggleQueryMode && (
+                    <Tooltip
+                      title={
+                        currentQueryMode === 'all-entities'
+                          ? t('Show only correlated observables and indicators')
+                          : t('Show all correlated entities')
+                      }
+                    >
+                      <span>
+                        <IconButton
+                          color={'secondary'}
+                          onClick={handleToggleQueryMode.bind(this)}
+                          size="large"
+                        >
+                          {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -1240,6 +1263,8 @@ GroupingKnowledgeGraphBar.propTypes = {
   classes: PropTypes.object,
   t: PropTypes.func,
   grouping: PropTypes.object,
+  handleToggleQueryMode: PropTypes.func,
+  currentQueryMode: PropTypes.string,
   handleToggle3DMode: PropTypes.func,
   currentMode3D: PropTypes.bool,
   handleToggleTreeMode: PropTypes.func,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class ReportKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.allGraphObjects = R.map((n) => n.node, props.report.objects.edges);
+    this.allGraphObjects = props.report.objects.edges.map((n) => n.node);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class ReportKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.graphObjects = R.map((n) => n.node, props.report.objects.edges);
+    this.allGraphObjects = R.map((n) => n.node, props.report.objects.edges);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),
@@ -282,7 +282,9 @@ class ReportKnowledgeCorrelationComponent extends Component {
       numberOfSelectedLinks: 0,
       keyword: '',
       navOpen: localStorage.getItem('navOpen') === 'true',
+      queryMode: 'indicators-and-observables',
     };
+    this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
     const filterAdjust = {
       markedBy: [],
       createdBy: [],
@@ -387,6 +389,29 @@ class ReportKnowledgeCorrelationComponent extends Component {
         },
       },
     });
+  }
+
+  handleToggleQueryMode() {
+    if (this.state.queryMode === 'indicators-and-observables') {
+      this.graphObjects = this.allGraphObjects;
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.report.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'all-entities' }, () => this.saveParameters(true));
+    }
+    if (this.state.queryMode === 'all-entities') {
+      this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.report.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'indicators-and-observables' }, () => this.saveParameters(true));
+    }
   }
 
   handleToggle3DMode() {
@@ -839,6 +864,7 @@ class ReportKnowledgeCorrelationComponent extends Component {
       selectModeFree,
       selectModeFreeReady,
       navOpen,
+      queryMode,
     } = this.state;
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
@@ -918,6 +944,8 @@ class ReportKnowledgeCorrelationComponent extends Component {
           return (
             <>
               <ReportKnowledgeGraphBar
+                handleToggleQueryMode={this.handleToggleQueryMode.bind(this)}
+                currentQueryMode={queryMode}
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}
                 handleToggleTreeMode={this.handleToggleTreeMode.bind(this)}
@@ -1274,12 +1302,65 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 reports(first: 20) {
                   edges {
                     node {
                       id
                       name
                       published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                cases(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
                       confidence
                       entity_type
                       parent_types
@@ -1379,12 +1460,65 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 reports(first: 20) {
                   edges {
                     node {
                       id
                       name
                       published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                cases(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
                       confidence
                       entity_type
                       parent_types

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -14,13 +14,15 @@ import {
   FilterAltOffOutlined,
   FilterListOutlined,
   GestureOutlined,
+  HubOutlined,
   LinkOutlined,
+  PolylineOutlined,
   ScatterPlotOutlined,
-  VisibilityOutlined,
-  SwipeVertical,
   SwipeDown,
   SwipeUp,
+  SwipeVertical,
   TouchApp,
+  VisibilityOutlined,
 } from '@mui/icons-material';
 import { AutoFix, FamilyTree, SelectAll, SelectGroup, SelectionDrag, Video3d } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
@@ -361,6 +363,7 @@ class ReportKnowledgeGraphBar extends Component {
     const {
       t,
       classes,
+      currentQueryMode,
       currentMode3D,
       currentModeTree,
       currentModeFixed,
@@ -370,6 +373,7 @@ class ReportKnowledgeGraphBar extends Component {
       currentSelectRectangleModeFree,
       currentSelectModeFree,
       selectModeFreeReady,
+      handleToggleQueryMode,
       handleToggle3DMode,
       handleToggleTreeMode,
       handleToggleFixedMode,
@@ -524,6 +528,25 @@ class ReportKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
+                  {handleToggleQueryMode && (
+                  <Tooltip
+                    title={
+                      currentQueryMode === 'all-entities'
+                        ? t('Show only correlated observables and indicators')
+                        : t('Show all correlated entities')
+                    }
+                  >
+                    <span>
+                      <IconButton
+                        color={'secondary'}
+                        onClick={handleToggleQueryMode.bind(this)}
+                        size="large"
+                      >
+                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -1304,6 +1327,8 @@ ReportKnowledgeGraphBar.propTypes = {
   classes: PropTypes.object,
   t: PropTypes.func,
   report: PropTypes.object,
+  handleToggleQueryMode: PropTypes.func,
+  currentQueryMode: PropTypes.string,
   handleToggle3DMode: PropTypes.func,
   handleToggleRectangleSelectModeFree: PropTypes.func,
   handleToggleSelectModeFree: PropTypes.func,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -536,15 +536,13 @@ class ReportKnowledgeGraphBar extends Component {
                         : t('Show all correlated entities')
                     }
                   >
-                    <span>
-                      <IconButton
-                        color={'secondary'}
-                        onClick={handleToggleQueryMode.bind(this)}
-                        size="large"
-                      >
-                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                      </IconButton>
-                    </span>
+                    <IconButton
+                      color={'secondary'}
+                      onClick={handleToggleQueryMode.bind(this)}
+                      size="large"
+                    >
+                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                    </IconButton>
                   </Tooltip>
                   )}
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.graphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),
@@ -282,7 +282,9 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       numberOfSelectedLinks: 0,
       keyword: '',
       navOpen: localStorage.getItem('navOpen') === 'true',
+      queryMode: 'indicators-and-observables',
     };
+    this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
     const filterAdjust = {
       markedBy: [],
       createdBy: [],
@@ -295,7 +297,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       decodeGraphData(props.caseData.x_opencti_graph_data),
       props.t,
       filterAdjust,
-      'cases',
     );
     this.state.graphData = { ...this.graphData };
   }
@@ -387,6 +388,29 @@ class IncidentKnowledgeCorrelationComponent extends Component {
         },
       },
     });
+  }
+
+  handleToggleQueryMode() {
+    if (this.state.queryMode === 'indicators-and-observables') {
+      this.graphObjects = this.allGraphObjects;
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'all-entities' }, () => this.saveParameters(true));
+    }
+    if (this.state.queryMode === 'all-entities') {
+      this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'indicators-and-observables' }, () => this.saveParameters(true));
+    }
   }
 
   handleToggle3DMode() {
@@ -481,7 +505,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -507,7 +530,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -533,7 +555,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -647,7 +668,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -673,7 +693,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -773,7 +792,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       {},
       this.props.t,
       this.state,
-      'cases',
     );
     this.setState(
       {
@@ -804,7 +822,6 @@ class IncidentKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -846,6 +863,7 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       selectModeFree,
       selectModeFreeReady,
       navOpen,
+      queryMode,
     } = this.state;
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
@@ -926,6 +944,8 @@ class IncidentKnowledgeCorrelationComponent extends Component {
           return (
             <>
               <IncidentKnowledgeGraphBar
+                handleToggleQueryMode={this.handleToggleQueryMode.bind(this)}
+                currentQueryMode={queryMode}
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}
                 handleToggleTreeMode={this.handleToggleTreeMode.bind(this)}
@@ -1286,6 +1306,60 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {
@@ -1390,6 +1464,60 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {
@@ -1406,7 +1534,7 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class IncidentKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = props.caseData.objects.edges.map((n) => n.node);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -510,15 +510,13 @@ class IncidentKnowledgeGraphBar extends Component {
                         : t('Show all correlated entities')
                     }
                   >
-                    <span>
-                      <IconButton
-                        color={'secondary'}
-                        onClick={handleToggleQueryMode.bind(this)}
-                        size="large"
-                      >
-                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                      </IconButton>
-                    </span>
+                    <IconButton
+                      color={'secondary'}
+                      onClick={handleToggleQueryMode.bind(this)}
+                      size="large"
+                    >
+                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                    </IconButton>
                   </Tooltip>
                   )}
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -14,7 +14,9 @@ import {
   FilterAltOffOutlined,
   FilterListOutlined,
   GestureOutlined,
+  HubOutlined,
   LinkOutlined,
+  PolylineOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -333,6 +335,7 @@ class IncidentKnowledgeGraphBar extends Component {
     const {
       t,
       classes,
+      currentQueryMode,
       currentMode3D,
       currentModeTree,
       currentModeFixed,
@@ -342,6 +345,7 @@ class IncidentKnowledgeGraphBar extends Component {
       currentSelectRectangleModeFree,
       currentSelectModeFree,
       selectModeFreeReady,
+      handleToggleQueryMode,
       handleToggle3DMode,
       handleToggleTreeMode,
       handleToggleFixedMode,
@@ -498,6 +502,25 @@ class IncidentKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
+                  {handleToggleQueryMode && (
+                  <Tooltip
+                    title={
+                      currentQueryMode === 'all-entities'
+                        ? t('Show only correlated observables and indicators')
+                        : t('Show all correlated entities')
+                    }
+                  >
+                    <span>
+                      <IconButton
+                        color={'secondary'}
+                        onClick={handleToggleQueryMode.bind(this)}
+                        size="large"
+                      >
+                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -1243,6 +1266,8 @@ IncidentKnowledgeGraphBar.propTypes = {
   classes: PropTypes.object,
   t: PropTypes.func,
   caseData: PropTypes.object,
+  handleToggleQueryMode: PropTypes.func,
+  currentQueryMode: PropTypes.string,
   handleToggle3DMode: PropTypes.func,
   handleToggleRectangleSelectModeFree: PropTypes.func,
   handleToggleSelectModeFree: PropTypes.func,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.graphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),
@@ -281,8 +281,9 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       numberOfSelectedNodes: 0,
       numberOfSelectedLinks: 0,
       keyword: '',
-      navOpen: localStorage.getItem('navOpen') === 'true',
+      queryMode: 'indicators-and-observables',
     };
+    this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
     const filterAdjust = {
       markedBy: [],
       createdBy: [],
@@ -295,7 +296,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       decodeGraphData(props.caseData.x_opencti_graph_data),
       props.t,
       filterAdjust,
-      'cases',
     );
     this.state.graphData = { ...this.graphData };
   }
@@ -387,6 +387,29 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
         },
       },
     });
+  }
+
+  handleToggleQueryMode() {
+    if (this.state.queryMode === 'indicators-and-observables') {
+      this.graphObjects = this.allGraphObjects;
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'all-entities' }, () => this.saveParameters(true));
+    }
+    if (this.state.queryMode === 'all-entities') {
+      this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'indicators-and-observables' }, () => this.saveParameters(true));
+    }
   }
 
   handleToggle3DMode() {
@@ -481,7 +504,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -507,7 +529,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -533,7 +554,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -647,7 +667,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -673,7 +692,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -773,7 +791,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       {},
       this.props.t,
       this.state,
-      'cases',
     );
     this.setState(
       {
@@ -804,7 +821,6 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -846,6 +862,7 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       selectModeFree,
       selectModeFreeReady,
       navOpen,
+      queryMode,
     } = this.state;
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
@@ -926,6 +943,8 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
           return (
             <>
               <CaseRfiKnowledgeGraphBar
+                handleToggleQueryMode={this.handleToggleQueryMode.bind(this)}
+                currentQueryMode={queryMode}
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}
                 handleToggleTreeMode={this.handleToggleTreeMode.bind(this)}
@@ -1286,6 +1305,60 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {
@@ -1390,6 +1463,60 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = props.caseData.objects.edges.map((n) => n.node);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -510,15 +510,13 @@ class CaseRfiKnowledgeGraphBar extends Component {
                         : t('Show all correlated entities')
                     }
                   >
-                    <span>
-                      <IconButton
-                        color={'secondary'}
-                        onClick={handleToggleQueryMode.bind(this)}
-                        size="large"
-                      >
-                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                      </IconButton>
-                    </span>
+                    <IconButton
+                      color={'secondary'}
+                      onClick={handleToggleQueryMode.bind(this)}
+                      size="large"
+                    >
+                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                    </IconButton>
                   </Tooltip>
                   )}
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -14,7 +14,9 @@ import {
   FilterAltOffOutlined,
   FilterListOutlined,
   GestureOutlined,
+  HubOutlined,
   LinkOutlined,
+  PolylineOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -336,6 +338,7 @@ class CaseRfiKnowledgeGraphBar extends Component {
     const {
       t,
       classes,
+      currentQueryMode,
       currentMode3D,
       currentModeTree,
       currentModeFixed,
@@ -345,6 +348,7 @@ class CaseRfiKnowledgeGraphBar extends Component {
       currentSelectRectangleModeFree,
       currentSelectModeFree,
       selectModeFreeReady,
+      handleToggleQueryMode,
       handleToggle3DMode,
       handleToggleTreeMode,
       handleToggleFixedMode,
@@ -498,6 +502,25 @@ class CaseRfiKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
+                  {handleToggleQueryMode && (
+                  <Tooltip
+                    title={
+                      currentQueryMode === 'all-entities'
+                        ? t('Show only correlated observables and indicators')
+                        : t('Show all correlated entities')
+                    }
+                  >
+                    <span>
+                      <IconButton
+                        color={'secondary'}
+                        onClick={handleToggleQueryMode.bind(this)}
+                        size="large"
+                      >
+                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -1240,6 +1263,8 @@ CaseRfiKnowledgeGraphBar.propTypes = {
   classes: PropTypes.object,
   t: PropTypes.func,
   caseData: PropTypes.object,
+  handleToggleQueryMode: PropTypes.func,
+  currentQueryMode: PropTypes.string,
   handleToggle3DMode: PropTypes.func,
   handleToggleRectangleSelectModeFree: PropTypes.func,
   handleToggleSelectModeFree: PropTypes.func,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = props.caseData.objects.edges.map((n) => n.node);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -245,7 +245,7 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       LOCAL_STORAGE_KEY,
     );
     this.zoom = R.propOr(null, 'zoom', params);
-    this.graphObjects = R.map((n) => n.node, props.caseData.objects.edges);
+    this.allGraphObjects = R.map((n) => n.node, props.caseData.objects.edges);
     const timeRangeInterval = computeTimeRangeInterval(
       R.uniqBy(
         R.prop('id'),
@@ -282,7 +282,9 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       numberOfSelectedLinks: 0,
       keyword: '',
       navOpen: localStorage.getItem('navOpen') === 'true',
+      queryMode: 'indicators-and-observables',
     };
+    this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
     const filterAdjust = {
       stixCoreObjectsTypes: [],
       markedBy: [],
@@ -295,7 +297,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       decodeGraphData(props.caseData.x_opencti_graph_data),
       props.t,
       filterAdjust,
-      'cases',
     );
     this.state.graphData = { ...this.graphData };
     this.canvas = null;
@@ -390,6 +391,29 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
     });
   }
 
+  handleToggleQueryMode() {
+    if (this.state.queryMode === 'indicators-and-observables') {
+      this.graphObjects = this.allGraphObjects;
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'all-entities' }, () => this.saveParameters(true));
+    }
+    if (this.state.queryMode === 'all-entities') {
+      this.graphObjects = this.allGraphObjects.filter((n) => n.entity_type === 'Indicator' || n.parent_types.includes('Stix-Cyber-Observable'));
+      this.graphData = buildCorrelationData(
+        this.graphObjects,
+        decodeGraphData(this.props.caseData.x_opencti_graph_data),
+        this.props.t,
+        this.state,
+      );
+      this.setState({ queryMode: 'indicators-and-observables' }, () => this.saveParameters(true));
+    }
+  }
+
   handleToggle3DMode() {
     this.setState({ mode3D: !this.state.mode3D }, () => this.saveParameters());
   }
@@ -482,7 +506,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -508,7 +531,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -534,7 +556,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -648,7 +669,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -674,7 +694,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
             decodeGraphData(this.props.caseData.x_opencti_graph_data),
             this.props.t,
             this.state,
-            'cases',
           );
           this.setState({
             graphData: { ...this.graphData },
@@ -774,7 +793,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       {},
       this.props.t,
       this.state,
-      'cases',
     );
     this.setState(
       {
@@ -805,7 +823,6 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
           decodeGraphData(this.props.caseData.x_opencti_graph_data),
           this.props.t,
           filterAdjust,
-          'cases',
         ),
       },
       () => this.saveParameters(false),
@@ -847,6 +864,7 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
       selectModeFree,
       selectModeFreeReady,
       navOpen,
+      queryMode,
     } = this.state;
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
     const sortByLabel = R.sortBy(R.compose(R.toLower, R.prop('tlabel')));
@@ -927,6 +945,8 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
           return (
             <>
               <CaseRftKnowledgeGraphBar
+                handleToggleQueryMode={this.handleToggleQueryMode.bind(this)}
+                currentQueryMode={queryMode}
                 handleToggle3DMode={this.handleToggle3DMode.bind(this)}
                 currentMode3D={mode3D}
                 handleToggleTreeMode={this.handleToggleTreeMode.bind(this)}
@@ -1287,6 +1307,60 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {
@@ -1391,6 +1465,60 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                reports(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 20) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 cases(first: 20) {
                   edges {
                     node {
@@ -1407,7 +1535,7 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -510,15 +510,13 @@ class CaseRftKnowledgeGraphBar extends Component {
                         : t('Show all correlated entities')
                     }
                   >
-                    <span>
-                      <IconButton
-                        color={'secondary'}
-                        onClick={handleToggleQueryMode.bind(this)}
-                        size="large"
-                      >
-                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                      </IconButton>
-                    </span>
+                    <IconButton
+                      color={'secondary'}
+                      onClick={handleToggleQueryMode.bind(this)}
+                      size="large"
+                    >
+                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                    </IconButton>
                   </Tooltip>
                   )}
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -14,7 +14,9 @@ import {
   FilterAltOffOutlined,
   FilterListOutlined,
   GestureOutlined,
+  HubOutlined,
   LinkOutlined,
+  PolylineOutlined,
   ScatterPlotOutlined,
   VisibilityOutlined,
 } from '@mui/icons-material';
@@ -336,6 +338,7 @@ class CaseRftKnowledgeGraphBar extends Component {
     const {
       t,
       classes,
+      currentQueryMode,
       currentMode3D,
       currentModeTree,
       currentModeFixed,
@@ -345,6 +348,7 @@ class CaseRftKnowledgeGraphBar extends Component {
       currentSelectRectangleModeFree,
       currentSelectModeFree,
       selectModeFreeReady,
+      handleToggleQueryMode,
       handleToggle3DMode,
       handleToggleTreeMode,
       handleToggleFixedMode,
@@ -498,6 +502,25 @@ class CaseRftKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
+                  {handleToggleQueryMode && (
+                  <Tooltip
+                    title={
+                      currentQueryMode === 'all-entities'
+                        ? t('Show only correlated observables and indicators')
+                        : t('Show all correlated entities')
+                    }
+                  >
+                    <span>
+                      <IconButton
+                        color={'secondary'}
+                        onClick={handleToggleQueryMode.bind(this)}
+                        size="large"
+                      >
+                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -1239,6 +1262,8 @@ CaseRftKnowledgeGraphBar.propTypes = {
   classes: PropTypes.object,
   t: PropTypes.func,
   caseData: PropTypes.object,
+  handleToggleQueryMode: PropTypes.func,
+  currentQueryMode: PropTypes.string,
   handleToggle3DMode: PropTypes.func,
   handleToggleRectangleSelectModeFree: PropTypes.func,
   handleToggleSelectModeFree: PropTypes.func,

--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -482,10 +482,12 @@ export const buildCorrelationData = (
     filterAdjust.markedBy,
     filterAdjust.createdBy,
   );
-  const thisContainerNodes = thisContainerOriginalNodes.map((n) => R.assoc('disabled', filteredNodesIds.includes(n.id), n));
-  const thisContainerLinkNodes = R.filter(
+  const thisContainerNodes = thisContainerOriginalNodes.map((n) => ({
+    ...n,
+    disabled: filteredNodesIds.includes(n.id),
+  }));
+  const thisContainerLinkNodes = thisContainerNodes.filter(
     (n) => n[key] && n.parent_types && n[key].edges.length > 1,
-    thisContainerNodes,
   );
   const relatedContainerOriginalNodes = R.pipe(
     R.map((n) => n[key].edges),
@@ -524,7 +526,10 @@ export const buildCorrelationData = (
     filterAdjust.markedBy,
     filterAdjust.createdBy,
   );
-  const relatedContainerNodes = relatedContainerOriginalNodes.map((n) => R.assoc('disabled', relatedContainerFilteredNodeIds.includes(n.id), n));
+  const relatedContainerNodes = relatedContainerOriginalNodes.map((n) => ({
+    ...n,
+    disabled: relatedContainerFilteredNodeIds.includes(n.id),
+  }));
   const links = R.pipe(
     R.map((n) => R.map(
       (e) => ({
@@ -556,7 +561,7 @@ export const buildCorrelationData = (
     )),
     R.flatten,
   )(thisContainerLinkNodes);
-  const combinedNodes = R.concat(thisContainerLinkNodes, relatedContainerNodes);
+  const combinedNodes = [...thisContainerLinkNodes, ...relatedContainerNodes];
   const nodes = R.pipe(
     R.map((n) => ({
       id: n.id,


### PR DESCRIPTION
### Proposed changes

* Modification of correlation graph queries to display filtering by indicators and stix-cyber-objects in common.
* Add a button to display all the entities in common.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3227
