### PR TITLE
[backend] fix internal_id being removed during observable fullsync (#8986)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -204,7 +204,6 @@ export const addStixCyberObservable = async (context, user, input) => {
     return artifactImport(context, user, { ...input, ...input[graphQLType] });
   }
   const observableInput = {
-    internal_id,
     stix_id,
     x_opencti_score,
     x_opencti_description,
@@ -216,6 +215,9 @@ export const addStixCyberObservable = async (context, user, input) => {
     update,
     ...input[graphQLType]
   };
+  if (internal_id) {
+    observableInput.internal_id = internal_id;
+  }
   if (isNotEmptyField(payload_bin) && isNotEmptyField(url)) {
     throw FunctionalError('Cannot create observable with both payload_bin and url filled.');
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* internal_id was being upserted to an undefined value in the case of fullsync. We now only set an internal_id in addStixCyberObservable if the internal_id is not undefined

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8986 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
