### PR TITLE
[backend] improve waiting time for obas scenario generation with AI (#8585)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -31,11 +31,12 @@ if (AI_ENABLED && AI_TOKEN) {
 }
 
 export const queryMistralAi = async (busId: string | null, question: string, user: AuthUser) => {
+  // const startingTime = new Date().getTime();
   if (!client) {
     throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }
   try {
-    logApp.info('[AI] Querying MistralAI with prompt', { questionStart: question.substring(0, 100) });
+    // logApp.info('[AI] Querying MistralAI with prompt', { questionStart: question.substring(0, 100) });
     const response = (client as MistralClient)?.chatStream({
       model: AI_MODEL,
       messages: [{ role: 'user', content: question }],
@@ -52,6 +53,8 @@ export const queryMistralAi = async (busId: string | null, question: string, use
           }
         }
       }
+      // const endingTime = new Date().getTime();
+      // logApp.info(`[AI][TIME] Mistral AI response in ${endingTime - startingTime} ms.`, { question: question.substring(0, 100) });
       return content;
     }
     logApp.error('[AI] No response from MistralAI', { busId, question });

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -36,7 +36,7 @@ export const queryMistralAi = async (busId: string | null, question: string, use
     throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }
   try {
-    // logApp.info('[AI] Querying MistralAI with prompt', { questionStart: question.substring(0, 100) });
+    logApp.debug('[AI] Querying MistralAI with prompt', { questionStart: question.substring(0, 100) });
     const response = (client as MistralClient)?.chatStream({
       model: AI_MODEL,
       messages: [{ role: 'user', content: question }],
@@ -53,8 +53,6 @@ export const queryMistralAi = async (busId: string | null, question: string, use
           }
         }
       }
-      // const endingTime = new Date().getTime();
-      // logApp.info(`[AI][TIME] Mistral AI response in ${endingTime - startingTime} ms.`, { question: question.substring(0, 100) });
       return content;
     }
     logApp.error('[AI] No response from MistralAI', { busId, question });

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -31,7 +31,6 @@ if (AI_ENABLED && AI_TOKEN) {
 }
 
 export const queryMistralAi = async (busId: string | null, question: string, user: AuthUser) => {
-  // const startingTime = new Date().getTime();
   if (!client) {
     throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -35,7 +35,7 @@ export const queryMistralAi = async (busId: string | null, question: string, use
     throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }
   try {
-    logApp.info('[AI] Querying MistralAI with prompt');
+    logApp.info('[AI] Querying MistralAI with prompt', { questionStart: question.substring(0, 100) });
     const response = (client as MistralClient)?.chatStream({
       model: AI_MODEL,
       messages: [{ role: 'user', content: question }],
@@ -99,7 +99,7 @@ export const queryChatGpt = async (busId: string | null, question: string, user:
   }
 };
 
-export const compute = async (busId: string | null, question: string, user: AuthUser) => {
+export const queryAi = async (busId: string | null, question: string, user: AuthUser) => {
   switch (AI_TYPE) {
     case 'mistralai':
       return queryMistralAi(busId, question, user);

--- a/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
+++ b/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
@@ -126,6 +126,7 @@ export const createInjectInScenario = async (
   content: string | null,
   tags: Label[]
 ) => {
+  console.time('[OBAS]CreateInjectInScenario');
   const httpClient = buildXTmOpenBasHttpClient();
   try {
     const obasTagsIds = [];
@@ -145,6 +146,7 @@ export const createInjectInScenario = async (
         inject_tags: obasTagsIds,
       }
     );
+    console.timeEnd('[OBAS]CreateInjectInScenario');
     return inject;
   } catch (err) {
     throw DatabaseError('Error querying OpenBAS', { cause: err });

--- a/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
+++ b/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
@@ -126,7 +126,7 @@ export const createInjectInScenario = async (
   content: string | null,
   tags: Label[]
 ) => {
-  console.time('[OBAS]CreateInjectInScenario');
+  console.time(`${title}:[OBAS]CreateInjectInScenario`);
   const httpClient = buildXTmOpenBasHttpClient();
   try {
     const obasTagsIds = [];
@@ -146,7 +146,7 @@ export const createInjectInScenario = async (
         inject_tags: obasTagsIds,
       }
     );
-    console.timeEnd('[OBAS]CreateInjectInScenario');
+    console.timeEnd(`${title}:[OBAS]CreateInjectInScenario`);
     return inject;
   } catch (err) {
     throw DatabaseError('Error querying OpenBAS', { cause: err });

--- a/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
+++ b/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
@@ -126,7 +126,6 @@ export const createInjectInScenario = async (
   content: string | null,
   tags: Label[]
 ) => {
-  console.time(`${title}:[OBAS]CreateInjectInScenario`);
   const httpClient = buildXTmOpenBasHttpClient();
   try {
     const obasTagsIds = [];
@@ -146,7 +145,6 @@ export const createInjectInScenario = async (
         inject_tags: obasTagsIds,
       }
     );
-    console.timeEnd(`${title}:[OBAS]CreateInjectInScenario`);
     return inject;
   } catch (err) {
     throw DatabaseError('Error querying OpenBAS', { cause: err });

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -24,7 +24,7 @@ import type { InputMaybe, MutationAiContainerGenerateReportArgs, MutationAiSumma
 import { Format, Tone } from '../../generated/graphql';
 import { isEmptyField, isNotEmptyField } from '../../database/utils';
 import { FROM_START_STR, UNTIL_END_STR } from '../../utils/format';
-import { compute } from '../../database/ai-llm';
+import { queryAi } from '../../database/ai-llm';
 import {
   RELATION_AMPLIFIES,
   RELATION_ATTRIBUTED_TO,
@@ -60,7 +60,7 @@ export const fixSpelling = async (context: AuthContext, user: AuthUser, id: stri
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -80,7 +80,7 @@ export const makeShorter = async (context: AuthContext, user: AuthUser, id: stri
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -101,7 +101,7 @@ export const makeLonger = async (context: AuthContext, user: AuthUser, id: strin
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -122,7 +122,7 @@ export const changeTone = async (context: AuthContext, user: AuthUser, id: strin
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -141,7 +141,7 @@ export const summarize = async (context: AuthContext, user: AuthUser, id: string
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -160,7 +160,7 @@ export const explain = async (context: AuthContext, user: AuthUser, id: string, 
   # Content
   ${content}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -243,7 +243,7 @@ export const generateContainerReport = async (context: AuthContext, user: AuthUs
     # Contextual information about the above facts
     ${entitiesInvolved.join('')}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -301,7 +301,7 @@ export const summarizeFiles = async (context: AuthContext, user: AuthUser, args:
   # Content
   ${filesContent.join('')}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };
 
@@ -344,6 +344,6 @@ export const convertFilesToStix = async (context: AuthContext, user: AuthUser, a
   # Content
   ${filesContent.join('')}
   `;
-  const response = await compute(id, prompt, user);
+  const response = await queryAi(id, prompt, user);
   return response;
 };

--- a/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
@@ -411,7 +411,7 @@ export const generateOpenBasScenario = async (context, user, stixCoreObject, att
   } // end loop for
   const aiAttackPatterEmailEnd = new Date().getTime();
   console.timeEnd('[XTM]obasAttackPattern loop');
-  logApp.info(`[XTM][TIME] AI generated ${sortedEnrichedFilteredObasAttackPatterns} attack pattern email in ${aiAttackPatterEmailEnd - aiAttackPatterEmailStart} ms.`);
+  logApp.info(`[XTM][TIME] AI generated ${sortedEnrichedFilteredObasAttackPatterns.length} attack pattern email in ${aiAttackPatterEmailEnd - aiAttackPatterEmailStart} ms.`);
   logApp.info(`[XTM][TIME] TOTAL everything processed and send to obas in ${aiAttackPatterEmailEnd - startingDate} ms`);
   console.timeEnd('[XTM]generateOpenBasScenario ALL');
   return `${XTM_OPENBAS_URL}/admin/scenarios/${obasScenario.scenario_id}/injects`;

--- a/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
@@ -408,7 +408,6 @@ export const generateOpenBasScenario = async (context, user, stixCoreObject, att
 };
 
 export const generateContainerScenario = async (context, user, args) => {
-  // ici
   if (getDraftContext(context, user)) throw new Error('Cannot generate scenario in draft');
   const { id, interval, selection, simulationType = 'technical', useAI = false } = args;
   if (useAI || simulationType !== 'technical') {

--- a/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/xtm-domain.js
@@ -101,9 +101,7 @@ export const resolveContent = async (context, user, stixCoreObject) => {
 };
 const generateTechnicalAttackPattern = async (obasAttackPattern, selection, simulationType, obasScenario, dependsOnDuration, interval) => {
   let dependsOnDurationLocal = dependsOnDuration;
-  console.time(`${obasAttackPattern.attack_pattern_id}:[XTM]obasGetInjectorContracts`);
   const obasInjectorContracts = await obasGetInjectorContracts(obasAttackPattern.attack_pattern_id);
-  console.timeEnd(`${obasAttackPattern.attack_pattern_id}:[XTM]obasGetInjectorContracts`);
   let finalObasInjectorContracts = R.take(5, getShuffledArr(obasInjectorContracts));
   if (selection === 'random') {
     finalObasInjectorContracts = R.take(1, finalObasInjectorContracts);
@@ -113,7 +111,6 @@ const generateTechnicalAttackPattern = async (obasAttackPattern, selection, simu
     for (const finalObasInjectorContract of finalObasInjectorContracts) {
       const obasInjectorContractContent = JSON.parse(finalObasInjectorContract.injector_contract_content);
       const title = `[${obasAttackPattern.attack_pattern_external_id}] ${obasAttackPattern.attack_pattern_name} - ${finalObasInjectorContract.injector_contract_labels.en}`;
-      console.time(`${obasAttackPattern.attack_pattern_id}-${obasAttackPattern.attack_pattern_name}:[XTM]obasCreateInjectInScenario-tech`);
       await obasCreateInjectInScenario(
         obasScenario.scenario_id,
         obasInjectorContractContent.config.type,
@@ -123,7 +120,6 @@ const generateTechnicalAttackPattern = async (obasAttackPattern, selection, simu
         null,
         [{ value: 'opencti', color: '#001bda' }, { value: 'technical', color: '#b9461a' }]
       );
-      console.timeEnd(`${obasAttackPattern.attack_pattern_id}-${obasAttackPattern.attack_pattern_name}:[XTM]obasCreateInjectInScenario-tech`);
       dependsOnDurationLocal += (interval * 60);
     }
   } else {
@@ -154,9 +150,7 @@ const generateAttackPatternEmail = async (obasAttackPattern, killChainPhaseName,
             # Content
             ${obasAttackPattern.attack_pattern_description}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-email`);
   const responseIncidentResponse = await queryAi(null, promptIncidentResponse, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-email`);
   const promptIncidentResponseSubject = `
             # Instructions
             - Generate a subject for the following email.
@@ -167,11 +161,8 @@ const generateAttackPatternEmail = async (obasAttackPattern, killChainPhaseName,
             # Email content
             ${responseIncidentResponse}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-subject`);
   const responseIncidentResponseSubject = await queryAi(null, promptIncidentResponseSubject, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-subject`);
   const titleIncidentResponse = `[${killChainPhaseName}] ${obasAttackPattern.attack_pattern_name} - Email to the incident response team`;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario`);
   await obasCreateInjectInScenario(
     obasScenario.scenario_id,
     'openbas_email',
@@ -181,7 +172,6 @@ const generateAttackPatternEmail = async (obasAttackPattern, killChainPhaseName,
     { expectations: [], subject: responseIncidentResponseSubject.replace('Subject: ', '').replace('"', ''), body: responseIncidentResponse },
     [{ value: 'opencti', color: '#001bda' }, { value: 'csirt', color: '#c28b0d' }]
   );
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario`);
 };
 
 const generateAttackPatternEmailCiso = async (obasAttackPattern, killChainPhaseName, killChainPhasesListOfNames, content, user, obasScenario, dependsOnDuration) => {
@@ -205,9 +195,7 @@ const generateAttackPatternEmailCiso = async (obasAttackPattern, killChainPhaseN
             # Content
             ${obasAttackPattern.attack_pattern_description}
         `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-email-ciso`);
   const responseCiso = await queryAi(null, promptCiso, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-email-ciso`);
   const promptCisoSubject = `
             # Instructions
             - Generate a subject for the following email.
@@ -218,12 +206,9 @@ const generateAttackPatternEmailCiso = async (obasAttackPattern, killChainPhaseN
             # Email content
             ${responseCiso}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-subject-ciso`);
   const responseCisoSubject = await queryAi(null, promptCisoSubject, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-subject-ciso`);
   const titleCiso = `[${killChainPhaseName}] ${obasAttackPattern.attack_pattern_name} - Email to the CISO`;
 
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario-ciso`);
   await obasCreateInjectInScenario(
     obasScenario.scenario_id,
     'openbas_email',
@@ -233,7 +218,6 @@ const generateAttackPatternEmailCiso = async (obasAttackPattern, killChainPhaseN
     { expectations: [], subject: responseCisoSubject.replace('Subject: ', '').replace('"', ''), body: responseCiso },
     [{ value: 'opencti', color: '#001bda' }, { value: 'ciso', color: '#b41313' }]
   );
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario-ciso`);
 };
 
 const generateKillChainEmailCiso = async (killChainPhaseName, killChainPhasesListOfNames, content, user, obasScenario, dependsOnDuration) => {
@@ -254,9 +238,7 @@ const generateKillChainEmailCiso = async (killChainPhaseName, killChainPhasesLis
             # Context about the attack
             ${content}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-email-ciso`);
   const responseCiso = await queryAi(null, promptCiso, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-email-ciso`);
   const promptCisoSubject = `
             # Instructions
             - Generate a subject for the following email.
@@ -267,11 +249,8 @@ const generateKillChainEmailCiso = async (killChainPhaseName, killChainPhasesLis
             # Email content
             ${responseCiso}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-subject-ciso`);
   const responseCisoSubject = await queryAi(null, promptCisoSubject, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-subject-ciso`);
   const titleCiso = `[${killChainPhaseName}] ${responseCisoSubject} - Email to the CISO`;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-obasCreateInjectInScenario-ciso`);
   await obasCreateInjectInScenario(
     obasScenario.scenario_id,
     'openbas_email',
@@ -285,10 +264,8 @@ const generateKillChainEmailCiso = async (killChainPhaseName, killChainPhasesLis
     },
     [{ value: 'opencti', color: '#001bda' }, { value: 'ciso', color: '#b41313' }]
   );
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-obasCreateInjectInScenario-ciso`);
 };
 
-// FIXME manage dependsOnDuration
 const generateKillChainEmail = async (killChainPhaseName, killChainPhasesListOfNames, content, user, obasScenario, dependsOnDuration) => {
   // Mail to incident response
   const promptIncidentResponse = `
@@ -307,9 +284,7 @@ const generateKillChainEmail = async (killChainPhaseName, killChainPhasesListOfN
             # Context about the attack
             ${content}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-email`);
   const responseIncidentResponse = await queryAi(null, promptIncidentResponse, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-email`);
   const promptIncidentResponseSubject = `
             # Instructions
             - Generate a subject for the following email.
@@ -320,11 +295,8 @@ const generateKillChainEmail = async (killChainPhaseName, killChainPhasesListOfN
             # Email content
             ${responseIncidentResponse}
             `;
-  console.time(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-subject`);
   const responseIncidentResponseSubject = await queryAi(null, promptIncidentResponseSubject, user);
-  console.timeEnd(`${killChainPhaseName}:[XTM]queryAi-obasKillChainPhase-subject`);
   const titleIncidentResponse = `[${killChainPhaseName}] ${responseIncidentResponseSubject} - Email to the incident response team`;
-  console.time(`${killChainPhaseName}:[XTM]obasCreateInjectInScenario-obasKillChainPhase`);
   await obasCreateInjectInScenario(
     obasScenario.scenario_id,
     'openbas_email',
@@ -338,12 +310,10 @@ const generateKillChainEmail = async (killChainPhaseName, killChainPhasesListOfN
     },
     [{ value: 'opencti', color: '#001bda' }, { value: 'csirt', color: '#c28b0d' }]
   );
-  console.timeEnd(`${killChainPhaseName}:[XTM]obasCreateInjectInScenario-obasKillChainPhase`);
 };
 
-export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, attackPatterns, labels, author, simulationType, interval, selection, useAI) => {
+export const generateOpenBasScenario = async (context, user, stixCoreObject, attackPatterns, labels, author, simulationType, interval, selection, useAI) => {
   logApp.info('[XTM] Starting to generate OBAS scenario', { useAI, simulationType });
-  console.time('[XTM]generateOpenBasScenario ALL');
   const startingDate = new Date().getTime();
   const content = await resolveContent(context, user, stixCoreObject);
   const finalAttackPatterns = R.take(RESOLUTION_LIMIT, attackPatterns);
@@ -354,7 +324,6 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
   const subtitle = `Based on cyber threat knowledge authored by ${author.name}`;
 
   // call to obas
-  console.time('[XTM]obasCreateScenario1');
   const obasScenario = await obasCreateScenario(
     name,
     subtitle,
@@ -364,13 +333,10 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
     stixCoreObject.entity_type,
     simulationType === 'simulated' ? 'global-crisis' : 'attack-scenario'
   );
-  console.timeEnd('[XTM]obasCreateScenario1');
 
   // Get kill chain phases
   const sortByPhaseOrder = R.sortBy(R.prop('phase_order'));
-  console.time('[XTM]obasGetKillChainPhases1');
   const obasKillChainPhases = await obasGetKillChainPhases(); // Why it's not called only inside  if (attackPatterns.length === 0)  ??
-  console.timeEnd('[XTM]obasGetKillChainPhases1');
   const sortedObasKillChainPhases = sortByPhaseOrder(obasKillChainPhases);
   const killChainPhasesListOfNames = sortedObasKillChainPhases.map((n) => n.phase_name).join(', ');
   const indexedSortedObasKillChainPhase = R.indexBy(R.prop('phase_id'), sortedObasKillChainPhases);
@@ -382,7 +348,6 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
     if (!useAI) {
       throw UnsupportedError('No attack pattern associated to this entity. Please use AI to generate the scenario. This feature will be enhanced in the future to cover more types of entities.');
     }
-    console.time('[XTM]obasKillChainPhase loop');
     // eslint-disable-next-line no-restricted-syntax
     for (const obasKillChainPhase of sortedObasKillChainPhases) {
       const killChainPhaseName = obasKillChainPhase.phase_name;
@@ -391,16 +356,13 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
       createAndInjectScenarioPromises.push(generateKillChainEmailCiso(killChainPhaseName, killChainPhasesListOfNames, content, user, obasScenario, dependsOnDuration));
       dependsOnDuration += (interval * 60);
     }
-    console.timeEnd('[XTM]obasKillChainPhase loop');
   } else {
-    logApp.info('[XTM] attack pattern found, no generation of kill chain phase email');
+    logApp.debug('[XTM] attack pattern found, no generation of kill chain phase email');
   }
   // Get contracts from OpenBAS related to found attack patterns
 
   // Get attack patterns
-  console.time('[XTM]obasGetAttackPatterns');
   const obasAttackPatterns = await obasGetAttackPatterns();
-  console.timeEnd('[XTM]obasGetAttackPatterns');
 
   // Extract attack patterns
   const attackPatternsMitreIds = finalAttackPatterns.filter((n) => isNotEmptyField(n.x_mitre_id)).map((n) => n.x_mitre_id);
@@ -417,7 +379,6 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
   const sortByKillChainPhase = R.sortBy(R.path(['attack_pattern_kill_chain_phase', 'phase_order']));
   const sortedEnrichedFilteredObasAttackPatterns = sortByKillChainPhase(enrichedFilteredObasAttackPatterns);
 
-  console.time('[XTM]obasAttackPattern loop');
   const aiAttackPatterEmailStart = new Date().getTime();
   // Get the injector contracts
   // eslint-disable-next-line no-restricted-syntax
@@ -438,330 +399,11 @@ export const generateOpenBasScenarioV2 = async (context, user, stixCoreObject, a
     }
   } // end loop for
   const aiAttackPatterEmailEnd = new Date().getTime();
-  console.timeEnd('[XTM]obasAttackPattern loop');
 
   await Promise.all(createAndInjectScenarioPromises);
 
   logApp.info(`[XTM][TIME] AI generated ${sortedEnrichedFilteredObasAttackPatterns.length} attack pattern email in ${aiAttackPatterEmailEnd - aiAttackPatterEmailStart} ms.`);
   logApp.info(`[XTM][TIME] TOTAL everything processed and send to obas in ${aiAttackPatterEmailEnd - startingDate} ms`);
-  console.timeEnd('[XTM]generateOpenBasScenario ALL');
-  return `${XTM_OPENBAS_URL}/admin/scenarios/${obasScenario.scenario_id}/injects`;
-};
-
-export const generateOpenBasScenario = async (context, user, stixCoreObject, attackPatterns, labels, author, simulationType, interval, selection, useAI) => {
-  logApp.info('[XTM] Starting to generate OBAS scenario', { useAI, simulationType });
-  console.time('[XTM]generateOpenBasScenario ALL');
-  const startingDate = new Date().getTime();
-  const content = await resolveContent(context, user, stixCoreObject);
-  const finalAttackPatterns = R.take(RESOLUTION_LIMIT, attackPatterns);
-
-  // Create the scenario
-  const name = `[${stixCoreObject.entity_type}] ${extractEntityRepresentativeName(stixCoreObject)}`;
-  const description = extractRepresentativeDescription(stixCoreObject);
-  const subtitle = `Based on cyber threat knowledge authored by ${author.name}`;
-
-  // call to obas
-  console.time('[XTM]obasCreateScenario1');
-  const obasScenario = await obasCreateScenario(
-    name,
-    subtitle,
-    description,
-    [...labels, { value: 'opencti', color: '#001bda' }],
-    stixCoreObject.id,
-    stixCoreObject.entity_type,
-    simulationType === 'simulated' ? 'global-crisis' : 'attack-scenario'
-  );
-  console.timeEnd('[XTM]obasCreateScenario1');
-
-  // Get kill chain phases
-  const sortByPhaseOrder = R.sortBy(R.prop('phase_order'));
-  console.time('[XTM]obasGetKillChainPhases1');
-  const obasKillChainPhases = await obasGetKillChainPhases(); // Why it's not called only inside  if (attackPatterns.length === 0)  ??
-  console.timeEnd('[XTM]obasGetKillChainPhases1');
-  const sortedObasKillChainPhases = sortByPhaseOrder(obasKillChainPhases);
-  const killChainPhasesListOfNames = sortedObasKillChainPhases.map((n) => n.phase_name).join(', ');
-  const indexedSortedObasKillChainPhase = R.indexBy(R.prop('phase_id'), sortedObasKillChainPhases);
-
-  let dependsOnDuration = 0;
-  if (attackPatterns.length === 0) {
-    if (!useAI) {
-      throw UnsupportedError('No attack pattern associated to this entity. Please use AI to generate the scenario. This feature will be enhanced in the future to cover more types of entities.');
-    }
-    console.time('[XTM]obasKillChainPhase loop');
-    // eslint-disable-next-line no-restricted-syntax
-    for (const obasKillChainPhase of sortedObasKillChainPhases) {
-      const killChainPhaseName = obasKillChainPhase.phase_name;
-      // Mail to incident response
-      const promptIncidentResponse = `
-            # Instructions
-            - The context is a cybersecurity breach and attack simulation and cybersecurity crisis management exercise
-            - The enterprise is under attack! The incident response team and the CISO will need to answer to fake injections and questions.
-            - You should fake it and not writing about the simulation but like if it is a true cybersecurity threat and / or incident.
-            - Order of kill chain phases is ${killChainPhasesListOfNames}.
-            - We are in the kill chain phase ${killChainPhaseName}.
-            - You should write an email message (only the content, NOT the subject) representing this kill chain phase (${killChainPhaseName}) targeting the enterprise of 3 paragraphs with 3 lines in each paragraph in HTML.
-            - The email message should be addressed from the security operation center team to the incident response team, talking about the phase of the attack.
-            - The incident response team is under attack.
-            - Ensure that all words are accurately spelled and that the grammar is correct and the output format is in HTML.
-            - Your response should be in HTML format. Be sure to respect this format and to NOT output anything else than the format.
-            
-            # Context about the attack
-            ${content}
-            `;
-      console.time('[XTM]queryAi-obasKillChainPhase-email');
-      const responseIncidentResponse = await queryAi(null, promptIncidentResponse, user);
-      console.timeEnd('[XTM]queryAi-obasKillChainPhase-email');
-      const promptIncidentResponseSubject = `
-            # Instructions
-            - Generate a subject for the following email.
-            - The subject should be short and comprehensible.
-            - Just output the subject and nothing else.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            
-            # Email content
-            ${responseIncidentResponse}
-            `;
-      console.time('[XTM]queryAi-obasKillChainPhase-subject');
-      const responseIncidentResponseSubject = await queryAi(null, promptIncidentResponseSubject, user);
-      console.timeEnd('[XTM]queryAi-obasKillChainPhase-subject');
-      const titleIncidentResponse = `[${killChainPhaseName}] ${responseIncidentResponseSubject} - Email to the incident response team`;
-      console.time('[XTM]obasCreateInjectInScenario-obasKillChainPhase');
-      await obasCreateInjectInScenario(
-        obasScenario.scenario_id,
-        'openbas_email',
-        '2790bd39-37d4-4e39-be7e-53f3ca783f86',
-        titleIncidentResponse,
-        dependsOnDuration,
-        {
-          expectations: [],
-          subject: responseIncidentResponseSubject.replace('Subject: ', '').replace('"', ''),
-          body: responseIncidentResponse
-        },
-        [{ value: 'opencti', color: '#001bda' }, { value: 'csirt', color: '#c28b0d' }]
-      );
-      console.timeEnd('[XTM]obasCreateInjectInScenario-obasKillChainPhase');
-      dependsOnDuration += (interval * 60);
-      // Mail to CISO
-      const promptCiso = `
-            # Instructions
-            - The context is a cybersecurity breach and attack simulation and cybersecurity crisis management exercise
-            - The enterprise is under attack! The incident response team and the CISO will need to answer to fake injections and questions.
-            - You should fake it and not writing about the simulation but like if it is a true cybersecurity threat and / or incident.
-            - Order of kill chain phases is ${killChainPhasesListOfNames}.
-            - We are in the kill chain phase ${killChainPhaseName}.
-            - You should write an email message (only the content, NOT the subject) representing this kill chain phase (${killChainPhaseName}) targeting the enterprise of 3 paragraphs with 3 lines in each paragraph in HTML.
-            - The email message should be addressed from the security operation center team to the chief security officer, talking about the phase of the attack.
-            - The incident response team is under attack.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            - Your response should be in HTML format. Be sure to respect this format and to NOT output anything else than the format.
-            
-            # Context about the attack
-            ${content}
-            `;
-      console.time('[XTM]queryAi-obasKillChainPhase-email-ciso');
-      const responseCiso = await queryAi(null, promptCiso, user);
-      console.timeEnd('[XTM]queryAi-obasKillChainPhase-email-ciso');
-      const promptCisoSubject = `
-            # Instructions
-            - Generate a subject for the following email.
-            - The subject should be short and comprehensible.
-            - Just output the subject and nothing else.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            
-            # Email content
-            ${responseCiso}
-            `;
-      console.time('[XTM]queryAi-obasKillChainPhase-subject-ciso');
-      const responseCisoSubject = await queryAi(null, promptCisoSubject, user);
-      console.timeEnd('[XTM]queryAi-obasKillChainPhase-subject-ciso');
-      const titleCiso = `[${killChainPhaseName}] ${responseCisoSubject} - Email to the CISO`;
-      console.time('[XTM]queryAi-obasKillChainPhase-obasCreateInjectInScenario-ciso');
-      await obasCreateInjectInScenario(
-        obasScenario.scenario_id,
-        'openbas_email',
-        '2790bd39-37d4-4e39-be7e-53f3ca783f86',
-        titleCiso,
-        dependsOnDuration,
-        {
-          expectations: [],
-          subject: responseCisoSubject.replace('Subject: ', '').replace('"', ''),
-          body: responseCiso
-        },
-        [{ value: 'opencti', color: '#001bda' }, { value: 'ciso', color: '#b41313' }]
-      );
-      console.timeEnd('[XTM]queryAi-obasKillChainPhase-obasCreateInjectInScenario-ciso');
-      dependsOnDuration += (interval * 60);
-    } // end for loop
-    console.timeEnd('[XTM]obasKillChainPhase loop');
-  } else {
-    logApp.info('[XTM] attack pattern found, no generation of kill chain phase email');
-  }
-  // Get contracts from OpenBAS related to found attack patterns
-
-  // Get attack patterns
-  console.time('[XTM]obasGetAttackPatterns');
-  const obasAttackPatterns = await obasGetAttackPatterns();
-  console.timeEnd('[XTM]obasGetAttackPatterns');
-
-  // Extract attack patterns
-  const attackPatternsMitreIds = finalAttackPatterns.filter((n) => isNotEmptyField(n.x_mitre_id)).map((n) => n.x_mitre_id);
-
-  // Keep only attack patterns matching the container ones
-  const filteredObasAttackPatterns = obasAttackPatterns.filter((n) => attackPatternsMitreIds.includes(n.attack_pattern_external_id));
-
-  // Enrich with the earliest kill chain phase
-  const enrichedFilteredObasAttackPatterns = filteredObasAttackPatterns.map(
-    (n) => R.assoc('attack_pattern_kill_chain_phase', sortByPhaseOrder(n.attack_pattern_kill_chain_phases.map((o) => indexedSortedObasKillChainPhase[o])).at(0), n)
-  );
-
-  // Sort attack pattern by kill chain phase
-  const sortByKillChainPhase = R.sortBy(R.path(['attack_pattern_kill_chain_phase', 'phase_order']));
-  const sortedEnrichedFilteredObasAttackPatterns = sortByKillChainPhase(enrichedFilteredObasAttackPatterns);
-
-  console.time('[XTM]obasAttackPattern loop');
-  const aiAttackPatterEmailStart = new Date().getTime();
-  // Get the injector contracts
-  // eslint-disable-next-line no-restricted-syntax
-  for (const obasAttackPattern of sortedEnrichedFilteredObasAttackPatterns) {
-    const killChainPhaseName = obasAttackPattern.attack_pattern_kill_chain_phase.phase_name;
-    if (simulationType === 'simulated') {
-      // Mail to incident response
-      const promptIncidentResponse = `
-            # Instructions
-            - The context is a cybersecurity breach and attack simulation and cybersecurity crisis management exercise
-            - The enterprise is under attack! The incident response team and the CISO will need to answer to fake injections and questions.
-            - You should fake it and not writing about the simulation but like if it is a true cybersecurity threat and / or incident.
-            - Order of kill chain phases is ${killChainPhasesListOfNames}.
-            - Examine the provided content which describes an attack technique in the context of the kill chain phase ${killChainPhaseName}.
-            - You should take into account the context about the attack.
-            - You should write an email message (only the content, NOT the subject) representing this attack technique targeting the enterprise of 3 paragraphs with 3 lines in each paragraph in HTML.
-            - The email message should be addressed from the security operation center team to the incident response team, talking about the phase of the attack.
-            - The incident response team is under attack.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            - Your response should be in HTML format. Be sure to respect this format and to NOT output anything else than the format.
-            
-            # Context about the attack
-            ${content}
-            
-            # Content
-            ${obasAttackPattern.attack_pattern_description}
-            `;
-      console.time('[XTM]queryAi-obasAttackPattern-email');
-      const responseIncidentResponse = await queryAi(null, promptIncidentResponse, user);
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-email');
-      const promptIncidentResponseSubject = `
-            # Instructions
-            - Generate a subject for the following email.
-            - The subject should be short and comprehensible.
-            - Just output the subject and nothing else.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            
-            # Email content
-            ${responseIncidentResponse}
-            `;
-      console.time('[XTM]queryAi-obasAttackPattern-subject');
-      const responseIncidentResponseSubject = await queryAi(null, promptIncidentResponseSubject, user);
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-subject');
-      const titleIncidentResponse = `[${killChainPhaseName}] ${obasAttackPattern.attack_pattern_name} - Email to the incident response team`;
-      console.time('[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario');
-      await obasCreateInjectInScenario(
-        obasScenario.scenario_id,
-        'openbas_email',
-        '2790bd39-37d4-4e39-be7e-53f3ca783f86',
-        titleIncidentResponse,
-        dependsOnDuration,
-        { expectations: [], subject: responseIncidentResponseSubject.replace('Subject: ', '').replace('"', ''), body: responseIncidentResponse },
-        [{ value: 'opencti', color: '#001bda' }, { value: 'csirt', color: '#c28b0d' }]
-      );
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario');
-      dependsOnDuration += (interval * 60);
-      const promptCiso = `
-            # Instructions
-            - The context is a cybersecurity breach and attack simulation and cybersecurity crisis management exercise
-            - The enterprise is under attack! The incident response team and the CISO will need to answer to fake injections and questions.
-            - You should fake it and not writing about the simulation but like if it is a true cybersecurity threat and / or incident.
-            - Order of kill chain phases is ${killChainPhasesListOfNames}.
-            - Examine the provided content which describes an attack technique in the context of the kill chain phase ${killChainPhaseName}.
-            - You should write an email message (only the content, NOT the subject) representing this attack technique targeting the enterprise of 3 paragraphs with 3 lines in each paragraph in HTML.
-            - You should take into account the context about the attack.
-            - The email message should be addressed from the security operation center team to the chief information security officer.
-            - The CISO is under attack.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            - Your response should be in HTML format. Be sure to respect this format and to NOT output anything else than the format.
-          
-            # Context about the attack
-            ${content}
-            
-            # Content
-            ${obasAttackPattern.attack_pattern_description}
-        `;
-      console.time('[XTM]queryAi-obasAttackPattern-email-ciso');
-      const responseCiso = await queryAi(null, promptCiso, user);
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-email-ciso');
-      const promptCisoSubject = `
-            # Instructions
-            - Generate a subject for the following email.
-            - The subject should be short and comprehensible.
-            - Just output the subject and nothing else.
-            - Ensure that all words are accurately spelled and that the grammar is correct.
-            
-            # Email content
-            ${responseCiso}
-            `;
-      console.time('[XTM]queryAi-obasAttackPattern-subject-ciso');
-      const responseCisoSubject = await queryAi(null, promptCisoSubject, user);
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-subject-ciso');
-      const titleCiso = `[${killChainPhaseName}] ${obasAttackPattern.attack_pattern_name} - Email to the CISO`;
-
-      console.time('[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario-ciso');
-      await obasCreateInjectInScenario(
-        obasScenario.scenario_id,
-        'openbas_email',
-        '2790bd39-37d4-4e39-be7e-53f3ca783f86',
-        titleCiso,
-        dependsOnDuration,
-        { expectations: [], subject: responseCisoSubject.replace('Subject: ', '').replace('"', ''), body: responseCiso },
-        [{ value: 'opencti', color: '#001bda' }, { value: 'ciso', color: '#b41313' }]
-      );
-      console.timeEnd('[XTM]queryAi-obasAttackPattern-obasCreateInjectInScenario-ciso');
-      dependsOnDuration += (interval * 60);
-    } else {
-      console.time('[XTM]obasGetInjectorContracts');
-      const obasInjectorContracts = await obasGetInjectorContracts(obasAttackPattern.attack_pattern_id);
-      console.timeEnd('[XTM]obasGetInjectorContracts');
-      let finalObasInjectorContracts = R.take(5, getShuffledArr(obasInjectorContracts));
-      if (selection === 'random') {
-        finalObasInjectorContracts = R.take(1, finalObasInjectorContracts);
-      }
-      if (simulationType === 'technical') {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const finalObasInjectorContract of finalObasInjectorContracts) {
-          const obasInjectorContractContent = JSON.parse(finalObasInjectorContract.injector_contract_content);
-          const title = `[${obasAttackPattern.attack_pattern_external_id}] ${obasAttackPattern.attack_pattern_name} - ${finalObasInjectorContract.injector_contract_labels.en}`;
-          console.time('[XTM]obasCreateInjectInScenario-tech');
-          await obasCreateInjectInScenario(
-            obasScenario.scenario_id,
-            obasInjectorContractContent.config.type,
-            finalObasInjectorContract.injector_contract_id,
-            title,
-            dependsOnDuration,
-            null,
-            [{ value: 'opencti', color: '#001bda' }, { value: 'technical', color: '#b9461a' }]
-          );
-          console.timeEnd('[XTM]obasCreateInjectInScenario-tech');
-          dependsOnDuration += (interval * 60);
-        }
-      } else {
-        // TODO
-        logApp.info(`[XTM] simulationType ${simulationType} not implemented yet.`);
-      }
-    }
-  } // end loop for
-  const aiAttackPatterEmailEnd = new Date().getTime();
-  console.timeEnd('[XTM]obasAttackPattern loop');
-  logApp.info(`[XTM][TIME] AI generated ${sortedEnrichedFilteredObasAttackPatterns.length} attack pattern email in ${aiAttackPatterEmailEnd - aiAttackPatterEmailStart} ms.`);
-  logApp.info(`[XTM][TIME] TOTAL everything processed and send to obas in ${aiAttackPatterEmailEnd - startingDate} ms`);
-  console.timeEnd('[XTM]generateOpenBasScenario ALL');
   return `${XTM_OPENBAS_URL}/admin/scenarios/${obasScenario.scenario_id}/injects`;
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use promises to send all scenario generation at once, instead of one after the other.
* Add a warn log in case the time is over 2 minutes.

Refactor:
- some renaming to know which part is an OBAS call, and which part is an AI call.

### Related issues
* closes #8585 
* 
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
