### PR TITLE
BUGFIX: [graph] Hide filtered nodes/edges in correlation graphs

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -477,7 +477,10 @@ export const buildCorrelationData = (
     filterAdjust.markedBy,
     filterAdjust.createdBy,
   );
-  const thisReportNodes = thisReportOriginalNodes.map((n) => R.assoc('disabled', filteredNodesIds.includes(n.id), n));
+  const thisReportNodes = R.filter(
+    (n) => !filteredNodesIds.includes(n.id),
+    thisReportOriginalNodes,
+  );
   const thisReportLinkNodes = R.filter(
     (n) => n[key] && n.parent_types && n[key].edges.length > 1,
     thisReportNodes,


### PR DESCRIPTION
Right now, these are simply greyed out as "disabled". However, when we filter items from the correlation graphs, we want it to "clean up" the graph. So, hide the affected nodes+edges from view so we can explore just the correlated items we include in the filters.

### Proposed changes

In `buildCorrelationData` in the `utils/Graph.js`, change the "filter" behavior from disabling filtered nodes (which simply changes their color) to remove them from the graph (and their edges). This is how the Correlation feature used to work, and the behavior regressed sometime later.

Keeping the disabled nodes + edges on the graph in correlation view significantly defeats the purpose of being able to filter these nodes out, as it makes large graphs difficult to navigate.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Screenshots

Example of filter behavior fixed with this PR:

![image](https://github.com/user-attachments/assets/1e84672d-c698-40d6-bc12-db6e10b8720e)
![image](https://github.com/user-attachments/assets/5a993004-fc8d-4964-aa0b-9d4485ea2dd3)
