### PR TITLE
BUGFIX: [graph] Increase count of related elements fetched by Correlation Graph to 500000

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -1255,7 +1255,7 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects {
+        objects(first: 500000) {
           edges {
             node {
               ... on BasicObject {

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -1279,7 +1279,7 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
-                groupings(first: 20) {
+                groupings(first: 500000) {
                   edges {
                     node {
                       id
@@ -1387,7 +1387,7 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                groupings(first: 20) {
+                groupings(first: 500000) {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -1279,12 +1279,65 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                cases(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 groupings(first: 500000) {
                   edges {
                     node {
                       id
                       name
                       context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
                       confidence
                       entity_type
                       parent_types
@@ -1387,6 +1440,32 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                cases(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 groupings(first: 500000) {
                   edges {
                     node {
@@ -1404,7 +1483,34 @@ const GroupingKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -1274,6 +1274,59 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
+                cases(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 reports(first: 500000) {
                   edges {
                     node {
@@ -1379,6 +1432,59 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
+                cases(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
                 reports(first: 500000) {
                   edges {
                     node {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -1250,7 +1250,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects(first: 500) {
+        objects(first: 500000) {
           edges {
             node {
               ... on BasicObject {
@@ -1274,7 +1274,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
-                reports(first: 20) {
+                reports(first: 500000) {
                   edges {
                     node {
                       id
@@ -1379,7 +1379,7 @@ const ReportKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                reports(first: 20) {
+                reports(first: 500000) {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -1286,7 +1286,7 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id
@@ -1390,7 +1390,7 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -1262,7 +1262,7 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects {
+        objects(first: 500000) {
           edges {
             node {
               ... on BasicObject {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -1312,6 +1312,60 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
                     }
                   }
                 }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
               }
               ... on StixDomainObject {
                 created
@@ -1407,6 +1461,60 @@ const IncidentKnowledgeCorrelation = createFragmentContainer(
                         }
                       }
                                             objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -1286,7 +1286,7 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id
@@ -1390,7 +1390,7 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -1302,7 +1302,61 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition
@@ -1406,7 +1460,61 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -1262,7 +1262,7 @@ const CaseRfiKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects {
+        objects(first: 500000) {
           edges {
             node {
               ... on BasicObject {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -1287,7 +1287,7 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
                   x_opencti_order
                   x_opencti_color
                 }
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id
@@ -1391,7 +1391,7 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
               }
               ... on StixCyberObservable {
                 observable_value
-                cases(first: 20) {
+                cases(first: 500000) {
                   edges {
                     node {
                       id

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -1263,7 +1263,7 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
           x_opencti_order
           x_opencti_color
         }
-        objects {
+        objects(first: 500000) {
           edges {
             node {
               ... on BasicObject {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -1303,7 +1303,61 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition
@@ -1407,7 +1461,61 @@ const CaseRftKnowledgeCorrelation = createFragmentContainer(
                           entity_type
                         }
                       }
-                                            objectMarking {
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                groupings(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      context
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
+                        id
+                        definition_type
+                        definition
+                        x_opencti_order
+                        x_opencti_color
+                      }
+                    }
+                  }
+                }
+                reports(first: 500000) {
+                  edges {
+                    node {
+                      id
+                      name
+                      published
+                      confidence
+                      entity_type
+                      parent_types
+                      created_at
+                      createdBy {
+                        ... on Identity {
+                          id
+                          name
+                          entity_type
+                        }
+                      }
+                      objectMarking {
                         id
                         definition_type
                         definition


### PR DESCRIPTION
The 500 upper limit is very low and results in a lot of correlation graphs displaying no correlations in the chart, while the main page of the Graph says there exist correlations. In some cases this limit was just 20. This fixes a lot of the reported problems where related reporting is seen on the Overview page of a analysis/case/etc. but the Correlation Graph is blank (because it isn't fetching all nodes, and the correlations don't show in the first 500 fetched). In some scenarios, the graph does show some items, but is missing other expected ones.

### Proposed changes

* Set `first: 500000` when fetching first-degree and second-degree related nodes for Correlation Graphs

### Related issues
* #9198 
* #6839

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
