### PR TITLE
[backend] filter notifications by trigger (#7309)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -734,6 +734,7 @@
   "Tool types": "Werkzeugarten",
   "Tool version": "Werkzeugversion",
   "Tracking number": "Tracking nummer",
+  "Trigger": "Auslöser",
   "Trigger for personal notifiers": "Auslöser für persönliche Melder",
   "Trigger IDs": "Auslöser-IDs",
   "Trigger scope": "Auslösender Bereich",

--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -737,6 +737,7 @@
   "Trigger": "Auslöser",
   "Trigger for personal notifiers": "Auslöser für persönliche Melder",
   "Trigger IDs": "Auslöser-IDs",
+  "Trigger name": "Name des Auslösers",
   "Trigger scope": "Auslösender Bereich",
   "Trigger time": "Auslösezeitpunkt",
   "Trigger type": "Auslösertyp",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -737,6 +737,7 @@
   "Trigger": "Trigger",
   "Trigger for personal notifiers": "Trigger for personal notifiers",
   "Trigger IDs": "Trigger IDs",
+  "Trigger name": "Trigger name",
   "Trigger scope": "Trigger scope",
   "Trigger time": "Trigger time",
   "Trigger type": "Trigger type",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -734,6 +734,7 @@
   "Tool types": "Tool types",
   "Tool version": "Tool version",
   "Tracking number": "Tracking number",
+  "Trigger": "Trigger",
   "Trigger for personal notifiers": "Trigger for personal notifiers",
   "Trigger IDs": "Trigger IDs",
   "Trigger scope": "Trigger scope",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -737,6 +737,7 @@
   "Trigger": "Disparador",
   "Trigger for personal notifiers": "Activación de notificadores personales",
   "Trigger IDs": "ID de activación",
+  "Trigger name": "Nombre del activador",
   "Trigger scope": "Ámbito de activación",
   "Trigger time": "Hora de activación",
   "Trigger type": "Tipo de disparo",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -734,6 +734,7 @@
   "Tool types": "Tipos de herramientas",
   "Tool version": "Versión de la herramienta",
   "Tracking number": "El número de rastreo",
+  "Trigger": "Disparador",
   "Trigger for personal notifiers": "Activación de notificadores personales",
   "Trigger IDs": "ID de activación",
   "Trigger scope": "Ámbito de activación",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -734,6 +734,7 @@
   "Tool types": "Types d'outils",
   "Tool version": "Version de l'outil",
   "Tracking number": "Numéro de suivi",
+  "Trigger": "Déclencheur",
   "Trigger for personal notifiers": "Déclencheur de notifications personnelles",
   "Trigger IDs": "ID de déclenchement",
   "Trigger scope": "Champ d'application du déclencheur",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -737,6 +737,7 @@
   "Trigger": "Déclencheur",
   "Trigger for personal notifiers": "Déclencheur de notifications personnelles",
   "Trigger IDs": "ID de déclenchement",
+  "Trigger name": "Nom du déclencheur",
   "Trigger scope": "Champ d'application du déclencheur",
   "Trigger time": "Heure de déclenchement",
   "Trigger type": "Type de déclencheur",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -734,6 +734,7 @@
   "Tool types": "道具のバージョン",
   "Tool version": "基本スコア",
   "Tracking number": "追跡番号",
+  "Trigger": "トリガー",
   "Trigger for personal notifiers": "個人通知機のトリガー",
   "Trigger IDs": "期間",
   "Trigger scope": "成果",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -737,6 +737,7 @@
   "Trigger": "トリガー",
   "Trigger for personal notifiers": "個人通知機のトリガー",
   "Trigger IDs": "期間",
+  "Trigger name": "トリガー名",
   "Trigger scope": "成果",
   "Trigger time": "トリガータイプ",
   "Trigger type": "インスタンス・トリガー",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -734,6 +734,7 @@
   "Tool types": "도구 유형",
   "Tool version": "도구 버전",
   "Tracking number": "추적 번호",
+  "Trigger": "트리거",
   "Trigger for personal notifiers": "개인 알림 트리거",
   "Trigger IDs": "트리거 ID",
   "Trigger scope": "트리거 범위",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -737,6 +737,7 @@
   "Trigger": "트리거",
   "Trigger for personal notifiers": "개인 알림 트리거",
   "Trigger IDs": "트리거 ID",
+  "Trigger name": "트리거 이름",
   "Trigger scope": "트리거 범위",
   "Trigger time": "트리거 시간",
   "Trigger type": "트리거 유형",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -734,6 +734,7 @@
   "Tool types": "工具类型",
   "Tool version": "工具版本",
   "Tracking number": "追踪号码",
+  "Trigger": "触发器",
   "Trigger for personal notifiers": "个人通知触发器",
   "Trigger IDs": "触发器 ID",
   "Trigger scope": "触发范围",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -737,6 +737,7 @@
   "Trigger": "触发器",
   "Trigger for personal notifiers": "个人通知触发器",
   "Trigger IDs": "触发器 ID",
+  "Trigger name": "触发器名称",
   "Trigger scope": "触发范围",
   "Trigger time": "触发时间",
   "Trigger type": "触发类型",

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -29,7 +29,7 @@ const Notifications: FunctionComponent = () => {
       orderAsc: false,
       filters: {
         ...emptyFilterGroup,
-        filters: useGetDefaultFilterObject(['is_read'], ['Notification']),
+        filters: useGetDefaultFilterObject(['is_read', 'trigger_id'], ['Notification']),
       },
       numberOfElements: {
         number: 0,
@@ -67,7 +67,7 @@ const Notifications: FunctionComponent = () => {
         isSortable: true,
       },
       name: {
-        label: 'Trigger',
+        label: 'Trigger name',
         width: '15%',
         isSortable: true,
       },

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -58,17 +58,17 @@ const Notifications: FunctionComponent = () => {
       },
       message: {
         label: 'Message',
-        width: '45%',
+        width: '48%',
         isSortable: false,
       },
       created: {
         label: 'Original creation date',
-        width: '15%',
+        width: '20%',
         isSortable: true,
       },
       name: {
         label: 'Trigger name',
-        width: '15%',
+        width: '12%',
         isSortable: true,
       },
     };

--- a/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/notifications/NotificationLine.tsx
@@ -98,8 +98,8 @@ interface NotificationLineProps {
   onLabelClick: (
     k: string,
     id: string,
-    value: Record<string, unknown>,
-    event: React.KeyboardEvent
+    value: Record<string, unknown> | string,
+    event: React.KeyboardEvent | React.MouseEvent
   ) => void;
   selectedElements: Record<string, NotificationLine_node$data>;
   deSelectedElements: Record<string, NotificationLine_node$data>;
@@ -143,6 +143,7 @@ NotificationLineProps
   selectedElements,
   deSelectedElements,
   onToggleEntity,
+  onLabelClick, // used for trigger name click
   selectAll,
   onToggleShiftEntity,
   index,
@@ -290,6 +291,11 @@ NotificationLineProps
                     }
                     variant="outlined"
                     label={data.name}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onLabelClick('name', data.name, 'eq', e);
+                    }}
                   />
                 </Tooltip>
               </div>

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersQueries.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggersQueries.tsx
@@ -48,3 +48,20 @@ export const triggersQueriesActivitySearchQuery = graphql`
     }
   }
 `;
+
+export const triggersQueriesSearchQuery = graphql`
+  query TriggersQueriesSearchQuery(
+    $search: String
+    $filters: FilterGroup
+  ) {
+    triggers(search: $search, filters: $filters) {
+      edges {
+        node {
+          id
+          name
+          trigger_type
+        }
+      }
+    }
+  }
+`;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8043,6 +8043,7 @@ type Query {
   narratives(first: Int, after: ID, orderBy: NarrativesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): NarrativeConnection
   triggerKnowledge(id: String!): Trigger
   triggersKnowledge(first: Int, after: ID, orderBy: TriggersOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): TriggerConnection
+  triggers(first: Int, after: ID, orderBy: TriggersOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): TriggerConnection
   triggersKnowledgeCount(filters: FilterGroup, includeAuthorities: Boolean, search: String): Int
   triggerActivity(id: String!): Trigger
   triggersActivity(first: Int, after: ID, orderBy: TriggersOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): TriggerConnection

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -26,8 +26,8 @@ import { NotifierFieldSearchQuery$data } from '@components/common/form/__generat
 import { killChainPhasesSearchQuery } from '@components/settings/KillChainPhases';
 import { KillChainPhasesSearchQuery$data } from '@components/settings/__generated__/KillChainPhasesSearchQuery.graphql';
 import { MarkingDefinitionsQuerySearchQuery$data } from '@components/settings/__generated__/MarkingDefinitionsQuerySearchQuery.graphql';
-import { triggersQueriesKnowledgeSearchQuery } from '@components/profile/triggers/TriggersQueries';
-import { TriggersQueriesSearchKnowledgeQuery$data } from '@components/profile/triggers/__generated__/TriggersQueriesSearchKnowledgeQuery.graphql';
+import { triggersQueriesSearchQuery } from '@components/profile/triggers/TriggersQueries';
+import { TriggersQueriesSearchQuery$data } from '@components/profile/triggers/__generated__/TriggersQueriesSearchQuery.graphql';
 import { markingDefinitionsLinesSearchQuery } from '../../private/components/settings/MarkingDefinitionsQuery';
 import useAuth, { FilterDefinition } from '../hooks/useAuth';
 import { useSearchEntitiesStixCoreObjectsSearchQuery$data } from './__generated__/useSearchEntitiesStixCoreObjectsSearchQuery.graphql';
@@ -961,13 +961,13 @@ const useSearchEntities = ({
                   );
                 });
             } else if (idEntityTypes.includes('Trigger')) {
-              fetchQuery(triggersQueriesKnowledgeSearchQuery, {
+              fetchQuery(triggersQueriesSearchQuery, {
                 search: event.target.value !== 0 ? event.target.value : '',
               })
                 .toPromise()
                 .then((data) => {
                   const triggers = (
-                    (data as TriggersQueriesSearchKnowledgeQuery$data).triggersKnowledge?.edges ?? []
+                    (data as TriggersQueriesSearchQuery$data).triggers?.edges ?? []
                   ).map((n) => ({
                     label: n.node.name,
                     value: n.node.id,

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -26,6 +26,8 @@ import { NotifierFieldSearchQuery$data } from '@components/common/form/__generat
 import { killChainPhasesSearchQuery } from '@components/settings/KillChainPhases';
 import { KillChainPhasesSearchQuery$data } from '@components/settings/__generated__/KillChainPhasesSearchQuery.graphql';
 import { MarkingDefinitionsQuerySearchQuery$data } from '@components/settings/__generated__/MarkingDefinitionsQuerySearchQuery.graphql';
+import { triggersQueriesKnowledgeSearchQuery } from '@components/profile/triggers/TriggersQueries';
+import { TriggersQueriesSearchKnowledgeQuery$data } from '@components/profile/triggers/__generated__/TriggersQueriesSearchKnowledgeQuery.graphql';
 import { markingDefinitionsLinesSearchQuery } from '../../private/components/settings/MarkingDefinitionsQuery';
 import useAuth, { FilterDefinition } from '../hooks/useAuth';
 import { useSearchEntitiesStixCoreObjectsSearchQuery$data } from './__generated__/useSearchEntitiesStixCoreObjectsSearchQuery.graphql';
@@ -956,6 +958,24 @@ const useSearchEntities = ({
                   unionSetEntities(
                     filterKey,
                     notifiers,
+                  );
+                });
+            } else if (idEntityTypes.includes('Trigger')) {
+              fetchQuery(triggersQueriesKnowledgeSearchQuery, {
+                search: event.target.value !== 0 ? event.target.value : '',
+              })
+                .toPromise()
+                .then((data) => {
+                  const triggers = (
+                    (data as TriggersQueriesSearchKnowledgeQuery$data).triggersKnowledge?.edges ?? []
+                  ).map((n) => ({
+                    label: n.node.name,
+                    value: n.node.id,
+                    type: 'Trigger',
+                  }));
+                  unionSetEntities(
+                    filterKey,
+                    triggers,
                   );
                 });
             } else if (idEntityTypes.includes('StatusTemplate')) {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19585,6 +19585,7 @@ export type Query = {
   tools?: Maybe<ToolConnection>;
   triggerActivity?: Maybe<Trigger>;
   triggerKnowledge?: Maybe<Trigger>;
+  triggers?: Maybe<TriggerConnection>;
   triggersActivity?: Maybe<TriggerConnection>;
   triggersKnowledge?: Maybe<TriggerConnection>;
   triggersKnowledgeCount?: Maybe<Scalars['Int']['output']>;
@@ -22036,6 +22037,17 @@ export type QueryTriggerActivityArgs = {
 
 export type QueryTriggerKnowledgeArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type QueryTriggersArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  includeAuthorities?: InputMaybe<Scalars['Boolean']['input']>;
+  orderBy?: InputMaybe<TriggersOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -38657,6 +38669,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   tools?: Resolver<Maybe<ResolversTypes['ToolConnection']>, ParentType, ContextType, Partial<QueryToolsArgs>>;
   triggerActivity?: Resolver<Maybe<ResolversTypes['Trigger']>, ParentType, ContextType, RequireFields<QueryTriggerActivityArgs, 'id'>>;
   triggerKnowledge?: Resolver<Maybe<ResolversTypes['Trigger']>, ParentType, ContextType, RequireFields<QueryTriggerKnowledgeArgs, 'id'>>;
+  triggers?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersArgs>>;
   triggersActivity?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersActivityArgs>>;
   triggersKnowledge?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeArgs>>;
   triggersKnowledgeCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeCountArgs>>;

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -46,7 +46,7 @@ export const internalProcessNotification = async (
   // eslint-disable-next-line consistent-return
 ): Promise<{ error: string } | void> => {
   try {
-    const { name: notification_name, trigger_type } = notification;
+    const { name: notification_name, id: trigger_id, trigger_type } = notification;
     const { notifier_connector_id, notifier_configuration: configuration } = notifier;
     const generatedContent: Record<string, Array<NotificationContentEvent>> = {};
     for (let index = 0; index < data.length; index += 1) {
@@ -72,6 +72,7 @@ export const internalProcessNotification = async (
     if (notifier_connector_id === NOTIFIER_CONNECTOR_UI) {
       const createNotification = {
         name: notification_name,
+        trigger_id,
         notification_type: trigger_type,
         user_id: user.user_id,
         notification_content: content,

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
@@ -278,6 +278,15 @@ export const triggersActivityFind = (context: AuthContext, user: AuthUser, opts:
   return listEntitiesPaginated<BasicStoreEntityTrigger>(context, user, [ENTITY_TYPE_TRIGGER], queryArgs);
 };
 
+export const triggersFind = (context: AuthContext, user: AuthUser, opts: QueryTriggersActivityArgs) => {
+  if (!isUserHasCapability(user, SETTINGS_SECURITYACTIVITY)) {
+    // if user doesn't have SETTINGS_SECURITYACTIVITY capabilities, we only return knowledge triggers
+    return triggersKnowledgeFind(context, user, opts);
+  }
+  const queryArgs = { ...opts, includeAuthorities: true };
+  return listEntitiesPaginated<BasicStoreEntityTrigger>(context, user, [ENTITY_TYPE_TRIGGER], queryArgs);
+};
+
 // region Notifications
 export const notificationGet = (context: AuthContext, user: AuthUser, narrativeId: string): BasicStoreEntityNotification => {
   return storeLoadById(context, user, narrativeId, ENTITY_TYPE_NOTIFICATION) as unknown as BasicStoreEntityNotification;

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-resolver.ts
@@ -18,6 +18,7 @@ import {
   triggerEdit,
   triggerGet,
   triggersActivityFind,
+  triggersFind,
   triggersGet,
   triggersKnowledgeCount,
   triggersKnowledgeFind,
@@ -34,6 +35,8 @@ const notificationResolvers: Resolvers = {
     // Activity trigger
     triggerActivity: (_, { id }, context) => triggerGet(context, context.user, id),
     triggersActivity: (_, args, context) => triggersActivityFind(context, context.user, args),
+    // All triggers : knowledge & activity if user has the right capability
+    triggers: (_, args, context) => triggersFind(context, context.user, args),
     // Notifications
     notification: (_, { id }, context) => notificationGet(context, context.user, id),
     notifications: (_, args, context) => notificationsFind(context, context.user, args),

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
@@ -70,6 +70,7 @@ export interface NotificationAddInput {
     title: string,
     events: Array<NotificationContentEvent>
   }>
+  trigger_id?: string
 }
 
 // region Database types

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.graphql
@@ -164,6 +164,15 @@ type Query {
         includeAuthorities: Boolean
         search: String
     ): TriggerConnection @auth
+    triggers(
+        first: Int
+        after: ID
+        orderBy: TriggersOrdering
+        orderMode: OrderingMode
+        filters: FilterGroup
+        includeAuthorities: Boolean
+        search: String
+    ): TriggerConnection @auth
     triggersKnowledgeCount(filters: FilterGroup, includeAuthorities: Boolean, search: String): Int @auth
     # Alerts
     triggerActivity(id: String!): Trigger @auth(for: [SETTINGS_SECURITYACTIVITY])

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -72,7 +72,7 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
     },
   },
   attributes: [
-    { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'name', label: 'Trigger name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'trigger_id', label: 'Trigger', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_TRIGGER], mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'notification_type', label: 'Notification type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     {

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -72,6 +72,8 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
     },
   },
   attributes: [
+    { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'trigger_id', label: 'Trigger', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_TRIGGER], mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'notification_type', label: 'Notification type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     {
       name: 'notification_content',

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/trigger-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/trigger-test.js
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, AMBER_GROUP, editorQuery, queryAsAdmin, securityQuery, USER_EDITOR } from '../../utils/testQuery';
+import { ADMIN_USER, AMBER_GROUP, editorQuery, queryAsAdmin, securityQuery, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
 import { EVENT_TYPE_CREATE } from '../../../src/database/utils';
 import { queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 
-const LIST_QUERY = gql`
-    query triggers(
+const LIST_TRIGGERS_KNOWLEDGE_QUERY = gql`
+    query triggersKnowledge(
         $search: String
         $filters: FilterGroup
         $includeAuthorities: Boolean
@@ -30,7 +30,7 @@ const LIST_QUERY = gql`
     }
 `;
 
-const READ_QUERY = gql`
+const READ_TRIGGER_KNOWLEDGE_QUERY = gql`
     query trigger($id: String!) {
         triggerKnowledge(id: $id) {
             id
@@ -39,7 +39,7 @@ const READ_QUERY = gql`
     }
 `;
 
-const CREATE_LIVE_QUERY = gql`
+const CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY = gql`
     mutation TriggerKnowledgeLiveAdd($input: TriggerLiveAddInput!) {
         triggerKnowledgeLiveAdd(input: $input) {
             id
@@ -48,7 +48,7 @@ const CREATE_LIVE_QUERY = gql`
     }
 `;
 
-const CREATE_DIGEST_QUERY = gql`
+const CREATE_TRIGGER_KNOWLEDGE_DIGEST_QUERY = gql`
     mutation TriggerKnowledgeDigestAdd($input: TriggerDigestAddInput!) {
         triggerKnowledgeDigestAdd(input: $input) {
             id
@@ -57,7 +57,7 @@ const CREATE_DIGEST_QUERY = gql`
     }
 `;
 
-const UPDATE_QUERY = gql`
+const UPDATE_TRIGGER_KNOWLEDGE_QUERY = gql`
     mutation TriggerKnowledgeEdit($id: ID!, $input: [EditInput!]!) {
         triggerKnowledgeFieldPatch(id: $id, input: $input) {
             id
@@ -66,13 +66,102 @@ const UPDATE_QUERY = gql`
     }
 `;
 
-const DELETE_QUERY = gql`
+const DELETE_TRIGGER_KNOWLEDGE_QUERY = gql`
     mutation triggerKnowledgeDelete($id: ID!) {
         triggerKnowledgeDelete(id: $id)
     }
 `;
 
-describe('Trigger resolver standard behavior', () => {
+// region trigger activity
+const CREATE_TRIGGER_ACTIVITY_LIVE_QUERY = gql`
+  mutation TriggerActivityLiveAdd($input: TriggerActivityLiveAddInput!) {
+    triggerActivityLiveAdd(input: $input) {
+      id
+      name
+    }
+  }
+`;
+const CREATE_TRIGGER_ACTIVITY_DIGEST_QUERY = gql`
+  mutation TriggerActivityDigestAdd($input: TriggerActivityDigestAddInput!) {
+    triggerActivityDigestAdd(input: $input) {
+      id
+      name
+    }
+  }
+`;
+const READ_TRIGGER_ACTIVITY_QUERY = gql`
+  query triggerActivity($id: String!) {
+    triggerActivity(id: $id) {
+      id
+      name
+    }
+  }
+`;
+const DELETE_TRIGGER_ACTIVITY_QUERY = gql`
+  mutation TriggerActivityDelete($id: ID!) {
+    triggerActivityDelete(id: $id)
+  }
+`;
+const UPDATE_TRIGGER_ACTIVITY_QUERY = gql`
+  mutation TriggerActivityEdit($id: ID!, $input: [EditInput!]!) {
+    triggerActivityFieldPatch(id: $id, input: $input) {
+      id
+      name
+    }
+  }
+`;
+const LIST_TRIGGERS_ACTIVITY_QUERY = gql`
+  query triggersActivity(
+    $search: String
+    $filters: FilterGroup
+  ) {
+    triggersActivity(search: $search, filters: $filters) {
+      edges {
+        node {
+          id
+          name
+          trigger_type
+          event_types
+          description
+          created
+          modified
+          notifiers {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+const LIST_TRIGGERS_QUERY = gql`
+  query triggers(
+    $search: String
+    $filters: FilterGroup
+    $includeAuthorities: Boolean
+  ) {
+    triggers(search: $search, filters: $filters, includeAuthorities: $includeAuthorities) {
+      edges {
+        node {
+          id
+          name
+          trigger_type
+          event_types
+          description
+          created
+          modified
+          notifiers {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+// end region
+
+describe('Trigger knowledge resolver standard behavior', () => {
   let triggerInternalId;
   let digestInternalId;
   let triggerUserInternalId;
@@ -90,7 +179,7 @@ describe('Trigger resolver standard behavior', () => {
         instance_trigger: false,
       },
     };
-    const trigger = await queryAsAdmin({ query: CREATE_LIVE_QUERY, variables: TRIGGER_TO_CREATE });
+    const trigger = await queryAsAdmin({ query: CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY, variables: TRIGGER_TO_CREATE });
     expect(trigger).not.toBeNull();
     expect(trigger.data.triggerKnowledgeLiveAdd).not.toBeNull();
     expect(trigger.data.triggerKnowledgeLiveAdd.name).toEqual('live trigger');
@@ -108,14 +197,14 @@ describe('Trigger resolver standard behavior', () => {
         notifiers: [],
       },
     };
-    const digest = await queryAsAdmin({ query: CREATE_DIGEST_QUERY, variables: DIGEST_TO_CREATE });
+    const digest = await queryAsAdmin({ query: CREATE_TRIGGER_KNOWLEDGE_DIGEST_QUERY, variables: DIGEST_TO_CREATE });
     expect(digest).not.toBeNull();
     expect(digest.data.triggerKnowledgeDigestAdd).not.toBeNull();
     expect(digest.data.triggerKnowledgeDigestAdd.name).toEqual('regular digest');
     digestInternalId = digest.data.triggerKnowledgeDigestAdd.id;
   });
   it('should trigger loaded by internal id', async () => {
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: triggerInternalId } });
+    const queryResult = await queryAsAdmin({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).not.toBeNull();
     expect(queryResult.data.triggerKnowledge.id).toEqual(triggerInternalId);
@@ -132,14 +221,14 @@ describe('Trigger resolver standard behavior', () => {
         instance_trigger: false,
       },
     };
-    const trigger = await securityQuery({ query: CREATE_LIVE_QUERY, variables: TRIGGER_TO_CREATE_FOR_USER });
+    const trigger = await securityQuery({ query: CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY, variables: TRIGGER_TO_CREATE_FOR_USER });
     expect(trigger).not.toBeNull();
     expect(trigger.data.triggerKnowledgeLiveAdd).not.toBeNull();
     expect(trigger.data.triggerKnowledgeLiveAdd.name).toEqual('trigger');
     triggerUserInternalId = trigger.data.triggerKnowledgeLiveAdd.id;
   });
   it('should list triggers', async () => {
-    const queryResult = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 10 } });
+    const queryResult = await queryAsAdmin({ query: LIST_TRIGGERS_KNOWLEDGE_QUERY, variables: { first: 10 } });
     expect(queryResult.data.triggersKnowledge.edges.length).toEqual(3);
   });
   it('security user should list Admin triggers', async () => {
@@ -151,40 +240,40 @@ describe('Trigger resolver standard behavior', () => {
         filterGroups: [],
       }
     };
-    const queryResult = await securityQuery({ query: LIST_QUERY, variables });
+    const queryResult = await securityQuery({ query: LIST_TRIGGERS_KNOWLEDGE_QUERY, variables });
     expect(queryResult.data.triggersKnowledge.edges.length).toEqual(3);
   });
   it('should update trigger', async () => {
     const queryResult = await queryAsAdmin({
-      query: UPDATE_QUERY,
+      query: UPDATE_TRIGGER_KNOWLEDGE_QUERY,
       variables: { id: triggerInternalId, input: { key: 'name', value: ['live trigger - updated'] } },
     });
     expect(queryResult.data.triggerKnowledgeFieldPatch.name).toEqual('live trigger - updated');
   });
   it('should trigger deleted', async () => {
     // Delete the trigger
-    await queryAsAdmin({ query: DELETE_QUERY, variables: { id: triggerInternalId } });
+    await queryAsAdmin({ query: DELETE_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerInternalId } });
     // Verify is no longer found
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: triggerInternalId } });
+    const queryResult = await queryAsAdmin({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).toBeNull();
   });
   it('should regular digest deleted', async () => {
     // Delete the digest
-    await queryAsAdmin({ query: DELETE_QUERY, variables: { id: digestInternalId } });
+    await queryAsAdmin({ query: DELETE_TRIGGER_KNOWLEDGE_QUERY, variables: { id: digestInternalId } });
     // Verify is no longer found
-    const queryResult = await queryAsAdmin({ query: READ_QUERY, variables: { id: digestInternalId } });
+    const queryResult = await queryAsAdmin({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: digestInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).toBeNull();
   });
   it('security user should Admin trigger deleted', async () => {
     // Delete the trigger
     await securityQuery({
-      query: DELETE_QUERY,
+      query: DELETE_TRIGGER_KNOWLEDGE_QUERY,
       variables: { id: triggerUserInternalId },
     });
     // Verify is no longer found
-    const queryResult = await securityQuery({ query: READ_QUERY, variables: { id: triggerUserInternalId } });
+    const queryResult = await securityQuery({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerUserInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).toBeNull();
   });
@@ -203,7 +292,7 @@ describe('Trigger resolver standard behavior', () => {
       },
     };
     const trigger = await securityQuery({
-      query: CREATE_LIVE_QUERY,
+      query: CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY,
       variables: GROUP_TRIGGER_TO_CREATE,
     });
     expect(trigger).not.toBeNull();
@@ -211,21 +300,25 @@ describe('Trigger resolver standard behavior', () => {
     expect(trigger.data.triggerKnowledgeLiveAdd.name).toEqual('group trigger');
     triggerGroupInternalId = trigger.data.triggerKnowledgeLiveAdd.id;
   });
-  it('editor user should list group trigger', async () => {
-    const queryResult = await editorQuery({ query: LIST_QUERY, variables: { first: 10 } });
+  it('editor user should list group triggers via knowledge triggers API', async () => {
+    const queryResult = await editorQuery({ query: LIST_TRIGGERS_KNOWLEDGE_QUERY, variables: { first: 10 } });
     expect(queryResult.data.triggersKnowledge.edges.length).toEqual(1);
+  });
+  it('editor user should list group triggers via triggers API', async () => {
+    const queryResult = await editorQuery({ query: LIST_TRIGGERS_QUERY, variables: { first: 10 } });
+    expect(queryResult.data.triggers.edges.length).toEqual(1);
   });
   it('editor user should not update group trigger', async () => {
     await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
-      query: UPDATE_QUERY,
+      query: UPDATE_TRIGGER_KNOWLEDGE_QUERY,
       variables: { id: triggerGroupInternalId, input: { key: 'name', value: ['group trigger - updated'] } },
     });
   });
   it('security user should group trigger deleted', async () => {
     // Delete the trigger
-    await securityQuery({ query: DELETE_QUERY, variables: { id: triggerGroupInternalId } });
+    await securityQuery({ query: DELETE_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerGroupInternalId } });
     // Verify is no longer found
-    const queryResult = await securityQuery({ query: READ_QUERY, variables: { id: triggerGroupInternalId } });
+    const queryResult = await securityQuery({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerGroupInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).toBeNull();
   });
@@ -244,7 +337,7 @@ describe('Trigger resolver standard behavior', () => {
       },
     };
     const trigger = await securityQuery({
-      query: CREATE_LIVE_QUERY,
+      query: CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY,
       variables: ORGANIZATION_TRIGGER_TO_CREATE,
     });
     expect(trigger).not.toBeNull();
@@ -253,22 +346,162 @@ describe('Trigger resolver standard behavior', () => {
     triggerOrganizationInternalId = trigger.data.triggerKnowledgeLiveAdd.id;
   });
   it('editor user should list organization trigger', async () => {
-    const queryResult = await editorQuery({ query: LIST_QUERY, variables: { first: 10 } });
+    const queryResult = await editorQuery({ query: LIST_TRIGGERS_KNOWLEDGE_QUERY, variables: { first: 10 } });
     expect(queryResult.data.triggersKnowledge.edges.length).toEqual(1);
   });
   it('editor user should not update organization trigger', async () => {
     await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
-      query: UPDATE_QUERY,
+      query: UPDATE_TRIGGER_KNOWLEDGE_QUERY,
       variables: { id: triggerOrganizationInternalId, input: { key: 'name', value: ['organization trigger - updated'] } },
     });
   });
   it('security user should organization trigger deleted', async () => {
     // Delete the trigger
-    await securityQuery({ query: DELETE_QUERY, variables: { id: triggerOrganizationInternalId } });
+    await securityQuery({ query: DELETE_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerOrganizationInternalId } });
     // Verify is no longer found
-    const queryResult = await securityQuery({ query: READ_QUERY, variables: { id: triggerOrganizationInternalId } });
+    const queryResult = await securityQuery({ query: READ_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerOrganizationInternalId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.triggerKnowledge).toBeNull();
   });
   // endregion
+});
+
+describe('Trigger activity resolver standard behavior', () => {
+  const TRIGGER_ACTIVITY_LIVE_TO_CREATE = {
+    input: {
+      name: 'activity live trigger',
+      description: '',
+      notifiers: ['f4ee7b33-006a-4b0d-b57d-411ad288653d'],
+      recipients: [USER_SECURITY.id],
+    },
+  };
+  let triggerActivityLiveInternalId;
+  let triggerActivityDigestInternalId;
+  it('should activity live trigger created', async () => {
+    // Create the trigger
+    const trigger = await securityQuery({ query: CREATE_TRIGGER_ACTIVITY_LIVE_QUERY, variables: TRIGGER_ACTIVITY_LIVE_TO_CREATE });
+    expect(trigger).not.toBeNull();
+    expect(trigger.data.triggerActivityLiveAdd).not.toBeNull();
+    expect(trigger.data.triggerActivityLiveAdd.name).toEqual('activity live trigger');
+    triggerActivityLiveInternalId = trigger.data.triggerActivityLiveAdd.id;
+  });
+  it('should activity regular digest created', async () => {
+    const TRIGGER_ACTIVITY_DIGEST_TO_CREATE = {
+      input: {
+        name: 'activity regular digest',
+        trigger_ids: [triggerActivityLiveInternalId],
+        period: 'hour',
+        notifiers: ['f4ee7b33-006a-4b0d-b57d-411ad288653d'],
+        recipients: [USER_SECURITY.id],
+      },
+    };
+    // Create the digest
+    const digest = await securityQuery({ query: CREATE_TRIGGER_ACTIVITY_DIGEST_QUERY, variables: TRIGGER_ACTIVITY_DIGEST_TO_CREATE });
+    expect(digest).not.toBeNull();
+    expect(digest.data.triggerActivityDigestAdd).not.toBeNull();
+    expect(digest.data.triggerActivityDigestAdd.name).toEqual('activity regular digest');
+    triggerActivityDigestInternalId = digest.data.triggerActivityDigestAdd.id;
+  });
+  it('should activity live trigger loaded by internal id', async () => {
+    const queryResult = await securityQuery({ query: READ_TRIGGER_ACTIVITY_QUERY, variables: { id: triggerActivityLiveInternalId } });
+    expect(queryResult).not.toBeNull();
+    expect(queryResult.data.triggerActivity).not.toBeNull();
+    expect(queryResult.data.triggerActivity.id).toEqual(triggerActivityLiveInternalId);
+    expect(queryResult.data.triggerActivity.name).toEqual('activity live trigger');
+  });
+  it('should activity digest trigger loaded by internal id', async () => {
+    const queryResult = await securityQuery({ query: READ_TRIGGER_ACTIVITY_QUERY, variables: { id: triggerActivityDigestInternalId } });
+    expect(queryResult).not.toBeNull();
+    expect(queryResult.data.triggerActivity).not.toBeNull();
+    expect(queryResult.data.triggerActivity.id).toEqual(triggerActivityDigestInternalId);
+    expect(queryResult.data.triggerActivity.name).toEqual('activity regular digest');
+  });
+  // make sure editor can't call activity APIs (missing capa)
+  it('editor user should not create / read / list / update / delete activity live trigger', async () => {
+    // create forbidden
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: CREATE_TRIGGER_ACTIVITY_LIVE_QUERY,
+      variables: TRIGGER_ACTIVITY_LIVE_TO_CREATE,
+    });
+    const TRIGGER_ACTIVITY_DIGEST_TO_CREATE = {
+      input: {
+        name: 'activity regular digest',
+        trigger_ids: [triggerActivityLiveInternalId],
+        period: 'hour',
+        notifiers: ['f4ee7b33-006a-4b0d-b57d-411ad288653d'],
+        recipients: [USER_SECURITY.id],
+      },
+    };
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: CREATE_TRIGGER_ACTIVITY_DIGEST_QUERY,
+      variables: TRIGGER_ACTIVITY_DIGEST_TO_CREATE,
+    });
+    // read forbidden
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: READ_TRIGGER_ACTIVITY_QUERY,
+      variables: { id: triggerActivityLiveInternalId },
+    });
+    // update forbidden
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: UPDATE_TRIGGER_ACTIVITY_QUERY,
+      variables: { id: triggerActivityLiveInternalId, input: { key: 'name', value: ['activity live trigger - updated'] } },
+    });
+    // delete forbidden
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: DELETE_TRIGGER_ACTIVITY_QUERY,
+      variables: { id: triggerActivityLiveInternalId },
+    });
+    // list forbidden
+    await queryAsUserIsExpectedForbidden(USER_EDITOR.client, {
+      query: LIST_TRIGGERS_ACTIVITY_QUERY,
+      variables: { first: 10 },
+    });
+  });
+  // list activity triggers
+  it('security user should list activity triggers', async () => {
+    const queryResult = await securityQuery({ query: LIST_TRIGGERS_ACTIVITY_QUERY, variables: { first: 10 } });
+    expect(queryResult.data.triggersActivity.edges.length).toEqual(2);
+  });
+  // update activity trigger
+  it('should update trigger', async () => {
+    const queryResult = await securityQuery({
+      query: UPDATE_TRIGGER_ACTIVITY_QUERY,
+      variables: { id: triggerActivityLiveInternalId, input: { key: 'name', value: ['activity live trigger - updated'] } },
+    });
+    expect(queryResult.data.triggerActivityFieldPatch.name).toEqual('activity live trigger - updated');
+  });
+  // create knowledge trigger & list all triggers & delete knowledge trigger
+  it('security user should list all triggers', async () => {
+    // Create a trigger knowledge live
+    const TRIGGER_TO_CREATE = {
+      input: {
+        name: 'live trigger for security user',
+        description: '',
+        event_types: [EVENT_TYPE_CREATE],
+        notifiers: [],
+        instance_trigger: false,
+      },
+    };
+    const trigger = await securityQuery({ query: CREATE_TRIGGER_KNOWLEDGE_LIVE_QUERY, variables: TRIGGER_TO_CREATE });
+    expect(trigger).not.toBeNull();
+    expect(trigger.data.triggerKnowledgeLiveAdd).not.toBeNull();
+    const triggerToDeleteId = trigger.data.triggerKnowledgeLiveAdd.id;
+    // list all triggers => we should have now 3 triggers : 2 activity & 1 knowledge
+    let queryResult = await securityQuery({ query: LIST_TRIGGERS_QUERY, variables: { first: 10 } });
+    expect(queryResult.data.triggers.edges.length).toEqual(3);
+    // delete the live trigger
+    await securityQuery({ query: DELETE_TRIGGER_KNOWLEDGE_QUERY, variables: { id: triggerToDeleteId } });
+    // list all triggers => we should have now only 2 triggers
+    queryResult = await securityQuery({ query: LIST_TRIGGERS_QUERY, variables: { first: 10 } });
+    expect(queryResult.data.triggers.edges.length).toEqual(2);
+  });
+  // delete activity triggers
+  it('security user should delete all activity triggers', async () => {
+    // Delete live & digest trigger
+    await securityQuery({ query: DELETE_TRIGGER_ACTIVITY_QUERY, variables: { id: triggerActivityLiveInternalId } });
+    await securityQuery({ query: DELETE_TRIGGER_ACTIVITY_QUERY, variables: { id: triggerActivityDigestInternalId } });
+    // Verify there is no activity triggers
+    const queryResult = await securityQuery({ query: LIST_TRIGGERS_ACTIVITY_QUERY, variables: { first: 10 } });
+    expect(queryResult.data.triggersActivity.edges.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Save new attribute trigger_id as filtrable ("trigger" filter)
* Append this filter as quick filter by default on notifications (works only if local storage is empty on "notifiers")
* add a filter on "Trigger name" (attribute saved is Name, it was already saved but the attribute was not declared on the schema)
* Enable to use this filter directly by clicking on the trigger name value on the notifications list
* Rename "Trigger" column to "Trigger name"

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7309 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
