### PR TITLE
[frontend] Fix 'Knowledge from container view' if no containers (#9247)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
@@ -208,11 +208,14 @@ const EntityStixCoreRelationshipsContextualViewComponent: FunctionComponent<Enti
 
   // Filters due to screen context
   const userFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, stixCoreObjectTypes);
+  // if no containers, the query should return nothing but the filter should be valid (empty array not authorized with the 'eq' operator)
+  // so we artificially add a non-existing id value
+  const containerFilterValues = containers.length > 0 ? containers.map((r) => r.id) : ['NO_CONTAINER'];
   const contextFilters: FilterGroup = {
     mode: 'and',
     filters: [
       { key: 'entity_type', operator: 'eq', mode: 'or', values: stixCoreObjectTypes },
-      { key: 'objects', operator: 'eq', mode: 'or', values: containers.map((r) => r.id) },
+      { key: 'objects', operator: 'eq', mode: 'or', values: containerFilterValues },
     ],
     filterGroups: userFilters && isFilterGroupNotEmpty(userFilters) ? [userFilters] : [],
   };


### PR DESCRIPTION
### Proposed changes
In 'Knowledge from container view' of Knowledge observables, don't do the query if there are no containers to avoid a query with a incorrect filter (eq operator with values=[]

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9247#issuecomment-2522482589

