### PR TITLE
[backend/frontend] add limitations to analyses graph loaded objects (#9293)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "Ein öffentliches Dashboard ist ein Schnappschuss eines privaten Dashboards zu einem bestimmten Zeitpunkt. Wenn Sie das private Dashboard ändern, werden die bereits erstellten öffentlichen Dashboards nicht geändert.",
   "About": "Über",
   "Abstract": "Zusammenfassung",
+  "Limitations applied, number of fully loaded containers: ": "Begrenzt, Anzahl der voll beladenen Container:",
+  "Open this entity in an investigation to be able to see all objects.": "Öffnen Sie diese Entität in einer Untersuchung, um alle Objekte sehen zu können.",
   "Accent color": "Akzentfarbe",
   "Accept": "Akzeptieren Sie",
   "Access administration": "Zugriff auf die Verwaltung",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "A public dashboard is a snapshot of a private dashboard at a specific time. If you modify the private dashboard, already created public dashboards won't be modified.",
   "About": "About",
   "Abstract": "Abstract",
+  "Limitations applied, number of fully loaded containers: ": "Limitations applied, number of fully loaded containers: ",
+  "Open this entity in an investigation to be able to see all objects.": "Open this entity in an investigation to be able to see all objects.",
   "Accent color": "Accent color",
   "Accept": "Accept",
   "Access administration": "Access administration",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "Un panel público es una instantánea de un panel privado en un momento determinado. Si modifica el panel privado, los paneles públicos ya creados no se modificarán.",
   "About": "Acerca de",
   "Abstract": "Resumen",
+  "Limitations applied, number of fully loaded containers: ": "Limitaciones aplicadas, número de contenedores completamente cargados:",
+  "Open this entity in an investigation to be able to see all objects.": "Abra esta entidad en una investigación para poder ver todos los objetos.",
   "Accent color": "Color de resalte",
   "Accept": "Aceptar",
   "Access administration": "Acceder a la administración",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "Un tableau de bord public est un instantané d'un tableau de bord privé à un moment précis. Si vous modifiez le tableau de bord privé, les tableaux de bord publics déjà créés ne seront pas modifiés.",
   "About": "A propos",
   "Abstract": "Résumé",
+  "Limitations applied, number of fully loaded containers: ": "Limitations appliquées, nombre de conteneurs entièrement chargés :",
+  "Open this entity in an investigation to be able to see all objects.": "Ouvrir cette entité dans le cadre d'une enquête pour pouvoir voir tous les objets.",
   "Accent color": "Couleur d'accentuation",
   "Accept": "Accepter",
   "Access administration": "Accéder à l'administration",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "パブリック・ダッシュボードは、特定の時刻におけるプライベート・ダッシュボードのスナップショットです。プライベートダッシュボードを変更しても、すでに作成されたパブリックダッシュボードは変更されません。",
   "About": "OpenCTIについて",
   "Abstract": "要旨",
+  "Limitations applied, number of fully loaded containers: ": "制限あり、満載コンテナ数：",
+  "Open this entity in an investigation to be able to see all objects.": "すべてのオブジェクトを見ることができるようにするには、調査でこのエンティティを開きます。",
   "Accent color": "アクセントカラー",
   "Accept": "受け入れる",
   "Access administration": "管理にアクセス",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "공개 대시보드는 특정 시점에서 개인 대시보드의 스냅샷입니다. 개인 대시보드를 수정해도 이미 생성된 공개 대시보드는 수정되지 않습니다.",
   "About": "정보",
   "Abstract": "요약",
+  "Limitations applied, number of fully loaded containers: ": "제한 사항 적용, 완전히 로드된 컨테이너 수:",
+  "Open this entity in an investigation to be able to see all objects.": "조사에서 이 엔티티를 열면 모든 개체를 볼 수 있습니다.",
   "Accent color": "강조 색상",
   "Accept": "수락",
   "Access administration": "액세스 관리",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -13,6 +13,8 @@
   "A public dashboard is a snapshot...": "公共仪表盘是私人仪表盘在特定时间的快照。如果修改了私人仪表盘，则不会修改已创建的公共仪表盘。",
   "About": "关于",
   "Abstract": "摘要",
+  "Limitations applied, number of fully loaded containers: ": "限制条件，满载集装箱数量：",
+  "Open this entity in an investigation to be able to see all objects.": "在调查中打开此实体，以便查看所有对象。",
   "Accent color": "辅助色",
   "Accept": "接受",
   "Access administration": "访问管理",

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.jsx
@@ -473,7 +473,9 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphComponent extends Compo
   render() {
     const {
       handleChangeView,
+      data,
       theme,
+      t,
     } = this.props;
     const {
       mode3D,
@@ -498,6 +500,9 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphComponent extends Compo
       this.graphObjects,
     );
     const selectedEntities = [...this.selectedLinks, ...this.selectedNodes];
+    const warningMessage = data.containersObjectsOfObject.pageInfo.hasNextPage
+      ? `${t('Limitations applied, number of fully loaded containers: ')} ${data.containersObjectsOfObject.pageInfo.globalCount}. ${t('Open this entity in an investigation to be able to see all objects.')}`
+      : undefined;
     return (
       <UserContext.Consumer>
         {({ bannerSettings }) => {
@@ -544,6 +549,7 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphComponent extends Compo
                 handleChangeView={handleChangeView.bind(this)}
                 handleSearch={this.handleSearch.bind(this)}
                 navOpen={navOpen}
+                warningMessage={warningMessage}
               />
               {selectedEntities.length > 0 && (
                 <EntitiesDetailsRightsBar

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraphBar.jsx
@@ -18,6 +18,7 @@ import Popover from '@mui/material/Popover';
 import Divider from '@mui/material/Divider';
 import { ResponsiveContainer, Scatter, ScatterChart, YAxis, ZAxis } from 'recharts';
 import Slide from '@mui/material/Slide';
+import Alert from '@mui/material/Alert';
 import inject18n from '../../../../components/i18n';
 import { dateFormat } from '../../../../utils/Time';
 import { truncate } from '../../../../utils/String';
@@ -140,6 +141,7 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
       stixCoreObjectsTypes,
       createdBy,
       markedBy,
+      warningMessage,
       report,
       numberOfSelectedNodes,
       numberOfSelectedLinks,
@@ -378,13 +380,13 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
                     </Tooltip>
                   </div>
                   {report && (
-                    <div
-                      style={{
-                        float: 'right',
-                        display: 'flex',
-                        height: '100%',
-                      }}
-                    ></div>
+                  <div
+                    style={{
+                      float: 'right',
+                      display: 'flex',
+                      height: '100%',
+                    }}
+                  ></div>
                   )}
                   <div className="clearfix" />
                 </div>
@@ -779,6 +781,11 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphBar extends Component {
                       </IconButton>
                     </span>
                   </Tooltip>
+                  {!!warningMessage && (
+                    <Alert severity="warning">
+                      {warningMessage}
+                    </Alert>
+                  )}
                 </div>
                 <div
                   style={{
@@ -894,6 +901,7 @@ StixCoreObjectOrStixCoreRelationshipContainersGraphBar.propTypes = {
   selectedNodes: PropTypes.array,
   selectedLinks: PropTypes.array,
   view: PropTypes.string,
+  warningMessage: PropTypes.string,
   handleChangeView: PropTypes.func,
   numberOfSelectedNodes: PropTypes.number,
   numberOfSelectedLinks: PropTypes.number,

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -186,6 +186,7 @@ export const ES_MAX_PAGINATION = conf.get('elasticsearch:max_pagination_result')
 export const MAX_BULK_OPERATIONS = conf.get('elasticsearch:max_bulk_operations') || 5000;
 export const MAX_RUNTIME_RESOLUTION_SIZE = conf.get('elasticsearch:max_runtime_resolutions') || 5000;
 export const MAX_RELATED_CONTAINER_RESOLUTION = conf.get('elasticsearch:max_container_resolutions') || 1000;
+export const MAX_RELATED_CONTAINER_OBJECT_RESOLUTION = conf.get('elasticsearch:max_container_object_resolutions') || 100000;
 export const ES_INDEX_PATTERN_SUFFIX = conf.get('elasticsearch:index_creation_pattern');
 const ES_MAX_RESULT_WINDOW = conf.get('elasticsearch:max_result_window') || 100000;
 const ES_INDEX_SHARD_NUMBER = conf.get('elasticsearch:number_of_shards');


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add limition on number of objects that can be loaded with an internalFindById call in containersObjectsOfObject
* display warning message when containersObjectsOfObject couldn't return all related containers objects

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9293

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
