### PR TITLE
[frontend] Add a confirmation popup before deleting any files (#9225)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "Architektur Ausführung env.",
   "Architecture mode": "Architekturmodus",
   "are updating...": "aktualisieren sich...",
+  "Are you sure you want to delete this file?": "Sind Sie sicher, dass Sie diese Datei löschen wollen?",
   "Are you sure you want to delete this public dashboard?": "Sind Sie sicher, dass Sie dieses öffentliche Dashboard löschen möchten?",
   "Are you sure you want to make the change?": "Sind Sie sicher, dass Sie die Änderung vornehmen wollen?",
   "Are you sure?": "Sind Sie sicher?",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "Architecture execution env.",
   "Architecture mode": "Architecture mode",
   "are updating...": "are updating...",
+  "Are you sure you want to delete this file?": "Are you sure you want to delete this file?",
   "Are you sure you want to delete this public dashboard?": "Are you sure you want to delete this public dashboard?",
   "Are you sure you want to make the change?": "Are you sure you want to make the change?",
   "Are you sure?": "Are you sure?",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "Arquitectura de ejecución",
   "Architecture mode": "Modo arquitectura",
   "are updating...": "se están modificando...",
+  "Are you sure you want to delete this file?": "¿Está seguro de que desea eliminar este archivo?",
   "Are you sure you want to delete this public dashboard?": "¿Está seguro de que desea eliminar este panel público?",
   "Are you sure you want to make the change?": "Estás seguro de que quieres hacer el cambio?",
   "Are you sure?": "¿Estás seguro?",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "Env. d'éxécution",
   "Architecture mode": "Mode d'architecture",
   "are updating...": "modifient actuellement...",
+  "Are you sure you want to delete this file?": "Êtes-vous sûr de vouloir supprimer ce fichier ?",
   "Are you sure you want to delete this public dashboard?": "Êtes-vous sûr de vouloir supprimer ce tableau de bord public ?",
   "Are you sure you want to make the change?": "Êtes-vous sûr de vouloir effectuer le changement ?",
   "Are you sure?": "Êtes-vous sûr ?",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "CPUアーキテクチャ",
   "Architecture mode": "アーキテクチャモード",
   "are updating...": "がアップデート中",
+  "Are you sure you want to delete this file?": "本当にこのファイルを削除しますか？",
   "Are you sure you want to delete this public dashboard?": "本当にこの公開ダッシュボードを削除しますか？",
   "Are you sure you want to make the change?": "本当に変更しますか？",
   "Are you sure?": "本当ですか？",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "아키텍처 실행 환경",
   "Architecture mode": "아키텍처 모드",
   "are updating...": "업데이트 중...",
+  "Are you sure you want to delete this file?": "이 파일을 삭제하시겠습니까?",
   "Are you sure you want to delete this public dashboard?": "이 공개 대시보드를 삭제하시겠습니까?",
   "Are you sure you want to make the change?": "변경하시겠습니까?",
   "Are you sure?": "확실합니까?",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -193,6 +193,7 @@
   "Architecture execution env.": "架构执行环境",
   "Architecture mode": "架构模式",
   "are updating...": "正在更新...",
+  "Are you sure you want to delete this file?": "您确定要删除此文件吗？",
   "Are you sure you want to delete this public dashboard?": "您确定要删除此公共仪表板吗？",
   "Are you sure you want to make the change?": "您确定要更改吗？",
   "Are you sure?": "你确定吗？",

--- a/opencti-platform/opencti-front/src/components/DeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/DeleteDialog.tsx
@@ -12,12 +12,14 @@ type DeleteDialogProps = {
   title: React.ReactNode
   deletion: Deletion
   submitDelete: () => void
+  onClose?: () => void
 };
 
 const DeleteDialog: React.FC<DeleteDialogProps> = ({
   title,
   deletion,
   submitDelete,
+  onClose,
 }) => {
   const { t_i18n } = useFormatter();
   return (
@@ -26,7 +28,7 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({
       PaperProps={{ elevation: 1 }}
       keepMounted={true}
       TransitionComponent={Transition}
-      onClose={deletion.handleCloseDelete}
+      onClose={onClose ?? deletion.handleCloseDelete}
     >
       <DialogContent>
         <DialogContentText>
@@ -34,7 +36,7 @@ const DeleteDialog: React.FC<DeleteDialogProps> = ({
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={deletion.handleCloseDelete} disabled={deletion.deleting}>
+        <Button onClick={onClose ?? deletion.handleCloseDelete} disabled={deletion.deleting}>
           {t_i18n('Cancel')}
         </Button>
         <Button color="secondary" onClick={submitDelete} disabled={deletion.deleting}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* useDeletion hook added
* confirmation popup added on delete action

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/9225

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
