### PR TITLE
[ci] use non-alpine image to have bash available for slack orb 5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
   build_platform_musl:
     working_directory: ~/opencti_musl
     docker:
-      - image: nikolaik/python-nodejs:python3.10-nodejs18-alpine
+      - image: nikolaik/python-nodejs:python3.10-nodejs18
     resource_class: medium+
     steps:
       - run:


### PR DESCRIPTION
slack orb 5.1x requires bash to work. We have been using an alpine image so far.