### PR TITLE
[backend] fix version of path-to-regexp for CVE-2024-52798

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -218,7 +218,8 @@
     "node-calls-python": "patch:node-calls-python@1.9.1#./patch/node-calls-python-1.9.1.patch",
     "domino": "patch:domino@2.1.6#./patch/domino-2.1.6.patch",
     "graphql": "patch:graphql@16.9.0#./patch/graphql-16.8.1.patch",
-    "openid-client": "patch:openid-client@5.6.5#./patch/openid-client-5.6.5.patch"
+    "openid-client": "patch:openid-client@5.6.5#./patch/openid-client-5.6.5.patch",
+    "path-to-regexp": "0.1.12"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -11393,10 +11393,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: 10/894e31f1b20e592732a87db61fff5b95c892a3fe430f9ab18455ebe69ee88ef86f8eb49912e261f9926fc53da9f93b46521523e33aefd9cb0a7b0d85d7096006
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: 10/2e30f6a0144679c1f95c98e166b96e6acd1e72be9417830fefc8de7ac1992147eb9a4c7acaa59119fb1b3c34eec393b2129ef27e24b2054a3906fc4fb0d1398e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixing vulnerability [CVE-2024-52798](https://www.cve.org/CVERecord?id=CVE-2024-52798) found in dependency `path-to-regexp`

See https://app.snyk.io/org/filigran-kRiK8dHF9eH77yuj6AJGxy/project/3b93899d-c973-4969-9f8c-08f7a77a69e4#issue-SNYK-JS-PATHTOREGEXP-8482416