### PR TITLE
[backend] fix file markings that could be undefined when building OCTI extensions  (#9301)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -384,7 +384,7 @@ export const loadElementsWithDependencies = async (context, user, elements, opts
     if (isNotEmptyField(element.x_opencti_files) && isNotEmptyField(fileMarkingsMap)) {
       element.x_opencti_files.forEach((f) => {
         if (isNotEmptyField(f.file_markings)) {
-          files.push({ ...f, [INPUT_MARKINGS]: f.file_markings.map((m) => fileMarkingsMap[m]) });
+          files.push({ ...f, [INPUT_MARKINGS]: f.file_markings.map((m) => fileMarkingsMap[m]).filter((fm) => fm) });
         } else {
           files.push(f);
         }

--- a/opencti-platform/opencti-graphql/src/database/stix-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-converter.ts
@@ -217,7 +217,7 @@ export const buildOCTIExtensions = (instance: StoreObject): S.StixOpenctiExtensi
       uri: `/storage/get/${file.id}`,
       version: file.version,
       mime_type: file.mime_type,
-      object_marking_refs: (file[INPUT_MARKINGS] ?? []).map((f) => f.standard_id),
+      object_marking_refs: (file[INPUT_MARKINGS] ?? []).filter((f) => f).map((f) => f.standard_id),
     })),
     stix_ids: (instance.x_opencti_stix_ids ?? []).filter((stixId: string) => isTrustedStixId(stixId)),
     is_inferred: instance._index ? isInferredIndex(instance._index) : undefined, // TODO Use case for empty _index?

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -686,7 +686,7 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
     const resolvedFiles = [];
     files.forEach((f) => {
       if (isNotEmptyField(f.file_markings)) {
-        resolvedFiles.push({ ...f, [INPUT_MARKINGS]: f.file_markings.map((m) => fileMarkingsMap[m]) });
+        resolvedFiles.push({ ...f, [INPUT_MARKINGS]: f.file_markings.map((m) => fileMarkingsMap[m]).filter((fm) => fm) });
       } else {
         resolvedFiles.push(f);
       }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* now check that file markings are defined before settings them to object_marking_refs in buildOCTIExtensions
* now check that file markings are defined when setting the INPUT_MARKINGS refs in stixCoreObjectImportPush
* now check that file markings are defined when setting the INPUT_MARKINGS refs in loadElementsWithDependencies

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9301 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
