### PR TITLE
[frontend] Align knowledge bar counters (#8115)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -121,7 +121,7 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
                     'sightings',
                     'channels',
                   ]}
-                  queryRef={channel}
+                  data={channel}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -52,10 +52,7 @@ const channelQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }   
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Channel_channel
       ...ChannelKnowledge_channel
       ...FileImportViewer_entity
@@ -124,7 +121,7 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
                     'sightings',
                     'channels',
                   ]}
-                  stixCoreObjectsDistribution={channel.stixCoreObjectsDistribution}
+                  queryRef={channel}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -128,7 +128,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
                     'infrastructures',
                     'sightings',
                   ]}
-                  queryRef={malware}
+                  data={malware}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -55,10 +55,7 @@ const malwareQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Malware_malware
       ...MalwareKnowledge_malware
       ...FileImportViewer_entity
@@ -131,7 +128,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
                     'infrastructures',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={malware.stixCoreObjectsDistribution}
+                  queryRef={malware}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -121,7 +121,7 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
                     'observables',
                     'sightings',
                   ]}
-                  queryRef={tool}
+                  data={tool}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -52,10 +52,7 @@ const toolQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Tool_tool
       ...ToolKnowledge_tool
       ...FileImportViewer_entity
@@ -124,7 +121,7 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
                     'observables',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={tool.stixCoreObjectsDistribution}
+                  queryRef={tool}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -121,7 +121,7 @@ const RootVulnerability = ({ queryRef, vulnerabilityId }: RootVulnerabilityProps
                     'sightings',
                     'infrastructures',
                   ]}
-                  queryRef={vulnerability}
+                  data={vulnerability}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -52,10 +52,7 @@ const vulnerabilityQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Vulnerability_vulnerability
       ...VulnerabilityKnowledge_vulnerability
       ...FileImportViewer_entity
@@ -124,9 +121,9 @@ const RootVulnerability = ({ queryRef, vulnerabilityId }: RootVulnerabilityProps
                     'sightings',
                     'infrastructures',
                   ]}
-                  stixCoreObjectsDistribution={vulnerability.stixCoreObjectsDistribution}
+                  queryRef={vulnerability}
                 />
-                                  }
+              }
             />
           </Routes>
           <div style={{ paddingRight }}>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -33,7 +33,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const stixCoreObjectKnowledgeBarFragment = graphql`
-  fragment StixCoreObjectKnowledgeBar_stixCoreObject on StixCoreObject {
+  fragment StixCoreObjectKnowledgeBar_stixCoreObject on StixCoreObject
+  @argumentDefinitions(
+    relatedRelationshipTypes: { type: "[String]", defaultValue: ["related-to"] }
+  ) {
     # distribution of entities without "related to" relationship
     relationshipsWithoutRelatedToDistribution: stixCoreRelationshipsDistribution(
       field: "entity_type"
@@ -56,11 +59,11 @@ const stixCoreObjectKnowledgeBarFragment = graphql`
       label
       value
     }
-    # distribution of entities with "related to" relationship
-    relationshipsRelatedToDistribution: stixCoreRelationshipsDistribution(
+    # distribution of entities with relatedRelationshipTypes ("related to" relationship by default)
+    relationshipsRelatedDistribution: stixCoreRelationshipsDistribution(
       field: "entity_type"
       operation: count
-      relationship_type: [ "related-to" ]
+      relationship_type: $relatedRelationshipTypes
     ) {
       label
       value
@@ -87,7 +90,7 @@ const StixCoreObjectKnowledgeBar = ({
   const location = useLocation();
   const { bannerSettings, schema } = useAuth();
   const isInAvailableSection = (sections) => availableSections.some((filter) => sections.includes(filter));
-  const { relationshipsWithoutRelatedToDistribution, relationshipsRelatedToDistribution, stixCoreObjectsDistribution } = useFragment(
+  const { relationshipsWithoutRelatedToDistribution, relationshipsRelatedDistribution, stixCoreObjectsDistribution } = useFragment(
     stixCoreObjectKnowledgeBarFragment,
     data,
   );
@@ -98,7 +101,7 @@ const StixCoreObjectKnowledgeBar = ({
     : {});
 
   const statisticsWithoutRelatedToRelationship = indexEntities(relationshipsWithoutRelatedToDistribution);
-  const statisticsRelatedToRelationship = indexEntities(relationshipsRelatedToDistribution);
+  const statisticsRelatedRelationship = indexEntities(relationshipsRelatedDistribution);
   const statisticsCoreObjects = indexEntities(stixCoreObjectsDistribution);
 
   const sumEntitiesByKeys = (stats, keys) => {
@@ -115,8 +118,8 @@ const StixCoreObjectKnowledgeBar = ({
   const statisticsVictims = sumEntitiesByKeys(statisticsWithoutRelatedToRelationship, ['Event', 'System', 'Sector', 'Organization', 'Individual', 'Region', 'Country', 'City', 'Position', 'Administrative-Area']);
   const statisticsAttributions = sumEntitiesByKeys(statisticsWithoutRelatedToRelationship, attribution ?? []);
   const statisticsLocations = sumEntitiesByKeys(statisticsWithoutRelatedToRelationship, ['Region', 'Country', 'City', 'Position', 'Administrative-Area']);
-  const statisticsObservables = sumEntitiesByKeys(statisticsRelatedToRelationship, [...schema.scos.map((s) => s.id), 'Stixfile', 'Ipv4-Addr', 'Ipv6-Addr']);
-  const statisticsRelatedEntities = sumEntitiesByKeys(statisticsRelatedToRelationship);
+  const statisticsObservables = sumEntitiesByKeys(statisticsRelatedRelationship, [...schema.scos.map((s) => s.id), 'Stixfile', 'Ipv4-Addr', 'Ipv6-Addr']);
+  const statisticsRelatedEntities = sumEntitiesByKeys(statisticsRelatedRelationship);
 
   return (
     <Drawer

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -74,7 +74,7 @@ const stixCoreObjectKnowledgeBarFragment = graphql`
 const StixCoreObjectKnowledgeBar = ({
   stixCoreObjectLink,
   availableSections,
-  queryRef,
+  data,
   attribution,
 }) => {
   const { t_i18n, n } = useFormatter();
@@ -84,7 +84,7 @@ const StixCoreObjectKnowledgeBar = ({
   const isInAvailableSection = (sections) => availableSections.some((filter) => sections.includes(filter));
   const { relationshipsWithoutRelatedToDistribution, stixCoreObjectsDistribution, relatedEntities } = useFragment(
     stixCoreObjectKnowledgeBarFragment,
-    queryRef,
+    data,
   );
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
 
@@ -812,7 +812,7 @@ StixCoreObjectKnowledgeBar.propTypes = {
   id: PropTypes.string,
   stixCoreObjectLink: PropTypes.string,
   availableSections: PropTypes.array,
-  queryRef: PropTypes.object,
+  data: PropTypes.object,
   attribution: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -50,6 +50,7 @@ const stixCoreObjectKnowledgeBarFragment = graphql`
         "targets"
         "compromises"
         "located-at"
+        "variant-of"
       ]
     ) {
       label

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -169,7 +169,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Sector" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Sectors')}${statisticsWithoutRelatedToRelationship.Sector && statisticsWithoutRelatedToRelationship.Sector.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.Sector.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Sectors')}${statisticsCoreObjects.Sector && statisticsCoreObjects.Sector.value > 0 ? ` (${n(statisticsCoreObjects.Sector.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('regions') && (
@@ -183,7 +183,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Region" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Regions')}${statisticsWithoutRelatedToRelationship.Region && statisticsWithoutRelatedToRelationship.Region.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.Region.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Regions')}${statisticsCoreObjects.Region && statisticsCoreObjects.Region.value > 0 ? ` (${n(statisticsCoreObjects.Region.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('countries') && (
@@ -199,7 +199,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Country" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Countries')}${statisticsWithoutRelatedToRelationship.Country && statisticsWithoutRelatedToRelationship.Country.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.Country.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Countries')}${statisticsCoreObjects.Country && statisticsCoreObjects.Country.value > 0 ? ` (${n(statisticsCoreObjects.Country.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('areas') && (
@@ -213,7 +213,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Administrative-Area" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Areas')}${statisticsWithoutRelatedToRelationship['Administrative-Area'] && statisticsWithoutRelatedToRelationship['Administrative-Area'].value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship['Administrative-Area'].value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Areas')}${statisticsCoreObjects['Administrative-Area'] && statisticsCoreObjects['Administrative-Area'].value > 0 ? ` (${n(statisticsCoreObjects['Administrative-Area'].value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('cities') && (
@@ -227,7 +227,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="City" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Cities')}${statisticsWithoutRelatedToRelationship.City && statisticsWithoutRelatedToRelationship.City.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.City.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Cities')}${statisticsCoreObjects.City && statisticsCoreObjects.City.value > 0 ? ` (${n(statisticsCoreObjects.City.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('organizations') && (
@@ -243,7 +243,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Organization" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Organizations')}${statisticsWithoutRelatedToRelationship.Organization && statisticsWithoutRelatedToRelationship.Organization.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.Organization.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Organizations')}${statisticsCoreObjects.Organization && statisticsCoreObjects.Organization.value > 0 ? ` (${n(statisticsCoreObjects.Organization.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('individuals') && (
@@ -259,7 +259,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Individual" />
                 </ListItemIcon>
-                <ListItemText primary={`${t_i18n('Individuals')}${statisticsWithoutRelatedToRelationship.Individual && statisticsWithoutRelatedToRelationship.Individual.value > 0 ? ` (${n(statisticsWithoutRelatedToRelationship.Individual.value)})` : ''}`} />
+                <ListItemText primary={`${t_i18n('Individuals')}${statisticsCoreObjects.Individual && statisticsCoreObjects.Individual.value > 0 ? ` (${n(statisticsCoreObjects.Individual.value)})` : ''}`} />
               </MenuItem>
             )}
             {availableSections.includes('locations') && (
@@ -291,7 +291,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemIcon style={{ minWidth: 28 }}>
                   <ItemIcon size="small" type="Tool" />
                 </ListItemIcon>
-                <ListItemText primary={t_i18n('Used tools')} />
+                <ListItemText primary={`${t_i18n('Used tools')}${statisticsCoreObjects.Tool && statisticsCoreObjects.Tool.value > 0 ? ` (${n(statisticsCoreObjects.Tool.value)})` : ''}`} />
               </MenuItem>
             )}
           </MenuList>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -124,7 +124,7 @@ const StixCoreObjectKnowledgeBar = ({
               </ListSubheader>
             }
           >
-            {R.includes('sectors', availableSections) && (
+            {availableSections.includes('sectors') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/sectors`}
@@ -138,7 +138,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Sectors')}${statistics.Sector && statistics.Sector.value > 0 ? ` (${n(statistics.Sector.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('regions', availableSections) && (
+            {availableSections.includes('regions') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/regions`}
@@ -152,7 +152,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Regions')}${statistics.Region && statistics.Region.value > 0 ? ` (${n(statistics.Region.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('countries', availableSections) && (
+            {availableSections.includes('countries') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/countries`}
@@ -168,7 +168,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Countries')}${statistics.Country && statistics.Country.value > 0 ? ` (${n(statistics.Country.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('areas', availableSections) && (
+            {availableSections.includes('areas') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/areas`}
@@ -182,7 +182,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Areas')}${statistics['Administrative-Area'] && statistics['Administrative-Area'].value > 0 ? ` (${n(statistics['Administrative-Area'].value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('cities', availableSections) && (
+            {availableSections.includes('cities') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/cities`}
@@ -196,7 +196,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Cities')}${statistics.City && statistics.City.value > 0 ? ` (${n(statistics.City.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('organizations', availableSections) && (
+            {availableSections.includes('organizations') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/organizations`}
@@ -212,7 +212,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Organizations')}${statistics.Organization && statistics.Organization.value > 0 ? ` (${n(statistics.Organization.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('individuals', availableSections) && (
+            {availableSections.includes('individuals') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/individuals`}
@@ -228,7 +228,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Individuals')}${statistics.Individual && statistics.Individual.value > 0 ? ` (${n(statistics.Individual.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('locations', availableSections) && (
+            {availableSections.includes('locations') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/locations`}
@@ -244,7 +244,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Locations')}${statisticsLocations > 0 ? ` (${n(statisticsLocations)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('used_tools', availableSections) && (
+            {availableSections.includes('used_tools') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/used_tools`}
@@ -263,7 +263,7 @@ const StixCoreObjectKnowledgeBar = ({
           </MenuList>
         ) : (
           <>
-            {R.includes('sectors', availableSections) && (
+            {availableSections.includes('sectors') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/sectors`}
@@ -277,7 +277,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Sectors')}${statistics.Sector && statistics.Sector.value > 0 ? ` (${n(statistics.Sector.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('regions', availableSections) && (
+            {availableSections.includes('regions') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/regions`}
@@ -291,7 +291,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Regions')}${statistics.Region && statistics.Region.value > 0 ? ` (${n(statistics.Region.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('countries', availableSections) && (
+            {availableSections.includes('countries') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/countries`}
@@ -307,7 +307,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Countries')}${statistics.Country && statistics.Country.value > 0 ? ` (${n(statistics.Country.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('areas', availableSections) && (
+            {availableSections.includes('areas') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/areas`}
@@ -321,7 +321,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Areas')}${statistics['Administrative-Area'] && statistics['Administrative-Area'].value > 0 ? ` (${n(statistics['Administrative-Area'].value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('cities', availableSections) && (
+            {availableSections.includes('cities') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/cities`}
@@ -335,7 +335,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Cities')}${statistics.City && statistics.City.value > 0 ? ` (${n(statistics.City.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('locations', availableSections) && (
+            {availableSections.includes('locations') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/locations`}
@@ -351,7 +351,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Locations')}${statisticsLocations > 0 ? ` (${n(statisticsLocations)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('organizations', availableSections) && (
+            {availableSections.includes('organizations') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/organizations`}
@@ -367,7 +367,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Organizations')}${statistics.Organization && statistics.Organization.value > 0 ? ` (${n(statistics.Organization.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('individuals', availableSections) && (
+            {availableSections.includes('individuals') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/individuals`}
@@ -383,7 +383,7 @@ const StixCoreObjectKnowledgeBar = ({
                 <ListItemText primary={`${t_i18n('Individuals')}${statistics.Individual && statistics.Individual.value > 0 ? ` (${n(statistics.Individual.value)})` : ''}`} />
               </MenuItem>
             )}
-            {R.includes('used_tools', availableSections) && (
+            {availableSections.includes('used_tools') && (
               <MenuItem
                 component={Link}
                 to={`${stixCoreObjectLink}/used_tools`}
@@ -416,7 +416,7 @@ const StixCoreObjectKnowledgeBar = ({
             <ListSubheader style={{ height: 35 }}>{t_i18n('Threats')}</ListSubheader>
           }
         >
-          {R.includes('threats', availableSections) && (
+          {availableSections.includes('threats') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/threats`}
@@ -430,7 +430,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('All threats')}${statisticsThreats > 0 ? ` (${n(statisticsThreats)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('attribution', availableSections) && (
+          {availableSections.includes('attribution') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/attribution`}
@@ -446,7 +446,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Attribution')}${statisticsAttributions > 0 ? ` (${n(statisticsAttributions)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('victimology', availableSections) && (
+          {availableSections.includes('victimology') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/victimology`}
@@ -462,7 +462,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Victimology')}${statisticsVictims > 0 ? ` (${n(statisticsVictims)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('threat_actors', availableSections) && (
+          {availableSections.includes('threat_actors') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/threat_actors`}
@@ -478,7 +478,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Threat actors')}${statisticsThreatActors > 0 ? ` (${n(statisticsThreatActors)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('intrusion_sets', availableSections) && (
+          {availableSections.includes('intrusion_sets') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/intrusion_sets`}
@@ -494,7 +494,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Intrusion sets')}${statistics['Intrusion-Set'] && statistics['Intrusion-Set'].value > 0 ? ` (${n(statistics['Intrusion-Set'].value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('campaigns', availableSections) && (
+          {availableSections.includes('campaigns') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/campaigns`}
@@ -526,7 +526,7 @@ const StixCoreObjectKnowledgeBar = ({
             <ListSubheader style={{ height: 35 }}>{t_i18n('Arsenal')}</ListSubheader>
           }
         >
-          {R.includes('variants', availableSections) && (
+          {availableSections.includes('variants') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/variants`}
@@ -540,7 +540,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Variants')}${statistics.Malware && statistics.Malware.value > 0 ? ` (${n(statistics.Malware.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('malwares', availableSections) && (
+          {availableSections.includes('malwares') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/malwares`}
@@ -554,7 +554,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Malwares')}${statistics.Malware && statistics.Malware.value > 0 ? ` (${n(statistics.Malware.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('channels', availableSections) && (
+          {availableSections.includes('channels') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/channels`}
@@ -568,7 +568,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Channels')}${statistics.Channel && statistics.Channel.value > 0 ? ` (${n(statistics.Channel.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('tools', availableSections) && (
+          {availableSections.includes('tools') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/tools`}
@@ -582,7 +582,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Tools')}${statistics.Tool && statistics.Tool.value > 0 ? ` (${n(statistics.Tool.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('vulnerabilities', availableSections) && (
+          {availableSections.includes('vulnerabilities') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/vulnerabilities`}
@@ -610,7 +610,7 @@ const StixCoreObjectKnowledgeBar = ({
             </ListSubheader>
           }
         >
-          {R.includes('attack_patterns', availableSections) && (
+          {availableSections.includes('attack_patterns') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/attack_patterns`}
@@ -626,7 +626,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Attack patterns')}${statistics['Attack-Pattern'] && statistics['Attack-Pattern'].value > 0 ? ` (${n(statistics['Attack-Pattern'].value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('narratives', availableSections) && (
+          {availableSections.includes('narratives') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/narratives`}
@@ -659,7 +659,7 @@ const StixCoreObjectKnowledgeBar = ({
             </ListSubheader>
           }
         >
-          {R.includes('indicators', availableSections) && (
+          {availableSections.includes('indicators') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/indicators`}
@@ -675,7 +675,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Indicators')}${statistics.Indicator && statistics.Indicator.value > 0 ? ` (${n(statistics.Indicator.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('observables', availableSections) && (
+          {availableSections.includes('observables') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/observables`}
@@ -691,7 +691,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Observables')}${statisticsObservables > 0 ? ` (${n(statisticsObservables)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('infrastructures', availableSections) && (
+          {availableSections.includes('infrastructures') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/infrastructures`}
@@ -717,7 +717,7 @@ const StixCoreObjectKnowledgeBar = ({
             <ListSubheader style={{ height: 35 }}>{t_i18n('Events')}</ListSubheader>
           }
         >
-          {R.includes('incidents', availableSections) && (
+          {availableSections.includes('incidents') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/incidents`}
@@ -731,7 +731,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Incidents')}${statistics.Incident && statistics.Incident.value > 0 ? ` (${n(statistics.Incident.value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('observed_data', availableSections) && (
+          {availableSections.includes('observed_data') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/observed_data`}
@@ -747,7 +747,7 @@ const StixCoreObjectKnowledgeBar = ({
               <ListItemText primary={`${t_i18n('Observed data')}${statistics['Observed-Data'] && statistics['Observed-Data'].value > 0 ? ` (${n(statistics['Observed-Data'].value)})` : ''}`} />
             </MenuItem>
           )}
-          {R.includes('sightings', availableSections) && (
+          {availableSections.includes('sightings') && (
             <MenuItem
               component={Link}
               to={`${stixCoreObjectLink}/sightings`}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -67,7 +67,7 @@ const StixCoreObjectKnowledgeBar = ({
   stixCoreObjectLink,
   availableSections,
   queryRef,
-  attribution = [],
+  attribution,
 }) => {
   const { t_i18n, n } = useFormatter();
   const classes = useStyles();

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.jsx
@@ -49,6 +49,7 @@ const stixCoreObjectKnowledgeBarFragment = graphql`
         "authored-by"
         "targets"
         "compromises"
+        "located-at"
       ]
     ) {
       label
@@ -780,7 +781,7 @@ const StixCoreObjectKnowledgeBar = ({
           <ListItemIcon style={{ minWidth: 28 }}>
             <ItemIcon size="small" type="related" />
           </ListItemIcon>
-          <ListItemText primary={`${t_i18n('Related entities')}${statisticsRelatedEntities > 0 ? ` (${n(statisticsRelatedEntities)}` : ''})`} />
+          <ListItemText primary={`${t_i18n('Related entities')}${statisticsRelatedEntities > 0 ? ` (${n(statisticsRelatedEntities)})` : ''}`} />
         </MenuItem>
       </MenuList>
     </Drawer>
@@ -791,6 +792,7 @@ StixCoreObjectKnowledgeBar.propTypes = {
   id: PropTypes.string,
   stixCoreObjectLink: PropTypes.string,
   availableSections: PropTypes.array,
+  queryRef: PropTypes.object,
   attribution: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
@@ -61,7 +61,7 @@ class StixCoreRelationshipStixCoreRelationshipsLinesContainer extends Component 
         >
           <StixCoreRelationshipCreationFromRelation
             entityId={entityId}
-            paddingRight={220}
+            paddingRight={true}
             variant="inLine"
             paginationOptions={paginationOptions}
           />

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -51,10 +51,7 @@ const eventQuery = graphql`
       entity_type
       name
       aliases
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Event_event
       ...EventKnowledge_event
       ...FileImportViewer_entity
@@ -121,7 +118,7 @@ const RootEvent = ({ eventId, queryRef }: RootEventProps) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={event.stixCoreObjectsDistribution}
+                  queryRef={event}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -118,7 +118,7 @@ const RootEvent = ({ eventId, queryRef }: RootEventProps) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={event}
+                  data={event}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -55,10 +55,7 @@ const individualQuery = graphql`
       entity_type
       name
       x_opencti_aliases
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Individual_individual
       ...IndividualKnowledge_individual
       ...FileImportViewer_entity
@@ -155,7 +152,7 @@ const RootIndividual = ({ individualId, queryRef }: RootIndividualProps) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={individual.stixCoreObjectsDistribution}
+                  queryRef={individual}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -152,7 +152,7 @@ const RootIndividual = ({ individualId, queryRef }: RootIndividualProps) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={individual}
+                  data={individual}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -54,10 +54,7 @@ const organizationQuery = graphql`
       entity_type
       name
       x_opencti_aliases
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Organization_organization
       ...OrganizationKnowledge_organization
       ...FileImportViewer_entity
@@ -153,7 +150,7 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
                     'vulnerabilities',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={organization.stixCoreObjectsDistribution}
+                  queryRef={organization}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -150,7 +150,7 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
                     'vulnerabilities',
                     'observables',
                   ]}
-                  queryRef={organization}
+                  data={organization}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -120,7 +120,7 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={sector}
+                  data={sector}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -53,10 +53,7 @@ const sectorQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Sector_sector
       ...SectorKnowledge_sector
       ...FileImportViewer_entity
@@ -123,7 +120,7 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={sector.stixCoreObjectsDistribution}
+                  queryRef={sector}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -53,10 +53,7 @@ const systemQuery = graphql`
       entity_type
       name
       x_opencti_aliases
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...System_system
       ...SystemKnowledge_system
       ...FileImportViewer_entity
@@ -148,7 +145,7 @@ const RootSystem = ({ systemId, queryRef }: RootSystemProps) => {
                     'observables',
                     'vulnerabilities',
                   ]}
-                  stixCoreObjectsDistribution={system.stixCoreObjectsDistribution}
+                  queryRef={system}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -145,7 +145,7 @@ const RootSystem = ({ systemId, queryRef }: RootSystemProps) => {
                     'observables',
                     'vulnerabilities',
                   ]}
-                  queryRef={system}
+                  data={system}
                 />
               )}
             />

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -120,7 +120,7 @@ const RootIncidentComponent = ({ queryRef }) => {
                     'vulnerabilities',
                     'observables',
                   ]}
-                  queryRef={incident}
+                  data={incident}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -56,10 +56,7 @@ const incidentQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Incident_incident
       ...IncidentKnowledge_incident
       ...StixCoreObjectContent_stixCoreObject
@@ -123,7 +120,7 @@ const RootIncidentComponent = ({ queryRef }) => {
                     'vulnerabilities',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={incident.stixCoreObjectsDistribution}
+                  queryRef={incident}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -121,6 +121,7 @@ const RootIncidentComponent = ({ queryRef }) => {
                     'observables',
                   ]}
                   data={incident}
+                  attribution={['Threat-Actor-Individual', 'Threat-Actor-Group', 'Intrusion-Set', 'Campaign']}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -54,10 +54,7 @@ const administrativeAreaQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AdministrativeArea_administrativeArea
       ...AdministrativeAreaKnowledge_administrativeArea
       ...FileImportViewer_entity
@@ -120,7 +117,7 @@ const RootAdministrativeAreaComponent = ({ queryRef, administrativeAreaId }) => 
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={administrativeArea.stixCoreObjectsDistribution}
+                  queryRef={administrativeArea}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -117,7 +117,7 @@ const RootAdministrativeAreaComponent = ({ queryRef, administrativeAreaId }) => 
                     'tools',
                     'observables',
                   ]}
-                  queryRef={administrativeArea}
+                  data={administrativeArea}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -115,7 +115,7 @@ const RootCityComponent = ({ queryRef, cityId }) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={city}
+                  data={city}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -54,10 +54,7 @@ const cityQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...City_city
       ...CityKnowledge_city
       ...FileImportViewer_entity
@@ -118,7 +115,7 @@ const RootCityComponent = ({ queryRef, cityId }) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={city.stixCoreObjectsDistribution}
+                  queryRef={city}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -117,7 +117,7 @@ const RootCountryComponent = ({ queryRef, countryId }) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={country}
+                  data={country}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -54,10 +54,7 @@ const countryQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Country_country
       ...CountryKnowledge_country
       ...FileImportViewer_entity
@@ -120,7 +117,7 @@ const RootCountryComponent = ({ queryRef, countryId }) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={country.stixCoreObjectsDistribution}
+                  queryRef={country}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -51,10 +51,7 @@ const positionQuery = graphql`
       entity_type
       name
       x_opencti_aliases
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Position_position
       ...PositionKnowledge_position
       ...FileImportViewer_entity
@@ -125,7 +122,7 @@ const RootPosition = ({ positionId, queryRef }: RootPositionProps) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={position.stixCoreObjectsDistribution}
+                  queryRef={position}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -122,7 +122,7 @@ const RootPosition = ({ positionId, queryRef }: RootPositionProps) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={position}
+                  data={position}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -119,7 +119,7 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
                     'tools',
                     'observables',
                   ]}
-                  queryRef={region}
+                  data={region}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -55,10 +55,7 @@ const regionQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Region_region
       ...RegionKnowledge_region
       ...FileImportViewer_entity
@@ -122,7 +119,7 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
                     'tools',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={region.stixCoreObjectsDistribution}
+                  queryRef={region}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -22,10 +22,7 @@ const infrastructureKnowledgeFragment = graphql`
     aliases
     first_seen
     last_seen
-    stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-      label
-      value
-    }
+    ...StixCoreObjectKnowledgeBar_stixCoreObject
   }
 `;
 
@@ -39,7 +36,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
     <>
       <StixCoreObjectKnowledgeBar
         stixCoreObjectLink={link}
-        stixCoreObjectsDistribution={infrastructureData.stixCoreObjectsDistribution}
+        queryRef={infrastructureData}
         availableSections={[
           'threats',
           'threat_actors',

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -36,7 +36,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
     <>
       <StixCoreObjectKnowledgeBar
         stixCoreObjectLink={link}
-        queryRef={infrastructureData}
+        data={infrastructureData}
         availableSections={[
           'threats',
           'threat_actors',

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -52,10 +52,7 @@ const attackPatternQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AttackPattern_attackPattern
       ...AttackPatternKnowledge_attackPattern
       ...FileImportViewer_entity
@@ -122,7 +119,7 @@ const RootAttackPattern = ({ attackPatternId, queryRef }: RootAttackPatternProps
                     'indicators',
                     'observables',
                   ]}
-                  stixCoreObjectsDistribution={attackPattern.stixCoreObjectsDistribution}
+                  queryRef={attackPattern}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -119,7 +119,7 @@ const RootAttackPattern = ({ attackPatternId, queryRef }: RootAttackPatternProps
                     'indicators',
                     'observables',
                   ]}
-                  queryRef={attackPattern}
+                  data={attackPattern}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -52,10 +52,7 @@ const narrativeQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Narrative_narrative
       ...NarrativeKnowledge_narrative
       ...FileImportViewer_entity
@@ -118,7 +115,7 @@ const RootNarrative = ({ narrativeId, queryRef }: RootNarrativeProps) => {
                     'observables',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={narrative.stixCoreObjectsDistribution}
+                  queryRef={narrative}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -115,7 +115,7 @@ const RootNarrative = ({ narrativeId, queryRef }: RootNarrativeProps) => {
                     'observables',
                     'sightings',
                   ]}
-                  queryRef={narrative}
+                  data={narrative}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -124,7 +124,7 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
                     'infrastructures',
                     'sightings',
                   ]}
-                  queryRef={campaign}
+                  data={campaign}
                   attribution={['Intrusion-Set', 'Threat-Actor-Individual', 'Threat-Actor-Group']}
                 />
               }

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -53,10 +53,7 @@ const campaignQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Campaign_campaign
       ...CampaignKnowledge_campaign
       ...FileImportViewer_entity
@@ -127,7 +124,7 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
                     'infrastructures',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={campaign.stixCoreObjectsDistribution}
+                  queryRef={campaign}
                   attribution={['Intrusion-Set', 'Threat-Actor-Individual', 'Threat-Actor-Group']}
                 />
               }

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -130,7 +130,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
                     'infrastructures',
                     'sightings',
                   ]}
-                  queryRef={intrusionSet}
+                  data={intrusionSet}
                   attribution={['Threat-Actor-Individual', 'Threat-Actor-Group']}
                 />
               }

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -57,10 +57,7 @@ const intrusionSetQuery = graphql`
         id
       }
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...IntrusionSet_intrusionSet
       ...IntrusionSetKnowledge_intrusionSet
       ...FileImportViewer_entity
@@ -133,7 +130,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
                     'infrastructures',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={intrusionSet.stixCoreObjectsDistribution}
+                  queryRef={intrusionSet}
                   attribution={['Threat-Actor-Individual', 'Threat-Actor-Group']}
                 />
               }

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -46,7 +46,7 @@ const subscription = graphql`
 `;
 
 const ThreatActorGroupQuery = graphql`
-  query RootThreatActorGroupQuery($id: String!) {
+  query RootThreatActorGroupQuery($id: String!, $relatedRelationshipTypes: [String!]) {
     threatActorGroup(id: $id) {
       id
       standard_id
@@ -54,7 +54,7 @@ const ThreatActorGroupQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      ...StixCoreObjectKnowledgeBar_stixCoreObject
+      ...StixCoreObjectKnowledgeBar_stixCoreObject @arguments(relatedRelationshipTypes: $relatedRelationshipTypes)
       ...ThreatActorGroup_ThreatActorGroup
       ...ThreatActorGroupKnowledge_ThreatActorGroup
       ...FileImportViewer_entity
@@ -72,6 +72,8 @@ const ThreatActorGroupQuery = graphql`
     }
   }
 `;
+
+const THREAT_ACTOR_GROUP_RELATED_RELATIONSHIP_TYPES = ['related-to', 'part-of'];
 
 type RootThreatActorGroupProps = {
   threatActorGroupId: string;
@@ -223,7 +225,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                 path="/knowledge/*"
                 element={
                   <div key={forceUpdate}>
-                    <ThreatActorGroupKnowledge threatActorGroup={threatActorGroup} />
+                    <ThreatActorGroupKnowledge threatActorGroup={threatActorGroup} related={THREAT_ACTOR_GROUP_RELATED_RELATIONSHIP_TYPES} />
                   </div>
                 }
               />
@@ -272,6 +274,7 @@ const Root = () => {
   const { threatActorGroupId } = useParams() as { threatActorGroupId: string; };
   const queryRef = useQueryLoading<RootThreatActorGroupQuery>(ThreatActorGroupQuery, {
     id: threatActorGroupId,
+    relatedRelationshipTypes: THREAT_ACTOR_GROUP_RELATED_RELATIONSHIP_TYPES,
   });
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -54,10 +54,7 @@ const ThreatActorGroupQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...ThreatActorGroup_ThreatActorGroup
       ...ThreatActorGroupKnowledge_ThreatActorGroup
       ...FileImportViewer_entity
@@ -131,7 +128,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                     'infrastructures',
                     'sightings',
                   ]}
-                  stixCoreObjectsDistribution={threatActorGroup.stixCoreObjectsDistribution}
+                  queryRef={threatActorGroup}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -128,7 +128,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                     'infrastructures',
                     'sightings',
                   ]}
-                  queryRef={threatActorGroup}
+                  data={threatActorGroup}
                 />
               }
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -225,7 +225,10 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                 path="/knowledge/*"
                 element={
                   <div key={forceUpdate}>
-                    <ThreatActorGroupKnowledge threatActorGroup={threatActorGroup} related={THREAT_ACTOR_GROUP_RELATED_RELATIONSHIP_TYPES} />
+                    <ThreatActorGroupKnowledge
+                      threatActorGroup={threatActorGroup}
+                      relatedRelationshipTypes={THREAT_ACTOR_GROUP_RELATED_RELATIONSHIP_TYPES}
+                    />
                   </div>
                 }
               />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -14,7 +14,7 @@ import EntityStixCoreRelationshipsStixCyberObservable from '../../common/stix_co
 
 class ThreatActorGroupKnowledgeComponent extends Component {
   render() {
-    const { threatActorGroup } = this.props;
+    const { threatActorGroup, relatedRelationshipTypes } = this.props;
     const link = `/dashboard/threats/threat_actors_group/${threatActorGroup.id}/knowledge`;
     return (
       <>
@@ -52,7 +52,7 @@ class ThreatActorGroupKnowledgeComponent extends Component {
             element={
               <EntityStixCoreRelationships
                 entityId={threatActorGroup.id}
-                relationshipTypes={['related-to', 'part-of']}
+                relationshipTypes={relatedRelationshipTypes}
                 entityLink={link}
                 defaultStartTime={threatActorGroup.first_seen}
                 defaultStopTime={threatActorGroup.last_seen}
@@ -271,6 +271,7 @@ class ThreatActorGroupKnowledgeComponent extends Component {
 
 ThreatActorGroupKnowledgeComponent.propTypes = {
   threatActorGroup: PropTypes.object,
+  relatedRelationshipTypes: PropTypes.array,
   classes: PropTypes.object,
   t: PropTypes.func,
 };

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -54,10 +54,7 @@ const ThreatActorIndividualQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      stixCoreObjectsDistribution(field: "entity_type", operation: count) {
-        label
-        value
-      }
+      ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...ThreatActorIndividual_ThreatActorIndividual
       ...ThreatActorIndividualKnowledge_ThreatActorIndividual
       ...FileImportViewer_entity
@@ -144,7 +141,7 @@ const RootThreatActorIndividualComponent = ({
                     'sightings',
                     'countries',
                   ]}
-                  stixCoreObjectsDistribution={threatActorIndividual.stixCoreObjectsDistribution}
+                  queryRef={threatActorIndividual}
                 />
              }
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -46,7 +46,7 @@ const subscription = graphql`
 `;
 
 const ThreatActorIndividualQuery = graphql`
-  query RootThreatActorIndividualQuery($id: String!) {
+  query RootThreatActorIndividualQuery($id: String!, $relatedRelationshipTypes: [String!]) {
     threatActorIndividual(id: $id) {
       id
       standard_id
@@ -54,7 +54,7 @@ const ThreatActorIndividualQuery = graphql`
       name
       aliases
       x_opencti_graph_data
-      ...StixCoreObjectKnowledgeBar_stixCoreObject
+      ...StixCoreObjectKnowledgeBar_stixCoreObject @arguments(relatedRelationshipTypes: $relatedRelationshipTypes)
       ...ThreatActorIndividual_ThreatActorIndividual
       ...ThreatActorIndividualKnowledge_ThreatActorIndividual
       ...FileImportViewer_entity
@@ -72,6 +72,8 @@ const ThreatActorIndividualQuery = graphql`
     }
   }
 `;
+
+const THREAT_ACTOR_INDIVIDUAL_RELATED_RELATIONSHIP_TYPES = ['related-to', 'part-of', 'impersonates', 'known-as'];
 
 type RootThreatActorIndividualProps = {
   threatActorIndividualId: string;
@@ -237,7 +239,7 @@ const RootThreatActorIndividualComponent = ({
                 path="/knowledge/*"
                 element={
                   <div key={forceUpdate}>
-                    <ThreatActorIndividualKnowledge threatActorIndividualData={threatActorIndividual} />
+                    <ThreatActorIndividualKnowledge threatActorIndividualData={threatActorIndividual} relatedRelationshipTypes={THREAT_ACTOR_INDIVIDUAL_RELATED_RELATIONSHIP_TYPES} />
                   </div>
                 }
               />
@@ -290,6 +292,7 @@ const Root = () => {
     ThreatActorIndividualQuery,
     {
       id: threatActorIndividualId,
+      relatedRelationshipTypes: THREAT_ACTOR_INDIVIDUAL_RELATED_RELATIONSHIP_TYPES,
     },
   );
   return (

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -141,7 +141,7 @@ const RootThreatActorIndividualComponent = ({
                     'sightings',
                     'countries',
                   ]}
-                  queryRef={threatActorIndividual}
+                  data={threatActorIndividual}
                 />
              }
             />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -239,7 +239,10 @@ const RootThreatActorIndividualComponent = ({
                 path="/knowledge/*"
                 element={
                   <div key={forceUpdate}>
-                    <ThreatActorIndividualKnowledge threatActorIndividualData={threatActorIndividual} relatedRelationshipTypes={THREAT_ACTOR_INDIVIDUAL_RELATED_RELATIONSHIP_TYPES} />
+                    <ThreatActorIndividualKnowledge
+                      threatActorIndividualData={threatActorIndividual}
+                      relatedRelationshipTypes={THREAT_ACTOR_INDIVIDUAL_RELATED_RELATIONSHIP_TYPES}
+                    />
                   </div>
                 }
               />

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
@@ -28,8 +28,10 @@ const threatActorIndividualKnowledgeFragment = graphql`
 
 const ThreatActorIndividualKnowledgeComponent = ({
   threatActorIndividualData,
+  relatedRelationshipTypes,
 }: {
   threatActorIndividualData: ThreatActorIndividualKnowledge_ThreatActorIndividual$key;
+  relatedRelationshipTypes: string[]
 }) => {
   const threatActorIndividual = useFragment<ThreatActorIndividualKnowledge_ThreatActorIndividual$key>(
     threatActorIndividualKnowledgeFragment,
@@ -71,7 +73,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         element={
           <EntityStixCoreRelationships
             entityId={threatActorIndividual.id}
-            relationshipTypes={['related-to', 'part-of', 'known-as', 'impersonates']}
+            relationshipTypes={relatedRelationshipTypes}
             entityLink={link}
             defaultStartTime={threatActorIndividual.first_seen}
             defaultStopTime={threatActorIndividual.last_seen}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix distribution counters, also add counter for related entities
* Refactor query with fragment for knowledge bar
* NB: counters update is still not sync when entity is added (it's another bug 🐛 )

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/8115
* Close https://github.com/OpenCTI-Platform/opencti/issues/9057
* Close https://github.com/OpenCTI-Platform/opencti/issues/8672

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
