### PR TITLE
[backend] Add dedicated error for orga restricted entities + Feature flag (#3345)

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -26,7 +26,7 @@
     "test:dev": "vitest run --config vitest.config.dev.ts",
     "test:watch:resume": "SKIP_CLEANUP_PLATFORM=true vitest watch --config vitest.config.dev.ts",
     "test:watch": "vitest watch --config vitest.config.dev.ts",
-    "test": "vitest --silent --bail 1 run --config vitest.config.test.ts --coverage",
+    "test": "vitest --silent run --config vitest.config.test.ts --coverage",
     "wait-api": "node build/script-wait-for-api.js"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -26,7 +26,7 @@
     "test:dev": "vitest run --config vitest.config.dev.ts",
     "test:watch:resume": "SKIP_CLEANUP_PLATFORM=true vitest watch --config vitest.config.dev.ts",
     "test:watch": "vitest watch --config vitest.config.dev.ts",
-    "test": "vitest --silent run --config vitest.config.test.ts --coverage",
+    "test": "vitest --silent --bail 1 run --config vitest.config.test.ts --coverage",
     "wait-api": "node build/script-wait-for-api.js"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -475,6 +475,7 @@ export const ENABLED_FEATURE_FLAGS = nconf.get('app:enabled_dev_features') ?? []
 // a special flag name allows to enable all feature flags at once
 export const FEATURE_FLAG_ALL = '*';
 export const isFeatureEnabled = (feature) => ENABLED_FEATURE_FLAGS.includes(FEATURE_FLAG_ALL) || ENABLED_FEATURE_FLAGS.includes(feature);
+export const ORGA_SHARING_REQUEST_FF = 'ORGA_SHARING_REQUEST_FF';
 
 export const REDIS_PREFIX = nconf.get('redis:namespace') ? `${nconf.get('redis:namespace')}:` : '';
 export const TOPIC_PREFIX = `${REDIS_PREFIX}_OPENCTI_DATA_`;

--- a/opencti-platform/opencti-graphql/src/config/errors.js
+++ b/opencti-platform/opencti-graphql/src/config/errors.js
@@ -84,6 +84,13 @@ export const UnknownError = (reason, data) => error('UNKNOWN_ERROR', reason || '
   ...data,
 });
 
+export const ACCESS_REQUIRED = 'ACCESS_REQUIRED';
+export const AccessRequiredError = (reason, data) => error(ACCESS_REQUIRED, reason || 'Access required', {
+  http_status: 500,
+  genre: CATEGORY_BUSINESS,
+  ...data,
+});
+
 export const UNSUPPORTED_ERROR = 'UNSUPPORTED_ERROR';
 export const UnsupportedError = (reason, data) => error(UNSUPPORTED_ERROR, reason || 'Unsupported operation', {
   http_status: 500,

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/access-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/access-test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { v4 as uuid } from 'uuid';
+import { isMarkingAllowed, isOrganizationAllowed } from '../../../src/utils/access';
+import type { BasicStoreCommon } from '../../../src/types/store';
+import { MARKING_TLP_AMBER, MARKING_TLP_CLEAR, MARKING_TLP_GREEN, MARKING_TLP_RED } from '../../../src/schema/identifier';
+import type { AuthUser } from '../../../src/types/user';
+import type { BasicStoreSettings } from '../../../src/types/settings';
+import { PLATFORM_ORGANIZATION, TEST_ORGANIZATION } from '../../utils/testQuery';
+import { RELATION_GRANTED_TO } from '../../../src/schema/stixRefRelationship';
+import type { BasicStoreEntityOrganization } from '../../../src/modules/organization/organization-types';
+
+describe('Check markings test coverage', () => {
+  it('should element with no marking be allowed', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      'object-marking': [],
+    };
+    const userAllowedMarking: string[] = [];
+    expect(isMarkingAllowed(element as BasicStoreCommon, userAllowedMarking)).toBeTruthy();
+  });
+
+  it('should element with marking refused for user without markings', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      'object-marking': [MARKING_TLP_GREEN],
+    };
+    const userAllowedMarking: string[] = [];
+    expect(isMarkingAllowed(element as BasicStoreCommon, userAllowedMarking)).toBeFalsy();
+  });
+
+  it('should element with marking refused for user with lower marking', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      'object-marking': [MARKING_TLP_GREEN],
+    };
+    const userAllowedMarking: string[] = [MARKING_TLP_CLEAR];
+    expect(isMarkingAllowed(element as BasicStoreCommon, userAllowedMarking)).toBeFalsy();
+  });
+
+  it('should element with marking allowed for user with higher marking', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      'object-marking': [MARKING_TLP_CLEAR],
+    };
+    const userAllowedMarking: string[] = [MARKING_TLP_GREEN, MARKING_TLP_CLEAR];
+    expect(isMarkingAllowed(element as BasicStoreCommon, userAllowedMarking)).toBeTruthy();
+  });
+
+  it('should element with one marking higher than user ones be refused', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      'object-marking': [MARKING_TLP_CLEAR, MARKING_TLP_RED],
+    };
+    const userAllowedMarking: string[] = [MARKING_TLP_GREEN, MARKING_TLP_AMBER];
+    expect(isMarkingAllowed(element as BasicStoreCommon, userAllowedMarking)).toBeFalsy();
+  });
+});
+
+describe('Check organization access for element.', () => {
+  it('should element when no platform organization setup be allowed', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      internal_id: uuid()
+    };
+
+    const user: Partial<AuthUser> = {
+      allowed_organizations: [],
+      internal_id: uuid()
+    };
+
+    const settings: Partial<BasicStoreSettings> = {
+      platform_organization: undefined,
+    };
+
+    expect(isOrganizationAllowed(element as BasicStoreCommon, user as AuthUser, settings as BasicStoreSettings)).toBeTruthy();
+  });
+
+  it('should element not shared be allowed to user in platform organization', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      internal_id: uuid()
+    };
+
+    const org : Partial<BasicStoreEntityOrganization> = {
+      internal_id: PLATFORM_ORGANIZATION.id,
+    };
+    const allOrgs: BasicStoreEntityOrganization[] = [];
+    allOrgs.push(org as BasicStoreEntityOrganization);
+
+    const user: Partial<AuthUser> = {
+      inside_platform_organization: true,
+      allowed_organizations: allOrgs,
+      internal_id: uuid()
+    };
+
+    const settings: Partial<BasicStoreSettings> = {
+      platform_organization: PLATFORM_ORGANIZATION.name,
+    };
+
+    expect(isOrganizationAllowed(element as BasicStoreCommon, user as AuthUser, settings as BasicStoreSettings)).toBeTruthy();
+  });
+
+  it('should element not shared not be allowed to user in another organization', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      internal_id: uuid()
+    };
+
+    const org : Partial<BasicStoreEntityOrganization> = {
+      internal_id: TEST_ORGANIZATION.id,
+    };
+    const allOrgs: BasicStoreEntityOrganization[] = [];
+    allOrgs.push(org as BasicStoreEntityOrganization);
+
+    const user: Partial<AuthUser> = {
+      inside_platform_organization: false,
+      allowed_organizations: allOrgs,
+      internal_id: uuid()
+    };
+
+    const settings: Partial<BasicStoreSettings> = {
+      platform_organization: PLATFORM_ORGANIZATION.name,
+    };
+
+    expect(isOrganizationAllowed(element as BasicStoreCommon, user as AuthUser, settings as BasicStoreSettings)).toBeFalsy();
+  });
+
+  it('should element shared to user organization be allowed', async () => {
+    const element: Partial<BasicStoreCommon> = {
+      internal_id: uuid()
+    };
+    element[RELATION_GRANTED_TO] = [TEST_ORGANIZATION.id];
+
+    const org : Partial<BasicStoreEntityOrganization> = {
+      internal_id: TEST_ORGANIZATION.id,
+      id: TEST_ORGANIZATION.id,
+    };
+    const allOrgs: BasicStoreEntityOrganization[] = [];
+    allOrgs.push(org as BasicStoreEntityOrganization);
+
+    const user: Partial<AuthUser> = {
+      inside_platform_organization: false,
+      allowed_organizations: allOrgs,
+      internal_id: uuid()
+    };
+
+    const settings: Partial<BasicStoreSettings> = {
+      platform_organization: PLATFORM_ORGANIZATION.name,
+    };
+
+    expect(isOrganizationAllowed(element as BasicStoreCommon, user as AuthUser, settings as BasicStoreSettings)).toBeTruthy();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -34,11 +34,12 @@ import {
   WRITE_PLATFORM_INDICES
 } from '../../../src/database/utils';
 import { utcDate } from '../../../src/utils/format';
-import { ADMIN_USER, buildStandardUser, testContext, TESTING_GROUPS, TESTING_ROLES, TESTING_USERS } from '../../utils/testQuery';
+import { ADMIN_USER, buildStandardUser, testContext, TESTING_GROUPS, TESTING_ORGS, TESTING_ROLES, TESTING_USERS } from '../../utils/testQuery';
 import { BASE_TYPE_RELATION, buildRefRelationKey, ENTITY_TYPE_IDENTITY } from '../../../src/schema/general';
 import { RELATION_OBJECT_LABEL, RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship';
 import { RELATION_USES } from '../../../src/schema/stixCoreRelationship';
 import { buildAggregationRelationFilter } from '../../../src/database/middleware-loader';
+import { mapCountPerEntityType, mapEdgesCountPerEntityType } from '../../utils/domainQueryHelper';
 
 const elWhiteUser = async () => {
   const opts = { types: ['Marking-Definition'], connectionFormat: false };
@@ -47,6 +48,8 @@ const elWhiteUser = async () => {
   const TLP_WHITE = await elLoadById(testContext, ADMIN_USER, 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9');
   return buildStandardUser([{ internal_id: TLP_WHITE.internal_id, standard_id: TLP_WHITE.standard_id }], ALL_TLP);
 };
+
+const VOCABULARY_COUNT = 340;
 
 describe('Elasticsearch configuration test', () => {
   it('should configuration correct', async () => {
@@ -233,7 +236,7 @@ describe('Elasticsearch computation', () => {
     // noinspection JSUnresolvedVariable
     const storedFormat = moment(R.head(data).date)._f;
     expect(storedFormat).toEqual('YYYY-MM-DD');
-    expect(R.head(data).value).toEqual(36);
+    expect(R.head(data).value).toEqual(34 + TESTING_ORGS.length);
   });
   it('should month histogram accurate', async () => {
     const data = await elHistogramCount(
@@ -405,7 +408,50 @@ describe('Elasticsearch pagination', () => {
   it('should entity paginate everything', async () => {
     const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { first: ES_MAX_PAGINATION });
     expect(data).not.toBeNull();
-    expect(data.edges.length).toEqual(521 + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
+    const entityTypeMap = mapEdgesCountPerEntityType(data);
+    expect(entityTypeMap.get('Attack-Pattern')).toBe(2);
+    expect(entityTypeMap.get('Campaign')).toBe(1);
+    expect(entityTypeMap.get('Capability')).toBe(39);
+    expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
+    expect(entityTypeMap.get('Credential')).toBe(1);
+    expect(entityTypeMap.get('DecayRule')).toBe(4);
+    expect(entityTypeMap.get('EntitySetting')).toBe(43);
+    expect(entityTypeMap.get('External-Reference')).toBe(7);
+    expect(entityTypeMap.get('StixFile')).toBe(1);
+    expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
+    expect(entityTypeMap.get('Individual')).toBe(1);
+    expect(entityTypeMap.get('Sector')).toBe(3);
+    expect(entityTypeMap.get('Organization')).toBe(6 + TESTING_ORGS.length);
+    expect(entityTypeMap.get('Incident')).toBe(1);
+    expect(entityTypeMap.get('Indicator')).toBe(3);
+    expect(entityTypeMap.get('Intrusion-Set')).toBe(1);
+    expect(entityTypeMap.get('Kill-Chain-Phase')).toBe(2);
+    expect(entityTypeMap.get('Label')).toBe(13);
+    expect(entityTypeMap.get('Region')).toBe(2);
+    expect(entityTypeMap.get('Country')).toBe(1);
+    expect(entityTypeMap.get('City')).toBe(1);
+    expect(entityTypeMap.get('Administrative-Area')).toBe(1);
+    expect(entityTypeMap.get('Malware')).toBe(2);
+    expect(entityTypeMap.get('Malware-Analysis')).toBe(1);
+    expect(entityTypeMap.get('ManagerConfiguration')).toBe(1);
+    expect(entityTypeMap.get('Marking-Definition')).toBe(11);
+    expect(entityTypeMap.get('Note')).toBe(1);
+    expect(entityTypeMap.get('Notifier')).toBe(2);
+    expect(entityTypeMap.get('Observed-Data')).toBe(1);
+    expect(entityTypeMap.get('Opinion')).toBe(1);
+    expect(entityTypeMap.get('Report')).toBe(1);
+    expect(entityTypeMap.get('Role')).toBe(TESTING_ROLES.length + 3);
+    expect(entityTypeMap.get('RuleManager')).toBe(1);
+    expect(entityTypeMap.get('Settings')).toBe(1);
+    expect(entityTypeMap.get('Software')).toBe(1);
+    expect(entityTypeMap.get('Status')).toBe(4);
+    expect(entityTypeMap.get('StatusTemplate')).toBe(6);
+    expect(entityTypeMap.get('Threat-Actor-Individual')).toBe(2);
+    expect(entityTypeMap.get('Threat-Actor-Group')).toBe(1);
+    expect(entityTypeMap.get('Tracking-Number')).toBe(1);
+    expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
+    expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
+    expect(data.edges.length).toEqual(519 + TESTING_ORGS.length + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
     const filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('ENTITY');
@@ -432,6 +478,16 @@ describe('Elasticsearch pagination', () => {
       orderMode: 'desc',
     });
     expect(data).not.toBeNull();
+    const entityTypeMap = mapEdgesCountPerEntityType(data);
+    expect(entityTypeMap.get('Report')).toBe(1);
+    expect(entityTypeMap.get('Attack-Pattern')).toBe(2);
+    expect(entityTypeMap.get('Campaign')).toBe(1);
+    expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
+    expect(entityTypeMap.get('Individual')).toBe(1);
+    expect(entityTypeMap.get('Sector')).toBe(3);
+    expect(entityTypeMap.get('Organization')).toBe(TESTING_ORGS.length + 6);
+    expect(entityTypeMap.get('Incident')).toBe(1);
+    expect(entityTypeMap.get('Indicator')).toBe(2);
     expect(data.edges.length).toEqual(20);
     expect(data.pageInfo.endCursor).toBeDefined();
 
@@ -501,6 +557,48 @@ describe('Elasticsearch pagination', () => {
       filterGroups: [],
     };
     const data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { filters, first: ES_MAX_PAGINATION });
+    const entityTypeMap = mapEdgesCountPerEntityType(data);
+    expect(entityTypeMap.get('Attack-Pattern')).toBe(2);
+    expect(entityTypeMap.get('Campaign')).toBe(1);
+    expect(entityTypeMap.get('Capability')).toBe(39);
+    expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
+    expect(entityTypeMap.get('Credential')).toBe(1);
+    expect(entityTypeMap.get('DecayRule')).toBe(4);
+    expect(entityTypeMap.get('EntitySetting')).toBe(43);
+    expect(entityTypeMap.get('External-Reference')).toBe(7);
+    expect(entityTypeMap.get('StixFile')).toBe(1);
+    expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
+    expect(entityTypeMap.get('Individual')).toBe(1);
+    expect(entityTypeMap.get('Sector')).toBe(3);
+    expect(entityTypeMap.get('Organization')).toBe(TESTING_ORGS.length + 6);
+    expect(entityTypeMap.get('Incident')).toBe(1);
+    expect(entityTypeMap.get('Indicator')).toBe(3);
+    expect(entityTypeMap.get('Intrusion-Set')).toBe(1);
+    expect(entityTypeMap.get('Kill-Chain-Phase')).toBe(2);
+    expect(entityTypeMap.get('Label')).toBe(13);
+    expect(entityTypeMap.get('Region')).toBe(2);
+    expect(entityTypeMap.get('Country')).toBe(1);
+    expect(entityTypeMap.get('City')).toBe(1);
+    expect(entityTypeMap.get('Administrative-Area')).toBe(1);
+    expect(entityTypeMap.get('Malware')).toBe(2);
+    expect(entityTypeMap.get('Malware-Analysis')).toBe(1);
+    expect(entityTypeMap.get('ManagerConfiguration')).toBe(1);
+    expect(entityTypeMap.get('Note')).toBe(1);
+    expect(entityTypeMap.get('Notifier')).toBe(2);
+    expect(entityTypeMap.get('Observed-Data')).toBe(1);
+    expect(entityTypeMap.get('Opinion')).toBe(1);
+    expect(entityTypeMap.get('Report')).toBe(1);
+    expect(entityTypeMap.get('Role')).toBe(9);
+    expect(entityTypeMap.get('RuleManager')).toBe(1);
+    expect(entityTypeMap.get('Settings')).toBe(1);
+    expect(entityTypeMap.get('Software')).toBe(1);
+    expect(entityTypeMap.get('Status')).toBe(4);
+    expect(entityTypeMap.get('StatusTemplate')).toBe(6);
+    expect(entityTypeMap.get('Threat-Actor-Individual')).toBe(2);
+    expect(entityTypeMap.get('Threat-Actor-Group')).toBe(1);
+    expect(entityTypeMap.get('Tracking-Number')).toBe(1);
+    expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
+    expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
     expect(data.edges.length).toEqual(528);
   });
   it('should entity paginate with field exist filter', async () => {
@@ -564,7 +662,20 @@ describe('Elasticsearch pagination', () => {
       filterGroups: [],
     };
     data = await elPaginate(testContext, ADMIN_USER, READ_ENTITIES_INDICES, { filters, first: ES_MAX_PAGINATION });
-    expect(data.edges.length).toEqual(368);
+    const entityTypeMap = mapEdgesCountPerEntityType(data);
+    expect(entityTypeMap.get('External-Reference')).toBe(7);
+    expect(entityTypeMap.get('Individual')).toBe(1);
+    expect(entityTypeMap.get('Organization')).toBe(TESTING_ORGS.length);
+    expect(entityTypeMap.get('Incident')).toBe(1);
+    expect(entityTypeMap.get('Kill-Chain-Phase')).toBe(2);
+    expect(entityTypeMap.get('Malware-Analysis')).toBe(1);
+    expect(entityTypeMap.get('Marking-Definition')).toBe(9);
+    expect(entityTypeMap.get('Note')).toBe(1);
+    expect(entityTypeMap.get('Notifier')).toBe(2);
+    expect(entityTypeMap.get('Opinion')).toBe(1);
+    expect(entityTypeMap.get('Threat-Actor-Individual')).toBe(1);
+    expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
+    expect(data.edges.length).toEqual(VOCABULARY_COUNT + TESTING_ORGS.length + 26);
     filters = {
       mode: 'and',
       filters: [
@@ -582,7 +693,50 @@ describe('Elasticsearch pagination', () => {
       orderMode: 'asc',
       first: ES_MAX_PAGINATION
     });
-    expect(data.edges.length).toEqual(521 + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
+    const entityTypeMap = mapEdgesCountPerEntityType(data);
+    expect(entityTypeMap.get('Capability')).toBe(39);
+    expect(entityTypeMap.get('Credential')).toBe(1);
+    expect(entityTypeMap.get('DecayRule')).toBe(4);
+    expect(entityTypeMap.get('EntitySetting')).toBe(43);
+    expect(entityTypeMap.get('StixFile')).toBe(1);
+    expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
+    expect(entityTypeMap.get('ManagerConfiguration')).toBe(1);
+    expect(entityTypeMap.get('Role')).toBe(TESTING_ROLES.length + 3);
+    expect(entityTypeMap.get('RuleManager')).toBe(1);
+    expect(entityTypeMap.get('Settings')).toBe(1);
+    expect(entityTypeMap.get('Software')).toBe(1);
+    expect(entityTypeMap.get('Status')).toBe(4);
+    expect(entityTypeMap.get('StatusTemplate')).toBe(6);
+    expect(entityTypeMap.get('Tracking-Number')).toBe(1);
+    expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
+    expect(entityTypeMap.get('Organization')).toBe(TESTING_ORGS.length + 6);
+    expect(entityTypeMap.get('Marking-Definition')).toBe(11);
+    expect(entityTypeMap.get('Attack-Pattern')).toBe(2);
+    expect(entityTypeMap.get('Threat-Actor-Individual')).toBe(2);
+    expect(entityTypeMap.get('Threat-Actor-Group')).toBe(1);
+    expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
+    expect(entityTypeMap.get('Intrusion-Set')).toBe(1);
+    expect(entityTypeMap.get('Malware')).toBe(2);
+    expect(entityTypeMap.get('Region')).toBe(2);
+    expect(entityTypeMap.get('Country')).toBe(1);
+    expect(entityTypeMap.get('Administrative-Area')).toBe(1);
+    expect(entityTypeMap.get('Sector')).toBe(3);
+    expect(entityTypeMap.get('Observed-Data')).toBe(1);
+    expect(entityTypeMap.get('Indicator')).toBe(3);
+    expect(entityTypeMap.get('Campaign')).toBe(1);
+    expect(entityTypeMap.get('City')).toBe(1);
+    expect(entityTypeMap.get('Report')).toBe(1);
+    expect(entityTypeMap.get('Note')).toBe(1);
+    expect(entityTypeMap.get('Opinion')).toBe(1);
+    expect(entityTypeMap.get('Incident')).toBe(1);
+    expect(entityTypeMap.get('Individual')).toBe(1);
+    expect(entityTypeMap.get('Malware-Analysis')).toBe(1);
+    expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
+    expect(entityTypeMap.get('Notifier')).toBe(2);
+    expect(entityTypeMap.get('Label')).toBe(13);
+    expect(entityTypeMap.get('Kill-Chain-Phase')).toBe(2);
+    expect(entityTypeMap.get('External-Reference')).toBe(7);
+    expect(data.edges.length).toEqual(539);
     const createdDates = R.map((e) => e.node.created, data.edges);
     let previousCreatedDate = null;
     for (let index = 0; index < createdDates.length; index += 1) {
@@ -680,10 +834,39 @@ describe('Elasticsearch pagination', () => {
     let data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { includeAuthorities: true });
     expect(data).not.toBeNull();
     const groupByIndices = R.groupBy((e) => e.node._index, data.edges);
-    expect(groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].length).toEqual(106);
+    const internalRelationships = groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].map((m) => m.node);
+    const internalRelationshipsByType = R.groupBy((m) => m.entity_type, internalRelationships);
+    expect(internalRelationshipsByType['accesses-to'].length).toEqual(28);
+    expect(internalRelationshipsByType['has-capability'].length).toEqual(54);
+    expect(internalRelationshipsByType['has-role'].length).toEqual(9);
+    expect(internalRelationshipsByType['member-of'].length).toEqual(13);
+    expect(internalRelationshipsByType['participate-to'].length).toEqual(2);
+
+    const stixCoreRelationships = groupByIndices[`${ES_INDEX_PREFIX}_stix_core_relationships-000001`].map((m) => m.node);
+    const stixCoreRelationshipsByType = R.groupBy((m) => m.entity_type, stixCoreRelationships);
+    expect(stixCoreRelationshipsByType['attributed-to'].length).toEqual(2);
+    expect(stixCoreRelationshipsByType.indicates.length).toEqual(4);
+    expect(stixCoreRelationshipsByType['located-at'].length).toEqual(4);
+    expect(stixCoreRelationshipsByType.mitigates.length).toEqual(1);
+    expect(stixCoreRelationshipsByType['part-of'].length).toEqual(6);
+    expect(stixCoreRelationshipsByType['related-to'].length).toEqual(2);
+    expect(stixCoreRelationshipsByType.targets.length).toEqual(2);
+    expect(stixCoreRelationshipsByType.uses.length).toEqual(3);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_core_relationships-000001`].length).toEqual(24);
+
+    const stixMetaRelationships = groupByIndices[`${ES_INDEX_PREFIX}_stix_meta_relationships-000001`].map((m) => m.node);
+    const stixMetaRelationshipsByType = R.groupBy((m) => m.entity_type, stixMetaRelationships);
+    expect(stixMetaRelationshipsByType['created-by'].length).toEqual(22);
+    expect(stixMetaRelationshipsByType['external-reference'].length).toEqual(7);
+    expect(stixMetaRelationshipsByType['kill-chain-phase'].length).toEqual(3);
+    expect(stixMetaRelationshipsByType['object-label'].length).toEqual(30);
+    expect(stixMetaRelationshipsByType['object-marking'].length).toEqual(28);
+    expect(stixMetaRelationshipsByType['operating-system'].length).toEqual(1);
+    expect(stixMetaRelationshipsByType.object.length).toEqual(38);
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_meta_relationships-000001`].length).toEqual(129);
+
     expect(groupByIndices[`${ES_INDEX_PREFIX}_stix_sighting_relationships-000001`].length).toEqual(2);
+
     const metas = groupByIndices[`${ES_INDEX_PREFIX}_stix_meta_relationships-000001`].map((m) => m.node);
     const metaByEntityType = R.groupBy((m) => m.entity_type, metas);
     expect(metaByEntityType.object.length).toEqual(38);
@@ -692,13 +875,37 @@ describe('Elasticsearch pagination', () => {
     expect(metaByEntityType['external-reference'].length).toEqual(7);
     expect(metaByEntityType['object-marking'].length).toEqual(28);
     expect(metaByEntityType['kill-chain-phase'].length).toEqual(3);
+    expect(metaByEntityType['operating-system'].length).toEqual(1);
     expect(data.edges.length).toEqual(261);
+
     let filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');
     // Same query with no pagination
     data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { connectionFormat: false });
     expect(data).not.toBeNull();
+    const entityTypeMap = mapCountPerEntityType(data);
+    expect(entityTypeMap.get('has-capability')).toBe(54);
+    expect(entityTypeMap.get('accesses-to')).toBe(28);
+    expect(entityTypeMap.get('member-of')).toBe(13);
+    expect(entityTypeMap.get('has-role')).toBe(9);
+    expect(entityTypeMap.get('participate-to')).toBe(2);
+    expect(entityTypeMap.get('uses')).toBe(3);
+    expect(entityTypeMap.get('part-of')).toBe(6);
+    expect(entityTypeMap.get('indicates')).toBe(4);
+    expect(entityTypeMap.get('located-at')).toBe(4);
+    expect(entityTypeMap.get('targets')).toBe(2);
+    expect(entityTypeMap.get('mitigates')).toBe(1);
+    expect(entityTypeMap.get('related-to')).toBe(2);
+    expect(entityTypeMap.get('attributed-to')).toBe(2);
+    expect(entityTypeMap.get('created-by')).toBe(22);
+    expect(entityTypeMap.get('object')).toBe(38);
+    expect(entityTypeMap.get('object-marking')).toBe(28);
+    expect(entityTypeMap.get('object-label')).toBe(30);
+    expect(entityTypeMap.get('kill-chain-phase')).toBe(3);
+    expect(entityTypeMap.get('external-reference')).toBe(7);
+    expect(entityTypeMap.get('operating-system')).toBe(1);
+    expect(entityTypeMap.get('stix-sighting-relationship')).toBe(2);
     expect(data.length).toEqual(261);
     filterBaseTypes = R.uniq(R.map((e) => e.base_type, data));
     expect(filterBaseTypes.length).toEqual(1);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-organization-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-organization-test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { now } from 'moment';
+import { GraphQLError } from 'graphql/index';
+import { enableCEAndUnSetOrganization, enableEEAndSetOrganization } from '../../utils/testQueryHelper';
+import { ADMIN_USER, PLATFORM_ORGANIZATION, testContext, TEST_ORGANIZATION, GREEN_GROUP } from '../../utils/testQuery';
+import type { ThreatActorIndividualAddInput } from '../../../src/generated/graphql';
+import { type BasicStoreEntityOrganization } from '../../../src/modules/organization/organization-types';
+import { addThreatActorIndividual } from '../../../src/modules/threatActorIndividual/threatActorIndividual-domain';
+import type { AuthUser } from '../../../src/types/user';
+import { MARKING_TLP_RED } from '../../../src/schema/identifier';
+import { isFeatureEnabled, ORGA_SHARING_REQUEST_FF } from '../../../src/config/conf';
+import { stixDomainObjectDelete } from '../../../src/domain/stixDomainObject';
+import { DEFAULT_ROLE } from '../../../src/utils/access';
+import { getFakeAuthUser, getGroupEntity, getOrganizationEntity } from '../../utils/domainQueryHelper';
+
+describe('Middleware test coverage on organization sharing verification', () => {
+  let userInPlatformOrg: AuthUser;
+  let userInExternalOrg: AuthUser;
+  let externalOrganizationEntity: BasicStoreEntityOrganization;
+  let platformOrganizationEntity: BasicStoreEntityOrganization;
+
+  beforeAll(async () => {
+    await enableEEAndSetOrganization(PLATFORM_ORGANIZATION);
+
+    platformOrganizationEntity = await getOrganizationEntity(PLATFORM_ORGANIZATION);
+    externalOrganizationEntity = await getOrganizationEntity(TEST_ORGANIZATION);
+    const greenGroup = await getGroupEntity(GREEN_GROUP);
+
+    userInPlatformOrg = getFakeAuthUser('userInPlatformOrgId');
+    userInPlatformOrg.groups = [greenGroup];
+    userInPlatformOrg.roles = [DEFAULT_ROLE];
+    userInPlatformOrg.capabilities = [{ name: 'KNOWLEDGE_KNUPDATE_KNDELETE' }];
+    userInPlatformOrg.inside_platform_organization = true;
+    userInPlatformOrg.organizations = [platformOrganizationEntity];
+
+    userInExternalOrg = getFakeAuthUser('userInPlatformOrgId');
+    userInExternalOrg.groups = [greenGroup];
+    userInExternalOrg.roles = [DEFAULT_ROLE];
+    userInExternalOrg.capabilities = [{ name: 'KNOWLEDGE_KNUPDATE_KNDELETE' }];
+    userInExternalOrg.inside_platform_organization = false;
+    userInExternalOrg.organizations = [externalOrganizationEntity];
+  });
+
+  afterAll(async () => {
+    await enableCEAndUnSetOrganization();
+  });
+
+  describe('Trying to create an existing entity that is not shared to user should raise a dedicated exception.', () => {
+    it('Should raise an AccessRequiredError when entity exists in another organization than the user-s one.', async () => {
+      const threatActorIndividualName = `Testing org segregation ${now()}`;
+      const inputOne: ThreatActorIndividualAddInput = {
+        name: threatActorIndividualName,
+        description: 'Created by user in org platform'
+      };
+      const threatActor = await addThreatActorIndividual(testContext, userInPlatformOrg, inputOne);
+
+      expect(threatActor.id).toBeDefined();
+      try {
+        const inputNext: ThreatActorIndividualAddInput = {
+          name: threatActorIndividualName,
+          description: 'Created by external user'
+        };
+        await addThreatActorIndividual(testContext, userInExternalOrg, inputNext);
+        expect(true, 'An exception should been raised before this line').toBeFalsy();
+      } catch (e) {
+        const exception = e as GraphQLError;
+        if (isFeatureEnabled(ORGA_SHARING_REQUEST_FF)) {
+          expect(exception.message).toBe('Restricted entity already exists, user can request access');
+        } else {
+          expect(exception.message).toBe('Restricted entity already exists');
+        }
+      }
+      await stixDomainObjectDelete(testContext, ADMIN_USER, threatActor.id);
+    });
+
+    it('Should raise an UnsupportedError when entity exists in higher marking than the user-s one.', async () => {
+      const threatActorIndividualName = `Testing marking segregation ${now()}`;
+      const inputOne: ThreatActorIndividualAddInput = {
+        name: threatActorIndividualName,
+        description: 'Created by user with TLP:RED',
+        objectMarking: [MARKING_TLP_RED]
+      };
+      const threatActor = await addThreatActorIndividual(testContext, ADMIN_USER, inputOne);
+      const inputNext: ThreatActorIndividualAddInput = {
+        name: threatActorIndividualName,
+        description: 'Created again by user with less marking',
+      };
+      try {
+        await addThreatActorIndividual(testContext, userInPlatformOrg, inputNext);
+        expect(true, 'An exception should been raised before this line').toBeFalsy();
+      } catch (e) {
+        const exception = e as GraphQLError;
+        expect(exception.message).toBe('Restricted entity already exists');
+      }
+      await stixDomainObjectDelete(testContext, ADMIN_USER, threatActor.id);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -95,7 +95,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(150);
+      expect(deleteEvents.length).toBe(152);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -29,7 +29,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.sighting.length).toBe(4);
       expect(createEventsByTypes.indicator.length).toBe(37);
       expect(createEventsByTypes['attack-pattern'].length).toBe(9);
-      expect(createEventsByTypes['threat-actor'].length).toBe(15);
+      expect(createEventsByTypes['threat-actor'].length).toBe(17);
       expect(createEventsByTypes['observed-data'].length).toBe(1);
       expect(createEventsByTypes['tracking-number'].length).toBe(1);
       expect(createEventsByTypes.credential.length).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -46,7 +46,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.tool.length).toBe(2);
       expect(createEventsByTypes.vocabulary.length).toBe(342); // 328 created at init + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(799);
+      expect(createEvents.length).toBe(801);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/utils/domainQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/domainQueryHelper.ts
@@ -1,0 +1,104 @@
+import { v4 as uuid } from 'uuid';
+import { ADMIN_USER, type GroupTestData, type OrganizationTestData, testContext } from './testQuery';
+import type { StoreEntityConnection } from '../../src/types/store';
+import type { BasicStoreEntityOrganization } from '../../src/modules/organization/organization-types';
+import { findAll as findAllOrganization } from '../../src/modules/organization/organization-domain';
+import { generateStandardId } from '../../src/schema/identifier';
+import { ENTITY_TYPE_GROUP } from '../../src/schema/internalObject';
+import { storeLoadById } from '../../src/database/middleware-loader';
+import type { Group } from '../../src/types/group';
+import type { AuthUser } from '../../src/types/user';
+import { ACCOUNT_STATUS_ACTIVE } from '../../src/config/conf';
+
+/**
+ * Utilities and helper for test that are done at domain level (so direct to database, no graphQL query)
+ */
+
+/**
+ * Resolve test organization data to entity organization.
+ * @param testOrg
+ */
+export const getOrganizationEntity = async (testOrg: OrganizationTestData) => {
+  const allOrgs: StoreEntityConnection<BasicStoreEntityOrganization> = await findAllOrganization(testContext, ADMIN_USER, { search: `"${testOrg.name}"` });
+  return allOrgs.edges.find((currentOrg) => currentOrg.node.name === testOrg.name)?.node as BasicStoreEntityOrganization;
+};
+
+/**
+ * Resolve test group data to entity group.
+ * @param testGroup
+ */
+export const getGroupEntity = async (testGroup: GroupTestData) => {
+  const groupId = generateStandardId(ENTITY_TYPE_GROUP, { name: testGroup.name });
+  const data = await storeLoadById(testContext, ADMIN_USER, groupId, ENTITY_TYPE_GROUP) as Group;
+  return data;
+};
+
+export const getFakeAuthUser = (userName: string) => {
+  const userId = uuid();
+  const user: AuthUser = {
+    api_token: uuid(),
+    individual_id: undefined,
+    administrated_organizations: [],
+    entity_type: 'User',
+    id: userId,
+    internal_id: userId,
+    organizations: [],
+    name: `${userName}`,
+    user_email: `${userName}@opencti.io`,
+    roles: [],
+    groups: [],
+    capabilities: [],
+    all_marking: [],
+    allowed_organizations: [],
+    inside_platform_organization: true,
+    allowed_marking: [],
+    default_marking: [],
+    origin: { referer: 'test', user_id: userId },
+    account_status: ACCOUNT_STATUS_ACTIVE,
+    account_lock_after_date: undefined,
+    effective_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    },
+    user_confidence_level: {
+      max_confidence: 100,
+      overrides: [],
+    },
+    max_shareable_marking: [],
+    restrict_delete: false,
+    no_creators: false
+  };
+  return user;
+};
+
+/**
+ * Helper for counter debug
+ * @param data
+ */
+export const mapEdgesCountPerEntityType = (data: any) => {
+  const map = new Map();
+  for (let i = 0; i < data.edges.length; i += 1) {
+    const entityType = data.edges[i].node.entity_type;
+    if (map.has(entityType)) {
+      const count = map.get(entityType);
+      map.set(entityType, count + 1);
+    } else {
+      map.set(entityType, 1);
+    }
+  }
+  return map;
+};
+
+export const mapCountPerEntityType = (data: any) => {
+  const map = new Map();
+  for (let i = 0; i < data.length; i += 1) {
+    const entityType = data[i].entity_type;
+    if (map.has(entityType)) {
+      const count = map.get(entityType);
+      map.set(entityType, count + 1);
+    } else {
+      map.set(entityType, 1);
+    }
+  }
+  return map;
+};

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1131;
+export const RAW_EVENTS_SIZE = 1135;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -185,7 +185,7 @@ export const ROLE_PLATFORM_ADMIN: Role = {
 TESTING_ROLES.push(ROLE_PLATFORM_ADMIN);
 
 // Groups
-interface Group {
+export interface GroupTestData {
   id: string,
   name: string,
   markings: string[],
@@ -194,9 +194,9 @@ interface Group {
   max_shareable_markings: string[],
 }
 
-export const TESTING_GROUPS: Group[] = [];
+export const TESTING_GROUPS: GroupTestData[] = [];
 
-export const GREEN_GROUP: Group = {
+export const GREEN_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'GREEN GROUP' }),
   name: 'GREEN GROUP',
   markings: [MARKING_TLP_GREEN],
@@ -209,7 +209,7 @@ export const GREEN_GROUP: Group = {
 };
 TESTING_GROUPS.push(GREEN_GROUP);
 
-export const AMBER_GROUP: Group = {
+export const AMBER_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER GROUP' }),
   name: 'AMBER GROUP',
   markings: [MARKING_TLP_AMBER],
@@ -222,7 +222,7 @@ export const AMBER_GROUP: Group = {
 };
 TESTING_GROUPS.push(AMBER_GROUP);
 
-export const AMBER_STRICT_GROUP: Group = {
+export const AMBER_STRICT_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER STRICT GROUP' }),
   name: 'AMBER STRICT GROUP',
   markings: [MARKING_TLP_AMBER_STRICT],
@@ -235,7 +235,7 @@ export const AMBER_STRICT_GROUP: Group = {
 };
 TESTING_GROUPS.push(AMBER_STRICT_GROUP);
 
-export const CONNECTOR_GROUP: Group = {
+export const CONNECTOR_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'TEST CONNECTOR GROUP' }),
   name: 'TEST CONNECTOR GROUP',
   markings: [MARKING_TLP_GREEN],
@@ -248,7 +248,7 @@ export const CONNECTOR_GROUP: Group = {
 };
 TESTING_GROUPS.push(CONNECTOR_GROUP);
 
-export const GREEN_DISINFORMATION_ANALYST_GROUP: Group = {
+export const GREEN_DISINFORMATION_ANALYST_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'GREEN DISINFORMATION ANALYST GROUP' }),
   name: 'GREEN DISINFORMATION ANALYST GROUP',
   markings: [MARKING_TLP_GREEN],
@@ -261,7 +261,7 @@ export const GREEN_DISINFORMATION_ANALYST_GROUP: Group = {
 };
 TESTING_GROUPS.push(GREEN_DISINFORMATION_ANALYST_GROUP);
 
-export const PLATFORM_ADMIN_GROUP: Group = {
+export const PLATFORM_ADMIN_GROUP: GroupTestData = {
   id: generateStandardId(ENTITY_TYPE_GROUP, { name: 'Platform admin group' }),
   name: 'Platform admin group',
   markings: [MARKING_TLP_CLEAR],
@@ -275,29 +275,32 @@ export const PLATFORM_ADMIN_GROUP: Group = {
 TESTING_GROUPS.push(PLATFORM_ADMIN_GROUP);
 
 // Organization
-export interface Organization {
+export interface OrganizationTestData {
   name: string,
   id: string
 }
 
-export const TEST_ORGANIZATION: Organization = {
+export const TESTING_ORGS: OrganizationTestData[] = [];
+export const TEST_ORGANIZATION: OrganizationTestData = {
   name: 'TestOrganization',
   id: generateStandardId(ENTITY_TYPE_IDENTITY_ORGANIZATION, { name: 'TestOrganization', identity_class: 'organization' }),
 };
+TESTING_ORGS.push(TEST_ORGANIZATION);
 
-export const PLATFORM_ORGANIZATION: Organization = {
+export const PLATFORM_ORGANIZATION: OrganizationTestData = {
   name: 'PlatformOrganization',
   id: generateStandardId(ENTITY_TYPE_IDENTITY_ORGANIZATION, { name: 'PlatformOrganization', identity_class: 'organization' }),
 };
+TESTING_ORGS.push(PLATFORM_ORGANIZATION);
 
 // Users
-interface User {
+interface UserTestData {
   id: string,
   email: string,
   password: string,
   roles?: Role[],
-  organizations?: Organization[],
-  groups: Group[],
+  organizations?: OrganizationTestData[],
+  groups: GroupTestData[],
   client: AxiosInstance,
 }
 
@@ -334,8 +337,8 @@ export const ADMIN_USER: AuthUser = {
   restrict_delete: false,
   no_creators: false,
 };
-export const TESTING_USERS: User[] = [];
-export const USER_PARTICIPATE: User = {
+export const TESTING_USERS: UserTestData[] = [];
+export const USER_PARTICIPATE: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'participate@opencti.io' }),
   email: 'participate@opencti.io',
   password: 'participate',
@@ -343,7 +346,7 @@ export const USER_PARTICIPATE: User = {
   client: createHttpClient('participate@opencti.io', 'participate')
 };
 TESTING_USERS.push(USER_PARTICIPATE);
-export const USER_EDITOR: User = {
+export const USER_EDITOR: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'editor@opencti.io' }),
   email: 'editor@opencti.io',
   password: 'editor',
@@ -353,7 +356,7 @@ export const USER_EDITOR: User = {
 };
 TESTING_USERS.push(USER_EDITOR);
 
-export const USER_SECURITY: User = {
+export const USER_SECURITY: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'security@opencti.io' }),
   email: 'security@opencti.io',
   password: 'security',
@@ -363,7 +366,7 @@ export const USER_SECURITY: User = {
 };
 TESTING_USERS.push(USER_SECURITY);
 
-export const USER_CONNECTOR: User = {
+export const USER_CONNECTOR: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'connector@opencti.io' }),
   email: 'connector@opencti.io',
   password: 'connector',
@@ -372,7 +375,7 @@ export const USER_CONNECTOR: User = {
 };
 TESTING_USERS.push(USER_CONNECTOR);
 
-export const USER_DISINFORMATION_ANALYST: User = {
+export const USER_DISINFORMATION_ANALYST: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'anais@opencti.io' }),
   email: 'anais@opencti.io',
   password: 'disinformation',
@@ -381,7 +384,7 @@ export const USER_DISINFORMATION_ANALYST: User = {
 };
 TESTING_USERS.push(USER_DISINFORMATION_ANALYST);
 
-export const USER_PLATFORM_ADMIN: User = {
+export const USER_PLATFORM_ADMIN: UserTestData = {
   id: generateStandardId(ENTITY_TYPE_USER, { user_email: 'platform@opencti.io' }),
   email: 'platform@opencti.io',
   password: 'platformadmin',
@@ -443,7 +446,7 @@ const GROUP_ASSIGN_MUTATION = `
     }
   }
 `;
-const createGroup = async (input: Group): Promise<string> => {
+const createGroup = async (input: GroupTestData): Promise<string> => {
   const { data } = await internalAdminQuery(GROUP_CREATION_MUTATION, {
     input: { name: input.name, group_confidence_level: input.group_confidence_level }
   });
@@ -465,7 +468,7 @@ const createGroup = async (input: Group): Promise<string> => {
   }
   return data.groupAdd.id;
 };
-const assignGroupToUser = async (group: Group, user: User) => {
+const assignGroupToUser = async (group: GroupTestData, user: UserTestData) => {
   await internalAdminQuery(GROUP_ASSIGN_MUTATION, { userId: user.id, toId: group.id });
 };
 // endregion
@@ -499,7 +502,7 @@ const createOrganization = async (input: { name: string }): Promise<string> => {
   return organization.data.organizationAdd.id;
 };
 
-const assignOrganizationToUser = async (organization: Organization, user: User) => {
+const assignOrganizationToUser = async (organization: OrganizationTestData, user: UserTestData) => {
   await internalAdminQuery(ORGANIZATION_ASSIGN_MUTATION, { userId: user.id, toId: organization.id });
 };
 // endregion
@@ -566,7 +569,7 @@ const USER_CREATION_MUTATION = `
     }
   }
 `;
-const createUser = async (user: User) => {
+const createUser = async (user: UserTestData) => {
   // Assign user to groups
   for (let indexGroup = 0; indexGroup < user.groups.length; indexGroup += 1) {
     const group = user.groups[indexGroup];

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -5,12 +5,23 @@ import readline from 'node:readline';
 import fs from 'node:fs';
 import path from 'node:path';
 import Upload from 'graphql-upload/Upload.mjs';
-import { ADMIN_USER, adminQuery, createUnauthenticatedClient, executeInternalQuery, getOrganizationIdByName, type Organization, queryAsAdmin, testContext } from './testQuery';
+import {
+  ADMIN_USER,
+  adminQuery,
+  createUnauthenticatedClient,
+  executeInternalQuery,
+  getOrganizationIdByName,
+  type OrganizationTestData,
+  queryAsAdmin,
+  testContext
+} from './testQuery';
 import { downloadFile, streamConverter } from '../../src/database/file-storage';
 import { logApp } from '../../src/config/conf';
 import { AUTH_REQUIRED, FORBIDDEN_ACCESS } from '../../src/config/errors';
 import { getSettings, settingsEditField } from '../../src/domain/settings';
 import { fileToReadStream } from '../../src/database/file-storage-helper';
+import { resetCacheForEntity } from '../../src/database/cache';
+import { ENTITY_TYPE_SETTINGS } from '../../src/schema/internalObject';
 
 // Helper for test usage whit expect inside.
 // vitest cannot be an import of testQuery, so it must be a separate file.
@@ -161,7 +172,7 @@ export const readCsvFromFileStream = async (filePath: string, fileName: string) 
  * Enable Enterprise edition and set the platform organisation.
  * @param organization organization to use as platform organization.
  */
-export const enableEEAndSetOrganization = async (organization: Organization) => {
+export const enableEEAndSetOrganization = async (organization: OrganizationTestData) => {
   const platformOrganizationId = await getOrganizationIdByName(organization.name);
   const platformSettings: any = await getSettings(testContext);
 
@@ -174,6 +185,7 @@ export const enableEEAndSetOrganization = async (organization: Organization) => 
   expect(settingsResult.platform_organization).not.toBeUndefined();
   expect(settingsResult.enterprise_edition).not.toBeUndefined();
   expect(settingsResult.platform_organization).toEqual(platformOrganizationId);
+  resetCacheForEntity(ENTITY_TYPE_SETTINGS);
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Have a dedicated exception for organization sharing issue on entity creation
* Add test coverage on the new exception
* Add a feature flag ORGA_SHARING_REQUEST_FF

Refactor:
- Add detailled counter (per entity type instead of a global count) in elasticSearch and middleware tests

Counter:
- middleware-organization-test: creates 2 threat-actors and delete them.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* relates but do not close #3345 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
