### PR TITLE
[frontend] Hide actions in Data tab according to capability (#8243)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
@@ -34,6 +34,8 @@ import { FileLine_file$data } from '../../common/files/__generated__/FileLine_fi
 import { scopesConn } from '../../common/stix_core_objects/StixCoreObjectFilesAndHistory';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
+import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -179,18 +181,19 @@ ExternalReferenceFileImportViewerBaseProps
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t_i18n('Uploaded files')}
         </Typography>
-        <div style={{ float: 'left', marginTop: -17 }}>
-          <FileUploader
-            entityId={id}
-            onUploadSuccess={() => {
-              if (relay.refetch) {
-                relay.refetch({ id });
-              }
-            }}
-            size={undefined}
-            placeholderIfNoRights={<div style={{ height: 47 }}/>}
-          />
-        </div>
+        <Security needs={[KNOWLEDGE_KNUPLOAD]} placeholder={<div style={{ height: 30 }} />}>
+          <div style={{ float: 'left', marginTop: -17 }}>
+            <FileUploader
+              entityId={id}
+              onUploadSuccess={() => {
+                if (relay.refetch) {
+                  relay.refetch({ id });
+                }
+              }}
+              size={undefined}
+            />
+          </div>
+        </Security>
         <div className="clearfix" />
         <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
           {importFiles?.edges?.length ? (

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceFileImportViewer.tsx
@@ -188,6 +188,7 @@ ExternalReferenceFileImportViewerBaseProps
               }
             }}
             size={undefined}
+            placeholderIfNoRights={<div style={{ height: 47 }}/>}
           />
         </div>
         <div className="clearfix" />

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as R from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
@@ -27,10 +26,8 @@ const useStyles = makeStyles((theme) => ({
 const ExternalReferenceStixCoreObjectsComponent = ({ externalReference }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
-  const stixCoreObjects = R.map(
-    (n) => n?.node,
-    externalReference.references?.edges ?? [],
-  );
+  const stixCoreObjects = (externalReference.references?.edges ?? [])
+    .map((n) => n?.node);
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -181,7 +181,7 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t('External references')}
         </Typography>
-        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+        <Security needs={[KNOWLEDGE_KNUPDATE]} placeholder={<div style={{ height: 29 }} />}>
           <AddExternalReferences
             stixCoreObjectOrStixCoreRelationshipId={stixSightingRelationshipId}
             stixCoreObjectOrStixCoreRelationshipReferences={

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileImportViewer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileImportViewer.tsx
@@ -13,6 +13,8 @@ import { useFormatter } from '../../../../components/i18n';
 import FreeTextUploader from './FreeTextUploader';
 import { FileImportViewer_entity$data } from './__generated__/FileImportViewer_entity.graphql';
 import { FileLine_file$data } from './__generated__/FileLine_file.graphql';
+import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -65,18 +67,20 @@ FileImportViewerComponentProps
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t_i18n('Uploaded files')}
         </Typography>
-        <div style={{ float: 'left', marginTop: -15 }}>
-          <FileUploader
-            entityId={id}
-            onUploadSuccess={() => relay.refetch({ id })}
-            size="medium"
-          />
-          <FreeTextUploader
-            entityId={id}
-            onUploadSuccess={() => relay.refetch({ id })}
-            size="medium"
-          />
-        </div>
+        <Security needs={[KNOWLEDGE_KNUPLOAD]} placeholder={<div style={{ height: 25 }} />}>
+          <div style={{ float: 'left', marginTop: -15 }}>
+            <FileUploader
+              entityId={id}
+              onUploadSuccess={() => relay.refetch({ id })}
+              size="medium"
+            />
+            <FreeTextUploader
+              entityId={id}
+              onUploadSuccess={() => relay.refetch({ id })}
+              size="medium"
+            />
+          </div>
+        </Security>
         <div className="clearfix" />
         <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
           {importFiles?.edges?.length ? (

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -32,6 +32,8 @@ import { FileLine_file$data } from './__generated__/FileLine_file.graphql';
 import { isNotEmptyField } from '../../../../utils/utils';
 import { truncate } from '../../../../utils/String';
 import ItemMarkings from '../../../../components/ItemMarkings';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNASKIMPORT } from '../../../../utils/hooks/useGranted';
 
 const Transition = React.forwardRef(({ children, ...otherProps }: SlideProps, ref) => (
   <Slide direction='up' ref={ref} {...otherProps}>{children}</Slide>
@@ -367,43 +369,45 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
             </>
           )}
           {!isExternalReferenceAttachment && (
-            <>
-              {isFail || isOutdated ? (
-                <Tooltip title={t_i18n('Delete this file')}>
-                  <span>
-                    <IconButton
-                      disabled={isProgress}
-                      color={nested ? 'inherit' : 'primary'}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleOpenRemove();
-                      }}
-                      size="small"
-                    >
-                      <DeleteOutlined fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              ) : (
-                <Tooltip title={t_i18n('Delete this file')}>
-                  <span>
-                    <IconButton
-                      disabled={isProgress}
-                      color={nested ? 'inherit' : 'primary'}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        handleOpenDelete();
-                      }}
-                      size="small"
-                    >
-                      <DeleteOutlined fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              )}
-            </>
+            <Security needs={[KNOWLEDGE_KNASKIMPORT]}>
+              <>
+                {isFail || isOutdated ? (
+                  <Tooltip title={t_i18n('Delete this file')}>
+                    <span>
+                      <IconButton
+                        disabled={isProgress}
+                        color={nested ? 'inherit' : 'primary'}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          handleOpenRemove();
+                        }}
+                        size="small"
+                      >
+                        <DeleteOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Tooltip title={t_i18n('Delete this file')}>
+                    <span>
+                      <IconButton
+                        disabled={isProgress}
+                        color={nested ? 'inherit' : 'primary'}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          handleOpenDelete();
+                        }}
+                        size="small"
+                      >
+                        <DeleteOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
+              </>
+            </Security>
           )}
         </ListItemSecondaryAction>
       </ListItemButton>

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement, useRef, useState } from 'react';
+import React, { FunctionComponent, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import { CloudUploadOutlined } from '@mui/icons-material';
@@ -11,8 +11,6 @@ import { useFormatter } from '../../../../components/i18n';
 import { FileUploaderEntityMutation$data } from './__generated__/FileUploaderEntityMutation.graphql';
 import { FileUploaderGlobalMutation$data } from './__generated__/FileUploaderGlobalMutation.graphql';
 import FileImportMarkingSelectionPopup from './FileImportMarkingSelectionPopup';
-import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
-import Security from '../../../../utils/Security';
 
 const fileUploaderGlobalMutation = graphql`
   mutation FileUploaderGlobalMutation($file: Upload!, $fileMarkings: [String]) {
@@ -50,7 +48,6 @@ interface FileUploaderProps {
   accept?: string;
   size: 'small' | 'large' | 'medium' | undefined;
   nameInCallback?: boolean;
-  placeholderIfNoRights?: ReactElement;
 }
 
 const FileUploader: FunctionComponent<FileUploaderProps> = ({
@@ -59,7 +56,6 @@ const FileUploader: FunctionComponent<FileUploaderProps> = ({
   accept,
   size,
   nameInCallback,
-  placeholderIfNoRights = <span />,
 }) => {
   const { t_i18n } = useFormatter();
   const uploadRef = useRef<HTMLInputElement | null>(null);
@@ -118,65 +114,64 @@ const FileUploader: FunctionComponent<FileUploaderProps> = ({
   const hasSelectedFile = !!selectedFile;
 
   return (
-    <Security needs={[KNOWLEDGE_KNUPLOAD]} placeholder={placeholderIfNoRights}>
-      <React.Fragment>
-        {accept ? (
-          <input
-            ref={uploadRef}
-            type="file"
-            style={{ display: 'none' }}
-            onChange={({ target: { validity, files } }) => {
-              const file = files?.item(0);
-              if (file && validity.valid) setSelectedFile(file);
-            }}
-            accept={accept}
-          />
-        ) : (
-          <input
-            ref={uploadRef}
-            type="file"
-            style={{ display: 'none' }}
-            onChange={({ target: { validity, files } }) => {
-              const file = files?.item(0);
-              if (file && validity.valid) setSelectedFile(file);
-            }}
-          />
-        )}
-        {hasSelectedFile && (
+
+    <React.Fragment>
+      {accept ? (
+        <input
+          ref={uploadRef}
+          type="file"
+          style={{ display: 'none' }}
+          onChange={({ target: { validity, files } }) => {
+            const file = files?.item(0);
+            if (file && validity.valid) setSelectedFile(file);
+          }}
+          accept={accept}
+        />
+      ) : (
+        <input
+          ref={uploadRef}
+          type="file"
+          style={{ display: 'none' }}
+          onChange={({ target: { validity, files } }) => {
+            const file = files?.item(0);
+            if (file && validity.valid) setSelectedFile(file);
+          }}
+        />
+      )}
+      {hasSelectedFile && (
         <FileImportMarkingSelectionPopup
           isOpen={hasSelectedFile}
           handleUpload={handleUpload}
           closePopup={closeFileImportMarkingSelectionPopup}
           entityId={entityId}
         />
-        )}
-        {upload ? (
-          <Tooltip
-            title={`Uploading ${upload}`}
-            aria-label={`Uploading ${upload}`}
-          >
-            <IconButton disabled={true} size={size || 'large'}>
-              <CircularProgress
-                size={24}
-                thickness={2}
-                color="primary"
-              />
-            </IconButton>
-          </Tooltip>
-        ) : (
-          <Tooltip title={t_i18n('Select your file')} aria-label="Select your file">
-            <IconButton
-              onClick={handleOpenUpload}
-              aria-haspopup="true"
+      )}
+      {upload ? (
+        <Tooltip
+          title={`Uploading ${upload}`}
+          aria-label={`Uploading ${upload}`}
+        >
+          <IconButton disabled={true} size={size || 'large'}>
+            <CircularProgress
+              size={24}
+              thickness={2}
               color="primary"
-              size={size || 'large'}
-            >
-              <CloudUploadOutlined />
-            </IconButton>
-          </Tooltip>
-        )}
-      </React.Fragment>
-    </Security>
+            />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title={t_i18n('Select your file')} aria-label="Select your file">
+          <IconButton
+            onClick={handleOpenUpload}
+            aria-haspopup="true"
+            color="primary"
+            size={size || 'large'}
+          >
+            <CloudUploadOutlined />
+          </IconButton>
+        </Tooltip>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useRef, useState } from 'react';
+import React, { FunctionComponent, ReactElement, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import { CloudUploadOutlined } from '@mui/icons-material';
@@ -50,6 +50,7 @@ interface FileUploaderProps {
   accept?: string;
   size: 'small' | 'large' | 'medium' | undefined;
   nameInCallback?: boolean;
+  placeholderIfNoRights?: ReactElement;
 }
 
 const FileUploader: FunctionComponent<FileUploaderProps> = ({
@@ -58,6 +59,7 @@ const FileUploader: FunctionComponent<FileUploaderProps> = ({
   accept,
   size,
   nameInCallback,
+  placeholderIfNoRights = <span />,
 }) => {
   const { t_i18n } = useFormatter();
   const uploadRef = useRef<HTMLInputElement | null>(null);
@@ -116,7 +118,7 @@ const FileUploader: FunctionComponent<FileUploaderProps> = ({
   const hasSelectedFile = !!selectedFile;
 
   return (
-    <Security needs={[KNOWLEDGE_KNUPLOAD]}>
+    <Security needs={[KNOWLEDGE_KNUPLOAD]} placeholder={placeholderIfNoRights}>
       <React.Fragment>
         {accept ? (
           <input

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
@@ -11,6 +11,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { FileUploaderEntityMutation$data } from './__generated__/FileUploaderEntityMutation.graphql';
 import { FileUploaderGlobalMutation$data } from './__generated__/FileUploaderGlobalMutation.graphql';
 import FileImportMarkingSelectionPopup from './FileImportMarkingSelectionPopup';
+import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 const fileUploaderGlobalMutation = graphql`
   mutation FileUploaderGlobalMutation($file: Upload!, $fileMarkings: [String]) {
@@ -114,63 +116,65 @@ const FileUploader: FunctionComponent<FileUploaderProps> = ({
   const hasSelectedFile = !!selectedFile;
 
   return (
-    <React.Fragment>
-      {accept ? (
-        <input
-          ref={uploadRef}
-          type="file"
-          style={{ display: 'none' }}
-          onChange={({ target: { validity, files } }) => {
-            const file = files?.item(0);
-            if (file && validity.valid) setSelectedFile(file);
-          }}
-          accept={accept}
-        />
-      ) : (
-        <input
-          ref={uploadRef}
-          type="file"
-          style={{ display: 'none' }}
-          onChange={({ target: { validity, files } }) => {
-            const file = files?.item(0);
-            if (file && validity.valid) setSelectedFile(file);
-          }}
-        />
-      )}
-      {hasSelectedFile && (
+    <Security needs={[KNOWLEDGE_KNUPLOAD]}>
+      <React.Fragment>
+        {accept ? (
+          <input
+            ref={uploadRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={({ target: { validity, files } }) => {
+              const file = files?.item(0);
+              if (file && validity.valid) setSelectedFile(file);
+            }}
+            accept={accept}
+          />
+        ) : (
+          <input
+            ref={uploadRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={({ target: { validity, files } }) => {
+              const file = files?.item(0);
+              if (file && validity.valid) setSelectedFile(file);
+            }}
+          />
+        )}
+        {hasSelectedFile && (
         <FileImportMarkingSelectionPopup
           isOpen={hasSelectedFile}
           handleUpload={handleUpload}
           closePopup={closeFileImportMarkingSelectionPopup}
           entityId={entityId}
         />
-      )}
-      {upload ? (
-        <Tooltip
-          title={`Uploading ${upload}`}
-          aria-label={`Uploading ${upload}`}
-        >
-          <IconButton disabled={true} size={size || 'large'}>
-            <CircularProgress
-              size={24}
-              thickness={2}
-              color="primary"
-            />
-          </IconButton>
-        </Tooltip>
-      ) : (
-        <Tooltip title={t_i18n('Select your file')} aria-label="Select your file">
-          <IconButton
-            onClick={handleOpenUpload}
-            aria-haspopup="true"
-            color="primary"
-            size={size || 'large'}
+        )}
+        {upload ? (
+          <Tooltip
+            title={`Uploading ${upload}`}
+            aria-label={`Uploading ${upload}`}
           >
-            <CloudUploadOutlined />
-          </IconButton>
-        </Tooltip>
-      )}
-    </React.Fragment>
+            <IconButton disabled={true} size={size || 'large'}>
+              <CircularProgress
+                size={24}
+                thickness={2}
+                color="primary"
+              />
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Tooltip title={t_i18n('Select your file')} aria-label="Select your file">
+            <IconButton
+              onClick={handleOpenUpload}
+              aria-haspopup="true"
+              color="primary"
+              size={size || 'large'}
+            >
+              <CloudUploadOutlined />
+            </IconButton>
+          </Tooltip>
+        )}
+      </React.Fragment>
+    </Security>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/FreeTextUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FreeTextUploader.tsx
@@ -18,6 +18,8 @@ import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
 import { now } from '../../../../utils/Time';
 import { isValidStixBundle } from '../../../../utils/String';
+import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 const freeTextUploaderGlobalMutation = graphql`
   mutation FreeTextUploaderGlobalMutation($file: Upload!, $fileMarkings: [String]) {
@@ -114,73 +116,75 @@ const FreeTextUploader = ({ color, entityId, onUploadSuccess, size }: FreeTextUp
   };
 
   return (
-    <>
-      <Tooltip title={t_i18n('Copy/paste text content')}>
-        <IconButton
-          color={color || 'primary'}
-          onClick={handleOpen}
-          size={size || 'large'}
-        >
-          <TextFieldsOutlined />
-        </IconButton>
-      </Tooltip>
-      <Formik<SubmittedValuesType>
-        enableReinitialize={true}
-        initialValues={{
-          content: '',
-          fileMarkings: [],
-        }}
-        onSubmit={handleSubmit}
-        validationSchema={freeTextValidation(t_i18n)}
-      >
-        {({ handleReset, isSubmitting, setFieldValue, submitForm }) => (
-          <Dialog
-            fullWidth={true}
-            onClose={handleClose}
-            open={isOpen}
-            PaperProps={{ elevation: 1 }}
+    <Security needs={[KNOWLEDGE_KNUPLOAD]}>
+      <>
+        <Tooltip title={t_i18n('Copy/paste text content')}>
+          <IconButton
+            color={color || 'primary'}
+            onClick={handleOpen}
+            size={size || 'large'}
           >
-            <DialogTitle>{t_i18n('Free text import')}</DialogTitle>
-            <DialogContent>
-              <Field
-                component={TextField}
-                fullWidth={true}
-                label={t_i18n('Content')}
-                multiline={true}
-                name="content"
-                rows="8"
-                variant="standard"
-              />
-              <ObjectMarkingField
-                label={t_i18n('File marking definition levels')}
-                name="fileMarkings"
-                style={fieldSpacingContainerStyle}
-                onChange={() => {
+            <TextFieldsOutlined />
+          </IconButton>
+        </Tooltip>
+        <Formik<SubmittedValuesType>
+          enableReinitialize={true}
+          initialValues={{
+            content: '',
+            fileMarkings: [],
+          }}
+          onSubmit={handleSubmit}
+          validationSchema={freeTextValidation(t_i18n)}
+        >
+          {({ handleReset, isSubmitting, setFieldValue, submitForm }) => (
+            <Dialog
+              fullWidth={true}
+              onClose={handleClose}
+              open={isOpen}
+              PaperProps={{ elevation: 1 }}
+            >
+              <DialogTitle>{t_i18n('Free text import')}</DialogTitle>
+              <DialogContent>
+                <Field
+                  component={TextField}
+                  fullWidth={true}
+                  label={t_i18n('Content')}
+                  multiline={true}
+                  name="content"
+                  rows="8"
+                  variant="standard"
+                />
+                <ObjectMarkingField
+                  label={t_i18n('File marking definition levels')}
+                  name="fileMarkings"
+                  style={fieldSpacingContainerStyle}
+                  onChange={() => {
+                  }}
+                  setFieldValue={setFieldValue}
+                  required={false}
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button disabled={isSubmitting} onClick={() => {
+                  handleReset();
+                  handleClose();
                 }}
-                setFieldValue={setFieldValue}
-                required={false}
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button disabled={isSubmitting} onClick={() => {
-                handleReset();
-                handleClose();
-              }}
-              >
-                {t_i18n('Cancel')}
-              </Button>
-              <Button
-                color="secondary"
-                disabled={isSubmitting}
-                onClick={submitForm}
-              >
-                {t_i18n('Import')}
-              </Button>
-            </DialogActions>
-          </Dialog>
-        )}
-      </Formik>
-    </>
+                >
+                  {t_i18n('Cancel')}
+                </Button>
+                <Button
+                  color="secondary"
+                  disabled={isSubmitting}
+                  onClick={submitForm}
+                >
+                  {t_i18n('Import')}
+                </Button>
+              </DialogActions>
+            </Dialog>
+          )}
+        </Formik>
+      </>
+    </Security>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
@@ -14,6 +14,8 @@ import { TEN_SECONDS } from '../../../../../utils/Time';
 import inject18n from '../../../../../components/i18n';
 import WorkbenchFileLine from './WorkbenchFileLine';
 import WorkbenchFileCreator from './WorkbenchFileCreator';
+import { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from "../../../../../utils/hooks/useGranted";
+import Security from "../../../../../utils/Security";
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -60,15 +62,17 @@ const WorkbenchFileViewerBase = ({
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t('Analyst workbenches')}
         </Typography>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={() => setOpenCreate(true)}
-          classes={{ root: classes.createButton }}
-          size="large"
-        >
-          <Add fontSize="small" />
-        </IconButton>
+        <Security needs={[KNOWLEDGE_KNASKIMPORT]}>
+          <IconButton
+            color="primary"
+            aria-label="Add"
+            onClick={() => setOpenCreate(true)}
+            classes={{ root: classes.createButton }}
+            size="large"
+          >
+            <Add fontSize="small" />
+          </IconButton>
+        </Security>
         <WorkbenchFileCreator
           handleCloseCreate={() => setOpenCreate(false)}
           openCreate={openCreate}

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
@@ -62,7 +62,7 @@ const WorkbenchFileViewerBase = ({
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t('Analyst workbenches')}
         </Typography>
-        <Security needs={[KNOWLEDGE_KNASKIMPORT]} placeholder={<div style={{ height: 22 }}/>}>
+        <Security needs={[KNOWLEDGE_KNASKIMPORT]} placeholder={<div style={{ height: 28 }}/>}>
           <IconButton
             color="primary"
             aria-label="Add"

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileViewer.jsx
@@ -14,8 +14,8 @@ import { TEN_SECONDS } from '../../../../../utils/Time';
 import inject18n from '../../../../../components/i18n';
 import WorkbenchFileLine from './WorkbenchFileLine';
 import WorkbenchFileCreator from './WorkbenchFileCreator';
-import { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from "../../../../../utils/hooks/useGranted";
-import Security from "../../../../../utils/Security";
+import { KNOWLEDGE_KNASKIMPORT } from '../../../../../utils/hooks/useGranted';
+import Security from '../../../../../utils/Security';
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -62,7 +62,7 @@ const WorkbenchFileViewerBase = ({
         <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
           {t('Analyst workbenches')}
         </Typography>
-        <Security needs={[KNOWLEDGE_KNASKIMPORT]}>
+        <Security needs={[KNOWLEDGE_KNASKIMPORT]} placeholder={<div style={{ height: 22 }}/>}>
           <IconButton
             color="primary"
             aria-label="Add"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
@@ -29,6 +29,8 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import type { Template } from '../../../../utils/outcome_template/template';
 import { MESSAGING$ } from '../../../../relay/environment';
+import { KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 interface ContentBlocProps {
   title: ReactNode
@@ -257,12 +259,14 @@ const StixCoreObjectContentFiles: FunctionComponent<StixCoreObjectContentFilesPr
       <ContentBloc
         title={t_i18n('Files')}
         actions={(<>
-          <FileUploader
-            entityId={stixCoreObjectId}
-            onUploadSuccess={onFileChange}
-            size="small"
-            nameInCallback={true}
-          />
+          <Security needs={[KNOWLEDGE_KNUPLOAD]}>
+            <FileUploader
+              entityId={stixCoreObjectId}
+              onUploadSuccess={onFileChange}
+              size="small"
+              nameInCallback={true}
+            />
+          </Security>
           <IconButton
             onClick={handleOpenCreate}
             color="primary"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
@@ -258,24 +258,25 @@ const StixCoreObjectContentFiles: FunctionComponent<StixCoreObjectContentFilesPr
 
       <ContentBloc
         title={t_i18n('Files')}
-        actions={(<>
+        actions={(
           <Security needs={[KNOWLEDGE_KNUPLOAD]}>
-            <FileUploader
-              entityId={stixCoreObjectId}
-              onUploadSuccess={onFileChange}
-              size="small"
-              nameInCallback={true}
-            />
-          </Security>
-          <IconButton
-            onClick={handleOpenCreate}
-            color="primary"
-            size="small"
-            aria-label={t_i18n('Add a file')}
-          >
-            <AddOutlined />
-          </IconButton>
-        </>)}
+            <>
+              <FileUploader
+                entityId={stixCoreObjectId}
+                onUploadSuccess={onFileChange}
+                size="small"
+                nameInCallback={true}
+              />
+              <IconButton
+                onClick={handleOpenCreate}
+                color="primary"
+                size="small"
+                aria-label={t_i18n('Add a file')}
+              >
+                <AddOutlined />
+              </IconButton>
+            </>
+          </Security>)}
       >
         <StixCoreObjectContentFilesList
           files={filesList}


### PR DESCRIPTION
### Proposed changes
In Data tab of an entity:
- Hide upload button if not the capa 'upload knowledge files'
- Hide the create a workbench button if not the capa 'import knowledge'

In a sighting overview: fix the padding of the external references tab if the user has not the capa to add an external reference

In the content tab of an entity:
hide the upload button if not the capa 'upload knowledge files'

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8243
