### PR TITLE
[frontend] The default "Latest Reports" dashboard widget list recent reports, not the oldest one

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -465,7 +465,6 @@ const DefaultDashboard = ({ timeField }) => {
           <StixCoreObjectsList
             title={t_i18n('Latest reports')}
             height={410}
-            parameters={{ number: 20 }}
             widgetId={'default_latest_reports_widget'}
             dataSelection={[{
               filters: {

--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -478,7 +478,6 @@ const DefaultDashboard = ({ timeField }) => {
                 filterGroups: [],
               },
               date_attribute: timeField === 'functional' ? 'start_time' : 'created_at',
-              sort_by: timeField === 'functional' ? 'start_time' : 'created_at',
               sort_mode: 'desc',
             }]}
           />

--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -465,6 +465,7 @@ const DefaultDashboard = ({ timeField }) => {
           <StixCoreObjectsList
             title={t_i18n('Latest reports')}
             height={410}
+            parameters={{ number: 20 }}
             widgetId={'default_latest_reports_widget'}
             dataSelection={[{
               filters: {
@@ -478,6 +479,8 @@ const DefaultDashboard = ({ timeField }) => {
                 filterGroups: [],
               },
               date_attribute: timeField === 'functional' ? 'start_time' : 'created_at',
+              sort_by: timeField === 'functional' ? 'start_time' : 'created_at',
+              sort_mode: 'desc',
             }]}
           />
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
@@ -258,7 +258,7 @@ const StixCoreObjectsList = ({
           types: dataSelectionTypes,
           first: selection.number ?? 10,
           orderBy: sortBy,
-          orderMode: selection.sort_mode ?? 'desc',
+          orderMode: selection.sort_mode ?? 'asc',
           filters,
         }}
         render={({ props }) => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
@@ -258,7 +258,7 @@ const StixCoreObjectsList = ({
           types: dataSelectionTypes,
           first: selection.number ?? 10,
           orderBy: sortBy,
-          orderMode: selection.sort_mode ?? 'asc',
+          orderMode: selection.sort_mode ?? 'desc',
           filters,
         }}
         render={({ props }) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change orderMode from 'asc' to 'desc' 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9264 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
