### PR TITLE
[frontend] Fix missing Task name on reload in related entities (#9191)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
@@ -233,6 +233,9 @@ export const ContainerStixObjectOrStixRelationshipLine = createFragmentContainer
         ... on Malware {
           name
         }
+        ... on Task {
+          name
+        }
         ... on ThreatActor {
           name
         }
@@ -349,6 +352,9 @@ export const ContainerStixObjectOrStixRelationshipLine = createFragmentContainer
             ... on Malware {
               name
             }
+            ... on Task {
+              name
+            }
             ... on ThreatActor {
               name
             }
@@ -438,6 +444,9 @@ export const ContainerStixObjectOrStixRelationshipLine = createFragmentContainer
               name
             }
             ... on Malware {
+              name
+            }
+            ... on Task {
               name
             }
             ... on ThreatActor {
@@ -548,6 +557,9 @@ export const ContainerStixObjectOrStixRelationshipLine = createFragmentContainer
               name
             }
             ... on Malware {
+              name
+            }
+            ... on Task {
               name
             }
             ... on ThreatActor {


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adding task name to fragment `ContainerStixObjectOrStixRelationshipLine_node`

#### Before:
![image](https://github.com/user-attachments/assets/abd3cb28-6696-4883-85ba-b77fed1f81f5)

#### After: 
![image](https://github.com/user-attachments/assets/55e02503-e1b6-4c88-b510-6729168a63a4)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/9191

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
