### PR TITLE
[frontend] Align containers view with enrich and enroll (#9367)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -119,6 +119,8 @@ const RootMalwareAnalysis = () => {
                       </Security>
                     )}
                     noAliases={true}
+                    enableEnricher={true}
+                    enableEnrollPlaybook={true}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -146,7 +146,8 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
                   <ChannelEdition channelId={channel.id} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -152,7 +152,8 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
                   />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -146,7 +146,8 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
                   <ToolEdition toolId={tool.id} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -146,7 +146,8 @@ const RootVulnerability = ({ queryRef, vulnerabilityId }: RootVulnerabilityProps
                   <VulnerabilityEdition vulnerabilityId={vulnerabilityId} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -144,6 +144,8 @@ const RootEvent = ({ eventId, queryRef }: RootEventProps) => {
                   <EventEdition eventId={event.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
             />
             <Box
               sx={{

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -179,6 +179,8 @@ const RootIndividual = ({ individualId, queryRef }: RootIndividualProps) => {
                   <IndividualEdition individualId={individual.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               onViewAs={handleChangeViewAs}
               viewAs={viewAs}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -178,6 +178,8 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
                   <OrganizationEdition organizationId={organization.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               onViewAs={handleChangeViewAs}
               viewAs={viewAs}
             />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -149,6 +149,8 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
                   <SectorEdition sectorId={sector.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
             />
             <Box
               sx={{

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -166,13 +166,14 @@ const RootSystem = ({ systemId, queryRef }: RootSystemProps) => {
               stixDomainObject={system}
               isOpenctiAlias={true}
               enableQuickSubscription={true}
-              enableEnricher={true}
               PopoverComponent={<SystemPopover id={system.id}/>}
               EditComponent={isFABReplaced && (
                 <Security needs={[KNOWLEDGE_KNUPDATE]}>
                   <SystemEdition systemId={system.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               onViewAs={handleChangeViewAs}
               viewAs={viewAs}
             />

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -149,6 +149,8 @@ const RootIncidentComponent = ({ queryRef }) => {
                 </Security>
               )}
               enableQuickSubscription={true}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
             />
             <Box
               sx={{

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.jsx
@@ -130,7 +130,8 @@ class RootObservedData extends Component {
                     )}
                     redirectToContent = {false}
                     disableAuthorizedMembers={true}
-                    enableEnricher={false}
+                    enableEnricher={true}
+                    enableEnrollPlaybook={true}
                   />
                   <Box
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -147,6 +147,8 @@ const RootAdministrativeAreaComponent = ({ queryRef, administrativeAreaId }) => 
                   />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -141,6 +141,8 @@ const RootCityComponent = ({ queryRef, cityId }) => {
                   <CityEdition cityId={city.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -144,6 +144,8 @@ const RootCountryComponent = ({ queryRef, countryId }) => {
                   <CountryEdition countryId={country.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -148,6 +148,8 @@ const RootPosition = ({ positionId, queryRef }: RootPositionProps) => {
                   <PositionEdition positionId={position.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -146,6 +146,8 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
                   <RegionEdition regionId={region.id} />
                 </Security>
               )}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
               isOpenctiAlias={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -119,8 +119,9 @@ const RootIndicator = ({ indicatorId, queryRef }: RootIndicatorProps) => {
                 <IndicatorEdition indicatorId={indicator.id} />
               </Security>
             )}
-            noAliases={true}
+            enableEnricher={true}
             enableEnrollPlaybook={true}
+            noAliases={true}
           />
           <Box
             sx={{

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -118,6 +118,8 @@ const RootInfrastructureComponent = ({ queryRef, infrastructureId }) => {
                 <InfrastructureEdition infrastructureId={infrastructure.id} />
               </Security>
             )}
+            enableEnricher={true}
+            enableEnrollPlaybook={true}
             enableQuickSubscription={true}
           />
           <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -146,7 +146,8 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
                   <CampaignEdition campaignId={campaign.id} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -152,7 +152,8 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
                   <IntrusionSetEdition intrusionSetId={intrusionSet.id} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -152,7 +152,8 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
                   <ThreatActorGroupEdition threatActorGroupId={threatActorGroup.id} />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -166,7 +166,8 @@ const RootThreatActorIndividualComponent = ({
                   />
                 </Security>
               )}
-              enableEnricher={isFABReplaced}
+              enableEnricher={true}
+              enableEnrollPlaybook={true}
               enableQuickSubscription={true}
             />
             <Box


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Align every view with enrich and enroll:

- [ ] Reports
- [x] Groupings
- [ ] Malware Analyses
- [x] Notes
- [ ] Incidents
- [ ] Observed Data
- [ ] Observables
- [ ] Artifact
- [ ] Indicators
- [ ] Infrastructures
- [ ] all Threats
- [ ] all Arsenal
- [ ] all Entities (except systems)
- [ ] Systems
- [ ] all Locations

With `FAB_REPLACEMENT` feature flag
- [x] Reports
- [x] Groupings
- [x] Malware Analyses
- [x] Notes
- [x] Incidents
- [x] Observed Data
- [ ] Observables
- [ ] Artifact
- [x] Indicators
- [x] Infrastructures
- [x] all Threats
- [x] all Arsenal
- [x] all Entities (except systems)
- [x] Systems
- [x] all Locations

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/9367


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Current state:

- Reports >enrich + enroll in popover
- Grouoings > No enrich, no Enroll
- Malware Analyses > No enrich, no Enroll
- Notes > No enrich, no Enroll
- Incidents > No enrich, no Enroll
- Observed Data > No enrich, no Enroll
- Observables > enrich CTA, enroll in popover
- Artifact >  enrich CTA, enroll in popover
- Indicators > enrich +enroll in popover
- Infrastructures > No enrich, no Enroll
- all Threats >enrich in popover, no enroll
- all Arsenal >enrich in popover, no enroll
- all Entities  (except systems) > No enrich, no Enroll
- Systems > enrich CTA, no enroll
- all Locations > No enrich, no Enroll
