### PR TITLE
[frontend/backend] Enabled/disabled “authorized members” in Containers' form creation + default values  (#4961)

### DIFF
--- a/opencti-platform/opencti-front/src/components/Accordion.jsx
+++ b/opencti-platform/opencti-front/src/components/Accordion.jsx
@@ -9,12 +9,15 @@ export const Accordion = styled((props) => (<MuiAccordion disableGutters elevati
   '&:before': {
     display: 'none',
   },
+  borderRadius: '4px',
+  backgroundColor: 'rgba(255, 255, 255, 0)',
 }));
 
 export const AccordionSummary = styled((props) => (
   <MuiAccordionSummary expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.9rem' }} />} {...props}/>
 ))(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, .05)' : 'rgba(0, 0, 0, .03)',
+  // backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, .05)' : 'rgba(0, 0, 0, .03)',
+  backgroundColor: 'rgba(255, 255, 255, .05)',
   flexDirection: 'row-reverse',
   '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
     transform: 'rotate(90deg)',

--- a/opencti-platform/opencti-front/src/components/Accordion.jsx
+++ b/opencti-platform/opencti-front/src/components/Accordion.jsx
@@ -16,8 +16,7 @@ export const Accordion = styled((props) => (<MuiAccordion disableGutters elevati
 export const AccordionSummary = styled((props) => (
   <MuiAccordionSummary expandIcon={<ArrowForwardIosSharpIcon sx={{ fontSize: '0.9rem' }} />} {...props}/>
 ))(({ theme }) => ({
-  // backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, .05)' : 'rgba(0, 0, 0, .03)',
-  backgroundColor: 'rgba(255, 255, 255, .05)',
+  backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, .05)' : 'rgba(0, 0, 0, .03)',
   flexDirection: 'row-reverse',
   '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
     transform: 'rotate(90deg)',

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -124,6 +124,7 @@ const meUserFragment = graphql`
   fragment RootMe_data on MeUser {
     id
     name
+    entity_type
     lastname
     language
     theme

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -33,6 +33,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
+import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -228,22 +230,26 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
-          <Alert
-            icon={false}
-            classes={{ root: classes.alert, message: classes.message }}
-            severity="warning"
-            variant="outlined"
-            style={fieldSpacingContainerStyle}
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
-            <Field
-              name={'authorizedMembers'}
-              component={AuthorizedMembersField}
-              showAllMembersLine
-              showCreatorLine
-              canDeactivate
-              disabled={isSubmitting}
-            />
-          </Alert>
+            <Alert
+              icon={false}
+              classes={{ root: classes.alert, message: classes.message }}
+              severity="warning"
+              variant="outlined"
+              style={fieldSpacingContainerStyle}
+            >
+              <Field
+                name={'authorizedMembers'}
+                component={AuthorizedMembersField}
+                showAllMembersLine
+                showCreatorLine
+                canDeactivate
+                disabled={isSubmitting}
+              />
+            </Alert>
+          </Security>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -293,7 +293,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
                 </AccordionSummary>
                 <AccordionDetails>
                   <Field
-                    name={'authorizedMembers'}
+                    name={'authorized_members'}
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -294,7 +294,6 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine
-                    showCreatorLine
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -300,7 +300,6 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights
-                    owner={values.createdBy}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -106,6 +106,10 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const { mandatoryAttributes } = useIsMandatoryAttribute(GROUPING_TYPE);
+
+  const { isFeatureEnable } = useHelper();
+  const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
+
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2),
     confidence: Yup.number().nullable(),
@@ -273,6 +277,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          {isAccessRestrictionCreationEnable && (
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
@@ -297,6 +302,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
               </Accordion>
             </div>
           </Security>
+          )}
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -10,6 +10,8 @@ import { FormikConfig } from 'formik/dist/types';
 import { useNavigate } from 'react-router-dom';
 import useHelper from 'src/utils/hooks/useHelper';
 import { GroupingsLinesPaginationQuery$variables } from '@components/analyses/__generated__/GroupingsLinesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
+import Alert from '@mui/material/Alert';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
@@ -71,6 +73,7 @@ interface GroupingAddInput {
   objectLabel: Option[];
   externalReferences: { value: string }[];
   file: File | undefined;
+  authorizedMembers: Option[];
 }
 
 interface GroupingFormProps {
@@ -108,6 +111,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
     createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
     file: Yup.mixed().nullable(),
+    authorized_members: Yup.array().nullable(),
   }, mandatoryAttributes);
   const validator = useDynamicSchemaCreationValidation(
     mandatoryAttributes,
@@ -133,6 +137,10 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
+      authorized_members: values.authorizedMembers.map(({ value }) => ({
+        id: value,
+        access_right: '',
+      })),
     };
     commit({
       variables: {
@@ -173,6 +181,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
+    authorizedMembers: [],
   });
 
   return (
@@ -219,6 +228,22 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
+          <Alert
+            icon={false}
+            classes={{ root: classes.alert, message: classes.message }}
+            severity="warning"
+            variant="outlined"
+            style={fieldSpacingContainerStyle}
+          >
+            <Field
+              name={'authorizedMembers'}
+              component={AuthorizedMembersField}
+              showAllMembersLine
+              showCreatorLine
+              canDeactivate
+              disabled={isSubmitting}
+            />
+          </Alert>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -11,7 +11,8 @@ import { useNavigate } from 'react-router-dom';
 import useHelper from 'src/utils/hooks/useHelper';
 import { GroupingsLinesPaginationQuery$variables } from '@components/analyses/__generated__/GroupingsLinesPaginationQuery.graphql';
 import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
-import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
@@ -35,6 +36,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -75,7 +77,7 @@ interface GroupingAddInput {
   objectLabel: Option[];
   externalReferences: { value: string }[];
   file: File | undefined;
-  authorizedMembers: Option[];
+  authorizedMembers: { value: string, accessRight: string }[];
 }
 
 interface GroupingFormProps {
@@ -139,9 +141,9 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value }) => ({
+      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
         id: value,
-        access_right: '',
+        access_right: accessRight,
       })),
     };
     commit({
@@ -230,28 +232,6 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <Alert
-              icon={false}
-              classes={{ root: classes.alert, message: classes.message }}
-              severity="warning"
-              variant="outlined"
-              style={fieldSpacingContainerStyle}
-            >
-              <Field
-                name={'authorizedMembers'}
-                component={AuthorizedMembersField}
-                showAllMembersLine
-                showCreatorLine
-                canDeactivate
-                disabled={isSubmitting}
-                addMeUserWithAdminRights
-                owner={values.createdBy}
-              />
-            </Alert>
-          </Security>
           <Field
             component={RichTextField}
             name="content"
@@ -293,6 +273,30 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+          >
+            <div style={fieldSpacingContainerStyle}>
+              <Accordion >
+                <AccordionSummary id="accordion-panel">
+                  <Typography>{t_i18n('Advanced options')}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Field
+                    name={'authorizedMembers'}
+                    component={AuthorizedMembersField}
+                    containerstyle={{ marginTop: 20 }}
+                    showAllMembersLine
+                    showCreatorLine
+                    canDeactivate
+                    disabled={isSubmitting}
+                    addMeUserWithAdminRights
+                    owner={values.createdBy}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </div>
+          </Security>
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -247,6 +247,8 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
                 showCreatorLine
                 canDeactivate
                 disabled={isSubmitting}
+                addMeUserWithAdminRights
+                owner={values.createdBy}
               />
             </Alert>
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -145,10 +145,12 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
-        id: value,
-        access_right: accessRight,
-      })),
+      ...(isAccessRestrictionCreationEnable && {
+        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+          id: value,
+          access_right: accessRight,
+        })),
+      }),
     };
     commit({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -10,6 +10,8 @@ import { useNavigate } from 'react-router-dom';
 import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/common/drawer/Drawer';
 import useHelper from 'src/utils/hooks/useHelper';
 import { ReportsLinesPaginationQuery$variables } from '@components/analyses/__generated__/ReportsLinesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
+import Alert from '@mui/material/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -79,6 +81,7 @@ interface ReportAddInput {
   objectParticipant: Option[];
   externalReferences: { value: string }[];
   file: File | undefined;
+  authorizedMembers: Option[];
 }
 
 interface ReportFormProps {
@@ -122,6 +125,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
     objectMarking: Yup.array().nullable(),
     externalReferences: Yup.array().nullable(),
     file: Yup.mixed().nullable(),
+    authorized_members: Yup.array().nullable(),
   }, mandatoryAttributes);
   const reportValidator = useDynamicSchemaCreationValidation(
     mandatoryAttributes,
@@ -136,6 +140,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
     values,
     { setSubmitting, setErrors, resetForm },
   ) => {
+    console.log('VALUES', values);
     const input: ReportCreationMutation$variables['input'] = {
       name: values.name,
       description: values.description,
@@ -151,6 +156,10 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
+      authorized_members: values.authorizedMembers.map(({ value }) => ({
+        id: value,
+        access_right: '',
+      })),
     };
     commit({
       variables: {
@@ -194,6 +203,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
+    authorizedMembers: [],
   });
   return (
     <Formik<ReportAddInput>
@@ -259,6 +269,22 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
+          <Alert
+            icon={false}
+            classes={{ root: classes.alert, message: classes.message }}
+            severity="warning"
+            variant="outlined"
+            style={fieldSpacingContainerStyle}
+          >
+            <Field
+              name={'authorizedMembers'}
+              component={AuthorizedMembersField}
+              showAllMembersLine
+              showCreatorLine
+              canDeactivate
+              disabled={isSubmitting}
+            />
+          </Alert>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -83,7 +83,7 @@ interface ReportAddInput {
   objectParticipant: Option[];
   externalReferences: { value: string }[];
   file: File | undefined;
-  authorizedMembers: Option[];
+  authorizedMembers: { value: string, accessRight: string }[];
 }
 
 interface ReportFormProps {
@@ -157,9 +157,9 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value }) => ({
+      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
         id: value,
-        access_right: '',
+        access_right: accessRight,
       })),
     };
     commit({

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -284,7 +284,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
                 name={'authorizedMembers'}
                 component={AuthorizedMembersField}
                 showAllMembersLine
-                showCreatorLine
+                showCreatorLine={false}
                 canDeactivate
                 disabled={isSubmitting}
                 addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -115,6 +115,10 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const { mandatoryAttributes } = useIsMandatoryAttribute(REPORT_TYPE);
+
+  const { isFeatureEnable } = useHelper();
+  const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
+
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')),
     published: Yup.date().typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -323,6 +327,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          {isAccessRestrictionCreationEnable && (
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
@@ -347,6 +352,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
               </Accordion>
             </div>
           </Security>
+          )}
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -217,6 +217,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
   if (!canEditAuthorizedMembers || !isAccessRestrictionCreationEnable) {
     delete initialValues.authorized_members;
   }
+  console.log('initialValues', { initialValues });
   return (
     <Formik<ReportAddInput>
       initialValues={initialValues}
@@ -347,7 +348,6 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine
-                    showCreatorLine={false}
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -163,10 +163,12 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
-        id: value,
-        access_right: accessRight,
-      })),
+      ...(isAccessRestrictionCreationEnable && {
+        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+          id: value,
+          access_right: accessRight,
+        })),
+      }),
     };
     commit({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -11,7 +11,8 @@ import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/co
 import useHelper from 'src/utils/hooks/useHelper';
 import { ReportsLinesPaginationQuery$variables } from '@components/analyses/__generated__/ReportsLinesPaginationQuery.graphql';
 import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
-import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
@@ -38,6 +39,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -270,28 +272,6 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <Alert
-              icon={false}
-              classes={{ root: classes.alert, message: classes.message }}
-              severity="warning"
-              variant="outlined"
-              style={fieldSpacingContainerStyle}
-            >
-              <Field
-                name={'authorizedMembers'}
-                component={AuthorizedMembersField}
-                showAllMembersLine
-                showCreatorLine={false}
-                canDeactivate
-                disabled={isSubmitting}
-                addMeUserWithAdminRights
-                owner={values.createdBy}
-              />
-            </Alert>
-          </Security>
           <Field
             component={RichTextField}
             name="content"
@@ -343,6 +323,30 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+          >
+            <div style={fieldSpacingContainerStyle}>
+              <Accordion >
+                <AccordionSummary id="accordion-panel">
+                  <Typography>{t_i18n('Advanced options')}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Field
+                    name={'authorizedMembers'}
+                    component={AuthorizedMembersField}
+                    containerstyle={{ marginTop: 20 }}
+                    showAllMembersLine
+                    showCreatorLine
+                    canDeactivate
+                    disabled={isSubmitting}
+                    addMeUserWithAdminRights
+                    owner={values.createdBy}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </div>
+          </Security>
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -85,7 +85,7 @@ interface ReportAddInput {
   objectParticipant: Option[];
   externalReferences: { value: string }[];
   file: File | undefined;
-  authorizedMembers: { value: string, accessRight: string }[];
+  authorized_members: { value: string, accessRight: string }[];
 }
 
 interface ReportFormProps {
@@ -164,7 +164,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
       ...(isAccessRestrictionCreationEnable && {
-        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+        authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,
         })),
@@ -212,7 +212,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
-    authorizedMembers: [],
+    authorized_members: [],
   });
   return (
     <Formik<ReportAddInput>
@@ -340,7 +340,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
                 </AccordionSummary>
                 <AccordionDetails>
                   <Field
-                    name={'authorizedMembers'}
+                    name={'authorized_members'}
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -337,7 +337,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
             <div style={fieldSpacingContainerStyle}>
-              <Accordion >
+              <Accordion>
                 <AccordionSummary id="accordion-panel">
                   <Typography>{t_i18n('Advanced options')}</Typography>
                 </AccordionSummary>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -217,7 +217,6 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
   if (!canEditAuthorizedMembers || !isAccessRestrictionCreationEnable) {
     delete initialValues.authorized_members;
   }
-  console.log('initialValues', { initialValues });
   return (
     <Formik<ReportAddInput>
       initialValues={initialValues}

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -140,7 +140,6 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
     values,
     { setSubmitting, setErrors, resetForm },
   ) => {
-    console.log('VALUES', values);
     const input: ReportCreationMutation$variables['input'] = {
       name: values.name,
       description: values.description,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -350,7 +350,6 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights
-                    owner={values.createdBy}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -287,6 +287,8 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
                 showCreatorLine
                 canDeactivate
                 disabled={isSubmitting}
+                addMeUserWithAdminRights
+                owner={values.createdBy}
               />
             </Alert>
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -36,6 +36,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
+import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -268,22 +270,26 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             style={{ marginTop: 20 }}
             askAi={true}
           />
-          <Alert
-            icon={false}
-            classes={{ root: classes.alert, message: classes.message }}
-            severity="warning"
-            variant="outlined"
-            style={fieldSpacingContainerStyle}
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
-            <Field
-              name={'authorizedMembers'}
-              component={AuthorizedMembersField}
-              showAllMembersLine
-              showCreatorLine
-              canDeactivate
-              disabled={isSubmitting}
-            />
-          </Alert>
+            <Alert
+              icon={false}
+              classes={{ root: classes.alert, message: classes.message }}
+              severity="warning"
+              variant="outlined"
+              style={fieldSpacingContainerStyle}
+            >
+              <Field
+                name={'authorizedMembers'}
+                component={AuthorizedMembersField}
+                showAllMembersLine
+                showCreatorLine
+                canDeactivate
+                disabled={isSubmitting}
+              />
+            </Alert>
+          </Security>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -291,6 +291,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
                 showCreatorLine
                 canDeactivate
                 disabled={isSubmitting}
+                addMeUserWithAdminRights
               />
             </Alert>
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -340,7 +340,6 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine
-                    showCreatorLine
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -156,10 +156,12 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
-        id: value,
-        access_right: accessRight,
-      })),
+      ...(isAccessRestrictionCreationEnable && {
+        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+          id: value,
+          access_right: accessRight,
+        })),
+      }),
     };
     commit({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -37,6 +37,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
+import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import Security from '../../../../utils/Security';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -272,22 +274,26 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
-          <Alert
-            icon={false}
-            classes={{ root: classes.alert, message: classes.message }}
-            severity="warning"
-            variant="outlined"
-            style={fieldSpacingContainerStyle}
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
-            <Field
-              name={'authorizedMembers'}
-              component={AuthorizedMembersField}
-              showAllMembersLine
-              showCreatorLine
-              canDeactivate
-              disabled={isSubmitting}
-            />
-          </Alert>
+            <Alert
+              icon={false}
+              classes={{ root: classes.alert, message: classes.message }}
+              severity="warning"
+              variant="outlined"
+              style={fieldSpacingContainerStyle}
+            >
+              <Field
+                name={'authorizedMembers'}
+                component={AuthorizedMembersField}
+                showAllMembersLine
+                showCreatorLine
+                canDeactivate
+                disabled={isSubmitting}
+              />
+            </Alert>
+          </Security>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -11,7 +11,8 @@ import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/co
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseIncidentsLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseIncidentsLinesCasesPaginationQuery.graphql';
 import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
-import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -39,6 +40,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -84,7 +86,7 @@ interface FormikCaseIncidentAddInput {
   created: Date | null;
   response_types: string[];
   caseTemplates?: Option[];
-  authorizedMembers: Option[];
+  authorizedMembers: { value: string, accessRight: string }[];
 }
 
 interface IncidentFormProps {
@@ -150,9 +152,9 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value }) => ({
+      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
         id: value,
-        access_right: '',
+        access_right: accessRight,
       })),
     };
     commit({
@@ -274,27 +276,6 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <Alert
-              icon={false}
-              classes={{ root: classes.alert, message: classes.message }}
-              severity="warning"
-              variant="outlined"
-              style={fieldSpacingContainerStyle}
-            >
-              <Field
-                name={'authorizedMembers'}
-                component={AuthorizedMembersField}
-                showAllMembersLine
-                showCreatorLine
-                canDeactivate
-                disabled={isSubmitting}
-                addMeUserWithAdminRights
-              />
-            </Alert>
-          </Security>
           <Field
             component={RichTextField}
             name="content"
@@ -338,6 +319,30 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+          >
+            <div style={fieldSpacingContainerStyle}>
+              <Accordion >
+                <AccordionSummary id="accordion-panel">
+                  <Typography>{t_i18n('Advanced options')}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Field
+                    name={'authorizedMembers'}
+                    component={AuthorizedMembersField}
+                    containerstyle={{ marginTop: 20 }}
+                    showAllMembersLine
+                    showCreatorLine
+                    canDeactivate
+                    disabled={isSubmitting}
+                    addMeUserWithAdminRights
+                    owner={values.createdBy}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </div>
+          </Security>
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -116,6 +116,10 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   const { t_i18n } = useFormatter();
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
+
+  const { isFeatureEnable } = useHelper();
+  const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
+
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -319,6 +323,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          {isAccessRestrictionCreationEnable && (
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
@@ -343,6 +348,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
               </Accordion>
             </div>
           </Security>
+          )}
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -10,6 +10,8 @@ import { useNavigate } from 'react-router-dom';
 import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/common/drawer/Drawer';
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseIncidentsLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseIncidentsLinesCasesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -80,6 +82,7 @@ interface FormikCaseIncidentAddInput {
   created: Date | null;
   response_types: string[];
   caseTemplates?: Option[];
+  authorizedMembers: Option[];
 }
 
 interface IncidentFormProps {
@@ -113,6 +116,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
+    authorized_members: Yup.array().nullable(),
   };
   const caseIncidentValidator = useSchemaCreationValidation(
     CASE_INCIDENT_TYPE,
@@ -144,6 +148,10 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
+      authorized_members: values.authorizedMembers.map(({ value }) => ({
+        id: value,
+        access_right: '',
+      })),
     };
     commit({
       variables: {
@@ -192,6 +200,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       objectLabel: [],
       externalReferences: [],
       file: undefined,
+      authorizedMembers: [],
     },
   );
 
@@ -263,6 +272,22 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
+          <Alert
+            icon={false}
+            classes={{ root: classes.alert, message: classes.message }}
+            severity="warning"
+            variant="outlined"
+            style={fieldSpacingContainerStyle}
+          >
+            <Field
+              name={'authorizedMembers'}
+              component={AuthorizedMembersField}
+              showAllMembersLine
+              showCreatorLine
+              canDeactivate
+              disabled={isSubmitting}
+            />
+          </Alert>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -345,7 +345,6 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights
-                    owner={values.createdBy}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -338,7 +338,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
                 </AccordionSummary>
                 <AccordionDetails>
                   <Field
-                    name={'authorizedMembers'}
+                    name={'authorized_members'}
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -341,7 +341,6 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights
-                    owner={values.createdBy}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -115,6 +115,10 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const { t_i18n } = useFormatter();
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
+
+  const { isFeatureEnable } = useHelper();
+  const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
+
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -314,6 +318,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          {isAccessRestrictionCreationEnable && (
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
@@ -338,6 +343,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
               </Accordion>
             </div>
           </Security>
+          )}
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -39,7 +39,7 @@ import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import Security from '../../../../utils/Security';
-import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -85,7 +85,7 @@ interface FormikCaseRfiAddInput {
   severity: string;
   priority: string;
   caseTemplates?: Option[];
-  authorizedMembers: { value: string, accessRight: string }[];
+  authorized_members: { value: string, accessRight: string }[] | undefined;
 }
 
 interface CaseRfiFormProps {
@@ -115,6 +115,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const { t_i18n } = useFormatter();
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
+  const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
 
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
@@ -154,8 +155,8 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      ...(isAccessRestrictionCreationEnable && {
-        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+        authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,
         })),
@@ -206,9 +207,11 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
-    authorizedMembers: [],
+    authorized_members: undefined,
   });
-
+  if (!canEditAuthorizedMembers || !isAccessRestrictionCreationEnable) {
+    delete initialValues.authorized_members;
+  }
   return (
     <Formik<FormikCaseRfiAddInput>
       initialValues={initialValues}

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -10,6 +10,8 @@ import { useNavigate } from 'react-router-dom';
 import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/common/drawer/Drawer';
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseRfisLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseRfisLinesCasesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -79,6 +81,7 @@ interface FormikCaseRfiAddInput {
   severity: string;
   priority: string;
   caseTemplates?: Option[];
+  authorizedMembers: Option[];
 }
 
 interface CaseRfiFormProps {
@@ -111,6 +114,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    authorized_members: Yup.array().nullable(),
   };
   const caseRfiValidator = useSchemaCreationValidation(
     CASE_RFI_TYPE,
@@ -142,6 +146,10 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
+      authorized_members: values.authorizedMembers.map(({ value }) => ({
+        id: value,
+        access_right: '',
+      })),
     };
     commit({
       variables: {
@@ -188,6 +196,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
+    authorizedMembers: [],
   });
 
   return (
@@ -258,6 +267,22 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
+          <Alert
+            icon={false}
+            classes={{ root: classes.alert, message: classes.message }}
+            severity="warning"
+            variant="outlined"
+            style={fieldSpacingContainerStyle}
+          >
+            <Field
+              name={'authorizedMembers'}
+              component={AuthorizedMembersField}
+              showAllMembersLine
+              showCreatorLine
+              canDeactivate
+              disabled={isSubmitting}
+            />
+          </Alert>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -37,6 +37,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -267,22 +269,26 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
-          <Alert
-            icon={false}
-            classes={{ root: classes.alert, message: classes.message }}
-            severity="warning"
-            variant="outlined"
-            style={fieldSpacingContainerStyle}
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
-            <Field
-              name={'authorizedMembers'}
-              component={AuthorizedMembersField}
-              showAllMembersLine
-              showCreatorLine
-              canDeactivate
-              disabled={isSubmitting}
-            />
-          </Alert>
+            <Alert
+              icon={false}
+              classes={{ root: classes.alert, message: classes.message }}
+              severity="warning"
+              variant="outlined"
+              style={fieldSpacingContainerStyle}
+            >
+              <Field
+                name={'authorizedMembers'}
+                component={AuthorizedMembersField}
+                showAllMembersLine
+                showCreatorLine
+                canDeactivate
+                disabled={isSubmitting}
+              />
+            </Alert>
+          </Security>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -154,10 +154,12 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
-        id: value,
-        access_right: accessRight,
-      })),
+      ...(isAccessRestrictionCreationEnable && {
+        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+          id: value,
+          access_right: accessRight,
+        })),
+      }),
     };
     commit({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -286,6 +286,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
                 showCreatorLine
                 canDeactivate
                 disabled={isSubmitting}
+                addMeUserWithAdminRights
               />
             </Alert>
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -335,7 +335,6 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine
-                    showCreatorLine
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -334,7 +334,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
                 </AccordionSummary>
                 <AccordionDetails>
                   <Field
-                    name={'authorizedMembers'}
+                    name={'authorized_members'}
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -11,7 +11,8 @@ import Drawer, { DrawerControlledDialProps, DrawerVariant } from '@components/co
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseRfisLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseRfisLinesCasesPaginationQuery.graphql';
 import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
-import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -39,6 +40,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -83,7 +85,7 @@ interface FormikCaseRfiAddInput {
   severity: string;
   priority: string;
   caseTemplates?: Option[];
-  authorizedMembers: Option[];
+  authorizedMembers: { value: string, accessRight: string }[];
 }
 
 interface CaseRfiFormProps {
@@ -148,9 +150,9 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value }) => ({
+      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
         id: value,
-        access_right: '',
+        access_right: accessRight,
       })),
     };
     commit({
@@ -269,27 +271,6 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             style={fieldSpacingContainerStyle}
             askAi={true}
           />
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <Alert
-              icon={false}
-              classes={{ root: classes.alert, message: classes.message }}
-              severity="warning"
-              variant="outlined"
-              style={fieldSpacingContainerStyle}
-            >
-              <Field
-                name={'authorizedMembers'}
-                component={AuthorizedMembersField}
-                showAllMembersLine
-                showCreatorLine
-                canDeactivate
-                disabled={isSubmitting}
-                addMeUserWithAdminRights
-              />
-            </Alert>
-          </Security>
           <Field
             component={RichTextField}
             name="content"
@@ -333,6 +314,30 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+          >
+            <div style={fieldSpacingContainerStyle}>
+              <Accordion >
+                <AccordionSummary id="accordion-panel">
+                  <Typography>{t_i18n('Advanced options')}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Field
+                    name={'authorizedMembers'}
+                    component={AuthorizedMembersField}
+                    containerstyle={{ marginTop: 20 }}
+                    showAllMembersLine
+                    showCreatorLine
+                    canDeactivate
+                    disabled={isSubmitting}
+                    addMeUserWithAdminRights
+                    owner={values.createdBy}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </div>
+          </Security>
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -10,6 +10,8 @@ import * as Yup from 'yup';
 import { useNavigate } from 'react-router-dom';
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseRftsLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseRftsLinesCasesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
+import Alert from '@mui/material/Alert';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -79,6 +81,7 @@ interface FormikCaseRftAddInput {
   severity: string;
   priority: string;
   caseTemplates?: Option[];
+  authorizedMembers: Option[];
 }
 
 interface CaseRftFormProps {
@@ -112,6 +115,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
+    authorized_members: Yup.array().nullable(),
   };
   const caseRftValidator = useSchemaCreationValidation(
     CASE_RFT_TYPE,
@@ -144,6 +148,10 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
+      authorized_members: values.authorizedMembers.map(({ value }) => ({
+        id: value,
+        access_right: '',
+      })),
     };
     commit({
       variables: {
@@ -190,6 +198,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
     objectLabel: [],
     externalReferences: [],
     file: undefined,
+    authorizedMembers: [],
   });
 
   return (
@@ -258,6 +267,22 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             rows="4"
             style={fieldSpacingContainerStyle}
           />
+          <Alert
+            icon={false}
+            classes={{ root: classes.alert, message: classes.message }}
+            severity="warning"
+            variant="outlined"
+            style={fieldSpacingContainerStyle}
+          >
+            <Field
+              name={'authorizedMembers'}
+              component={AuthorizedMembersField}
+              showAllMembersLine
+              showCreatorLine
+              canDeactivate
+              disabled={isSubmitting}
+            />
+          </Alert>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -286,6 +286,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
                 showCreatorLine
                 canDeactivate
                 disabled={isSubmitting}
+                addMeUserWithAdminRights
               />
             </Alert>
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -11,7 +11,8 @@ import { useNavigate } from 'react-router-dom';
 import { handleErrorInForm } from 'src/relay/environment';
 import { CaseRftsLinesCasesPaginationQuery$variables } from '@components/cases/__generated__/CaseRftsLinesCasesPaginationQuery.graphql';
 import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
-import Alert from '@mui/material/Alert';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -39,6 +40,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -83,7 +85,7 @@ interface FormikCaseRftAddInput {
   severity: string;
   priority: string;
   caseTemplates?: Option[];
-  authorizedMembers: Option[];
+  authorizedMembers: { value: string, accessRight: string }[];
 }
 
 interface CaseRftFormProps {
@@ -150,9 +152,9 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value }) => ({
+      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
         id: value,
-        access_right: '',
+        access_right: accessRight,
       })),
     };
     commit({
@@ -269,27 +271,6 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             rows="4"
             style={fieldSpacingContainerStyle}
           />
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <Alert
-              icon={false}
-              classes={{ root: classes.alert, message: classes.message }}
-              severity="warning"
-              variant="outlined"
-              style={fieldSpacingContainerStyle}
-            >
-              <Field
-                name={'authorizedMembers'}
-                component={AuthorizedMembersField}
-                showAllMembersLine
-                showCreatorLine
-                canDeactivate
-                disabled={isSubmitting}
-                addMeUserWithAdminRights
-              />
-            </Alert>
-          </Security>
           <Field
             component={RichTextField}
             name="content"
@@ -332,6 +313,30 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+          >
+            <div style={fieldSpacingContainerStyle}>
+              <Accordion >
+                <AccordionSummary id="accordion-panel">
+                  <Typography>{t_i18n('Advanced options')}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Field
+                    name={'authorizedMembers'}
+                    component={AuthorizedMembersField}
+                    containerstyle={{ marginTop: 20 }}
+                    showAllMembersLine
+                    showCreatorLine
+                    canDeactivate
+                    disabled={isSubmitting}
+                    addMeUserWithAdminRights
+                    owner={values.createdBy}
+                  />
+                </AccordionDetails>
+              </Accordion>
+            </div>
+          </Security>
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -334,7 +334,6 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine
-                    showCreatorLine
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -37,6 +37,8 @@ import CustomFileUploader from '../../common/files/CustomFileUploader';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useHelper from '../../../../utils/hooks/useHelper';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
+import Security from '../../../../utils/Security';
+import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -267,22 +269,26 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             rows="4"
             style={fieldSpacingContainerStyle}
           />
-          <Alert
-            icon={false}
-            classes={{ root: classes.alert, message: classes.message }}
-            severity="warning"
-            variant="outlined"
-            style={fieldSpacingContainerStyle}
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
-            <Field
-              name={'authorizedMembers'}
-              component={AuthorizedMembersField}
-              showAllMembersLine
-              showCreatorLine
-              canDeactivate
-              disabled={isSubmitting}
-            />
-          </Alert>
+            <Alert
+              icon={false}
+              classes={{ root: classes.alert, message: classes.message }}
+              severity="warning"
+              variant="outlined"
+              style={fieldSpacingContainerStyle}
+            >
+              <Field
+                name={'authorizedMembers'}
+                component={AuthorizedMembersField}
+                showAllMembersLine
+                showCreatorLine
+                canDeactivate
+                disabled={isSubmitting}
+              />
+            </Alert>
+          </Security>
           <Field
             component={RichTextField}
             name="content"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -156,10 +156,12 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
-        id: value,
-        access_right: accessRight,
-      })),
+      ...(isAccessRestrictionCreationEnable && {
+        authorized_members: values.authorizedMembers.map(({ value, accessRight }) => ({
+          id: value,
+          access_right: accessRight,
+        })),
+      }),
     };
     commit({
       variables: {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -115,6 +115,10 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
   const { t_i18n } = useFormatter();
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
+
+  const { isFeatureEnable } = useHelper();
+  const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
+
   const basicShape = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
@@ -313,6 +317,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
+          {isAccessRestrictionCreationEnable && (
           <Security
             needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
           >
@@ -337,6 +342,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
               </Accordion>
             </div>
           </Security>
+          )}
           <div className={classes.buttons}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -332,7 +332,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
                 </AccordionSummary>
                 <AccordionDetails>
                   <Field
-                    name={'authorizedMembers'}
+                    name={'authorized_members'}
                     component={AuthorizedMembersField}
                     containerstyle={{ marginTop: 20 }}
                     showAllMembersLine

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -339,7 +339,6 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
                     canDeactivate
                     disabled={isSubmitting}
                     addMeUserWithAdminRights
-                    owner={values.createdBy}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -85,7 +85,7 @@ const AuthorizedMembersField = ({
   // Require to use a state in addition to the Formik field because
   // we use the value outside the scope of the internal Formik form.
   const [applyAccesses, setApplyAccesses] = useState(
-    value !== null && value.length > 0,
+    value && Array.isArray(value) && value.length > 0,
   );
 
   const accessForAllMembers = (value ?? []).find(
@@ -258,7 +258,7 @@ const AuthorizedMembersField = ({
         validateOnChange={false}
         validateOnBlur={false}
         initialValues={{
-          applyAccesses,
+          applyAccesses: applyAccesses ?? false,
           newAccessMember: null,
           newAccessRight: 'view',
           allAccessRight: accessForAllMembers?.accessRight ?? 'none',
@@ -279,7 +279,7 @@ const AuthorizedMembersField = ({
             {canDeactivate && (
               <Field
                 component={SwitchField}
-                containerstyle={{ marginTop: 15 }}
+                containerstyle={{ marginTop: 15, paddingLeft: 2 }}
                 type="checkbox"
                 name="applyAccesses"
                 label={t_i18n('Activate access restriction')}

--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -279,7 +279,7 @@ const AuthorizedMembersField = ({
             {canDeactivate && (
               <Field
                 component={SwitchField}
-                containerstyle={{ marginTop: 15, paddingLeft: 2 }}
+                containerstyle={{ marginTop: 15, paddingLeft: 10 }}
                 type="checkbox"
                 name="applyAccesses"
                 label={t_i18n('Activate access restriction')}

--- a/opencti-platform/opencti-front/src/private/components/data/Management.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Management.tsx
@@ -170,7 +170,7 @@ const Management = () => {
       isSortable: true,
     },
     name: {
-      percentWidth: 20,
+      percentWidth: 15,
     },
     createdBy: {
       isSortable: isRuntimeSort,
@@ -184,10 +184,10 @@ const Management = () => {
       percentWidth: 10,
     },
     created_at: {
-      percentWidth: 20,
+      percentWidth: 15,
     },
     authorized_members_activation_date: {
-      percentWidth: 10,
+      percentWidth: 15,
     },
     objectMarking: {
       percentWidth: 10,

--- a/opencti-platform/opencti-front/src/private/components/data/Management.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Management.tsx
@@ -184,7 +184,7 @@ const Management = () => {
       percentWidth: 10,
     },
     created_at: {
-      percentWidth: 15,
+      percentWidth: 20,
     },
     authorized_members_activation_date: {
       percentWidth: 15,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
 import { Field, Form, Formik, FormikErrors, FormikValues } from 'formik';
 import Button from '@mui/material/Button';
@@ -6,7 +6,6 @@ import * as Yup from 'yup';
 import makeStyles from '@mui/styles/makeStyles';
 import { FormikConfig } from 'formik/dist/types';
 import Drawer from '@components/common/drawer/Drawer';
-import { EntitySettingAttributeEditionMembersQuery$data } from '@components/settings/sub_types/entity_setting/__generated__/EntitySettingAttributeEditionMembersQuery.graphql';
 import DefaultValueField from '@components/common/form/DefaultValueField';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
@@ -19,8 +18,7 @@ import ScaleConfiguration from '../scale_configuration/ScaleConfiguration';
 import { isCustomScale } from '../../../../../utils/hooks/useScale';
 import { Option } from '../../../common/form/ReferenceField';
 import { useComputeDefaultValues } from '../../../../../utils/hooks/useDefaultValues';
-import { fetchQuery, handleErrorInForm } from '../../../../../relay/environment';
-import { AccessRight, INPUT_AUTHORIZED_MEMBERS } from '../../../../../utils/authorizedMembers';
+import { handleErrorInForm } from '../../../../../relay/environment';
 import { defaultValuesToStringArray } from '../../../../../utils/defaultValues';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 
@@ -43,20 +41,6 @@ const entitySettingAttributeEditionPatch = graphql`
   ) {
     entitySettingsFieldPatch(ids: $ids, input: $input) {
       ...EntitySettingAttributes_entitySetting
-    }
-  }
-`;
-
-const entitySettingAttributeEditionMembersQuery = graphql`
-  query EntitySettingAttributeEditionMembersQuery($filters: FilterGroup) {
-    members(filters: $filters) {
-      edges {
-        node {
-          id
-          entity_type
-          name
-        }
-      }
     }
   }
 `;
@@ -107,34 +91,6 @@ const EntitySettingAttributeEdition = ({
   );
 
   const [commit] = useApiMutation(entitySettingAttributeEditionPatch);
-
-  const [membersData, setMembersData] = useState<EntitySettingAttributeEditionMembersQuery$data>();
-
-  useEffect(() => {
-    if (attribute.name === INPUT_AUTHORIZED_MEMBERS) {
-      const defaultAuthorizedMembers: { id: string, access_right: AccessRight }[] = (attribute.defaultValues ?? [])
-        .map((v) => JSON.parse(v.id))
-        .filter((v) => !!v.id && !!v.access_right);
-
-      const fetchMembers = async () => {
-        // Old way to fetch query here because doing it new way is a bit complicated
-        // due to the fact that this component managed all types of fields and this
-        // query is used only for one particular case.
-        const data = (await fetchQuery(entitySettingAttributeEditionMembersQuery, {
-          filters: defaultAuthorizedMembers.length > 0 ? {
-            mode: 'and',
-            filters: [{
-              key: 'ids',
-              values: defaultAuthorizedMembers.map((m) => m.id),
-            }],
-            filterGroups: [],
-          } : undefined,
-        }).toPromise()) as EntitySettingAttributeEditionMembersQuery$data;
-        setMembersData(data);
-      };
-      fetchMembers();
-    }
-  }, [attribute]);
 
   const onSubmit: FormikConfig<AttributeFormikValues>['onSubmit'] = (
     values,
@@ -193,7 +149,6 @@ const EntitySettingAttributeEdition = ({
       attribute.multiple ?? false,
       attribute.type,
       values,
-      attribute.name === INPUT_AUTHORIZED_MEMBERS ? membersData : undefined,
     );
   };
 

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributeEdition.tsx
@@ -142,7 +142,9 @@ const EntitySettingAttributeEdition = ({
   };
 
   const defaultValues = () => {
-    const values = attribute.defaultValues ? [...attribute.defaultValues] : [];
+    const defaultValueAttribute = entitySetting.defaultValuesAttributes.find((element) => element.name === attribute.name);
+    const attributeDefaultValues = defaultValueAttribute?.defaultValues ?? attribute.defaultValues;
+    const values = attributeDefaultValues ? [...attributeDefaultValues] : [];
     return computeDefaultValues(
       entitySetting.target_type,
       attribute.name,

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributes.tsx
@@ -22,6 +22,14 @@ const entitySettingAttributesFragment = graphql`
       ...EntitySettingAttributeLine_attribute
     }
     attributes_configuration
+    defaultValuesAttributes {
+      name
+      type
+      defaultValues {
+        id
+        name
+      }
+    }
   }
 `;
 

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -3404,6 +3404,7 @@ input ReportAddInput {
   clientMutationId: String
   update: Boolean
   file: Upload
+  authorized_members: [MemberAccessInput!]
 }
 
 enum CoursesOfActionOrdering {
@@ -9445,6 +9446,7 @@ input GroupingAddInput {
   x_opencti_workflow_id: String
   update: Boolean
   file: Upload
+  authorized_members: [MemberAccessInput!]
 }
 
 type Narrative implements BasicObject & StixCoreObject & StixDomainObject & StixObject {
@@ -10531,6 +10533,7 @@ input CaseIncidentAddInput {
   file: Upload
   clientMutationId: String
   update: Boolean
+  authorized_members: [MemberAccessInput!]
 }
 
 type CaseRfi implements BasicObject & StixObject & StixCoreObject & StixDomainObject & Container & Case {
@@ -10655,6 +10658,7 @@ input CaseRfiAddInput {
   update: Boolean
   information_types: [String!]
   caseTemplates: [String!]
+  authorized_members: [MemberAccessInput!]
 }
 
 type CaseRft implements BasicObject & StixObject & StixCoreObject & StixDomainObject & Container & Case {
@@ -10780,6 +10784,7 @@ input CaseRftAddInput {
   update: Boolean
   takedown_types: [String!]
   caseTemplates: [String!]
+  authorized_members: [MemberAccessInput!]
 }
 
 type Feedback implements BasicObject & StixObject & StixCoreObject & StixDomainObject & Container & Case {

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -93,6 +93,7 @@ const useDefaultValues = <Values extends FormikValues>(
 ) => {
   const computeDefaultValues = useComputeDefaultValues();
   const { getEffectiveConfidenceLevel } = useConfidenceLevel();
+  const { me } = useAuth();
 
   const entitySettings = useEntitySettings(id).at(0);
   if (!entitySettings) {
@@ -121,6 +122,14 @@ const useDefaultValues = <Values extends FormikValues>(
           attr.type,
           attr.defaultValues,
         );
+        if (attr.name === INPUT_AUTHORIZED_MEMBERS) {
+          const creatorRule = (defaultValues[attr.name] as Option[])?.find((v) => v.value === 'CREATOR');
+          if (creatorRule) {
+            creatorRule.value = me.id;
+            creatorRule.label = me.name;
+            creatorRule.type = me.entity_type;
+          }
+        }
       }
     },
   );
@@ -141,7 +150,6 @@ const useDefaultValues = <Values extends FormikValues>(
     defaultValues.created = now();
   }
 
-  const { me } = useAuth();
   const defaultMarkings = me.default_marking;
   if (
     keys.includes('objectMarking')

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -1,6 +1,5 @@
 import { head, isEmpty } from 'ramda';
 import { FormikValues } from 'formik/dist/types';
-import { EntitySettingAttributeEditionMembersQuery$data } from '@components/settings/sub_types/entity_setting/__generated__/EntitySettingAttributeEditionMembersQuery.graphql';
 import { Option } from '@components/common/form/ReferenceField';
 import { useCallback } from 'react';
 import useEntitySettings from './useEntitySettings';
@@ -22,7 +21,6 @@ export const useComputeDefaultValues = () => {
     multiple: boolean,
     type: string,
     defaultValues: readonly { id: string; name: string }[],
-    membersData?: EntitySettingAttributeEditionMembersQuery$data, // TODO cleanup
   ) => {
     const ovCategory = fieldToCategory(entityType, attributeName);
     // Handle createdBy

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -22,7 +22,7 @@ export const useComputeDefaultValues = () => {
     multiple: boolean,
     type: string,
     defaultValues: readonly { id: string; name: string }[],
-    membersData?: EntitySettingAttributeEditionMembersQuery$data,
+    membersData?: EntitySettingAttributeEditionMembersQuery$data, // TODO cleanup
   ) => {
     const ovCategory = fieldToCategory(entityType, attributeName);
     // Handle createdBy
@@ -43,13 +43,10 @@ export const useComputeDefaultValues = () => {
       const defaultAuthorizedMembers: AuthorizedMembers = defaultValues
         .map((v) => {
           const parsed = JSON.parse(v.id);
-          const member = membersData?.members?.edges?.find(({ node }) => node.id === parsed.id);
-          // TODO membersData is not filled for report creation form
-          // TODO replace 'CREATOR' by current user
           return {
             id: parsed.id,
-            name: member?.node.name ?? '',
-            entity_type: member?.node.entity_type ?? '',
+            name: parsed.name ?? '',
+            entity_type: parsed.entity_type ?? '',
             access_right: parsed.access_right,
           };
         })

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -44,6 +44,8 @@ export const useComputeDefaultValues = () => {
         .map((v) => {
           const parsed = JSON.parse(v.id);
           const member = membersData?.members?.edges?.find(({ node }) => node.id === parsed.id);
+          // TODO membersData is not filled for report creation form
+          // TODO replace 'CREATOR' by current user
           return {
             id: parsed.id,
             name: member?.node.name ?? '',

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -4130,6 +4130,7 @@ input ReportAddInput {
   clientMutationId: String
   update: Boolean
   file: Upload
+  authorized_members: [MemberAccessInput!]
 }
 
 ############## CoursesOfAction

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2987,8 +2987,13 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
   // endregion
   // validate authorized members access (when creating a new entity with authorized members)
-  if (input.authorized_members?.length > 0 && !validateUserAccessOperation(user, input, 'manage-access')) {
-    throw ForbiddenAccess();
+  if (input.authorized_members?.length > 0) {
+    if (!validateUserAccessOperation(user, input, 'manage-access')) {
+      throw ForbiddenAccess();
+    }
+    if (schemaAttributesDefinition.getAttribute(type, authorizedMembersActivationDate.name)) {
+      input.authorized_members_activation_date = now();
+    }
   }
   // region - Pre-Check
   const entitySetting = await getEntitySettingFromCache(context, type);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2986,6 +2986,10 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input, type);
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
   // endregion
+  // validate authorized members access (when creating a new entity with authorized members)
+  if (input.authorized_members?.length > 0 && !validateUserAccessOperation(user, input, 'manage-access')) {
+    throw ForbiddenAccess();
+  }
   // region - Pre-Check
   const entitySetting = await getEntitySettingFromCache(context, type);
   const filledInput = fillDefaultValues(user, input, entitySetting);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -2442,6 +2442,7 @@ export type CaseIncidentStixCoreRelationshipsDistributionArgs = {
 };
 
 export type CaseIncidentAddInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
   caseTemplates?: InputMaybe<Array<Scalars['String']['input']>>;
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   confidence?: InputMaybe<Scalars['Int']['input']>;
@@ -2745,6 +2746,7 @@ export type CaseRfiStixCoreRelationshipsDistributionArgs = {
 };
 
 export type CaseRfiAddInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
   caseTemplates?: InputMaybe<Array<Scalars['String']['input']>>;
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   confidence?: InputMaybe<Scalars['Int']['input']>;
@@ -3047,6 +3049,7 @@ export type CaseRftStixCoreRelationshipsDistributionArgs = {
 };
 
 export type CaseRftAddInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
   caseTemplates?: InputMaybe<Array<Scalars['String']['input']>>;
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   confidence?: InputMaybe<Scalars['Int']['input']>;
@@ -8639,6 +8642,7 @@ export type GroupingStixCoreRelationshipsDistributionArgs = {
 };
 
 export type GroupingAddInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   confidence?: InputMaybe<Scalars['Int']['input']>;
   content?: InputMaybe<Scalars['String']['input']>;
@@ -23026,6 +23030,7 @@ export type ReportStixCoreRelationshipsDistributionArgs = {
 };
 
 export type ReportAddInput = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   confidence?: InputMaybe<Scalars['Int']['input']>;
   content?: InputMaybe<Scalars['String']['input']>;

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
@@ -242,6 +242,7 @@ input CaseIncidentAddInput {
   file: Upload
   clientMutationId: String
   update: Boolean
+  authorized_members: [MemberAccessInput!]
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
@@ -241,6 +241,7 @@ input CaseRfiAddInput {
   update: Boolean
   information_types: [String!]
   caseTemplates: [String!]
+  authorized_members: [MemberAccessInput!]
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
@@ -242,6 +242,7 @@ input CaseRftAddInput {
   update: Boolean
   takedown_types: [String!]
   caseTemplates: [String!]
+  authorized_members: [MemberAccessInput!]
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
@@ -263,6 +263,7 @@ input GroupingAddInput {
     x_opencti_workflow_id: String
     update: Boolean
     file: Upload
+    authorized_members: [MemberAccessInput!]
 }
 
 type Mutation {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add authorizedMembersField in Report, Grouping, Case incident, RFI, RFT (in the creation form)
* Add security access in the frontend (with security, canEdit and CAPA manage authorized members)
* Implement forbiden access in backend using the method in CreateEntityRaw within middleware.js
* Rework the UseDefaultValue, EntitySettings-domain, EntitySettingsEdition
* Improve accordion style

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #4961 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
