### PR TITLE
[backend] fix file access restriction to also target trash index (#9424)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-search.js
+++ b/opencti-platform/opencti-graphql/src/database/file-search.js
@@ -117,7 +117,7 @@ export const elUpdateRemovedFiles = async (entity, removed = true) => {
       script: { source, params },
       query: {
         term: {
-          'entity_id.keyword': entity.internal_id
+          'metadata.entity_id.keyword': entity.internal_id
         }
       },
     },

--- a/opencti-platform/opencti-graphql/src/database/file-search.js
+++ b/opencti-platform/opencti-graphql/src/database/file-search.js
@@ -117,7 +117,7 @@ export const elUpdateRemovedFiles = async (entity, removed = true) => {
       script: { source, params },
       query: {
         term: {
-          'metadata.entity_id.keyword': entity.internal_id
+          'entity_id.keyword': entity.internal_id
         }
       },
     },

--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -11,7 +11,7 @@ import conf, { booleanConf, ENABLED_FILE_INDEX_MANAGER, isFeatureEnabled, logApp
 import { now, sinceNowInMinutes, truncate, utcDate } from '../utils/format';
 import { DatabaseError, FunctionalError, UnsupportedError } from '../config/errors';
 import { createWork, deleteWorkForFile } from '../domain/work';
-import { isNotEmptyField } from './utils';
+import { isNotEmptyField, READ_DATA_INDICES, READ_INDEX_DELETED_OBJECTS } from './utils';
 import { connectorsForImport } from './repository';
 import { pushToConnector } from './rabbitmq';
 import { elDeleteFilesByIds } from './file-search';
@@ -296,7 +296,7 @@ export const loadFile = async (context, user, fileS3Path, opts = {}) => {
       if (!isUserHasCapability(user, KNOWLEDGE)) {
         throw FunctionalError('File not found or restricted', { filename: fileS3Path });
       }
-      const instance = await internalLoadById(context, user, metaData.entity_id);
+      const instance = await internalLoadById(context, user, metaData.entity_id, { indices: [...READ_DATA_INDICES, READ_INDEX_DELETED_OBJECTS] });
       if (!instance) {
         throw FunctionalError('File not found or restricted', { filename: fileS3Path });
       }

--- a/opencti-platform/opencti-graphql/src/python/testing/local_exporter.py
+++ b/opencti-platform/opencti-graphql/src/python/testing/local_exporter.py
@@ -6,10 +6,11 @@ from pycti.api.opencti_api_client import OpenCTIApiClient
 
 
 class TestLocalExporter:
-    def __init__(self, api_url, api_token, entity_id, file_name, file_markings):
+    def __init__(self, api_url, api_token, entity_id, entity_type, file_name, file_markings):
         self.api_url = api_url
         self.api_token = api_token
         self.entity_id = entity_id
+        self.entity_type = entity_type
         self.file_name = file_name
         self.file_markings = file_markings
 
@@ -17,7 +18,7 @@ class TestLocalExporter:
         opencti_api_client = OpenCTIApiClient(self.api_url, self.api_token)
         # Generate a json bundle from openCTI
         bundle = opencti_api_client.stix2.get_stix_bundle_or_object_from_entity_id(
-            entity_type="Malware", entity_id=self.entity_id, mode="full"
+            entity_type=self.entity_type, entity_id=self.entity_id, mode="full"
         )
         json_bundle = json.dumps(bundle, indent=4)
         # Upload the export inside the entity to ack like an import
@@ -33,11 +34,11 @@ class TestLocalExporter:
     def upload_list(self):
         opencti_api_client = OpenCTIApiClient(self.api_url, self.api_token)
         # Generate a json bundle from openCTI
-        bundle = opencti_api_client.stix2.export_list("Malware")
+        bundle = opencti_api_client.stix2.export_list(self.entity_type)
         json_bundle = json.dumps(bundle, indent=4)
         # Upload the export inside the entity to ack like an import
         opencti_api_client.stix_domain_object.push_list_export(
-            "Malware", self.file_name, json_bundle
+            self.entity_type, self.file_name, json_bundle
         )
         # Upload it like a simple file to import
         opencti_api_client.upload_file(file_name=self.file_name, data=json_bundle)
@@ -49,8 +50,9 @@ if __name__ == "__main__":
             api_url=sys.argv[1],
             api_token=sys.argv[2],
             entity_id=sys.argv[3],
-            file_name=sys.argv[4],
-            file_markings=sys.argv[5],
+            entity_type=sys.argv[4],
+            file_name=sys.argv[5],
+            file_markings=sys.argv[6],
         ).upload()
     except Exception as e:  # pylint: disable=broad-except
         logging.exception(str(e))

--- a/opencti-platform/opencti-graphql/src/python/testing/local_uploader.py
+++ b/opencti-platform/opencti-graphql/src/python/testing/local_uploader.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import sys
+
+from pycti.api.opencti_api_client import OpenCTIApiClient
+
+
+class TestLocalExporter:
+    def __init__(self, api_url, api_token, entity_id, file_name, file_markings):
+        self.api_url = api_url
+        self.api_token = api_token
+        self.entity_id = entity_id
+        self.file_name = file_name
+        self.file_markings = file_markings
+
+    def upload(self):
+        opencti_api_client = OpenCTIApiClient(self.api_url, self.api_token)
+
+        # Upload the given file to the entity
+        opencti_api_client.stix_domain_object.add_file(
+            id=self.entity_id,
+            file_name=self.file_name,
+            file_markings=self.file_markings,
+        )
+
+if __name__ == "__main__":
+    try:
+        TestLocalExporter(
+            api_url=sys.argv[1],
+            api_token=sys.argv[2],
+            entity_id=sys.argv[3],
+            file_name=sys.argv[4],
+            file_markings=sys.argv[5],
+        ).upload()
+    except Exception as e:  # pylint: disable=broad-except
+        logging.exception(str(e))
+        sys.exit(1)

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/file-storage-test.js
@@ -15,7 +15,7 @@ const importFileId = `import/global/${exportFileName.toLowerCase()}`;
 describe('File storage file listing', () => {
   it('should file upload succeed', async () => {
     const malware = await elLoadById(testContext, ADMIN_USER, 'malware--faa5b705-cf44-4e50-8472-29e5fec43c3c');
-    const importOpts = [API_URI, ADMIN_API_TOKEN, malware.id, exportFileName, [MARKING_TLP_AMBER_STRICT]];
+    const importOpts = [API_URI, ADMIN_API_TOKEN, malware.id, 'Malware', exportFileName, [MARKING_TLP_AMBER_STRICT]];
     // local exporter create an export and also upload the file as an import
     const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_exporter.py', importOpts);
     expect(execution).not.toBeNull();

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -1,10 +1,11 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
-import { editorQuery, queryAsAdmin, TEST_ORGANIZATION, USER_PARTICIPATE } from '../../utils/testQuery';
+import { ADMIN_API_TOKEN, ADMIN_USER, API_URI, editorQuery, PYTHON_PATH, queryAsAdmin, TEST_ORGANIZATION, testContext, USER_PARTICIPATE } from '../../utils/testQuery';
 import { queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
-import { MARKING_TLP_RED } from '../../../src/schema/identifier';
+import { MARKING_TLP_AMBER_STRICT, MARKING_TLP_RED } from '../../../src/schema/identifier';
 import { wait } from '../../../src/database/utils';
+import { execChildPython } from '../../../src/python/pythonBridge';
 
 const CREATE_REPORT_QUERY = gql`
     mutation ReportAdd($input: ReportAddInput!) {
@@ -35,6 +36,14 @@ const READ_REPORT_QUERY = gql`
             description
             published
             toStix
+            importFiles {
+                edges {
+                    node { 
+                        id
+                        name
+                    }
+                }
+            }
         }
     }
 `;
@@ -117,6 +126,8 @@ const DELETE_RESTORE_MUTATION = gql`
     }
 `;
 
+const filename = './tests/data/poisonivy.json';
+
 describe('Delete operation resolver testing', () => {
   let reportInternalId = '';
   let deleteOperationId = '';
@@ -135,6 +146,17 @@ describe('Delete operation resolver testing', () => {
     };
     const report = await queryAsAdmin({ query: CREATE_REPORT_QUERY, variables: REPORT_TO_CREATE });
     reportInternalId = report.data?.reportAdd.id;
+    expect(reportInternalId).toBeDefined();
+
+    // upload a file to this report, to also test it after permanent deletion
+    const uploadOpts = [API_URI, ADMIN_API_TOKEN, reportInternalId, filename, [MARKING_TLP_AMBER_STRICT]];
+    const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_uploader.py', uploadOpts);
+    expect(execution).not.toBeNull();
+    expect(execution.status).toEqual('success');
+    const reportAfterImport = await queryAsAdminWithSuccess({ query: READ_REPORT_QUERY, variables: { id: reportInternalId } });
+    expect(reportAfterImport.data?.report.id).toBe(reportInternalId);
+    expect(reportAfterImport.data?.report.importFiles.edges[0].node.name).toBe('poisonivy.json');
+
     await queryAsAdmin({ query: DELETE_REPORT_QUERY, variables: { id: reportInternalId }, });
 
     // Check that an associated delete operation was created
@@ -173,7 +195,7 @@ describe('Delete operation resolver testing', () => {
     expect(getDeleteOperation.data?.deleteOperation).toBeNull();
   });
 
-  it('should deleteOperation be deleted', async () => {
+  it('should deleteOperation be confirmed', async () => {
     await queryAsAdmin({ query: DELETE_CONFIRM_MUTATION, variables: { id: deleteOperationId }, });
 
     const queryResult = await queryAsAdminWithSuccess({ query: READ_DELETE_OPERATION_QUERY, variables: { id: deleteOperationId } });
@@ -192,6 +214,13 @@ describe('Delete operation resolver testing', () => {
 
     const report = await queryAsAdmin({ query: CREATE_REPORT_QUERY, variables: REPORT_TO_CREATE });
     reportInternalId = report.data?.reportAdd.id;
+    // import a file to this report, to also test it after restore
+    const uploadOpts = [API_URI, ADMIN_API_TOKEN, reportInternalId, filename, [MARKING_TLP_AMBER_STRICT]];
+    // local exporter create an export and also upload the file as an import
+    const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_uploader.py', uploadOpts);
+    expect(execution).not.toBeNull();
+    expect(execution.status).toEqual('success');
+
     await queryAsAdmin({ query: DELETE_REPORT_QUERY, variables: { id: reportInternalId }, });
 
     // Retrieve the associated delete operation
@@ -219,6 +248,7 @@ describe('Delete operation resolver testing', () => {
 
     const reportQueryAfterResult = await queryAsAdminWithSuccess({ query: READ_REPORT_QUERY, variables: { id: reportInternalId } });
     expect(reportQueryAfterResult.data?.report.id).toBe(reportInternalId);
+    expect(reportQueryAfterResult.data?.report.importFiles.edges[0].node.name).toBe('poisonivy.json');
 
     await queryAsAdmin({ query: DELETE_REPORT_QUERY, variables: { id: reportInternalId }, });
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -216,7 +216,6 @@ describe('Delete operation resolver testing', () => {
     reportInternalId = report.data?.reportAdd.id;
     // import a file to this report, to also test it after restore
     const uploadOpts = [API_URI, ADMIN_API_TOKEN, reportInternalId, filename, [MARKING_TLP_AMBER_STRICT]];
-    // local exporter create an export and also upload the file as an import
     const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_uploader.py', uploadOpts);
     expect(execution).not.toBeNull();
     expect(execution.status).toEqual('success');

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -77,14 +77,14 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
-      expect(updateEventsByTypes['report'].length).toBe(13);
+      expect(updateEventsByTypes['report'].length).toBe(15);
       expect(updateEventsByTypes['ipv4-addr'].length).toBe(3);
       expect(updateEventsByTypes['tool'].length).toBe(9);
       expect(updateEventsByTypes['sighting'].length).toBe(4);
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(177);
+      expect(updateEvents.length).toBe(179);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1139;
+export const RAW_EVENTS_SIZE = 1141;
 export const SYNC_LIVE_EVENTS_SIZE = 608;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

When using `internalLoadById` to do a file access check, target also the trash index and not only the read indices.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #9424

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
