### PR TITLE
[frontend] fix infinite loading in advanced search (#9452)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/search/SearchContainerQuery.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchContainerQuery.tsx
@@ -105,7 +105,7 @@ const SearchContainerQuery = ({ children }: SearchContainerQueryProps) => {
     search: searchTerm,
   };
   useEffect(() => {
-    if (fileSearchEnabled && searchTerm) {
+    if (fileSearchEnabled) {
       loadQuery(queryArgs, { fetchPolicy: 'store-and-network' });
     }
   }, []);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Ensure query is loaded regardless of search term presence.
Removed dependency on `searchTerm` in the `useEffect` hook to ensure the query is always loaded when file search is enabled. This resolves the issue where the page would indefinitely load when no search term is provided.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/9452

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
