### PR TITLE
[frontend] empty string displayed as '-' in entities lists (#9453)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -99,7 +99,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 const defaultRender: DataTableColumn['render'] = (data, { column: { size } }, displayDraftChip = false) => {
   return (<Tooltip title={data}>
     <div>
-      {truncate(data, size * MAGICAL_SIZE)}
+      {data && data.length > 0 ? truncate(data, size * MAGICAL_SIZE) : '-'}
       {displayDraftChip && (<DraftChip/>)}
     </div>
   </Tooltip>);

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksLine.tsx
@@ -104,7 +104,9 @@ export const tasksDataColumns: DataColumns = {
     width: '18%',
     isSortable: true,
     // eslint-disable-next-line @typescript-eslint/no-shadow
-    render: (task: TasksLine_node$data) => (task.objectAssignee ?? []).map((node) => node.name).join(', '),
+    render: (task: TasksLine_node$data) => ((task.objectAssignee ?? []).length > 0
+      ? (task.objectAssignee ?? []).map((node) => node.name).join(', ')
+      : '-'),
   },
   objectLabel: {
     label: 'Labels',

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLine.jsx
@@ -14,7 +14,7 @@ import Skeleton from '@mui/material/Skeleton';
 import FeedPopover from './FeedPopover';
 import inject18n from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
-import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 import { TAXIIAPI_SETCOLLECTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 
@@ -106,11 +106,13 @@ class FeedLineLineComponent extends Component {
                 className={classes.filtersItem}
                 style={{ width: dataColumns.filters.width }}
               >
-                <FilterIconButton
-                  filters={filters}
-                  styleNumber={3}
-                  dataColumns={dataColumns}
-                />
+                {isFilterGroupNotEmpty(filters)
+                  ? <FilterIconButton
+                      filters={filters}
+                      styleNumber={3}
+                      dataColumns={dataColumns}
+                    />
+                  : '-'}
               </div>
             </>
           }

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookLine.tsx
@@ -13,6 +13,7 @@ import { PlaybookLine_node$key } from './__generated__/PlaybookLine_node.graphql
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { useFormatter } from '../../../../components/i18n';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -91,7 +92,7 @@ export const PlaybookLineComponent: FunctionComponent<PlaybookLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.description.width }}
             >
-              {data.description}
+              <FieldOrEmpty source={data.description}>{data.description}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamLine.jsx
@@ -15,9 +15,10 @@ import inject18n from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import ItemCopy from '../../../../components/ItemCopy';
 import ItemBoolean from '../../../../components/ItemBoolean';
-import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 import Security from '../../../../utils/Security';
 import { TAXIIAPI_SETCOLLECTIONS } from '../../../../utils/hooks/useGranted';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
@@ -99,7 +100,7 @@ class StreamLineLineComponent extends Component {
                 className={classes.bodyItem}
                 style={{ width: dataColumns.description.width }}
               >
-                {node.description}
+                <FieldOrEmpty source={node.description}>{node.description}</FieldOrEmpty>
               </div>
               <div
                 className={classes.bodyItem}
@@ -131,12 +132,14 @@ class StreamLineLineComponent extends Component {
                 className={classes.filtersItem}
                 style={{ width: dataColumns.filters.width }}
               >
-                <FilterIconButton
-                  filters={filters}
-                  dataColumns={dataColumns}
-                  styleNumber={3}
-                  entityTypes={['Stix-Filtering']}
-                />
+                {isFilterGroupNotEmpty(filters)
+                  ? <FilterIconButton
+                      filters={filters}
+                      dataColumns={dataColumns}
+                      styleNumber={3}
+                      entityTypes={['Stix-Filtering']}
+                    />
+                  : '-'}
               </div>
             </>
           }

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLine.jsx
@@ -15,9 +15,10 @@ import TaxiiPopover from './TaxiiPopover';
 import inject18n from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import ItemCopy from '../../../../components/ItemCopy';
-import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 import { TAXIIAPI_SETCOLLECTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
@@ -106,7 +107,7 @@ class TaxiiLineLineComponent extends Component {
                 className={classes.bodyItem}
                 style={{ width: dataColumns.description.width }}
               >
-                {node.description}
+                <FieldOrEmpty source={node.description}>{node.description}</FieldOrEmpty>
               </div>
               <div
                 className={classes.bodyItem}
@@ -118,11 +119,13 @@ class TaxiiLineLineComponent extends Component {
                 className={classes.filtersItem}
                 style={{ width: dataColumns.filters.width }}
               >
-                <FilterIconButton
-                  filters={filters}
-                  dataColumns={dataColumns}
-                  styleNumber={3}
-                />
+                {isFilterGroupNotEmpty(filters)
+                  ? <FilterIconButton
+                      filters={filters}
+                      dataColumns={dataColumns}
+                      styleNumber={3}
+                    />
+                  : '-'}
               </div>
             </>
           }

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
@@ -12,6 +12,7 @@ import { EventLine_node$key } from '@components/entities/events/__generated__/Ev
 import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -97,7 +98,7 @@ export const EventLine: FunctionComponent<EventLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.event_types.width }}
             >
-              {data.event_types?.join(', ')}
+              <FieldOrEmpty source={data.event_types}>{data.event_types?.join(', ')}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
@@ -13,6 +13,7 @@ import { useFormatter } from '../../../../components/i18n';
 import StixCoreObjectLabels from '../../common/stix_core_objects/StixCoreObjectLabels';
 import ItemIcon from '../../../../components/ItemIcon';
 import { DataColumns } from '../../../../components/list_lines';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -107,7 +108,7 @@ export const OrganizationLine: FunctionComponent<OrganizationLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.x_opencti_organization_type.width }}
             >
-              {data.x_opencti_organization_type ?? ''}
+              <FieldOrEmpty source={data.x_opencti_organization_type}>{data.x_opencti_organization_type}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -16,7 +16,7 @@ import { useFormatter } from '../../../../components/i18n';
 import TriggerPopover from './TriggerPopover';
 import { dayStartDate, formatTimeForToday } from '../../../../utils/Time';
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
-import { deserializeFilterGroupForFrontend } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -159,10 +159,11 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.notifiers.width }}
             >
-              {data.notifiers
-                && data.notifiers.length > 0
-                && data.notifiers
+              {(data.notifiers
+                && data.notifiers.length > 0)
+                ? data.notifiers
                   .map<React.ReactNode>((n) => <code key={n.id} style={{ marginRight: 5 }}>{n.name}</code>)
+                : '-'
               }
             </div>
             <div
@@ -195,7 +196,7 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
                 className={classes.filtersItem}
                 style={{ width: dataColumns.filters.width }}
               >
-                {filters && (
+                {isFilterGroupNotEmpty(filters) ? (
                   <FilterIconButton
                     filters={filters}
                     dataColumns={dataColumns}
@@ -203,7 +204,7 @@ export const TriggerLineComponent: FunctionComponent<TriggerLineProps> = ({
                     redirection
                     entityTypes={data.instance_trigger ? ['Instance'] : ['Stix-Core-Object', 'Stix-Filtering']}
                   />
-                )}
+                ) : '-'}
               </div>
             )}
             {data.trigger_type === 'digest' && (

--- a/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
@@ -60,7 +60,7 @@ const SettingsOrganizations = () => {
       label: 'Type',
       width: '20%',
       isSortable: true,
-      render: (node: Organization) => (node.x_opencti_organization_type ?? ''),
+      render: (node: Organization) => (node.x_opencti_organization_type ?? '-'),
     },
     created: {
       label: 'Original creation date',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
@@ -12,6 +12,7 @@ import { UserLine_node$data } from '@components/settings/users/__generated__/Use
 import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';
 import type { Theme } from '../../../../components/Theme';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -83,13 +84,13 @@ const UserLineComponent: React.FC<UserLineComponentProps> = (props) => {
               className={classes.bodyItem}
               style={{ width: dataColumns.firstname.width }}
             >
-              {node.firstname}
+              <FieldOrEmpty source={node.firstname}>{node.firstname}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}
               style={{ width: dataColumns.lastname.width }}
             >
-              {node.lastname}
+              <FieldOrEmpty source={node.lastname}>{node.lastname}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
@@ -16,6 +16,7 @@ import ItemIcon from '../../../components/ItemIcon';
 import Security from '../../../utils/Security';
 import { EXPLORE, INVESTIGATION_INUPDATE } from '../../../utils/hooks/useGranted';
 import ItemBoolean from '../../../components/ItemBoolean';
+import FieldOrEmpty from "../../../components/FieldOrEmpty";
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -82,10 +83,10 @@ const WorkspaceLineComponent = ({ dataColumns, node, paginationOptions }) => {
               className={classes.bodyItem}
               style={{ width: dataColumns.tags.width }}
             >
-              {node.tags
+              <FieldOrEmpty source={node.tags}>{node.tags
                 && node.tags.map((tag) => (
                   <Chip className={classes.chip} key={tag} label={tag} />
-                ))}
+                ))}</FieldOrEmpty>
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceLine.jsx
@@ -16,7 +16,7 @@ import ItemIcon from '../../../components/ItemIcon';
 import Security from '../../../utils/Security';
 import { EXPLORE, INVESTIGATION_INUPDATE } from '../../../utils/hooks/useGranted';
 import ItemBoolean from '../../../components/ItemBoolean';
-import FieldOrEmpty from "../../../components/FieldOrEmpty";
+import FieldOrEmpty from '../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.


### PR DESCRIPTION
### Proposed changes
In entities list and data tables, empty string should be displayed as '-' instead of as an empty string

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9453
