### PR TITLE
[CI] Add a test-result folder in backend to help debug stream count issues.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -124,6 +124,8 @@ steps:
       # Archive and upload each artefact that we need
       - tar -czvf frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-front/test-results
       - jf rt u frontend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
+      - tar -czvf backend-test-results-$DRONE_BUILD_NUMBER.tar.gz opencti-platform/opencti-graphql/test-results
+      - jf rt u backend-test-results-$DRONE_BUILD_NUMBER.tar.gz $JFROG_REPOSITORY --build-name=$JFROG_BUILD_NAME --build-number=$DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN
       # Next line should be done only once at the end: it's recording and gathering build info
       - jf rt bp $JFROG_BUILD_NAME $DRONE_BUILD_NUMBER --url=$JFROG_URL --access-token=$JFROG_TOKEN --build-url=$DRONE_BUILD_LINK
       # Cleaning up old build in JFrog

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -14,7 +14,7 @@ describe('Raw streams tests', () => {
     async () => {
       // Read all events from the beginning.
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });
-      writeTestDataToFile(JSON.stringify(events), 'raw-test-all-event.log');
+      writeTestDataToFile(JSON.stringify(events), 'raw-test-all-event.json');
       // Check the number of events
       // 01 - CHECK CREATE EVENTS.
       const createEvents = events.filter((e) => e.type === EVENT_TYPE_CREATE);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -3,8 +3,9 @@ import { describe, expect, it } from 'vitest';
 import * as R from 'ramda';
 import { FIVE_MINUTES, RAW_EVENTS_SIZE } from '../../utils/testQuery';
 import { checkStreamData, checkStreamGenericContent, fetchStreamEvents, } from '../../utils/testStream';
-import { PORT } from '../../../src/config/conf';
+import { logApp, PORT } from '../../../src/config/conf';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE } from '../../../src/database/utils';
+import { writeTestDataToFile } from '../../utils/testOutput';
 
 describe('Raw streams tests', () => {
   // We need to check the event format to be sure that everything is setup correctly
@@ -13,6 +14,9 @@ describe('Raw streams tests', () => {
     async () => {
       // Read all events from the beginning.
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });
+      logApp.warn('[TEST OUTPUT] Writing event to file');
+      writeTestDataToFile(JSON.stringify(events), 'raw-test-all-event.log');
+      logApp.warn('[TEST OUTPUT] Writing event to file, done.');
       // Check the number of events
       // 01 - CHECK CREATE EVENTS.
       const createEvents = events.filter((e) => e.type === EVENT_TYPE_CREATE);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import * as R from 'ramda';
 import { FIVE_MINUTES, RAW_EVENTS_SIZE } from '../../utils/testQuery';
 import { checkStreamData, checkStreamGenericContent, fetchStreamEvents, } from '../../utils/testStream';
-import { logApp, PORT } from '../../../src/config/conf';
+import { PORT } from '../../../src/config/conf';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE } from '../../../src/database/utils';
 import { writeTestDataToFile } from '../../utils/testOutput';
 
@@ -14,9 +14,7 @@ describe('Raw streams tests', () => {
     async () => {
       // Read all events from the beginning.
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });
-      logApp.warn('[TEST OUTPUT] Writing event to file');
       writeTestDataToFile(JSON.stringify(events), 'raw-test-all-event.log');
-      logApp.warn('[TEST OUTPUT] Writing event to file, done.');
       // Check the number of events
       // 01 - CHECK CREATE EVENTS.
       const createEvents = events.filter((e) => e.type === EVENT_TYPE_CREATE);

--- a/opencti-platform/opencti-graphql/tests/03-streams/01-Live/live-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/01-Live/live-test.js
@@ -8,6 +8,7 @@ import { convertStoreToStix, convertTypeToStixType } from '../../../src/database
 import { utcDate } from '../../../src/utils/format';
 import { PORT } from '../../../src/config/conf';
 import { READ_DATA_INDICES } from '../../../src/database/utils';
+import { writeTestDataToFile } from '../../utils/testOutput';
 
 describe('Live streams tests', () => {
   const getElementsCounting = async () => {
@@ -49,6 +50,7 @@ describe('Live streams tests', () => {
       const stixReport = convertStoreToStix(report);
       const now = utcDate().toISOString();
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream/live?from=0&recover=${now}`);
+      writeTestDataToFile(JSON.stringify(events), 'live-test-all-event.json');
       expect(events.length).toBe(SYNC_LIVE_EVENTS_SIZE);
       await checkResultCounting(events);
       for (let index = 0; index < events.length; index += 1) {

--- a/opencti-platform/opencti-graphql/tests/utils/testOutput.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testOutput.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+const TEST_OUTPUT_FOLDER = 'test-results';
+
+/**
+ * Write content to a folder that will be archived at the end of test in CI.
+ * @param fileContent
+ * @param filename
+ */
+export const writeTestDataToFile = (fileContent: string, filename: string) => {
+  if (!fs.existsSync(TEST_OUTPUT_FOLDER)) {
+    fs.mkdirSync(TEST_OUTPUT_FOLDER, { recursive: true });
+  }
+  const filePath = join(TEST_OUTPUT_FOLDER, filename);
+  fs.writeFileSync(filePath, fileContent, {});
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

It's hard to understand number different on counter without data reference on master. I propose to add a dump of event content in the JFrog archived artefact.

* add an test utily to dump data to file in a dedicated folder "test-results" (similar to frontend folder name)
* compress and send to JFrog

### Related issues
No issue, it's out of band.
done in context of https://github.com/OpenCTI-Platform/opencti/pull/9394

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

After a "json format" locally, it gives a diff like this:
![image](https://github.com/user-attachments/assets/e90f6cb5-3173-4430-bc63-e2748fa939bc)

