### PR TITLE
[backend] add field patch validation for updates in draft (#6728)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -215,6 +215,7 @@
   "Draft ids": "Entwurfs-Ids",
   "Draft name": "Name des Entwurfs",
   "Draft operation": "Entwurf einer Operation",
+  "Draft update patch": "Entwurf eines Aktualisierungspatches",
   "DST": "DST",
   "DST byte count": "DST-Byte-Anzahl",
   "DST packets": "DST-Pakete",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -215,6 +215,7 @@
   "Draft ids": "Draft ids",
   "Draft name": "Draft name",
   "Draft operation": "Draft operation",
+  "Draft update patch": "Draft update patch",
   "DST": "DST",
   "DST byte count": "DST byte count",
   "DST packets": "DST packets",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -215,6 +215,7 @@
   "Draft ids": "Id. de borrador",
   "Draft name": "Nombre del proyecto",
   "Draft operation": "Operación borrador",
+  "Draft update patch": "Proyecto de parche de actualización",
   "DST": "DST",
   "DST byte count": "DST byte count",
   "DST packets": "Paquetes DST",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -215,6 +215,7 @@
   "Draft ids": "Identifiants de draft",
   "Draft name": "Nom du brouillon",
   "Draft operation": "Opération de brouillon",
+  "Draft update patch": "Patch de mise à jour de brouillon",
   "DST": "DST",
   "DST byte count": "Nombre d'octets DST",
   "DST packets": "Paquets DST",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -215,6 +215,7 @@
   "Draft ids": "ドラフトID",
   "Draft name": "ドラフト名",
   "Draft operation": "ドラフト操作",
+  "Draft update patch": "ドラフト更新パッチ",
   "DST": "DST",
   "DST byte count": "DST バイト数",
   "DST packets": "DSTパケット",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -215,6 +215,7 @@
   "Draft ids": "초안 ID",
   "Draft name": "초안 이름",
   "Draft operation": "초안 작업",
+  "Draft update patch": "업데이트 패치 초안",
   "DST": "DST",
   "DST byte count": "DST 바이트 수",
   "DST packets": "DST 패킷",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -215,6 +215,7 @@
   "Draft ids": "草案 ID",
   "Draft name": "草案名称",
   "Draft operation": "草案操作",
+  "Draft update patch": "更新补丁草案",
   "DST": "DST",
   "DST byte count": "DST 字节数",
   "DST packets": "DST 数据包",

--- a/opencti-platform/opencti-front/src/components/ItemOperations.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOperations.tsx
@@ -34,6 +34,14 @@ const operationStylesLight = {
     backgroundColor: '#ff9800',
     color: '#ffffff',
   },
+  lightYellow: {
+    backgroundColor: '#e5ce6b',
+    color: '#ffffff',
+  },
+  grey: {
+    backgroundColor: '#6c6c7a',
+    color: '#ffffff',
+  },
 };
 
 const operationStylesDark = {
@@ -45,6 +53,12 @@ const operationStylesDark = {
   },
   yellow: {
     backgroundColor: '#ff9800',
+  },
+  lightYellow: {
+    backgroundColor: '#e5ce6b',
+  },
+  grey: {
+    backgroundColor: '#6c6c7a',
   },
 };
 
@@ -62,10 +76,18 @@ const ItemOperations: FunctionComponent<ItemOperationsProps> = ({ draftOperation
         return theme.palette.mode === 'light'
           ? { ...operationStylesLight.yellow }
           : { ...operationStylesDark.yellow };
+      case 'update_linked':
+        return theme.palette.mode === 'light'
+          ? { ...operationStylesLight.lightYellow }
+          : { ...operationStylesDark.lightYellow };
       case 'delete':
         return theme.palette.mode === 'light'
           ? { ...operationStylesLight.red }
           : { ...operationStylesDark.red };
+      case 'unchanged':
+        return theme.palette.mode === 'light'
+          ? { ...operationStylesLight.grey }
+          : { ...operationStylesDark.grey };
       default:
         return {};
     }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2027,6 +2027,7 @@ enum DraftOperation {
   update_linked
   delete
   delete_linked
+  unchanged
 }
 
 type DraftVersion {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2024,7 +2024,9 @@ type Inference {
 enum DraftOperation {
   create
   update
+  update_linked
   delete
+  delete_linked
 }
 
 type DraftVersion {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1950,6 +1950,7 @@ enum DraftOperation {
   update_linked
   delete
   delete_linked
+  unchanged
 }
 
 type DraftVersion {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -1947,7 +1947,9 @@ type Inference {
 enum DraftOperation {
   create
   update
+  update_linked
   delete
+  delete_linked
 }
 
 type DraftVersion {

--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -9,6 +9,7 @@ export const DRAFT_OPERATION_UPDATE = 'update';
 export const DRAFT_OPERATION_UPDATE_LINKED = 'update_linked';
 export const DRAFT_OPERATION_DELETE = 'delete';
 export const DRAFT_OPERATION_DELETE_LINKED = 'delete_linked';
+export const DRAFT_OPERATION_UNCHANGED = 'unchanged';
 
 export const buildDraftFilter = (context, user, opts = {}) => {
   const { includeDeletedInDraft = false } = opts;
@@ -91,7 +92,10 @@ export const buildUpdateFieldPatch = (rawUpdatePatch) => {
 // If instance already contained a draft_change with a draft_update_patch, consolidate updated inputs in existing draft_update_patch
 export const getDraftChanges = (initialInstance, updatedInputs) => {
   const currentDraftChanges = initialInstance.draft_change ?? { draft_operation: DRAFT_OPERATION_UPDATE };
-  if (updatedInputs.length === 0) {
+  if (updatedInputs.length === 0
+      || currentDraftChanges?.draft_operation === DRAFT_OPERATION_CREATE
+      || currentDraftChanges?.draft_operation === DRAFT_OPERATION_DELETE
+      || currentDraftChanges?.draft_operation === DRAFT_OPERATION_DELETE_LINKED) {
     return currentDraftChanges;
   }
 
@@ -137,5 +141,5 @@ export const getDraftChanges = (initialInstance, updatedInputs) => {
 
   const stringifiedUpdatePatch = JSON.stringify(currentUpdatePatch);
 
-  return { ...currentDraftChanges, draft_updates_patch: stringifiedUpdatePatch };
+  return { draft_operation: DRAFT_OPERATION_UPDATE, draft_updates_patch: stringifiedUpdatePatch };
 };

--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -55,53 +55,83 @@ export const isDraftSupportedEntity = (element) => {
   return !isInternalObject(element.entity_type) && !isInternalRelationship(element.entity_type);
 };
 
+// Transform a raw update patched stored in a draft_updates_patch to a list of field patch inputs
+export const buildUpdateFieldPatch = (rawUpdatePatch) => {
+  const resultFieldPatch = [];
+  if (rawUpdatePatch) {
+    const parsedUpdatePatch = JSON.parse(rawUpdatePatch);
+    const updatePatchKeys = Object.keys(parsedUpdatePatch);
+    for (let i = 0; i < updatePatchKeys.length; i += 1) {
+      const currentKey = updatePatchKeys[i];
+      const currentValues = parsedUpdatePatch[currentKey];
+      if (currentValues) {
+        if (currentValues.replaced_value && currentValues.replaced_value.length > 0) {
+          const replaceInput = { key: currentKey, value: currentValues.replaced_value, operation: 'replace' };
+          resultFieldPatch.push(replaceInput);
+        } else {
+          if (currentValues.added_value && currentValues.added_value.length > 0) {
+            const addInput = { key: currentKey, value: currentValues.added_value, operation: 'add' };
+            resultFieldPatch.push(addInput);
+          }
+          if (currentValues.removed_value && currentValues.removed_value.length > 0) {
+            const removeInput = { key: currentKey, value: currentValues.removed_value, operation: 'remove' };
+            resultFieldPatch.push(removeInput);
+          }
+        }
+      }
+    }
+  }
+
+  return JSON.stringify(resultFieldPatch);
+};
+
 export const getDraftChanges = (initialInstance, updatedInputs) => {
   const currentDraftChanges = initialInstance.draft_change ?? { draft_operation: DRAFT_OPERATION_UPDATE };
   if (updatedInputs.length === 0) {
     return currentDraftChanges;
   }
 
-  const currentInputs = currentDraftChanges.draftupdateinputs ? JSON.parse(currentDraftChanges.draftupdateinputs) : {};
-  const nonResolvedInput = updatedInputs.map((i) => { return { key: i.key, value: i.value.map((v) => v.internal_id ?? v), operation: i.operation ?? UPDATE_OPERATION_REPLACE }; });
+  const currentUpdatePatch = currentDraftChanges.draft_updates_patch ? JSON.parse(currentDraftChanges.draft_updates_patch) : {};
+  const nonResolvedInput = updatedInputs.map((i) => { return { key: i.key, value: i.value.map((v) => v.standard_id ?? v), operation: i.operation ?? UPDATE_OPERATION_REPLACE }; });
 
   for (let i = 0; i < nonResolvedInput.length; i += 1) {
-    const updatedInput = nonResolvedInput[i];
-    const currentUpdates = currentInputs[updatedInput.key];
+    const currentNonResolvedInput = nonResolvedInput[i];
+    const currentUpdates = currentUpdatePatch[currentNonResolvedInput.key];
     // If there is currently an update, we have to handle deduplication
     if (currentUpdates) {
       // If new input is an add
-      if (updatedInput.operation === UPDATE_OPERATION_ADD) {
+      if (currentNonResolvedInput.operation === UPDATE_OPERATION_ADD) {
         // if current input was a replace, add updateInput values to the replaced values
-        if (currentUpdates.replacedValue.length > 0) {
-          const newReplacedValues = [...currentUpdates.replacedValue, ...updatedInput.value];
-          currentInputs[updatedInput.key] = { replacedValue: newReplacedValues, addedValue: [], removedValue: [] };
-        } else { // Otherwise, remove added inputs from removedValues and add them to addedValues
-          const newAddedValues = [...currentUpdates.addedValue, ...updatedInput.value];
-          const newRemovedValues = currentUpdates.removedValue.filter((v) => !updatedInput.value.includes(v));
-          currentInputs[updatedInput.key] = { replacedValue: [], addedValue: newAddedValues, removedValue: newRemovedValues };
+        if (currentUpdates.replaced_value.length > 0) {
+          const newReplacedValues = [...currentUpdates.replaced_value, ...currentNonResolvedInput.value];
+          currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value: newReplacedValues, added_value: [], removed_value: [] };
+        } else { // Otherwise, remove added inputs from removed_value and add them to added_value
+          const newAddedValues = [...currentUpdates.added_value, ...currentNonResolvedInput.value];
+          const newRemovedValues = currentUpdates.removed_value.filter((v) => !currentNonResolvedInput.value.includes(v));
+          currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value: [], added_value: newAddedValues, removed_value: newRemovedValues };
         }
-      } else if (updatedInput.operation === UPDATE_OPERATION_REMOVE) { // Else if new input is a remove
+      } else if (currentNonResolvedInput.operation === UPDATE_OPERATION_REMOVE) { // Else if new input is a remove
         // if current input was a replace, remove updateInput values from the replaced values
-        if (currentUpdates.replacedValue.length > 0) {
-          const newReplacedValues = currentUpdates.replacedValue.filter((v) => !updatedInput.value.includes(v));
-          currentInputs[updatedInput.key] = { replacedValue: newReplacedValues, addedValue: [], removedValue: [] };
-        } else { // Otherwise, remove added inputs from addedValues and add them to removedValues
-          const newAddedValues = currentUpdates.addedValue.filter((v) => !updatedInput.value.includes(v));
-          const newRemovedValues = [...currentUpdates.removedValue, ...updatedInput.value];
-          currentInputs[updatedInput.key] = { replacedValue: [], addedValue: newAddedValues, removedValue: newRemovedValues };
+        if (currentUpdates.replaced_value.length > 0) {
+          const newReplacedValues = currentUpdates.replaced_value.filter((v) => !currentNonResolvedInput.value.includes(v));
+          currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value: newReplacedValues, added_value: [], removed_value: [] };
+        } else { // Otherwise, remove added inputs from added_value and add them to removed_value
+          const newAddedValues = currentUpdates.added_value.filter((v) => !currentNonResolvedInput.value.includes(v));
+          const newRemovedValues = [...currentUpdates.removed_value, ...currentNonResolvedInput.value];
+          currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value: [], added_value: newAddedValues, removed_value: newRemovedValues };
         }
-      } else { // Else if new input is a replace or not defined, remove all addedValues and removedValues, and overwrite replacedValues with current input
-        currentInputs[updatedInput.key] = { replacedValue: updatedInput.value, addedValue: [], removedValue: [] };
+      } else { // Else if new input is a replace or not defined, remove all added_value and removedValues, and overwrite replaced_value with current input
+        currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value: currentNonResolvedInput.value, added_value: [], removed_value: [] };
       }
     } else { // If no update is currently defined for this key, we just initialize it with current operation
-      const replacedValue = updatedInput.operation === UPDATE_OPERATION_REPLACE ? updatedInput.value : [];
-      const addedValue = updatedInput.operation === UPDATE_OPERATION_ADD ? updatedInput.value : [];
-      const removedValue = updatedInput.operation === UPDATE_OPERATION_REMOVE ? updatedInput.value : [];
-      currentInputs[updatedInput.key] = { replacedValue, addedValue, removedValue };
+      const replaced_value = currentNonResolvedInput.operation === UPDATE_OPERATION_REPLACE ? currentNonResolvedInput.value : [];
+      const added_value = currentNonResolvedInput.operation === UPDATE_OPERATION_ADD ? currentNonResolvedInput.value : [];
+      const removed_value = currentNonResolvedInput.operation === UPDATE_OPERATION_REMOVE ? currentNonResolvedInput.value : [];
+      currentUpdatePatch[currentNonResolvedInput.key] = { replaced_value, added_value, removed_value };
     }
   }
 
-  const stringifiedInputs = JSON.stringify(currentInputs);
+  const stringifiedUpdatePatch = JSON.stringify(currentUpdatePatch);
 
-  return { ...currentDraftChanges, draftupdateinputs: stringifiedInputs };
+  return { ...currentDraftChanges, draft_updates_patch: stringifiedUpdatePatch };
 };

--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -5,6 +5,7 @@ import { READ_INDEX_DRAFT_OBJECTS, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE
 
 export const DRAFT_OPERATION_CREATE = 'create';
 export const DRAFT_OPERATION_UPDATE = 'update';
+export const DRAFT_OPERATION_UPDATE_LINKED = 'update_linked';
 export const DRAFT_OPERATION_DELETE = 'delete';
 export const DRAFT_OPERATION_DELETE_LINKED = 'delete_linked';
 
@@ -85,6 +86,8 @@ export const buildUpdateFieldPatch = (rawUpdatePatch) => {
   return JSON.stringify(resultFieldPatch);
 };
 
+// Get the resulting draft_change to apply to instance depending on updated inputs
+// If instance already contained a draft_change with a draft_update_patch, consolidate updated inputs in existing draft_update_patch
 export const getDraftChanges = (initialInstance, updatedInputs) => {
   const currentDraftChanges = initialInstance.draft_change ?? { draft_operation: DRAFT_OPERATION_UPDATE };
   if (updatedInputs.length === 0) {

--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -1,7 +1,7 @@
 import { isInternalObject } from '../schema/internalObject';
 import { isInternalRelationship } from '../schema/internalRelationship';
 import { getDraftContext } from '../utils/draftContext';
-import { READ_INDEX_DRAFT_OBJECTS } from './utils';
+import { READ_INDEX_DRAFT_OBJECTS, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE, UPDATE_OPERATION_REPLACE } from './utils';
 
 export const DRAFT_OPERATION_CREATE = 'create';
 export const DRAFT_OPERATION_UPDATE = 'update';
@@ -55,7 +55,53 @@ export const isDraftSupportedEntity = (element) => {
   return !isInternalObject(element.entity_type) && !isInternalRelationship(element.entity_type);
 };
 
-// TODO: once update metadata is better refined, add it to draft_change
-export const getDraftChanges = (initialInstance) => {
-  return initialInstance.draft_change ?? { draft_operation: DRAFT_OPERATION_UPDATE };
+export const getDraftChanges = (initialInstance, updatedInputs) => {
+  const currentDraftChanges = initialInstance.draft_change ?? { draft_operation: DRAFT_OPERATION_UPDATE };
+  if (updatedInputs.length === 0) {
+    return currentDraftChanges;
+  }
+
+  const currentInputs = currentDraftChanges.draftupdateinputs ? JSON.parse(currentDraftChanges.draftupdateinputs) : {};
+  const nonResolvedInput = updatedInputs.map((i) => { return { key: i.key, value: i.value.map((v) => v.internal_id ?? v), operation: i.operation ?? UPDATE_OPERATION_REPLACE }; });
+
+  for (let i = 0; i < nonResolvedInput.length; i += 1) {
+    const updatedInput = nonResolvedInput[i];
+    const currentUpdates = currentInputs[updatedInput.key];
+    // If there is currently an update, we have to handle deduplication
+    if (currentUpdates) {
+      // If new input is an add
+      if (updatedInput.operation === UPDATE_OPERATION_ADD) {
+        // if current input was a replace, add updateInput values to the replaced values
+        if (currentUpdates.replacedValue.length > 0) {
+          const newReplacedValues = [...currentUpdates.replacedValue, ...updatedInput.value];
+          currentInputs[updatedInput.key] = { replacedValue: newReplacedValues, addedValue: [], removedValue: [] };
+        } else { // Otherwise, remove added inputs from removedValues and add them to addedValues
+          const newAddedValues = [...currentUpdates.addedValue, ...updatedInput.value];
+          const newRemovedValues = currentUpdates.removedValue.filter((v) => !updatedInput.value.includes(v));
+          currentInputs[updatedInput.key] = { replacedValue: [], addedValue: newAddedValues, removedValue: newRemovedValues };
+        }
+      } else if (updatedInput.operation === UPDATE_OPERATION_REMOVE) { // Else if new input is a remove
+        // if current input was a replace, remove updateInput values from the replaced values
+        if (currentUpdates.replacedValue.length > 0) {
+          const newReplacedValues = currentUpdates.replacedValue.filter((v) => !updatedInput.value.includes(v));
+          currentInputs[updatedInput.key] = { replacedValue: newReplacedValues, addedValue: [], removedValue: [] };
+        } else { // Otherwise, remove added inputs from addedValues and add them to removedValues
+          const newAddedValues = currentUpdates.addedValue.filter((v) => !updatedInput.value.includes(v));
+          const newRemovedValues = [...currentUpdates.removedValue, ...updatedInput.value];
+          currentInputs[updatedInput.key] = { replacedValue: [], addedValue: newAddedValues, removedValue: newRemovedValues };
+        }
+      } else { // Else if new input is a replace or not defined, remove all addedValues and removedValues, and overwrite replacedValues with current input
+        currentInputs[updatedInput.key] = { replacedValue: updatedInput.value, addedValue: [], removedValue: [] };
+      }
+    } else { // If no update is currently defined for this key, we just initialize it with current operation
+      const replacedValue = updatedInput.operation === UPDATE_OPERATION_REPLACE ? updatedInput.value : [];
+      const addedValue = updatedInput.operation === UPDATE_OPERATION_ADD ? updatedInput.value : [];
+      const removedValue = updatedInput.operation === UPDATE_OPERATION_REMOVE ? updatedInput.value : [];
+      currentInputs[updatedInput.key] = { replacedValue, addedValue, removedValue };
+    }
+  }
+
+  const stringifiedInputs = JSON.stringify(currentInputs);
+
+  return { ...currentDraftChanges, draftupdateinputs: stringifiedInputs };
 };

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -167,7 +167,14 @@ import { rule_definitions } from '../rules/rules-definition';
 import { buildElasticSortingForAttributeCriteria } from '../utils/sorting';
 import { ENTITY_TYPE_DELETE_OPERATION } from '../modules/deleteOperation/deleteOperation-types';
 import { buildEntityData } from './data-builder';
-import { buildDraftFilter, DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE_LINKED, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_UPDATE, isDraftSupportedEntity } from './draft-utils';
+import {
+  buildDraftFilter,
+  DRAFT_OPERATION_CREATE,
+  DRAFT_OPERATION_DELETE_LINKED,
+  DRAFT_OPERATION_DELETE,
+  isDraftSupportedEntity,
+  DRAFT_OPERATION_UPDATE_LINKED
+} from './draft-utils';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { getDraftContext } from '../utils/draftContext';
 import { enrichWithRemoteCredentials } from '../config/credentials';
@@ -3932,7 +3939,7 @@ export const elListExistingDraftWorkspaces = async (context, user) => {
   return elList(context, user, READ_INDEX_INTERNAL_OBJECTS, listArgs);
 };
 // Creates a copy of a live element in the draft index with the current draft context
-const copyLiveElementToDraft = async (context, user, element, draftOperation = DRAFT_OPERATION_UPDATE) => {
+const copyLiveElementToDraft = async (context, user, element, draftOperation = DRAFT_OPERATION_UPDATE_LINKED) => {
   const draftContext = getDraftContext(context, user);
   if (!draftContext || element._index.includes(INDEX_DRAFT_OBJECTS)) return element;
 

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3939,7 +3939,7 @@ export const elListExistingDraftWorkspaces = async (context, user) => {
   return elList(context, user, READ_INDEX_INTERNAL_OBJECTS, listArgs);
 };
 // Creates a copy of a live element in the draft index with the current draft context
-const copyLiveElementToDraft = async (context, user, element, draftOperation = DRAFT_OPERATION_UPDATE_LINKED) => {
+export const copyLiveElementToDraft = async (context, user, element, draftOperation = DRAFT_OPERATION_UPDATE_LINKED) => {
   const draftContext = getDraftContext(context, user);
   if (!draftContext || element._index.includes(INDEX_DRAFT_OBJECTS)) return element;
 

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3639,7 +3639,8 @@ export const elReindexElements = async (context, user, ids, sourceIndex, destInd
     + "ctx._source.remove('i_stop_time_year'); ctx._source.remove('i_start_time_year'); "
     + "ctx._source.remove('i_start_time_month'); ctx._source.remove('i_stop_time_month'); "
     + "ctx._source.remove('i_start_time_day'); ctx._source.remove('i_stop_time_day'); "
-    + "ctx._source.remove('i_created_at_year'); ctx._source.remove('i_created_at_month'); ctx._source.remove('i_created_at_day'); ";
+    + "ctx._source.remove('i_created_at_year'); ctx._source.remove('i_created_at_month'); ctx._source.remove('i_created_at_day'); "
+    + "ctx._source.remove('rel_can-share'); ";
   const idReplaceScript = 'if (params.replaceId) { ctx._id = params.newId }';
   const sourceUpdateScript = 'for (change in params.changes.entrySet()) { ctx._source[change.getKey()] = change.getValue() }';
   const source = `${sourceCleanupScript} ${idReplaceScript} ${sourceUpdateScript}`;

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2160,10 +2160,10 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
     }
     // endregion
     // Impacting information
-    if (impactedInputs.length > 0) {
+    if (impactedInputs.length > 0 || (getDraftContext(context, user) && isDraftSupportedEntity(initial) && updatedInputs.length > 0)) {
       const updateAsInstance = partialInstanceWithInputs(updatedInstance, impactedInputs);
       if (getDraftContext(context, user) && isDraftSupportedEntity(initial)) {
-        updateAsInstance.draft_change = getDraftChanges(initial, impactedInputs);
+        updateAsInstance.draft_change = getDraftChanges(initial, updatedInputs);
       }
       await elUpdateElement(context, user, updateAsInstance);
     }

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2161,9 +2161,11 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
     // endregion
     // Impacting information
     if (impactedInputs.length > 0 || (getDraftContext(context, user) && isDraftSupportedEntity(initial) && updatedInputs.length > 0)) {
-      const updateAsInstance = partialInstanceWithInputs(updatedInstance, impactedInputs);
+      let updateAsInstance = partialInstanceWithInputs(updatedInstance, impactedInputs);
       if (getDraftContext(context, user) && isDraftSupportedEntity(initial)) {
-        updateAsInstance.draft_change = getDraftChanges(initial, updatedInputs);
+        const lastElementVersion = await internalLoadById(context, user, initial.internal_id);
+        updateAsInstance = partialInstanceWithInputs(updatedInstance, impactedInputs);
+        updateAsInstance.draft_change = getDraftChanges(lastElementVersion, updatedInputs);
       }
       await elUpdateElement(context, user, updateAsInstance);
     }

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6477,6 +6477,7 @@ export enum DraftOperation {
   Create = 'create',
   Delete = 'delete',
   DeleteLinked = 'delete_linked',
+  Unchanged = 'unchanged',
   Update = 'update',
   UpdateLinked = 'update_linked'
 }

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6476,7 +6476,9 @@ export type DraftObjectsCount = {
 export enum DraftOperation {
   Create = 'create',
   Delete = 'delete',
-  Update = 'update'
+  DeleteLinked = 'delete_linked',
+  Update = 'update',
+  UpdateLinked = 'update_linked'
 }
 
 export type DraftVersion = {

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -137,7 +137,7 @@ export const draftChange: AttributeDefinition = {
   featureFlag: 'DRAFT_WORKSPACE',
   mappings: [
     { name: 'draft_operation', label: 'Draft operation', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: false },
-    // draftUpdatePatch
+    { name: 'draftupdateinputs', label: 'Draft update inputs', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ]
 };
 

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -137,7 +137,7 @@ export const draftChange: AttributeDefinition = {
   featureFlag: 'DRAFT_WORKSPACE',
   mappings: [
     { name: 'draft_operation', label: 'Draft operation', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: true },
-    { name: 'draft_updates_patch', label: 'Draft update patch', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'draft_updates_patch', label: 'Draft update patch', type: 'string', format: 'json', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ]
 };
 

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -136,8 +136,8 @@ export const draftChange: AttributeDefinition = {
   isFilterable: false,
   featureFlag: 'DRAFT_WORKSPACE',
   mappings: [
-    { name: 'draft_operation', label: 'Draft operation', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: false },
-    { name: 'draftupdateinputs', label: 'Draft update inputs', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'draft_operation', label: 'Draft operation', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: true },
+    { name: 'draft_updates_patch', label: 'Draft update patch', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ]
 };
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { buildUpdateFieldPatch, getConsolidatedUpdatePatch } from '../../../src/database/draft-utils';
+import { UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE, UPDATE_OPERATION_REPLACE } from '../../../src/database/utils';
+import { EditOperation } from '../../../src/generated/graphql';
+
+describe('draft-utils', () => {
+  let currentUpdatePatch: any = {};
+  const keyA = 'keyA';
+  const keyB = 'keyB';
+  const valueA = 'valueA';
+  const valueB = 'valueB';
+
+  it('should getConsolidatedUpdatePatch consolidate updates correctly', () => {
+    const newUpdateAAddA = [{ key: keyA, value: [valueA], operation: UPDATE_OPERATION_ADD }];
+    const newUpdateARemoveA = [{ key: keyA, value: [valueA], operation: UPDATE_OPERATION_REMOVE }];
+    const newUpdateAReplaceAB = [{ key: keyA, value: [valueA, valueB], operation: UPDATE_OPERATION_REPLACE }];
+
+    const newUpdateBAddA = [{ key: keyB, value: [valueA], operation: UPDATE_OPERATION_ADD }];
+    const newUpdateBRemoveB = [{ key: keyB, value: [valueB], operation: UPDATE_OPERATION_REMOVE }];
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, newUpdateAAddA);
+    expect(currentUpdatePatch.keyA.replaced_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.added_value.length).toBe(1);
+    expect(currentUpdatePatch.keyA.added_value[0]).toBe(valueA);
+    expect(currentUpdatePatch.keyA.removed_value.length).toBe(0);
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, newUpdateARemoveA);
+    expect(currentUpdatePatch.keyA.replaced_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.added_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.removed_value.length).toBe(1);
+    expect(currentUpdatePatch.keyA.removed_value[0]).toBe(valueA);
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, newUpdateAReplaceAB);
+    expect(currentUpdatePatch.keyA.replaced_value.length).toBe(2);
+    expect(currentUpdatePatch.keyA.added_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.removed_value.length).toBe(0);
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, newUpdateARemoveA);
+    expect(currentUpdatePatch.keyA.replaced_value.length).toBe(1);
+    expect(currentUpdatePatch.keyA.replaced_value[0]).toBe(valueB);
+    expect(currentUpdatePatch.keyA.added_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.removed_value.length).toBe(0);
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, newUpdateAAddA);
+    expect(currentUpdatePatch.keyA.replaced_value.length).toBe(2);
+    expect(currentUpdatePatch.keyA.added_value.length).toBe(0);
+    expect(currentUpdatePatch.keyA.removed_value.length).toBe(0);
+
+    currentUpdatePatch = getConsolidatedUpdatePatch(currentUpdatePatch, [...newUpdateBAddA, ...newUpdateBRemoveB]);
+    expect(currentUpdatePatch.keyB.replaced_value.length).toBe(0);
+    expect(currentUpdatePatch.keyB.added_value.length).toBe(1);
+    expect(currentUpdatePatch.keyB.added_value[0]).toBe(valueA);
+    expect(currentUpdatePatch.keyB.removed_value.length).toBe(1);
+    expect(currentUpdatePatch.keyB.removed_value[0]).toBe(valueB);
+  });
+
+  it('should buildUpdateFieldPatch build a correct field patch input', () => {
+    const stringifiedUpdatePatch = JSON.stringify(currentUpdatePatch);
+    const fieldPatchResult = buildUpdateFieldPatch(stringifiedUpdatePatch);
+    expect(fieldPatchResult.length).toBe(3);
+    expect(fieldPatchResult.find((f: any) => f.key === keyA && f.operation === EditOperation.Replace && f.value.length === 2)).toBeTruthy();
+    expect(fieldPatchResult.find((f: any) => f.key === keyB && f.operation === EditOperation.Add && f.value[0] === valueA)).toBeTruthy();
+    expect(fieldPatchResult.find((f: any) => f.key === keyB && f.operation === EditOperation.Remove && f.value[0] === valueB)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
Linked PR: https://github.com/OpenCTI-Platform/client-python/pull/808

### Proposed changes

* fix a reindex error that could occur because of rel-can-share attributes leftover on elastic
* added field patch metadata to entities updated in a draft, containing every updates done on the entity during the draft
* now send updated entities in draft to worker with a patch: they will now be ingested with a field patch instead of an upsert
* added an updated_linked draft operation, to differentiate "real" updates and elements only added to the draft as dependencies
* added an unchanged operation, to still import entities into draft even when there is nothing to upsert/update during import

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6728 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
