### PR TITLE
[backend] Change marking values order: TLP:AMBER+STRICT to be hierarchically greater than TLP:AMBER (#9450)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -158,13 +158,13 @@ const createMarkingDefinitions = async (context) => {
     definition_type: 'TLP',
     definition: 'TLP:AMBER+STRICT',
     x_opencti_color: '#d84315',
-    x_opencti_order: 3,
+    x_opencti_order: 4,
   });
   await addAllowedMarkingDefinition(context, SYSTEM_USER, {
     definition_type: 'TLP',
     definition: 'TLP:RED',
     x_opencti_color: '#c62828',
-    x_opencti_order: 4,
+    x_opencti_order: 5,
   });
 
   // Creation markings for PAP


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change marking values order during database initialization

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9450 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
