### PR TITLE
[frontend] display virtual types in entity type filter list (#7637)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -746,7 +746,8 @@ const useSearchEntities = ({
                 ...result,
               ];
               // if there are not only stix cyber observables in the entity types list, add the 'Stix Cyber Observable' abstract type
-              if (availableEntityTypes && (availableEntityTypes.length > 1 || availableEntityTypes.includes('Stix-Core-Object'))) {
+              if (!availableEntityTypes
+                || (availableEntityTypes && (availableEntityTypes.length > 1 || availableEntityTypes.includes('Stix-Core-Object')))) {
                 result = [
                   {
                     label: t_i18n('entity_Stix-Cyber-Observable'),
@@ -772,7 +773,8 @@ const useSearchEntities = ({
                 ...result,
               ];
               // if there are not only stix domain objects in the entity types list, add the 'Stix Domain Object' abstract type
-              if (availableEntityTypes && (availableEntityTypes.length > 1 || availableEntityTypes.includes('Stix-Core-Object'))) {
+              if (!availableEntityTypes
+                || (availableEntityTypes && (availableEntityTypes.length > 1 || availableEntityTypes.includes('Stix-Core-Object')))) {
                 result = [
                   {
                     label: t_i18n('entity_Stix-Domain-Object'),
@@ -796,6 +798,18 @@ const useSearchEntities = ({
                 })),
                 ...result,
               ];
+              // if there are not only stix core relationships in the entity types list, add the 'Stix Core Relationship' abstract type
+              if (!availableEntityTypes
+                || (availableEntityTypes && availableEntityTypes.length > 1)) {
+                result = [
+                  {
+                    label: t_i18n('entity_Stix-Core-Relationship'),
+                    value: 'Stix-Core-Relationship',
+                    type: 'Stix-Core-Relationship',
+                  },
+                  ...result,
+                ];
+              }
             }
             // push the sighting relationship
             if (

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -188,10 +188,8 @@ export const keepMostRestrictiveTypes = (entityTypes) => {
   let restrictedEntityTypes = [...entityTypes];
   for (let i = 0; i < entityTypes.length; i += 1) {
     const type = entityTypes[i];
-    const parentTypes = getParentTypes(type);
-    restrictedEntityTypes = parentTypes.includes(type)
-      ? restrictedEntityTypes
-      : restrictedEntityTypes.filter((t) => !parentTypes.includes(t));
+    const parentTypes = getParentTypes(type).filter((p) => p !== type);
+    restrictedEntityTypes = restrictedEntityTypes.filter((t) => !parentTypes.includes(t));
   }
   return restrictedEntityTypes;
 };

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -189,7 +189,9 @@ export const keepMostRestrictiveTypes = (entityTypes) => {
   for (let i = 0; i < entityTypes.length; i += 1) {
     const type = entityTypes[i];
     const parentTypes = getParentTypes(type);
-    restrictedEntityTypes = restrictedEntityTypes.filter((t) => !parentTypes.includes(t));
+    restrictedEntityTypes = parentTypes.includes(type)
+      ? restrictedEntityTypes
+      : restrictedEntityTypes.filter((t) => !parentTypes.includes(t));
   }
   return restrictedEntityTypes;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/schemaUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/schemaUtils-test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { keepMostRestrictiveTypes } from '../../../src/schema/schemaUtils';
+
+describe('Schema Utils tests', () => {
+  it('keepMostRestrictiveTypes should keep all types if no overlap', () => {
+    const types = keepMostRestrictiveTypes(['Report', 'City']);
+    expect(types.length).toEqual(2);
+    expect(types).toContain('Report');
+    expect(types).toContain('City');
+  });
+  it('keepMostRestrictiveTypes should keep most restrictive types', () => {
+    const types = keepMostRestrictiveTypes(['Report', 'Stix-Domain-Object', 'City']);
+    expect(types.length).toEqual(2);
+    expect(types).toContain('Report');
+    expect(types).toContain('City');
+  });
+  it('keepMostRestrictiveTypes should keep abstract types', () => {
+    const types = keepMostRestrictiveTypes(['Stix-Domain-Object']);
+    expect(types.length).toEqual(1);
+    expect(types).toContain('Stix-Domain-Object');
+  });
+  it('keepMostRestrictiveTypes should keep most restrictive abstract types', () => {
+    const types = keepMostRestrictiveTypes(['Stix-Domain-Object', 'Stix-Core-Object']);
+    expect(types.length).toEqual(1);
+    expect(types).toContain('Stix-Domain-Object');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -958,7 +958,7 @@ describe('Complex filters combinations for elastic queries', () => {
       }
     });
     expect(queryResult.data.globalSearch.edges.length).toEqual(5); // 5 reports
-    // (entity_type = Report AND container AND Stix-Core-Object)
+    // (entity_type = Report AND Container AND Stix-Core-Object)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,
       variables: {
@@ -969,7 +969,7 @@ describe('Complex filters combinations for elastic queries', () => {
             {
               key: 'entity_type',
               operator: 'eq',
-              values: [ABSTRACT_STIX_CORE_OBJECT, ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_CONTAINER, ABSTRACT_INTERNAL_OBJECT],
+              values: [ABSTRACT_STIX_CORE_OBJECT, ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_CONTAINER],
               mode: 'and',
             }
           ],
@@ -978,6 +978,26 @@ describe('Complex filters combinations for elastic queries', () => {
       }
     });
     expect(queryResult.data.globalSearch.edges.length).toEqual(5); // 5 reports
+    // (entity_type = Report AND Container AND Internal-Object)
+    queryResult = await queryAsAdmin({
+      query: LIST_QUERY,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'or',
+          filters: [
+            {
+              key: 'entity_type',
+              operator: 'eq',
+              values: [ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_CONTAINER, ABSTRACT_INTERNAL_OBJECT],
+              mode: 'and',
+            }
+          ],
+          filterGroups: [],
+        },
+      }
+    });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(0); // reports are not internal objects
     // (entity_type = Malware OR Software)
     queryResult = await queryAsAdmin({
       query: LIST_QUERY,


### PR DESCRIPTION
### Proposed changes
Add the 'Stix Domain Object', 'Stix Cyber Observable' and 'Stix core relationship' abstract types in the entity type filter when it's needed (playbooks, triggers).

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/7637
