### PR TITLE
[frontend] Error when accessing the Observables tab in a workbench (#9543)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -307,7 +307,6 @@ const defaultValueKeys = {
     'hashes.SHA-1',
     'hashes.SHA-256',
     'hashes.SHA-512',
-    'dst_port',
   ],
 };
 


### PR DESCRIPTION
### Proposed changes

* Remove 'dst_port' attribute in sorting by default_value

Since it's a wrong usage of filter that is used by the workbenck when checking if an observable already exists it's hard to write a test coverage.

Root cause is that generated filter is this one with dst_port that is a number in satabase shemas :
```
{
  "types": [
    "Domain-Name"
  ],
  "search": null,
  "filters": {
    "mode": "and",
    "filters": [
      {
        "key": [
          "name",
          "value",
          "aliases",
          "x_opencti_aliases",
          "value",
          "content",
          "attribute_key",
          "path",
          "hashes.MD5",
          "hashes.SHA-1",
          "hashes.SHA-256",
          "hashes.SHA-512",
          "dst_port"
        ],
        "values": [
          "wwww.toto.fr"
        ]
      }
    ],
    "filterGroups": []
  },
  "count": 1
}
```

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/9543