### PR TITLE
[backend] keep increasing back pressure delay if queue size keeps increasing (#9358)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -65,7 +65,7 @@ const syncManagerInstance = (syncId) => {
     if (connectionId) {
       const connectionManagement = `${httpBase(uri)}stream/connection/${connectionId}`;
       const currentQueueLength = eventsQueue.getLength();
-      // If queue length keeps increasing even with an increased delay, we keep increasing the delay until we are able to go back below MON_QUEUE_SIZE
+      // If queue length keeps increasing even with an increased delay, we keep increasing the delay until we are able to go back below MIN_QUEUE_SIZE
       if (currentQueueLength > MAX_QUEUE_SIZE && currentDelay * MAX_QUEUE_SIZE < hDelay * (currentQueueLength - MAX_QUEUE_SIZE)) {
         const newDelay = currentDelay + hDelay;
         await httpClient.post(connectionManagement, { delay: newDelay });

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -64,12 +64,15 @@ const syncManagerInstance = (syncId) => {
   const manageBackPressure = async (httpClient, { uri }, currentDelay) => {
     if (connectionId) {
       const connectionManagement = `${httpBase(uri)}stream/connection/${connectionId}`;
-      if (currentDelay === lDelay && eventsQueue.getLength() > MAX_QUEUE_SIZE) {
-        await httpClient.post(connectionManagement, { delay: hDelay });
-        logApp.info(`[OPENCTI] Sync ${syncId}: connection setup to use ${hDelay} delay`);
-        return hDelay;
+      const currentQueueLength = eventsQueue.getLength();
+      // If queue length keeps increasing even with an increased delay, we keep increasing the delay until we are able to go back below MON_QUEUE_SIZE
+      if (currentQueueLength > MAX_QUEUE_SIZE && currentDelay * MAX_QUEUE_SIZE < hDelay * (currentQueueLength - MAX_QUEUE_SIZE)) {
+        const newDelay = currentDelay + hDelay;
+        await httpClient.post(connectionManagement, { delay: newDelay });
+        logApp.info(`[OPENCTI] Sync ${syncId}: connection setup to use ${newDelay} delay`);
+        return newDelay;
       }
-      if (currentDelay === hDelay && eventsQueue.getLength() < MIN_QUEUE_SIZE) {
+      if (currentQueueLength < MIN_QUEUE_SIZE && currentDelay !== lDelay) {
         await httpClient.post(connectionManagement, { delay: lDelay });
         logApp.info(`[OPENCTI] Sync ${syncId}: connection setup to use ${lDelay} delay`);
         return lDelay;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* before, we only increased connection delay once in manageBackPressure. We now keep increasing the delay if the first delay increase wasn't enough to be able to reduce current queue size

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9358 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
