### PR TITLE
[frontend] CSS changes for correlation graph query buttons (#3227)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -43,6 +43,8 @@ import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import { ToggleButtonGroup } from '@mui/material';
+import ToggleButton from '@mui/material/ToggleButton';
 import CommitMessage from '../../common/form/CommitMessage';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import inject18n from '../../../../components/i18n';
@@ -499,23 +501,6 @@ class GroupingKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
-                  {handleToggleQueryMode && (
-                    <Tooltip
-                      title={
-                        currentQueryMode === 'all-entities'
-                          ? t('Show only correlated observables and indicators')
-                          : t('Show all correlated entities')
-                      }
-                    >
-                      <IconButton
-                        color={'secondary'}
-                        onClick={handleToggleQueryMode.bind(this)}
-                        size="large"
-                      >
-                        {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                      </IconButton>
-                    </Tooltip>
-                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -928,6 +913,40 @@ class GroupingKnowledgeGraphBar extends Component {
                         confidence={grouping.confidence}
                         enableReferences={enableReferences}
                       />
+                    )}
+                    {handleToggleQueryMode && (
+                    <ToggleButtonGroup
+                      size="small"
+                      value={currentQueryMode}
+                      exclusive
+                      onChange={handleToggleQueryMode}
+                      style={{
+                        padding: '4px 8px',
+                      }}
+                    >
+                      <Tooltip title={t('Show all correlated entities')}>
+                        <ToggleButton
+                          value="all-entities"
+                          selected={currentQueryMode === 'all-entities'}
+                        >
+                          <HubOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title={t('Show only correlated observables and indicators')}>
+                        <ToggleButton
+                          value="indicators-and-observables"
+                          selected={currentQueryMode === 'indicators-and-observables'}
+                        >
+                          <PolylineOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                    </ToggleButtonGroup>
                     )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraphBar.jsx
@@ -915,38 +915,39 @@ class GroupingKnowledgeGraphBar extends Component {
                       />
                     )}
                     {handleToggleQueryMode && (
-                    <ToggleButtonGroup
-                      size="small"
-                      value={currentQueryMode}
-                      exclusive
-                      onChange={handleToggleQueryMode}
-                      style={{
-                        padding: '4px 8px',
-                      }}
-                    >
-                      <Tooltip title={t('Show all correlated entities')}>
-                        <ToggleButton
-                          value="all-entities"
-                          selected={currentQueryMode === 'all-entities'}
-                        >
-                          <HubOutlined
-                            fontSize="small"
-                            color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
-                          />
-                        </ToggleButton>
-                      </Tooltip>
-                      <Tooltip title={t('Show only correlated observables and indicators')}>
-                        <ToggleButton
-                          value="indicators-and-observables"
-                          selected={currentQueryMode === 'indicators-and-observables'}
-                        >
-                          <PolylineOutlined
-                            fontSize="small"
-                            color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
-                          />
-                        </ToggleButton>
-                      </Tooltip>
-                    </ToggleButtonGroup>
+                      <ToggleButtonGroup
+                        size="small"
+                        value={currentQueryMode}
+                        exclusive
+                        onChange={handleToggleQueryMode}
+                        sx={{
+                          padding: '6px 8px',
+                          marginBottom: '3px',
+                        }}
+                      >
+                        <Tooltip title={t('Show all correlated entities')}>
+                          <ToggleButton
+                            value="all-entities"
+                            selected={currentQueryMode === 'all-entities'}
+                          >
+                            <HubOutlined
+                              fontSize="small"
+                              color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                            />
+                          </ToggleButton>
+                        </Tooltip>
+                        <Tooltip title={t('Show only correlated observables and indicators')}>
+                          <ToggleButton
+                            value="indicators-and-observables"
+                            selected={currentQueryMode === 'indicators-and-observables'}
+                          >
+                            <PolylineOutlined
+                              fontSize="small"
+                              color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                            />
+                          </ToggleButton>
+                        </Tooltip>
+                      </ToggleButtonGroup>
                     )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -988,7 +988,8 @@ class ReportKnowledgeGraphBar extends Component {
                         exclusive
                         onChange={handleToggleQueryMode}
                         style={{
-                          padding: '4px 8px',
+                          padding: '6px 8px',
+                          marginBottom: '3px',
                         }}
                       >
                         <Tooltip title={t('Show all correlated entities')}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraphBar.jsx
@@ -47,6 +47,8 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
 import { Form, Formik } from 'formik';
+import ToggleButton from '@mui/material/ToggleButton';
+import { ToggleButtonGroup } from '@mui/material';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
@@ -528,23 +530,6 @@ class ReportKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
-                  {handleToggleQueryMode && (
-                  <Tooltip
-                    title={
-                      currentQueryMode === 'all-entities'
-                        ? t('Show only correlated observables and indicators')
-                        : t('Show all correlated entities')
-                    }
-                  >
-                    <IconButton
-                      color={'secondary'}
-                      onClick={handleToggleQueryMode.bind(this)}
-                      size="large"
-                    >
-                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                    </IconButton>
-                  </Tooltip>
-                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -996,6 +981,40 @@ class ReportKnowledgeGraphBar extends Component {
                         enableReferences={enableReferences}
                       />
                     )}
+                    {handleToggleQueryMode && (
+                      <ToggleButtonGroup
+                        size="small"
+                        value={currentQueryMode}
+                        exclusive
+                        onChange={handleToggleQueryMode}
+                        style={{
+                          padding: '4px 8px',
+                        }}
+                      >
+                        <Tooltip title={t('Show all correlated entities')}>
+                          <ToggleButton
+                            value="all-entities"
+                            selected={currentQueryMode === 'all-entities'}
+                          >
+                            <HubOutlined
+                              fontSize="small"
+                              color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                            />
+                          </ToggleButton>
+                        </Tooltip>
+                        <Tooltip title={t('Show only correlated observables and indicators')}>
+                          <ToggleButton
+                            value="indicators-and-observables"
+                            selected={currentQueryMode === 'indicators-and-observables'}
+                          >
+                            <PolylineOutlined
+                              fontSize="small"
+                              color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                            />
+                          </ToggleButton>
+                        </Tooltip>
+                      </ToggleButtonGroup>
+                    )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>
                         <IconButton
@@ -1004,7 +1023,7 @@ class ReportKnowledgeGraphBar extends Component {
                           disabled={!editionEnabled}
                           size="large"
                         >
-                          <EditOutlined />
+                          <EditOutlined/>
                         </IconButton>
                       </span>
                     </Tooltip>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -927,7 +927,8 @@ class IncidentKnowledgeGraphBar extends Component {
                       exclusive
                       onChange={handleToggleQueryMode}
                       style={{
-                        padding: '4px 8px',
+                        padding: '6px 8px',
+                        marginBottom: '3px',
                       }}
                     >
                       <Tooltip title={t('Show all correlated entities')}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraphBar.jsx
@@ -43,6 +43,8 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
 import { Form, Formik } from 'formik';
+import { ToggleButtonGroup } from '@mui/material';
+import ToggleButton from '@mui/material/ToggleButton';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
@@ -502,23 +504,6 @@ class IncidentKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
-                  {handleToggleQueryMode && (
-                  <Tooltip
-                    title={
-                      currentQueryMode === 'all-entities'
-                        ? t('Show only correlated observables and indicators')
-                        : t('Show all correlated entities')
-                    }
-                  >
-                    <IconButton
-                      color={'secondary'}
-                      onClick={handleToggleQueryMode.bind(this)}
-                      size="large"
-                    >
-                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                    </IconButton>
-                  </Tooltip>
-                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -934,6 +919,40 @@ class IncidentKnowledgeGraphBar extends Component {
                         confidence={caseData.confidence}
                         enableReferences={enableReferences}
                       />
+                    )}
+                    {handleToggleQueryMode && (
+                    <ToggleButtonGroup
+                      size="small"
+                      value={currentQueryMode}
+                      exclusive
+                      onChange={handleToggleQueryMode}
+                      style={{
+                        padding: '4px 8px',
+                      }}
+                    >
+                      <Tooltip title={t('Show all correlated entities')}>
+                        <ToggleButton
+                          value="all-entities"
+                          selected={currentQueryMode === 'all-entities'}
+                        >
+                          <HubOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title={t('Show only correlated observables and indicators')}>
+                        <ToggleButton
+                          value="indicators-and-observables"
+                          selected={currentQueryMode === 'indicators-and-observables'}
+                        >
+                          <PolylineOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                    </ToggleButtonGroup>
                     )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -924,7 +924,8 @@ class CaseRfiKnowledgeGraphBar extends Component {
                       exclusive
                       onChange={handleToggleQueryMode}
                       style={{
-                        padding: '4px 8px',
+                        padding: '6px 8px',
+                        marginBottom: '3px',
                       }}
                     >
                       <Tooltip title={t('Show all correlated entities')}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraphBar.jsx
@@ -43,6 +43,8 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
 import { Form, Formik } from 'formik';
+import { ToggleButtonGroup } from '@mui/material';
+import ToggleButton from '@mui/material/ToggleButton';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
@@ -502,23 +504,6 @@ class CaseRfiKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
-                  {handleToggleQueryMode && (
-                  <Tooltip
-                    title={
-                      currentQueryMode === 'all-entities'
-                        ? t('Show only correlated observables and indicators')
-                        : t('Show all correlated entities')
-                    }
-                  >
-                    <IconButton
-                      color={'secondary'}
-                      onClick={handleToggleQueryMode.bind(this)}
-                      size="large"
-                    >
-                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                    </IconButton>
-                  </Tooltip>
-                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -931,6 +916,40 @@ class CaseRfiKnowledgeGraphBar extends Component {
                         confidence={caseData.confidence}
                         enableReferences={enableReferences}
                       />
+                    )}
+                    {handleToggleQueryMode && (
+                    <ToggleButtonGroup
+                      size="small"
+                      value={currentQueryMode}
+                      exclusive
+                      onChange={handleToggleQueryMode}
+                      style={{
+                        padding: '4px 8px',
+                      }}
+                    >
+                      <Tooltip title={t('Show all correlated entities')}>
+                        <ToggleButton
+                          value="all-entities"
+                          selected={currentQueryMode === 'all-entities'}
+                        >
+                          <HubOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title={t('Show only correlated observables and indicators')}>
+                        <ToggleButton
+                          value="indicators-and-observables"
+                          selected={currentQueryMode === 'indicators-and-observables'}
+                        >
+                          <PolylineOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                    </ToggleButtonGroup>
                     )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -43,6 +43,8 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Slide from '@mui/material/Slide';
 import { Form, Formik } from 'formik';
+import { ToggleButtonGroup } from '@mui/material';
+import ToggleButton from '@mui/material/ToggleButton';
 import StixNestedRefRelationshipCreationFromKnowledgeGraph from '../../common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromKnowledgeGraph';
 import CommitMessage from '../../common/form/CommitMessage';
 import inject18n from '../../../../components/i18n';
@@ -502,23 +504,6 @@ class CaseRftKnowledgeGraphBar extends Component {
                     display: 'flex',
                   }}
                 >
-                  {handleToggleQueryMode && (
-                  <Tooltip
-                    title={
-                      currentQueryMode === 'all-entities'
-                        ? t('Show only correlated observables and indicators')
-                        : t('Show all correlated entities')
-                    }
-                  >
-                    <IconButton
-                      color={'secondary'}
-                      onClick={handleToggleQueryMode.bind(this)}
-                      size="large"
-                    >
-                      {currentQueryMode === 'all-entities' ? <HubOutlined /> : <PolylineOutlined />}
-                    </IconButton>
-                  </Tooltip>
-                  )}
                   <Tooltip
                     title={
                       currentMode3D ? t('Disable 3D mode') : t('Enable 3D mode')
@@ -931,6 +916,40 @@ class CaseRftKnowledgeGraphBar extends Component {
                         confidence={caseData.confidence}
                         enableReferences={enableReferences}
                       />
+                    )}
+                    {handleToggleQueryMode && (
+                    <ToggleButtonGroup
+                      size="small"
+                      value={currentQueryMode}
+                      exclusive
+                      onChange={handleToggleQueryMode}
+                      style={{
+                        padding: '4px 8px',
+                      }}
+                    >
+                      <Tooltip title={t('Show all correlated entities')}>
+                        <ToggleButton
+                          value="all-entities"
+                          selected={currentQueryMode === 'all-entities'}
+                        >
+                          <HubOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'all-entities' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title={t('Show only correlated observables and indicators')}>
+                        <ToggleButton
+                          value="indicators-and-observables"
+                          selected={currentQueryMode === 'indicators-and-observables'}
+                        >
+                          <PolylineOutlined
+                            fontSize="small"
+                            color={currentQueryMode === 'indicators-and-observables' ? 'secondary' : 'primary'}
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                    </ToggleButtonGroup>
                     )}
                     <Tooltip title={t('Edit the selected item')}>
                       <span>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraphBar.jsx
@@ -924,7 +924,8 @@ class CaseRftKnowledgeGraphBar extends Component {
                       exclusive
                       onChange={handleToggleQueryMode}
                       style={{
-                        padding: '4px 8px',
+                        padding: '6px 8px',
+                        marginBottom: '3px',
                       }}
                     >
                       <Tooltip title={t('Show all correlated entities')}>


### PR DESCRIPTION
### Proposed changes

* Add a button for each correlation graph display
* Move the buttons to the right of the toolbar

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/3227#event-15265369027
