### PR TITLE
[frontend] reset searchTerm when highlighting changes in content mapping (#9520)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -146,7 +146,18 @@ const ContainerAddStixCoreObjects = (props) => {
   const contextFilters = useBuildEntityTypeBasedFilterContext(targetStixCoreObjectTypes, filters);
 
   const containerRef = useRef(null);
-  const keyword = mapping && (searchTerm ?? '').length === 0 ? selectedText : searchTerm;
+  const [mappingSearch, setMappingSearch] = useState(null);
+  const [currentSelectedText, setCurrentSelectedText] = useState(selectedText);
+  if (currentSelectedText !== selectedText) {
+    setMappingSearch(null);
+    setCurrentSelectedText(selectedText);
+  }
+  let keyword;
+  if (!mapping) {
+    keyword = searchTerm;
+  } else {
+    keyword = !mappingSearch ? selectedText : mappingSearch;
+  }
   const handleOpenCreateEntity = () => {
     setOpenCreateEntity(true);
     setOpenSpeedDial(false);
@@ -319,7 +330,7 @@ const ContainerAddStixCoreObjects = (props) => {
         sortBy={sortBy}
         orderAsc={orderAsc}
         dataColumns={buildColumns()}
-        handleSearch={helpers.handleSearch}
+        handleSearch={mapping ? setMappingSearch : helpers.handleSearch}
         keyword={keyword}
         handleSort={helpers.handleSort}
         handleAddFilter={helpers.handleAddFilter}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* now use a local search state in ContainerAddStixCoreObjects when used for mapping, instead of using local storage

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9520 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
