### PR TITLE
[frontend] Sighting redirection from an entity Sighting tab (#8146)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
@@ -16,6 +16,7 @@ import { EntityStixSightingRelationshipLine_node$key } from '@components/events/
 import {
   EntityStixSightingRelationshipsLinesPaginationQuery$variables,
 } from '@components/events/stix_sighting_relationships/__generated__/EntityStixSightingRelationshipsLinesPaginationQuery.graphql';
+import { ListItemButton } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemConfidence from '../../../../components/ItemConfidence';
@@ -257,12 +258,11 @@ export const EntityStixSightingRelationshipLine: FunctionComponent<EntityStixSig
   );
   const entity = isTo ? data.from : data.to;
   const restricted = entity === null;
-  const link = (data?.entity_type) ? `${resolveLink(data.entity_type)}/${data.id}` : undefined;
+  const link = `${resolveLink(data.entity_type)}/${data.id}`;
   return (
-    <ListItem
+    <ListItemButton
       classes={{ root: classes.item }}
       divider={true}
-      button={true}
       component={Link}
       to={link}
       disabled={restricted}
@@ -351,7 +351,7 @@ export const EntityStixSightingRelationshipLine: FunctionComponent<EntityStixSig
           />
         )}
       </ListItemSecondaryAction>
-    </ListItem>
+    </ListItemButton>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
@@ -256,10 +256,8 @@ export const EntityStixSightingRelationshipLine: FunctionComponent<EntityStixSig
     node,
   );
   const entity = isTo ? data.from : data.to;
-  const isObservable = !!entity?.observable_value;
   const restricted = entity === null;
-  const entityLink = (entity?.entity_type) ? `${resolveLink(entity.entity_type)}/${entity.id}` : undefined;
-  const link = isObservable ? `${entityLink}` : `${entityLink}/knowledge/sightings/${data.id}`;
+  const link = (data?.entity_type) ? `${resolveLink(data.entity_type)}/${data.id}` : undefined;
   return (
     <ListItem
       classes={{ root: classes.item }}


### PR DESCRIPTION
### Proposed changes
When in an entity Sighting tab, when clicking on a sighting line, be redirected to the Sigthing overview (and not in the knowledge tab of an entity)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8146
