### PR TITLE
[frontend] rename files on download to avoid UUID as names (#9634)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
@@ -7,13 +7,13 @@ import { graphql } from 'react-relay';
 import { ExclusionListsLine_node$data } from '@components/settings/exclusion_lists/__generated__/ExclusionListsLine_node.graphql';
 import { ExclusionListsLinesPaginationQuery$variables } from '@components/settings/exclusion_lists/__generated__/ExclusionListsLinesPaginationQuery.graphql';
 import ExclusionListEdition, { exclusionListMutationFieldPatch } from '@components/settings/exclusion_lists/ExclusionListEdition';
-import { Link } from 'react-router-dom';
 import { APP_BASE_PATH } from 'src/relay/environment';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { deleteNode } from '../../../../utils/store';
+import downloadAs from '../../../../utils/downloadAs';
 
 export const exclusionListPopoverDeletionMutation = graphql`
   mutation ExclusionListPopoverDeletionMutation($id: ID!) {
@@ -87,7 +87,10 @@ const ExclusionListPopover: FunctionComponent<ExclusionListPopoverProps> = ({
 
   const handleCloseEditionForm = () => setIsEditionFormOpen(false);
 
-  const downloadFileLink = `${APP_BASE_PATH}/storage/get/${encodeURIComponent(data.file_id)}`;
+  const handleDownload = () => {
+    const downloadFileLink = `${APP_BASE_PATH}/storage/get/${encodeURIComponent(data.file_id)}`;
+    downloadAs(downloadFileLink, data.name).then(handleClose);
+  };
 
   return (
     <>
@@ -102,11 +105,7 @@ const ExclusionListPopover: FunctionComponent<ExclusionListPopoverProps> = ({
         <MenuItem onClick={handleEnable}>{data.enabled ? t_i18n('Disable') : t_i18n('Enable')}</MenuItem>
         <MenuItem onClick={handleDisplayEdit}>{t_i18n('Update')}</MenuItem>
         <MenuItem
-          component={Link}
-          to={downloadFileLink}
-          onClick={handleClose}
-          target="_blank"
-          rel="noopener noreferrer"
+          onClick={handleDownload}
         >{t_i18n('Download file')}</MenuItem>
         <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
       </Menu>

--- a/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackageLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackageLine.tsx
@@ -26,6 +26,7 @@ import { hexToRGB } from '../../../../utils/Colors';
 import { DataColumns } from '../../../../components/list_lines';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { minutesBetweenDates, now } from '../../../../utils/Time';
+import downloadAs from '../../../../utils/downloadAs';
 
 const styles = {
   bodyItem: {
@@ -164,7 +165,7 @@ const SupportPackageLine: FunctionComponent<SupportPackageLineProps> = ({
         // Check if there is a valid URL and initiate download
         if (res.supportPackageForceZip?.package_url) {
           MESSAGING$.notifySuccess('Force zip launched. Your download will start shortly.');
-          window.location.href = `${APP_BASE_PATH}/storage/get/${encodeURIComponent(res.supportPackageForceZip.package_url)}`;
+          downloadAs(`${APP_BASE_PATH}/storage/get/${encodeURIComponent(res.supportPackageForceZip.package_url)}`, data.name);
         } else {
           MESSAGING$.notifyError('No download URL available.');
         }
@@ -231,9 +232,9 @@ const SupportPackageLine: FunctionComponent<SupportPackageLineProps> = ({
             <span>
               <IconButton
                 disabled={!data.package_url}
-                href={`${APP_BASE_PATH}/storage/get/${encodeURIComponent(
-                  data.package_url || '',
-                )}`}
+                onClick={() => {
+                  downloadAs(`${APP_BASE_PATH}/storage/get/${encodeURIComponent(data.package_url || '')}`, data.name);
+                }}
               >
                 <GetAppOutlined fontSize="small" />
               </IconButton>

--- a/opencti-platform/opencti-front/src/utils/downloadAs.ts
+++ b/opencti-platform/opencti-front/src/utils/downloadAs.ts
@@ -1,0 +1,40 @@
+import { MESSAGING$ } from '../relay/environment';
+
+/**
+ * Starts download of a file at given URL, saving it under a given name.
+ *
+ * @param url original URL to fetch from
+ * @param filename the final name for the downloaded file
+ */
+async function downloadAs(url: string, filename: string): Promise<void> {
+  try {
+    // Fetch the file
+    const response = await fetch(url);
+
+    // Check if the response is OK
+    if (!response.ok) {
+      MESSAGING$.notifyError(`Failed to fetch file. HTTP status: ${response.status}`);
+    }
+
+    // Get the file as a Blob
+    const blob = await response.blob();
+
+    // Create a temporary URL for the Blob
+    const blobUrl = URL.createObjectURL(blob);
+
+    // Create a hidden anchor element
+    const anchor = document.createElement('a');
+    anchor.href = blobUrl;
+    anchor.download = filename; // Force the desired filename
+    document.body.appendChild(anchor); // Append to the DOM temporarily
+    anchor.click(); // Trigger the download
+    document.body.removeChild(anchor); // Clean up
+
+    // Release the Blob URL to free memory
+    URL.revokeObjectURL(blobUrl);
+  } catch (error) {
+    MESSAGING$.notifyError(`Failed to download file. Error: ${error}`);
+  }
+}
+
+export default downloadAs;


### PR DESCRIPTION
When downloading a file, we use direct links to the storage.
Some files are generated and named as UUID, not very easy to use once downloaded.

In this PR, I add a quick workaround to be able to override the filename at download time, and use it for exclusion lists and support packages.

Note that a proper implementation would be to do this backend side, so that we are able to fetch files with proper naming, according to data / business logic. This is significantly more work than this workaround.

closes #9634 

Issue #9635 addresses a long-term solution, for another PR.