### PR TITLE
[worker] Pool thread control

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -388,7 +388,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             "OPENCTI_JSON_LOGGING", ["opencti", "json_logging"], config, default=True
         )
         self.opencti_pool_size = get_config_variable(
-            "OPENCTI_EXECUTION_POOL_SIZE", ["opencti", "execution_pool_size"], config, default=1
+            "OPENCTI_EXECUTION_POOL_SIZE", ["opencti", "execution_pool_size"], config, default=5
         )
         # Load worker config
         self.log_level = get_config_variable(


### PR DESCRIPTION
In order to make worker predictable in term of api calls concurrency
By default a worker will create consumer thread for each queue but message execution will integrate a thread pool of only 1 slot