### PR TITLE
[backend] Introduce child fork to handle locking get/release and renewal

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,7 @@ steps:
       - apt-get -y install netcat-traditional
       - cd opencti-platform/opencti-front
       - yarn install
-      - npx playwright install --with-deps chromium
+      - npx playwright install --with-deps chrome
       - yarn build
       - yarn test:e2e
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
     environment:
       APP__BASE_URL: http://api-tests:4010/
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__SYNC_RAW_START_REMOTE_URI: http://opencti-raw-start:4100/graphql
@@ -215,6 +216,7 @@ services:
     environment:
       APP__PORT: 4100
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -249,6 +251,7 @@ services:
     environment:
       APP__PORT: 4200
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -282,6 +285,7 @@ services:
     environment:
       APP__PORT: 4300
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -335,6 +339,7 @@ services:
     environment:
       APP__PORT: 4400
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
@@ -369,6 +374,7 @@ services:
       APP__PORT: 4500
       APP__ENABLED_DEV_FEATURES: '["*"]'
       APP__ADMIN__PASSWORD: admin
+      APP__CHILD_LOCKING_PROCESS__ENABLED: true
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159

--- a/.drone.yml
+++ b/.drone.yml
@@ -84,7 +84,6 @@ steps:
       - yarn lint
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
 
-
   - name: frontend-e2e-tests
     image: node:20.18.1
     volumes:
@@ -94,6 +93,7 @@ steps:
       BACK_END_URL: http://opencti-e2e-start:4500
       E2E_TEST: true
       TEAMS_WEBHOOK: teams-webhook-url
+    ipc: host
     commands:
       - apt-get update
       - apt-get -y install netcat-traditional

--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,7 @@ steps:
       - apt-get -y install netcat-traditional
       - cd opencti-platform/opencti-front
       - yarn install
-      - npx playwright install --with-deps chrome
+      - npx playwright install --with-deps chromium
       - yarn build
       - yarn test:e2e
     depends_on:

--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -62,14 +62,16 @@ export default defineConfig({
       testMatch: "init.data.ts",
       use: {
         ...devices['Desktop Chrome'],
+        channel: 'chrome',
         storageState: 'tests_e2e/.setup/.auth/user.json',
       },
       dependencies: ['setup'],
     },
     {
-      name: 'chromium',
+      name: 'chrome',
       use: {
         ...devices['Desktop Chrome'],
+        channel: 'chrome',
         storageState: 'tests_e2e/.setup/.auth/user.json',
         viewport: {
           width: 1920,

--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -62,16 +62,14 @@ export default defineConfig({
       testMatch: "init.data.ts",
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome',
         storageState: 'tests_e2e/.setup/.auth/user.json',
       },
       dependencies: ['setup'],
     },
     {
-      name: 'chrome',
+      name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome',
         storageState: 'tests_e2e/.setup/.auth/user.json',
         viewport: {
           width: 1920,

--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -50,7 +50,7 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
   await expect(dataTable.getNumberElements(1)).toBeVisible();
   await dataTable.getCheckAll().click();
   await taskPopup.launchAddLabel('background-task-search-add-label', false);
-
+  await sleep(3000); // Wait 3 secs for task creation
   await tasksPage.goto();
   await expect(tasksPage.getPage()).toBeVisible();
 

--- a/opencti-platform/opencti-graphql/builder/dev/dev.js
+++ b/opencti-platform/opencti-graphql/builder/dev/dev.js
@@ -26,6 +26,7 @@ esbuild.build({
     ],
     entryPoints: [
         'src/back.js',
+        'src/lock/child-lock.manager.ts',
         'script/script-clean-relations.js',
         'script/script-insert-dataset.js',
         'script/script-wait-for-api.js',

--- a/opencti-platform/opencti-graphql/builder/prod/prod.js
+++ b/opencti-platform/opencti-graphql/builder/prod/prod.js
@@ -26,6 +26,7 @@ esbuild.build({
     ],
     entryPoints: [
         'src/back.js',
+        'src/lock/child-lock.manager.ts',
         'script/script-clean-relations.js'
     ],
     entryNames: "[name]",

--- a/opencti-platform/opencti-graphql/src/back.js
+++ b/opencti-platform/opencti-graphql/src/back.js
@@ -55,6 +55,7 @@ if (ENABLED_EVENT_LOOP_MONITORING) {
     }
   }, { threshold });
 }
+
 // -- Start the platform
 // noinspection JSIgnoredPromiseFromCall
 platformStart();

--- a/opencti-platform/opencti-graphql/src/boot.js
+++ b/opencti-platform/opencti-graphql/src/boot.js
@@ -1,9 +1,9 @@
-import { fork } from 'child_process';
 import { environment, getStoppingState, logApp, setStoppingState } from './config/conf';
 import platformInit, { checkFeatureFlags, checkSystemDependencies } from './initialization';
 import cacheManager from './manager/cacheManager';
 import { shutdownRedisClients } from './database/redis';
 import { shutdownModules, startModules } from './managers';
+import { initLockFork, lockResources } from './lock/master-lock';
 
 // region platform start and stop
 export const platformStart = async () => {
@@ -38,60 +38,29 @@ export const platformStart = async () => {
       logApp.error('[OPENCTI] Modules startup failed', { cause: modulesError });
       throw modulesError;
     }
-    // -- Start the control lock manager
-    const forked = fork('./build/child-lock.manager.js', { test: 'test' }, {});
-    const lockResources = async (operation, ids) => {
-      return new Promise((resolve, reject) => {
-        forked.send({ type: 'lock', operation, ids },);
-        forked.on('message', (msg) => {
-          if (msg.operation === operation && msg.type === 'lock') {
-            if (msg.success) {
-              resolve(msg);
-            } else {
-              reject(msg.error);
-            }
-          }
-        });
-      });
-    };
-    const unlockResources = async (operation) => {
-      return new Promise((resolve, reject) => {
-        forked.send({ type: 'unlock', operation },);
-        forked.on('message', (msg) => {
-          if (msg.operation === operation && msg.type === 'unlock') {
-            if (msg.success) {
-              resolve(msg);
-            } else {
-              reject(msg.error);
-            }
-          }
-        });
-      });
-    };
+    // Init the lock manager
     try {
-      const d = await lockResources('operation_id', ['id1', 'id2']);
+      initLockFork();
+    } catch (lockManagerError) {
+      logApp.error('[OPENCTI] Lock process startup failed', { cause: lockManagerError });
+      throw lockManagerError;
+    }
+
+    // TODO remove test
+    try {
+      const d = await lockResources(['id1', 'id2']);
       console.log('success locking ???? ', d);
+      setTimeout(async () => {
+        try {
+          d.unlock();
+          console.log('success unlocking ???? ', d);
+        } catch (err) {
+          console.log('err unlocking ???? ', err);
+        }
+      }, 75000);
     } catch (err) {
       console.log('err locking ???? ', err);
     }
-
-    setTimeout(async () => {
-      try {
-        const d = await lockResources('operation_id', ['id1']);
-        console.log('success unlocking ???? ', d);
-      } catch (err) {
-        console.log('err unlocking ???? ', err);
-      }
-    }, 15000);
-
-    setTimeout(async () => {
-      try {
-        const d = await unlockResources('operation_id');
-        console.log('success unlocking ???? ', d);
-      } catch (err) {
-        console.log('err unlocking ???? ', err);
-      }
-    }, 75000);
   } catch (mainError) {
     process.exit(1);
   }

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -187,7 +187,7 @@ import { getDraftContext } from '../utils/draftContext';
 import { enrichWithRemoteCredentials } from '../config/credentials';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_IPV4_ADDR, ENTITY_IPV6_ADDR, isStixCyberObservable } from '../schema/stixCyberObservable';
-import { lockResource } from './redis';
+import { lockResources } from '../lock/master-lock';
 import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_DELETE_LINKED, DRAFT_OPERATION_UPDATE_LINKED } from '../modules/draftWorkspace/draftOperations';
 
 const ELK_ENGINE = 'elk';
@@ -4049,7 +4049,7 @@ const loadDraftElement = async (context, user, element) => {
   const currentDraft = getDraftContext(context, user);
   const lockKey = `${draftCopyLockPrefix}_${currentDraft}_${element.internal_id}`;
   try {
-    lock = await lockResource([lockKey]);
+    lock = await lockResources([lockKey]);
     const loadedElement = await elLoadById(context, user, element.internal_id);
     if (loadedElement && loadedElement._index.includes(INDEX_DRAFT_OBJECTS)) return loadedElement;
 

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -88,7 +88,7 @@ import {
   X_DETECTION,
   X_WORKFLOW_ID
 } from '../schema/identifier';
-import { lockResource, notify, redisAddDeletions, storeCreateEntityEvent, storeCreateRelationEvent, storeDeleteEvent, storeMergeEvent, storeUpdateEvent } from './redis';
+import { notify, redisAddDeletions, storeCreateEntityEvent, storeCreateRelationEvent, storeDeleteEvent, storeMergeEvent, storeUpdateEvent } from './redis';
 import { cleanStixIds } from './stix';
 import {
   ABSTRACT_BASIC_RELATIONSHIP,
@@ -210,6 +210,7 @@ import { deleteAllObjectFiles, moveAllFilesFromEntityToAnother, uploadToStorage 
 import { storeFileConverter } from './file-storage';
 import { getDraftContext } from '../utils/draftContext';
 import { getDraftChanges, isDraftSupportedEntity } from './draft-utils';
+import { lockResources } from '../lock/master-lock';
 
 // region global variables
 const MAX_BATCH_SIZE = 300;
@@ -1468,7 +1469,7 @@ export const mergeEntities = async (context, user, targetEntityId, sourceEntityI
   let lock;
   try {
     // Lock the participants that will be merged
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
     // Entities must be fully loaded with admin user to resolve/move all dependencies
     const initialInstance = await storeLoadByIdWithRefs(context, user, targetEntityId);
     const target = { ...initialInstance };
@@ -1991,7 +1992,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
   const participantIds = R.uniq(locksIds.filter((e) => !locks.includes(e)));
   try {
     // Try to get the lock in redis
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
     // region handle attributes
     // Only for StixCyberObservable
     const lookingEntities = [];
@@ -2819,7 +2820,7 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
   const participantIds = inputIds.filter((e) => !locks.includes(e));
   try {
     // Try to get the lock in redis
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
     // region check existing relationship
     const existingRelationships = await getExistingRelations(context, user, resolvedInput, opts);
     let existingRelationship = null;
@@ -3000,7 +3001,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   let lock;
   try {
     // Try to get the lock in redis
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
     // Generate the internal id if needed
     const standardId = resolvedInput.standard_id || generateStandardId(type, resolvedInput);
     // Check if the entity exists, must be done with SYSTEM USER to really find it.
@@ -3197,7 +3198,7 @@ const draftInternalDeleteElement = async (context, user, draftElement) => {
   const participantIds = [draftElement.internal_id];
   try {
     // Try to get the lock in redis
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
 
     await elDeleteElements(context, user, [draftElement]);
   } catch (err) {
@@ -3248,7 +3249,7 @@ export const internalDeleteElementById = async (context, user, id, opts = {}) =>
   const participantIds = [element.internal_id];
   try {
     // Try to get the lock in redis
-    lock = await lockResource(participantIds, { draftId: getDraftContext(context, user) });
+    lock = await lockResources(participantIds, { draftId: getDraftContext(context, user) });
     if (isStixRefRelationship(element.entity_type)) {
       const referencesPromises = opts.references ? internalFindByIds(context, user, opts.references, { type: ENTITY_TYPE_EXTERNAL_REFERENCE }) : Promise.resolve([]);
       const references = await Promise.all(referencesPromises);

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -334,7 +334,7 @@ export const consumeQueue = async (context, connectorId, connectionSetterCallbac
         if (err) {
           reject(err);
         } else { // Connection success
-          logApp.info('[QUEUEING] Starting connector queue consuming', { connectorId });
+          logApp.debug('[QUEUEING] Starting connector queue consuming', { connectorId });
           conn.on('close', (onConnectError) => {
             if (onConnectError) {
               reject(onConnectError);

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -141,6 +141,14 @@ type RedisConnection = Cluster | Redis ;
 interface RedisClients { base: RedisConnection, lock: RedisConnection, pubsub: RedisPubSub }
 
 let redisClients: RedisClients;
+// Method reserved for lock child process
+export const initializeOnlyRedisLockClient = async () => {
+  const lock = await createRedisClient('lock', true);
+  // Disable typescript check for this specific use case.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  redisClients = { lock, base: null, pubsub: null };
+};
 export const initializeRedisClients = async () => {
   const base = await createRedisClient('base', true);
   const lock = await createRedisClient('lock', true);

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -8,7 +8,7 @@ import { initializeBucket, storageInit } from './database/file-storage';
 import { enforceQueuesConsistency, initializeInternalQueues, rabbitMQIsAlive } from './database/rabbitmq';
 import { initDefaultNotifiers } from './modules/notifier/notifier-domain';
 import { checkPythonAvailability } from './python/pythonBridge';
-import { lockResource, redisInit } from './database/redis';
+import { redisInit } from './database/redis';
 import { ENTITY_TYPE_MIGRATION_STATUS } from './schema/internalObject';
 import { applyMigration, lastAvailableMigrationTime } from './database/migration';
 import { createEntity, loadEntity } from './database/middleware';
@@ -21,6 +21,7 @@ import { initManagerConfigurations } from './modules/managerConfiguration/manage
 import { initializeData } from './database/data-initialization';
 import { initExclusionListCache } from './database/exclusionListCache';
 import { initFintelTemplates } from './modules/fintelTemplate/fintelTemplate-domain';
+import { lockResources } from './lock/master-lock';
 
 // region Platform constants
 const PLATFORM_LOCK_ID = 'platform_init_lock';
@@ -91,7 +92,7 @@ const isCompatiblePlatform = async (context) => {
 const platformInit = async (withMarkings = true) => {
   let lock;
   try {
-    lock = await lockResource([PLATFORM_LOCK_ID]);
+    lock = await lockResources([PLATFORM_LOCK_ID]);
     const context = executionContext('platform_initialization');
     logApp.info('[INIT] Starting platform initialization');
     const alreadyExists = await isExistingPlatform(context);

--- a/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
+++ b/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
@@ -12,20 +12,21 @@ interface LockData {
   type: 'lock' | 'unlock'
   operation: string
   ids: string[]
+  args: object
 }
 
 redisInit().then(() => {
   process.on('message', async (data: LockData) => {
-    console.log('> child message', data);
     if (data.type === 'lock') {
+      // console.log('> locking', data.operation, data.ids);
       try {
-        const lock = await lockResource(data.ids);
+        const lock = await lockResource(data.ids, data.args);
         activeLocks.set(data.operation, lock);
         if (process.send) {
           process.send({ operation: data.operation, type: data.type, success: true });
         }
       } catch (err) {
-        console.log('> child err', err);
+        // console.log('> child err', err);
         if (process.send) {
           process.send({ operation: data.operation, error: err, type: data.type, success: false });
         }
@@ -34,6 +35,7 @@ redisInit().then(() => {
     if (data.type === 'unlock') {
       const currentLock = activeLocks.get(data.operation);
       if (currentLock) {
+        // console.log('> unlocking', data.operation);
         try {
           await currentLock.unlock();
           if (process.send) {

--- a/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
+++ b/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
@@ -23,7 +23,9 @@ initializeOnlyRedisLockClient().then(() => {
       try {
         const lock = await lockResource(data.ids, data.args);
         activeLocks.set(data.operation, lock);
-        if (process.send) process.send({ operation: data.operation, type: data.type, success: true });
+        if (process.send) {
+          process.send({ operation: data.operation, type: data.type, success: true });
+        }
       } catch (err) {
         if (process.send) {
           process.send({ operation: data.operation, error: err, type: data.type, success: false });
@@ -34,12 +36,17 @@ initializeOnlyRedisLockClient().then(() => {
     if (data.type === 'unlock') {
       const currentLock = activeLocks.get(data.operation);
       if (currentLock) {
-        // console.log('> unlocking', data.operation);
         try {
           await currentLock.unlock();
-          if (process.send) process.send({ operation: data.operation, type: data.type, success: true });
+          if (process.send) {
+            process.send({ operation: data.operation, type: data.type, success: true });
+          }
         } catch (err) {
-          if (process.send) process.send({ operation: data.operation, error: err, type: data.type, success: false });
+          if (process.send) {
+            process.send({ operation: data.operation, error: err, type: data.type, success: false });
+          }
+        } finally {
+          activeLocks.delete(data.operation);
         }
       }
     }

--- a/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
+++ b/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
@@ -1,0 +1,50 @@
+import { lockResource, redisInit } from '../database/redis';
+
+interface InternalLock {
+  signal: AbortSignal
+  extend: () => Promise<void>
+  unlock: () => Promise<void>
+}
+
+const activeLocks: Map<string, InternalLock> = new Map<string, InternalLock>();
+
+interface LockData {
+  type: 'lock' | 'unlock'
+  operation: string
+  ids: string[]
+}
+
+redisInit().then(() => {
+  process.on('message', async (data: LockData) => {
+    console.log('> child message', data);
+    if (data.type === 'lock') {
+      try {
+        const lock = await lockResource(data.ids);
+        activeLocks.set(data.operation, lock);
+        if (process.send) {
+          process.send({ operation: data.operation, type: data.type, success: true });
+        }
+      } catch (err) {
+        console.log('> child err', err);
+        if (process.send) {
+          process.send({ operation: data.operation, error: err, type: data.type, success: false });
+        }
+      }
+    }
+    if (data.type === 'unlock') {
+      const currentLock = activeLocks.get(data.operation);
+      if (currentLock) {
+        try {
+          await currentLock.unlock();
+          if (process.send) {
+            process.send({ operation: data.operation, type: data.type, success: true });
+          }
+        } catch (err) {
+          if (process.send) {
+            process.send({ operation: data.operation, error: err, type: data.type, success: false });
+          }
+        }
+      }
+    }
+  });
+});

--- a/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
+++ b/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
@@ -21,7 +21,8 @@ initializeOnlyRedisLockClient().then(() => {
     // In case of lock
     if (data.type === 'lock') {
       try {
-        const lock = await lockResource(data.ids, data.args);
+        const options = { child_operation: data.operation, ...data.args };
+        const lock = await lockResource(data.ids, options);
         activeLocks.set(data.operation, lock);
         if (process.send) {
           process.send({ operation: data.operation, type: data.type, success: true });
@@ -51,4 +52,9 @@ initializeOnlyRedisLockClient().then(() => {
       }
     }
   });
+  // Don't do anything in exist event, process is attached to the parent
+  // The parent will close the process as an operating system behavior
+  process.on('exit', () => {});
+  process.on('SIGTERM', () => {});
+  process.on('SIGINT', () => {});
 });

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -6,8 +6,12 @@ import { logApp } from '../config/conf';
 // -- Start the control lock manager
 let forked;
 export const initLockFork = () => {
-  forked = fork('./build/child-lock.manager.js');
-  logApp.info('[CHECK] Locking fork process started', forked);
+  if (!forked) {
+    forked = fork('./build/child-lock.manager.js');
+    logApp.info('[CHECK] Locking fork process started');
+  } else {
+    logApp.info('[CHECK] Locking fork process already started');
+  }
 };
 
 const unlockResources = async (operation) => {

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -20,7 +20,7 @@ export const initLockFork = () => {
   if (!lockProcess.forked) {
     lockProcess.forked = fork('./build/child-lock.manager.js', {
       execArgv: [`--max-old-space-size=${CHILD_PROCESS_MEMORY}`]
-    });
+    }, { detached: false });
     lockProcess.forked.on('message', (msg) => {
       const messageKey = `${msg.operation}-${msg.type}`;
       if (lockProcess.callbacks.has(messageKey)) {

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -1,0 +1,52 @@
+import { fork } from 'child_process';
+import { v4 as uuidv4 } from 'uuid';
+import { TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
+
+// -- Start the control lock manager
+let forked;
+export const initLockFork = () => {
+  forked = fork('./build/child-lock.manager.js');
+};
+
+const unlockResources = async (operation) => {
+  return new Promise((resolve, reject) => {
+    forked.send({ type: 'unlock', operation },);
+    forked.on('message', (msg) => {
+      if (msg.operation === operation && msg.type === 'unlock') {
+        if (msg.success) {
+          resolve(msg);
+        } else {
+          reject(msg.error);
+        }
+      }
+    });
+  });
+};
+export const lockResources = async (ids) => {
+  if (!forked) {
+    throw UnsupportedError('Lock child fork not initialize');
+  }
+  const operation = uuidv4();
+  const controller = new AbortController();
+  const { signal } = controller;
+  return new Promise((resolve, reject) => {
+    forked.send({ type: 'lock', operation, ids },);
+    forked.on('message', (msg) => {
+      if (msg.operation === operation && msg.type === 'lock') {
+        if (msg.success) {
+          resolve({
+            operation,
+            signal,
+            unlock: () => unlockResources(msg.operation),
+            result: msg
+          });
+        } else {
+          reject(msg.error);
+        }
+      }
+      if (msg.operation === operation && msg.operation === 'abort') {
+        controller.abort({ name: TYPE_LOCK_ERROR });
+      }
+    });
+  });
+};

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -5,7 +5,7 @@ import conf, { booleanConf, logApp } from '../config/conf';
 import { lockResource } from '../database/redis';
 
 // Global variable for the child process
-const USE_CHILD_LOCK = booleanConf('app:child_locking_process:enabled', true);
+const USE_CHILD_LOCK = booleanConf('app:child_locking_process:enabled', false);
 const CHILD_PROCESS_MEMORY = conf.get('app:child_locking_process:max_memory') ?? '256';
 const lockProcess = {
   forked: undefined,
@@ -77,12 +77,8 @@ const childLockResources = async (ids, args = {}) => {
     // Set up the lock callback
     lockProcess.callbacks.set(`${operation}-lock`, (msg) => {
       if (msg.success) {
-        resolve({
-          operation,
-          signal,
-          unlock: () => childUnlockResources(msg.operation),
-          result: msg
-        });
+        const unlock = () => childUnlockResources(msg.operation);
+        resolve({ operation, signal, unlock, result: msg });
       } else {
         reject(msg.error);
       }

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -1,58 +1,83 @@
 import { fork } from 'child_process';
-import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
 import { TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
-import { logApp } from '../config/conf';
+import conf, { logApp } from '../config/conf';
+
+// Global variable for the child process
+const CHILD_PROCESS_MEMORY = conf.get('app:locking_process:max_memory') ?? '256';
+const lockProcess = {
+  forked: undefined,
+  callbacks: new Map() // [op, { lock: fn, unlock: fn }]
+};
 
 // -- Start the control lock manager
-let forked;
 export const initLockFork = () => {
-  if (!forked) {
-    forked = fork('./build/child-lock.manager.js');
-    logApp.info('[CHECK] Locking fork process started');
+  if (!lockProcess.forked) {
+    lockProcess.forked = fork('./build/child-lock.manager.js', {
+      execArgv: [`--max-old-space-size=${CHILD_PROCESS_MEMORY}`]
+    });
+    lockProcess.forked.on('message', (msg) => {
+      const messageKey = `${msg.operation}-${msg.type}`;
+      if (lockProcess.callbacks.has(messageKey)) {
+        lockProcess.callbacks.get(messageKey)(msg);
+      } else {
+        logApp.warn('[LOCKING] Locking message with invalid operation', { operation: msg.operation });
+      }
+    });
+    logApp.info('[LOCKING] Locking fork process started');
   } else {
-    logApp.info('[CHECK] Locking fork process already started');
+    logApp.info('[LOCKING] Locking fork process already started');
   }
 };
 
+// Unlock definition
 const unlockResources = async (operation) => {
   return new Promise((resolve, reject) => {
-    forked.send({ type: 'unlock', operation },);
-    forked.on('message', (msg) => {
-      if (msg.operation === operation && msg.type === 'unlock') {
-        if (msg.success) {
-          resolve(msg);
-        } else {
-          reject(msg.error);
-        }
+    // Set up the unlock callback
+    lockProcess.callbacks.set(`${operation}-unlock`, (msg) => {
+      // Cleanup the callback map
+      lockProcess.callbacks.delete(`${operation}-lock`);
+      lockProcess.callbacks.delete(`${operation}-unlock`);
+      lockProcess.callbacks.delete(`${operation}-abort`);
+      // Resolve or reject depending on the unlock result
+      if (msg.success) {
+        resolve(msg);
+      } else {
+        reject(msg.error);
       }
     });
+    // Send the unlock operation to the child process
+    lockProcess.forked.send({ type: 'unlock', operation },);
   });
 };
+
+// Lock resources definition
 export const lockResources = async (ids, args = {}) => {
-  if (!forked) {
+  if (!lockProcess.forked) {
     throw UnsupportedError('Lock child fork not initialize');
   }
-  const operation = uuidv4();
+  const operation = crypto.randomUUID(); // Use crypto to fast ramdom generation
   const controller = new AbortController();
   const { signal } = controller;
   return new Promise((resolve, reject) => {
-    forked.send({ type: 'lock', operation, ids, args });
-    forked.on('message', (msg) => {
-      if (msg.operation === operation && msg.type === 'lock') {
-        if (msg.success) {
-          resolve({
-            operation,
-            signal,
-            unlock: () => unlockResources(msg.operation),
-            result: msg
-          });
-        } else {
-          reject(msg.error);
-        }
-      }
-      if (msg.operation === operation && msg.operation === 'abort') {
-        controller.abort({ name: TYPE_LOCK_ERROR });
+    // Set up the abort callback
+    lockProcess.callbacks.set(`${operation}-abort`, () => {
+      controller.abort({ name: TYPE_LOCK_ERROR });
+    });
+    // Set up the lock callback
+    lockProcess.callbacks.set(`${operation}-lock`, (msg) => {
+      if (msg.success) {
+        resolve({
+          operation,
+          signal,
+          unlock: () => unlockResources(msg.operation),
+          result: msg
+        });
+      } else {
+        reject(msg.error);
       }
     });
+    // Send the lock operation to the child process
+    lockProcess.forked.send({ type: 'lock', operation, ids, args });
   });
 };

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -5,7 +5,7 @@ import conf, { booleanConf, logApp } from '../config/conf';
 import { lockResource } from '../database/redis';
 
 // Global variable for the child process
-const USE_CHILD_LOCK = booleanConf('app:child_locking_process:enabled', false);
+const USE_CHILD_LOCK = booleanConf('app:child_locking_process:enabled', true);
 const CHILD_PROCESS_MEMORY = conf.get('app:child_locking_process:max_memory') ?? '256';
 const lockProcess = {
   forked: undefined,

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -26,8 +26,13 @@ export const initLockFork = () => {
       if (lockProcess.callbacks.has(messageKey)) {
         lockProcess.callbacks.get(messageKey)(msg);
       } else {
-        logApp.warn('[LOCKING] Locking message with invalid operation', { operation: msg.operation });
+        logApp.warn('[LOCKING] Locking message with invalid operation', { key: messageKey });
       }
+    });
+    lockProcess.forked.on('exit', (code) => {
+      // If exit is detected, exit the parent process
+      // It should not happen in standard situation
+      process.exit(code);
     });
     logApp.info('[LOCKING] Locking fork process started');
   } else {

--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
-import { ACTIVITY_STREAM_NAME, createStreamProcessor, lockResource, storeNotificationEvent, type StreamProcessor } from '../database/redis';
+import { ACTIVITY_STREAM_NAME, createStreamProcessor, storeNotificationEvent, type StreamProcessor } from '../database/redis';
 import conf, { booleanConf, ENABLED_DEMO_MODE, logApp } from '../config/conf';
 import { INDEX_HISTORY, isEmptyField } from '../database/utils';
 import { TYPE_LOCK_ERROR } from '../config/errors';
@@ -35,6 +35,7 @@ import type { ActivityNotificationEvent, NotificationUser, ResolvedLive, Resolve
 import { convertToNotificationUser, EVENT_NOTIFICATION_VERSION, getNotifications } from './notificationManager';
 import { isActivityEventMatchFilterGroup } from '../utils/filtering/filtering-activity-event/activity-event-filtering';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
+import { lockResources } from '../lock/master-lock';
 
 const ACTIVITY_ENGINE_KEY = conf.get('activity_manager:lock_key');
 const SCHEDULE_TIME = 10000;
@@ -154,7 +155,7 @@ const initActivityManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([ACTIVITY_ENGINE_KEY], { retryCount: 0 });
+      lock = await lockResources([ACTIVITY_ENGINE_KEY], { retryCount: 0 });
       running = true;
       logApp.info('[OPENCTI-MODULE] Running activity manager');
       const streamOpts = { streamName: ACTIVITY_STREAM_NAME };

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -1,5 +1,6 @@
 import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
-import { lockResource, redisDeleteWorks, redisGetConnectorStatus, redisGetWork } from '../database/redis';
+import { redisDeleteWorks, redisGetConnectorStatus, redisGetWork } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { connectors } from '../database/repository';
@@ -111,7 +112,7 @@ const connectorHandler = async () => {
   let lock;
   try {
     // Lock the manager
-    lock = await lockResource([CONNECTOR_MANAGER_KEY], { retryCount: 0 });
+    lock = await lockResources([CONNECTOR_MANAGER_KEY], { retryCount: 0 });
     running = true;
     const context = executionContext('connector_manager');
     // Execute the cleaning

--- a/opencti-platform/opencti-graphql/src/manager/expiredManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/expiredManager.js
@@ -1,6 +1,6 @@
 import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
 import { Promise } from 'bluebird';
-import { lockResource } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import { elList, ES_MAX_CONCURRENCY } from '../database/engine';
 import { READ_DATA_INDICES, READ_INDEX_INTERNAL_OBJECTS } from '../database/utils';
 import { prepareDate } from '../utils/format';
@@ -72,7 +72,7 @@ const expireHandler = async () => {
   let lock;
   try {
     // Lock the manager
-    lock = await lockResource([EXPIRED_MANAGER_KEY], { retryCount: 0 });
+    lock = await lockResources([EXPIRED_MANAGER_KEY], { retryCount: 0 });
     running = true;
     const context = executionContext('expiration_manager');
     const revokedInstancesPromise = revokedInstances(context);

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -19,7 +19,8 @@ import * as R from 'ramda';
 import type { BasicStoreSettings } from '../types/settings';
 import { EVENT_TYPE_UPDATE, waitInSec } from '../database/utils';
 import conf, { ENABLED_FILE_INDEX_MANAGER, logApp } from '../config/conf';
-import { createStreamProcessor, lockResource, type StreamProcessor, } from '../database/redis';
+import { createStreamProcessor, type StreamProcessor, } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { getEntityFromCache } from '../database/cache';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
@@ -147,7 +148,7 @@ const initFileIndexManager = () => {
       let lock;
       try {
         // Lock the manager
-        lock = await lockResource([FILE_INDEX_MANAGER_KEY], { retryCount: 0 });
+        lock = await lockResources([FILE_INDEX_MANAGER_KEY], { retryCount: 0 });
         running = true;
         logApp.debug('[OPENCTI-MODULE] Running file index manager');
         const managerConfiguration = await getManagerConfigurationFromCache(context, SYSTEM_USER, 'FILE_INDEX_MANAGER');
@@ -178,7 +179,7 @@ const initFileIndexManager = () => {
       let lock;
       try {
         // Lock the manager
-        lock = await lockResource([FILE_INDEX_MANAGER_STREAM_KEY], { retryCount: 0 });
+        lock = await lockResources([FILE_INDEX_MANAGER_STREAM_KEY], { retryCount: 0 });
         running = true;
         logApp.info('[OPENCTI-MODULE] Running file index manager stream handler');
         streamProcessor = createStreamProcessor(SYSTEM_USER, 'File index manager', handleStreamEvents);

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -1,7 +1,8 @@
 import * as R from 'ramda';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import * as jsonpatch from 'fast-json-patch';
-import { createStreamProcessor, lockResource, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, ENABLED_DEMO_MODE, logApp } from '../config/conf';
 import { EVENT_TYPE_UPDATE, INDEX_HISTORY, isEmptyField, isNotEmptyField } from '../database/utils';
 import { TYPE_LOCK_ERROR } from '../config/errors';
@@ -219,7 +220,7 @@ const initHistoryManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([HISTORY_ENGINE_KEY], { retryCount: 0 });
+      lock = await lockResources([HISTORY_ENGINE_KEY], { retryCount: 0 });
       running = true;
       logApp.info('[OPENCTI-MODULE] Running history manager');
       streamProcessor = createStreamProcessor(SYSTEM_USER, 'History manager', historyStreamHandler);

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -7,7 +7,7 @@ import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
 import type { SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import type { Moment } from 'moment';
 import { AxiosError } from 'axios';
-import { lockResource } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
 import { executionContext, SYSTEM_USER } from '../utils/access';
@@ -574,7 +574,7 @@ const ingestionHandler = async () => {
   try {
     // Lock the manager
     const turndownService = new TurndownService();
-    lock = await lockResource([INGESTION_MANAGER_KEY], { retryCount: 0 });
+    lock = await lockResources([INGESTION_MANAGER_KEY], { retryCount: 0 });
     running = true;
     // noinspection JSUnusedLocalSymbols
     const context = executionContext('ingestion_manager');

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -1,7 +1,8 @@
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import { clearIntervalAsync as clearDynamicIntervalAsync, setIntervalAsync as setDynamicIntervalAsync } from 'set-interval-async/dynamic';
 import moment from 'moment/moment';
-import { createStreamProcessor, lockResource, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import type { BasicStoreSettings } from '../types/settings';
 import { logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
@@ -60,7 +61,7 @@ const initManager = (manager: ManagerDefinition) => {
       try {
         // date
         // Lock the manager
-        lock = await lockResource([manager.cronSchedulerHandler.lockKey], { retryCount: 0 });
+        lock = await lockResources([manager.cronSchedulerHandler.lockKey], { retryCount: 0 });
         running = true;
         cronInput = cronInputFn ? await cronInputFn() : undefined;
         if (manager.cronSchedulerHandler.infiniteInterval) {
@@ -97,7 +98,7 @@ const initManager = (manager: ManagerDefinition) => {
       let lock;
       try {
       // Lock the manager
-        lock = await lockResource([manager.streamSchedulerHandler.lockKey], { retryCount: 0 });
+        lock = await lockResources([manager.streamSchedulerHandler.lockKey], { retryCount: 0 });
         running = true;
         logApp.info(`[OPENCTI-MODULE] Running ${manager.label} stream handler`);
         streamProcessor = createStreamProcessor(SYSTEM_USER, 'File index manager', manager.streamSchedulerHandler.handler, manager.streamSchedulerHandler.streamOpts);

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -3,7 +3,8 @@ import { head } from 'ramda';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import type { Moment } from 'moment';
-import { createStreamProcessor, fetchRangeNotifications, lockResource, storeNotificationEvent, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, fetchRangeNotifications, storeNotificationEvent, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';
 import { executionContext, INTERNAL_USERS, isUserCanAccessStixElement, isUserCanAccessStoreElement, SYSTEM_USER } from '../utils/access';
@@ -630,7 +631,7 @@ const initNotificationManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([NOTIFICATION_LIVE_KEY], { retryCount: 0 });
+      lock = await lockResources([NOTIFICATION_LIVE_KEY], { retryCount: 0 });
       running = true;
       logApp.info('[OPENCTI-MODULE] Running notification manager (live)');
       streamProcessor = createStreamProcessor(SYSTEM_USER, 'Notification manager', notificationLiveStreamHandler);
@@ -657,7 +658,7 @@ const initNotificationManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([NOTIFICATION_DIGEST_KEY], { retryCount: 0 });
+      lock = await lockResources([NOTIFICATION_DIGEST_KEY], { retryCount: 0 });
       logApp.info('[OPENCTI-MODULE] Running notification manager (digest)');
       while (!shutdown) {
         lock.signal.throwIfAborted();

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -19,7 +19,8 @@ import type { Operation } from 'fast-json-patch';
 import * as jsonpatch from 'fast-json-patch';
 import moment from 'moment';
 import type { Moment } from 'moment/moment';
-import { createStreamProcessor, lockResource, redisPlaybookUpdate, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, redisPlaybookUpdate, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
 import { executionContext, RETENTION_MANAGER_USER, SYSTEM_USER } from '../utils/access';
@@ -377,7 +378,7 @@ const initPlaybookManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([PLAYBOOK_LIVE_KEY], { retryCount: 0 });
+      lock = await lockResources([PLAYBOOK_LIVE_KEY], { retryCount: 0 });
       running = true;
       logApp.info('[OPENCTI-MODULE] Running playbook manager');
       streamProcessor = createStreamProcessor(SYSTEM_USER, 'Playbook manager', playbookStreamHandler);
@@ -502,7 +503,7 @@ const initPlaybookManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([PLAYBOOK_CRON_KEY], { retryCount: 0 });
+      lock = await lockResources([PLAYBOOK_CRON_KEY], { retryCount: 0 });
       logApp.info('[OPENCTI-MODULE] Running playbook manager (cron)');
       while (!shutdown) {
         lock.signal.throwIfAborted();

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -4,7 +4,8 @@ import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from
 import conf, { booleanConf, getBaseUrl, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { getEntitiesListFromCache, getEntitiesMapFromCache, getEntityFromCache } from '../database/cache';
-import { createStreamProcessor, lockResource, NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import { sendMail, smtpIsAlive } from '../database/smtp';
 import type { NotifierTestInput } from '../generated/graphql';
 import { addNotification } from '../modules/notification/notification-domain';
@@ -231,7 +232,7 @@ const initPublisherManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([PUBLISHER_ENGINE_KEY], { retryCount: 0 });
+      lock = await lockResources([PUBLISHER_ENGINE_KEY], { retryCount: 0 });
       running = true;
       logApp.info('[OPENCTI-PUBLISHER] Running publisher manager');
       const opts = { withInternal: false, streamName: NOTIFICATION_STREAM_NAME };

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -3,7 +3,8 @@ import * as R from 'ramda';
 import type { Operation } from 'fast-json-patch';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
-import { createStreamProcessor, EVENT_CURRENT_VERSION, lockResource, REDIS_STREAM_NAME, type StreamProcessor } from '../database/redis';
+import { createStreamProcessor, EVENT_CURRENT_VERSION, REDIS_STREAM_NAME, type StreamProcessor } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { createEntity, patchAttribute, storeLoadByIdWithRefs } from '../database/middleware';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE, isEmptyField, isNotEmptyField, READ_DATA_INDICES } from '../database/utils';
@@ -287,7 +288,7 @@ const initRuleManager = () => {
     let lock;
     try {
       // Lock the manager
-      lock = await lockResource([RULE_ENGINE_KEY], { retryCount: 0 });
+      lock = await lockResources([RULE_ENGINE_KEY], { retryCount: 0 });
       running = true;
       const ruleManager = await getInitRuleManager();
       const { lastEventId } = ruleManager;

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -6,7 +6,8 @@ import { TYPE_LOCK_ERROR } from '../config/errors';
 import Queue from '../utils/queue';
 import { ENTITY_TYPE_SYNC } from '../schema/internalObject';
 import { patchSync } from '../domain/connector';
-import { EVENT_CURRENT_VERSION, lockResource } from '../database/redis';
+import { EVENT_CURRENT_VERSION } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import { STIX_EXT_OCTI } from '../types/stix-extensions';
 import { utcDate } from '../utils/format';
 import { listEntities, storeLoadById } from '../database/middleware-loader';
@@ -225,7 +226,7 @@ const initSyncManager = () => {
     let lock;
     try {
       logApp.debug('[OPENCTI-MODULE] Running sync manager');
-      lock = await lockResource([SYNC_MANAGER_KEY], { retryCount: 0 });
+      lock = await lockResources([SYNC_MANAGER_KEY], { retryCount: 0 });
       managerRunning = true;
       await processingLoop(lock);
     } catch (e) {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -5,7 +5,8 @@ import { Promise as BluePromise } from 'bluebird';
 import { editAuthorizedMembers } from '../utils/authorizedMembers';
 import { ENTITY_TYPE_WORKSPACE } from '../modules/workspace/workspace-types';
 import { ENTITY_TYPE_PUBLIC_DASHBOARD } from '../modules/publicDashboard/publicDashboard-types';
-import { buildCreateEvent, lockResource, storeUpdateEvent } from '../database/redis';
+import { buildCreateEvent, storeUpdateEvent } from '../database/redis';
+import { lockResources } from '../lock/master-lock';
 import {
   ACTION_TYPE_ADD,
   ACTION_TYPE_ENRICHMENT,
@@ -605,7 +606,7 @@ export const taskHandler = async () => {
   let lock;
   try {
     // Lock the manager
-    lock = await lockResource([TASK_MANAGER_KEY], { retryCount: 0 });
+    lock = await lockResources([TASK_MANAGER_KEY], { retryCount: 0 });
     logApp.debug('[OPENCTI-MODULE][TASK-MANAGER] Starting task handler');
     running = true;
     const startingTime = new Date().getMilliseconds();

--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
@@ -18,7 +18,7 @@ import { elUpdateRemovedFiles } from '../../database/file-search';
 import { logApp } from '../../config/conf';
 import { extractRepresentative } from '../../database/entity-representative';
 import { isStixSightingRelationship } from '../../schema/stixSightingRelationship';
-import { lockResource } from '../../database/redis';
+import { lockResources } from '../../lock/master-lock';
 import { RULE_PREFIX } from '../../schema/general';
 import { createRuleContent } from '../../rules/rules-utils';
 import { controlUserRestrictDeleteAgainstElement } from '../../utils/access';
@@ -267,7 +267,7 @@ export const confirmDelete = async (context: AuthContext, user: AuthUser, id: st
   // lock the delete operation
   let lock;
   try {
-    lock = await lockResource([id]);
+    lock = await lockResources([id]);
     return await processDeleteOperation(context, user, id, { isRestoring: false });
   } catch (e: any) {
     if (e.name === TYPE_LOCK_ERROR) {
@@ -301,7 +301,7 @@ export const restoreDelete = async (context: AuthContext, user: AuthUser, id: st
   // lock the delete operation
   let lock;
   try {
-    lock = await lockResource([id]);
+    lock = await lockResources([id]);
 
     // restore main element
     let result: any;

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/redis-test.js
@@ -1,14 +1,7 @@
 import { expect, it, describe } from 'vitest';
 import { v4 as uuid } from 'uuid';
 import { head } from 'ramda';
-import {
-  delEditContext,
-  delUserContext,
-  fetchEditContext,
-  getRedisVersion,
-  lockResource,
-  setEditContext,
-} from '../../../src/database/redis';
+import { delEditContext, delUserContext, fetchEditContext, getRedisVersion, lockResource, setEditContext } from '../../../src/database/redis';
 import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
 
 describe('Redis basic and utils', () => {

--- a/opencti-platform/opencti-graphql/tests/utils/globalSetup.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/globalSetup.ts
@@ -19,6 +19,7 @@ import { initializeData } from '../../src/database/data-initialization';
 import { shutdownModules, startModules } from '../../src/managers';
 import { deleteAllBucketContent } from '../../src/database/file-storage-helper';
 import { initExclusionListCache } from '../../src/database/exclusionListCache';
+import { initLockFork } from '../../src/lock/master-lock';
 /**
  * Vitest setup is configurable with environment variables, as you can see in our package.json scripts
  *   INIT_TEST_PLATFORM=1 > cleanup the test platform, removing elastic indices, and setup it again
@@ -109,6 +110,7 @@ export async function setup() {
   await initializeRedisClients();
   await searchEngineInit();
   await storageInit();
+  initLockFork();
   // cleanup and setup a seeded platform, with all the tests users, ready to run some tests.
   if (INIT_TEST_PLATFORM) {
     logApp.info('[vitest-global-setup] only running test platform initialization');

--- a/opencti-platform/opencti-graphql/tests/utils/testSetup.js
+++ b/opencti-platform/opencti-graphql/tests/utils/testSetup.js
@@ -4,9 +4,11 @@ import { initializeRedisClients } from '../../src/database/redis';
 import { searchEngineInit } from '../../src/database/engine';
 import { initializeFileStorageClient } from '../../src/database/file-storage';
 import { initExclusionListCache } from '../../src/database/exclusionListCache';
+import { initLockFork } from '../../src/lock/master-lock';
 
 await initializeRedisClients();
 await searchEngineInit();
 await initializeFileStorageClient();
 cacheManager.init();
 await initExclusionListCache();
+initLockFork();


### PR DESCRIPTION
Extending lock is important in OpenCTI.
Locking in a dedicated process will improve any cpu burn preventing locking to renew.