### PR TITLE
[frontend] put the auth member admin panel under EE (#4961)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -37,6 +37,7 @@ import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeCo
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -110,6 +111,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const { mandatoryAttributes } = useIsMandatoryAttribute(GROUPING_TYPE);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
+  const isEnterpriseEdition = useEnterpriseEdition();
 
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
@@ -149,7 +151,7 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+      ...(isEnterpriseEdition && canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
         authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,
@@ -285,29 +287,29 @@ export const GroupingCreationForm: FunctionComponent<GroupingFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
-          {isAccessRestrictionCreationEnable && (
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <div style={fieldSpacingContainerStyle}>
-              <Accordion >
-                <AccordionSummary id="accordion-panel">
-                  <Typography>{t_i18n('Advanced options')}</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Field
-                    name={'authorized_members'}
-                    component={AuthorizedMembersField}
-                    containerstyle={{ marginTop: 20 }}
-                    showAllMembersLine
-                    canDeactivate
-                    disabled={isSubmitting}
-                    addMeUserWithAdminRights
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-          </Security>
+          {isEnterpriseEdition && isAccessRestrictionCreationEnable && (
+            <Security
+              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+            >
+              <div style={fieldSpacingContainerStyle}>
+                <Accordion >
+                  <AccordionSummary id="accordion-panel">
+                    <Typography>{t_i18n('Advanced options')}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Field
+                      name={'authorized_members'}
+                      component={AuthorizedMembersField}
+                      containerstyle={{ marginTop: 20 }}
+                      showAllMembersLine
+                      canDeactivate
+                      disabled={isSubmitting}
+                      addMeUserWithAdminRights
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </div>
+            </Security>
           )}
           <div className={classes.buttons}>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -169,7 +169,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
       objectLabel: values.objectLabel.map((v) => v.value),
       externalReferences: values.externalReferences.map(({ value }) => value),
       file: values.file,
-      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+      ...(isEnterpriseEdition && canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
         authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -40,6 +40,7 @@ import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeCo
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -119,6 +120,8 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const { mandatoryAttributes } = useIsMandatoryAttribute(REPORT_TYPE);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
+  const isEnterpriseEdition = useEnterpriseEdition();
+
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
 
@@ -335,29 +338,29 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
-          {isAccessRestrictionCreationEnable && (
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <div style={fieldSpacingContainerStyle}>
-              <Accordion>
-                <AccordionSummary id="accordion-panel">
-                  <Typography>{t_i18n('Advanced options')}</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Field
-                    name={'authorized_members'}
-                    component={AuthorizedMembersField}
-                    containerstyle={{ marginTop: 20 }}
-                    showAllMembersLine
-                    canDeactivate
-                    disabled={isSubmitting}
-                    addMeUserWithAdminRights
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-          </Security>
+          {isEnterpriseEdition && isAccessRestrictionCreationEnable && (
+            <Security
+              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+            >
+              <div style={fieldSpacingContainerStyle}>
+                <Accordion>
+                  <AccordionSummary id="accordion-panel">
+                    <Typography>{t_i18n('Advanced options')}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Field
+                      name={'authorized_members'}
+                      component={AuthorizedMembersField}
+                      containerstyle={{ marginTop: 20 }}
+                      showAllMembersLine
+                      canDeactivate
+                      disabled={isSubmitting}
+                      addMeUserWithAdminRights
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </div>
+            </Security>
           )}
           <div className={classes.buttons}>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -41,6 +41,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -120,6 +121,8 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
+  const isEnterpriseEdition = useEnterpriseEdition();
+
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
 
@@ -330,29 +333,29 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
-          {isAccessRestrictionCreationEnable && (
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <div style={fieldSpacingContainerStyle}>
-              <Accordion >
-                <AccordionSummary id="accordion-panel">
-                  <Typography>{t_i18n('Advanced options')}</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Field
-                    name={'authorized_members'}
-                    component={AuthorizedMembersField}
-                    containerstyle={{ marginTop: 20 }}
-                    showAllMembersLine
-                    canDeactivate
-                    disabled={isSubmitting}
-                    addMeUserWithAdminRights
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-          </Security>
+          {isEnterpriseEdition && isAccessRestrictionCreationEnable && (
+            <Security
+              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+            >
+              <div style={fieldSpacingContainerStyle}>
+                <Accordion >
+                  <AccordionSummary id="accordion-panel">
+                    <Typography>{t_i18n('Advanced options')}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Field
+                      name={'authorized_members'}
+                      component={AuthorizedMembersField}
+                      containerstyle={{ marginTop: 20 }}
+                      showAllMembersLine
+                      canDeactivate
+                      disabled={isSubmitting}
+                      addMeUserWithAdminRights
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </div>
+            </Security>
           )}
           <div className={classes.buttons}>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -162,7 +162,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+      ...(isEnterpriseEdition && canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
         authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -41,6 +41,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import Security from '../../../../utils/Security';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -119,6 +120,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
+  const isEnterpriseEdition = useEnterpriseEdition();
 
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
@@ -326,29 +328,29 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
-          {isAccessRestrictionCreationEnable && (
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <div style={fieldSpacingContainerStyle}>
-              <Accordion >
-                <AccordionSummary id="accordion-panel">
-                  <Typography>{t_i18n('Advanced options')}</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Field
-                    name={'authorized_members'}
-                    component={AuthorizedMembersField}
-                    containerstyle={{ marginTop: 20 }}
-                    showAllMembersLine
-                    canDeactivate
-                    disabled={isSubmitting}
-                    addMeUserWithAdminRights
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-          </Security>
+          {isEnterpriseEdition && isAccessRestrictionCreationEnable && (
+            <Security
+              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+            >
+              <div style={fieldSpacingContainerStyle}>
+                <Accordion >
+                  <AccordionSummary id="accordion-panel">
+                    <Typography>{t_i18n('Advanced options')}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Field
+                      name={'authorized_members'}
+                      component={AuthorizedMembersField}
+                      containerstyle={{ marginTop: 20 }}
+                      showAllMembersLine
+                      canDeactivate
+                      disabled={isSubmitting}
+                      addMeUserWithAdminRights
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </div>
+            </Security>
           )}
           <div className={classes.buttons}>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -160,7 +160,7 @@ export const CaseRfiCreationForm: FunctionComponent<CaseRfiFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+      ...(isEnterpriseEdition && canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
         authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -162,7 +162,7 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
       externalReferences: values.externalReferences.map(({ value }) => value),
       createdBy: values.createdBy?.value,
       file: values.file,
-      ...(canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
+      ...(isEnterpriseEdition && canEditAuthorizedMembers && isAccessRestrictionCreationEnable && values.authorized_members && {
         authorized_members: values.authorized_members.map(({ value, accessRight }) => ({
           id: value,
           access_right: accessRight,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -41,6 +41,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import Security from '../../../../utils/Security';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../../utils/hooks/useGranted';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -119,6 +120,8 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
   const navigate = useNavigate();
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
+  const isEnterpriseEdition = useEnterpriseEdition();
+
   const { isFeatureEnable } = useHelper();
   const isAccessRestrictionCreationEnable = isFeatureEnable('ACCESS_RESTRICTION_AT_CREATION');
 
@@ -324,29 +327,29 @@ export const CaseRftCreationForm: FunctionComponent<CaseRftFormProps> = ({
             values={values.externalReferences}
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
-          {isAccessRestrictionCreationEnable && (
-          <Security
-            needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-          >
-            <div style={fieldSpacingContainerStyle}>
-              <Accordion >
-                <AccordionSummary id="accordion-panel">
-                  <Typography>{t_i18n('Advanced options')}</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Field
-                    name={'authorized_members'}
-                    component={AuthorizedMembersField}
-                    containerstyle={{ marginTop: 20 }}
-                    showAllMembersLine
-                    canDeactivate
-                    disabled={isSubmitting}
-                    addMeUserWithAdminRights
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-          </Security>
+          {isEnterpriseEdition && isAccessRestrictionCreationEnable && (
+            <Security
+              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+            >
+              <div style={fieldSpacingContainerStyle}>
+                <Accordion >
+                  <AccordionSummary id="accordion-panel">
+                    <Typography>{t_i18n('Advanced options')}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Field
+                      name={'authorized_members'}
+                      component={AuthorizedMembersField}
+                      containerstyle={{ marginTop: 20 }}
+                      showAllMembersLine
+                      canDeactivate
+                      disabled={isSubmitting}
+                      addMeUserWithAdminRights
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </div>
+            </Security>
           )}
           <div className={classes.buttons}>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -633,19 +633,21 @@ const ContainerHeader = (props) => {
             {!knowledge && disableSharing !== true && (
               <StixCoreObjectSharing elementId={container.id} variant="header" disabled={disableOrgaSharingButton} />
             )}
-            <Security
-              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-              hasAccess={!!enableManageAuthorizedMembers}
-            >
-              <FormAuthorizedMembersDialog
-                id={container.id}
-                owner={container.creators?.[0]}
-                authorizedMembers={authorizedMembersToOptions(
-                  container.authorized_members,
-                )}
-                mutation={containerHeaderEditAuthorizedMembersMutation}
-              />
-            </Security>
+            {!knowledge && (
+              <Security
+                needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
+                hasAccess={!!enableManageAuthorizedMembers}
+              >
+                <FormAuthorizedMembersDialog
+                  id={container.id}
+                  owner={container.creators?.[0]}
+                  authorizedMembers={authorizedMembersToOptions(
+                    container.authorized_members,
+                  )}
+                  mutation={containerHeaderEditAuthorizedMembersMutation}
+                />
+              </Security>
+            )}
             {!knowledge && (
               <Security needs={[KNOWLEDGE_KNGETEXPORT_KNASKEXPORT]}>
                 <StixCoreObjectFileExport

--- a/opencti-platform/opencti-front/src/private/components/data/Management.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Management.tsx
@@ -6,6 +6,7 @@ import {
   ManagementDefinitionsLinesPaginationQuery$variables,
 } from '@components/data/__generated__/ManagementDefinitionsLinesPaginationQuery.graphql';
 import { ManagementDefinitionsLines_data$data } from '@components/data/__generated__/ManagementDefinitionsLines_data.graphql';
+import EnterpriseEdition from '../common/entreprise_edition/EnterpriseEdition';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import AlertInfo from '../../../components/AlertInfo';
 import { useFormatter } from '../../../components/i18n';
@@ -17,6 +18,7 @@ import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloade
 import useAuth from '../../../utils/hooks/useAuth';
 import { addFilter, emptyFilterGroup, useBuildEntityTypeBasedFilterContext, useGetDefaultFilterObject } from '../../../utils/filters/filtersUtils';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
+import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 
 const LOCAL_STORAGE_KEY = 'restrictedEntities';
 
@@ -137,6 +139,8 @@ const Management = () => {
   const { isFeatureEnable } = useHelper();
   const isRightMenuManagementEnable = isFeatureEnable('DATA_MANAGEMENT_RIGHT_MENU');
 
+  const isEnterpriseEdition = useEnterpriseEdition();
+
   const initialValues = {
     filters: {
       ...emptyFilterGroup,
@@ -209,7 +213,7 @@ const Management = () => {
     setNumberOfElements: helpers.handleSetNumberOfElements,
   } as UsePreloadedPaginationFragment<ManagementDefinitionsLinesPaginationQuery>;
 
-  return (
+  return isEnterpriseEdition ? (
     <div data-testid='data-management-page'>
       <div style={{ paddingRight: isRightMenuManagementEnable ? '200px' : 0 }}>
         <Breadcrumbs elements={[
@@ -240,6 +244,8 @@ const Management = () => {
         )}
       </div>
     </div>
+  ) : (
+    <EnterpriseEdition feature={t_i18n('Authorized_members')}/>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -914,7 +914,7 @@ const LeftBar = () => {
                   { granted: isGrantedToImport && !draftContext, link: '/dashboard/data/import', label: 'Import' },
                   { granted: isGrantedToProcessing && !draftContext, link: '/dashboard/data/processing', label: 'Processing' },
                   { granted: isGrantedToSharing && !draftContext, link: '/dashboard/data/sharing', label: 'Data sharing' },
-                  ...([{ granted: isGrantedToManage && !draftContext, link: '/dashboard/data/restriction', label: 'Restriction' }]),
+                  ...(isEnterpriseEdition ? [{ granted: isGrantedToManage && !draftContext, link: '/dashboard/data/restriction', label: 'Restriction' }] : []),
                 ],
               )}
             </Security>


### PR DESCRIPTION
### Proposed changes

Authorized members (a.k.a access restrictions) are a feature under Entreprise Edition.
As such, the admin panel for these entities should also be under EE.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* follow-up for #4961

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

