### PR TITLE
[frontend] fix inferred icon in WidgetListRelationships (#7295)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemIcon.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.jsx
@@ -70,6 +70,7 @@ import {
   PlaylistRemoveOutlined,
 } from '@mui/icons-material';
 import {
+  AutoFix,
   ArchiveOutline,
   Biohazard,
   BriefcaseCheckOutline,
@@ -545,6 +546,8 @@ const iconSelector = (type, variant, fontSize, color, isReversed) => {
       return <ArchitectureOutlined style={style} fontSize={fontSize} role="img" />;
     case 'exclusion-list':
       return <PlaylistRemoveOutlined style={style} fontSize={fontSize} role="img" />;
+    case 'autofix':
+      return <AutoFix style={style} fontSize={fontSize} role="img" />;
     case 'default':
       return <CircleOutlined style={style} fontSize={fontSize} role="img" />;
     default:

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetListRelationships.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetListRelationships.tsx
@@ -42,7 +42,7 @@ const WidgetListRelationships = ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       render: (stixRelationship: any) => (
         <ItemIcon
-          type={stixRelationship.entity_type}
+          type={stixRelationship.is_inferred ? 'autofix' : stixRelationship.entity_type}
           color="primary"
         />
       ),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix inferred icon in WidgetListRelationships
![image](https://github.com/user-attachments/assets/4f08b6c2-6d92-433a-8a8f-0c0f55c6ec47)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/7296

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
