### PR TITLE
[backend] extend grace period for deprecated "promote" API

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8637,7 +8637,7 @@ type StixCyberObservableEditMutations {
   importPush(file: Upload!, fileMarkings: [String], version: DateTime, noTriggerImport: Boolean): File
   exportAsk(format: String!, exportType: String!, maxMarkingDefinition: String): [File!]
   exportPush(file: Upload!): Boolean
-  promote: StixCyberObservable @deprecated(reason: "[>=6.2 & <6.5]. Use `promoteToIndicator`.")
+  promote: StixCyberObservable @deprecated(reason: "[>=6.2 & <6.8]. Use `promoteToIndicator`.")
 }
 
 type StixRelationshipEditMutations {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -25025,7 +25025,7 @@ export type StixCyberObservableEditMutations = {
   exportPush?: Maybe<Scalars['Boolean']['output']>;
   fieldPatch?: Maybe<StixCyberObservable>;
   importPush?: Maybe<File>;
-  /** @deprecated [>=6.2 & <6.5]. Use `promoteToIndicator`. */
+  /** @deprecated [>=6.2 & <6.8]. Use `promoteToIndicator`. */
   promote?: Maybe<StixCyberObservable>;
   promoteToIndicator?: Maybe<Indicator>;
   relationAdd?: Maybe<StixRefRelationship>;

--- a/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable-domain.js
+++ b/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable-domain.js
@@ -3,9 +3,9 @@ import { INPUT_CREATED_BY, INPUT_GRANTED_REFS, INPUT_LABELS, INPUT_MARKINGS } fr
 import { controlUserConfidenceAgainstElement } from '../../../utils/confidence-level';
 import { createIndicatorFromObservable } from '../../../domain/stixCyberObservable';
 
-// region [>=6.2 & <6.5]
+// region [>=6.2 & <6.8]
 /**
- * @deprecated [>=6.2 & <6.5]. Use `promoteToIndicator`.
+ * @deprecated [>=6.2 & <6.8]. Use `promoteToIndicator`.
  */
 export const promoteObservableToIndicator = async (context, user, observableId) => {
   const observable = await storeLoadByIdWithRefs(context, user, observableId);

--- a/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable-resolver.js
+++ b/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable-resolver.js
@@ -8,7 +8,7 @@ const stixCyberObservableResolvers_deprecated = {
       const baseResolvers = stixCyberObservableResolvers.Mutation.stixCyberObservableEdit(_, { id }, context);
       return {
         ...baseResolvers,
-        // region [>=6.2 & <6.5]
+        // region [>=6.2 & <6.8]
         promote: () => promoteObservableToIndicator(context, context.user, id),
         // endregion
       };

--- a/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/stixCyberObservable/deprecated/stixCyberObservable.graphql
@@ -1,4 +1,4 @@
 # this will be merged into the base StixCyberObservableEditMutations
 type StixCyberObservableEditMutations {
-  promote: StixCyberObservable  @auth(for: [KNOWLEDGE_KNUPDATE]) @deprecated(reason: "[>=6.2 & <6.5]. Use `promoteToIndicator`.")
+  promote: StixCyberObservable  @auth(for: [KNOWLEDGE_KNUPDATE]) @deprecated(reason: "[>=6.2 & <6.8]. Use `promoteToIndicator`.")
 }

--- a/opencti-platform/opencti-graphql/tests/06-deprecated/stixCyberObservable-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/06-deprecated/stixCyberObservable-domain-test.ts
@@ -22,7 +22,7 @@ const LIST_QUERY = gql`
   }
 `;
 
-describe('stixCyberObservable deprecated API [>=6.2 & <6.5]', () => {
+describe('stixCyberObservable deprecated API [>=6.2 & <6.8]', () => {
   it('Promote observable to indicator shall return the observable', async () => {
     const observable = await addStixCyberObservable(testContext, ADMIN_USER, {
       type: 'Domain-Name',


### PR DESCRIPTION
The deprecation period for API function `stixCyberObservableEdit.promoteToIndicator` is extended to octi 6.8, to let people migrate serenely.

If you are still using this deprecated function, please read https://docs.opencti.io/latest/deployment/breaking-changes/6.2-promote-to-indicator/ 