### PR TITLE
[backend] only kill session in sseMiddleware for auth bearer sessions (#9216)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -77,7 +77,7 @@ import { cleanMarkings } from '../utils/markingDefinition-utils';
 
 const BEARER = 'Bearer ';
 const BASIC = 'Basic ';
-const AUTH_BEARER = 'Bearer';
+export const AUTH_BEARER = 'Bearer';
 const AUTH_BASIC = 'BasicAuth';
 export const TAXIIAPI = 'TAXIIAPI';
 const PLATFORM_ORGANIZATION = 'settings_platform_organization';

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -3,7 +3,7 @@ import * as jsonpatch from 'fast-json-patch';
 import { Promise } from 'bluebird';
 import { LRUCache } from 'lru-cache';
 import conf, { basePath, logApp } from '../config/conf';
-import { authenticateUserFromRequest, TAXIIAPI } from '../domain/user';
+import { AUTH_BEARER, authenticateUserFromRequest, TAXIIAPI } from '../domain/user';
 import { createStreamProcessor, EVENT_CURRENT_VERSION } from '../database/redis';
 import { generateInternalId } from '../schema/identifier';
 import { stixLoadById, storeLoadByIdsWithRefs } from '../database/middleware';
@@ -63,7 +63,8 @@ const HEARTBEAT_PERIOD = conf.get('app:live_stream:heartbeat_period') ?? 5000;
 const sendErrorStatusAndKillSession = (req, res, httpStatus) => {
   try {
     res.status(httpStatus).end();
-    if (req.session) {
+    // only kill bearer sessions
+    if (req.session && req.session?.session_provider?.provider === AUTH_BEARER) {
       req.session.destroy();
     }
   } catch (error) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* killing all sessions was making it it so local user were being disconnected if they tried accessing a closed stream

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9216 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
