### PR TITLE
[frontend] Fix for user deletion on cache + prevent loop on error on Private Root (#9719)

### DIFF
--- a/opencti-platform/opencti-front/src/app.tsx
+++ b/opencti-platform/opencti-front/src/app.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom';
 import React, { Suspense, lazy } from 'react';
+import { HighLevelError, ErrorBoundary } from '@components/Error';
 import { APP_BASE_PATH } from './relay/environment';
 import { RedirectManager } from './components/RedirectManager';
 import AuthBoundaryComponent from './private/components/AuthBoundary';
@@ -13,15 +14,17 @@ const App = () => (
     <AuthBoundaryComponent>
       <RedirectManager>
         <Suspense fallback={<Loader />}>
-          <Routes>
-            <Route path="/dashboard/*" Component={PrivateRoot} />
-            <Route path="/public/*" Component={PublicRoot} />
-            {/* By default, redirect to dashboard */}
-            <Route
-              path="/*"
-              element={<Navigate to="/dashboard" replace={true} />}
-            />
-          </Routes>
+          <ErrorBoundary display={HighLevelError}>
+            <Routes>
+              <Route path="/dashboard/*" Component={PrivateRoot} />
+              <Route path="/public/*" Component={PublicRoot} />
+              {/* By default, redirect to dashboard */}
+              <Route
+                path="/*"
+                element={<Navigate to="/dashboard" replace={true} />}
+              />
+            </Routes>
+          </ErrorBoundary>
         </Suspense>
       </RedirectManager>
     </AuthBoundaryComponent>

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -9,6 +9,11 @@ import ErrorNotFound from '../../components/ErrorNotFound';
 import { useFormatter } from '../../components/i18n';
 import { commitMutation } from '../../relay/environment';
 
+// Highest level of error catching, do not rely on any tierce (intl, theme, ...) pure fallback
+export const HighLevelError = () => (
+  <Alert severity="error">An unknown error occurred. Please contact your administrator or OpenCTI maintainers</Alert>
+);
+
 // Really simple error display
 export const SimpleError = () => {
   const { t_i18n } = useFormatter();
@@ -78,7 +83,7 @@ class ErrorBoundaryComponent extends React.Component {
       const types = map((e) => e.extensions.code, [...baseErrors, ...retroErrors]);
       // Specific error catching
       if (includes('COMPLEX_SEARCH_ERROR', types)) {
-        return <DedicatedWarning title={'Complex search'} description={'Your search have too much terms to be executed. Please limit the number of words or the complexity'}/>;
+        return <DedicatedWarning title={'Complex search'} description={'Your search have too much terms to be executed. Please limit the number of words or the complexity'} />;
       }
       // Access error must be forwarded
       if (includes('FORBIDDEN_ACCESS', types) || includes('AUTH_REQUIRED', types)) {
@@ -91,6 +96,7 @@ class ErrorBoundaryComponent extends React.Component {
     return this.props.children;
   }
 }
+
 ErrorBoundaryComponent.propTypes = {
   display: PropTypes.object,
   children: PropTypes.node,

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -141,7 +141,7 @@ const platformUsers = (context: AuthContext) => {
   const reloadUsers = async () => {
     const users = await listAllEntities(context, SYSTEM_USER, [ENTITY_TYPE_USER], { connectionFormat: false });
     const allUserIds = users.map((user) => user.internal_id);
-    return Bluebird.map(allUserIds, (userId: string) => resolveUserById(context, userId), { concurrency: ES_MAX_CONCURRENCY });
+    return Bluebird.map(allUserIds, (userId: string) => resolveUserById(context, userId), { concurrency: ES_MAX_CONCURRENCY }).filter((u) => u != null);
   };
   return { values: null, fn: reloadUsers };
 };


### PR DESCRIPTION
Closes #9719 

1 - User deletion doesn't trigger cache reset, hence we are trying to get a user from the cache that is deleted
2 - The default error boundary component is not usable is RootPrivate fails because it requires Intl