### PR TITLE
[frontend] fix Fintel templates pdf export button (#8336)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -103,7 +103,7 @@ const StixCoreObjectFileExportForm = ({
   const { t_i18n } = useFormatter();
   const isEnterpriseEdition = useEnterpriseEdition();
   const { fullyActive } = useAI();
-  const [stepIndex, setStepIndex] = useState(0);
+  const [stepIndex, setStepIndex] = useState(defaultValues?.format ? 1 : 0);
   const isBuiltInConnector = (connector?: string) => [BUILT_IN_FROM_TEMPLATE.value, BUILT_IN_HTML_TO_PDF.value].includes(connector ?? '');
 
   const validation = () => Yup.object().shape({


### PR DESCRIPTION
### Proposed changes
In content tab of a container, when we want to export an html fintel template in pdf, the ‘generate a pdf export’ redirects to the general export pop-up instead of the pre-built one (with 'html to pdf' connector by default)