### PR TITLE
[frontend] Fix reset default columns on widgets perspective changes (#7295)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationPerspective.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationPerspective.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography';
 import { LibraryBooksOutlined } from '@mui/icons-material';
 import React from 'react';
 import { v4 as uuid } from 'uuid';
+import { getDefaultWidgetColumns } from '@components/widgets/WidgetListsDefaultColumns';
 import { useFormatter } from '../../../components/i18n';
 import { indexedVisualizationTypes } from '../../../utils/widget/widgetUtils';
 import { useWidgetConfigContext } from './WidgetConfigContext';
@@ -33,12 +34,14 @@ const WidgetCreationPerspective = () => {
     const initialFilters = context === 'fintelTemplate' && perspective === 'entities'
       ? fintelTemplateEntitiesInitialFilters
       : emptyFilterGroup;
+    const initialColumns = perspective === 'entities' || perspective === 'relationships' ? getDefaultWidgetColumns(perspective) : [];
     const newDataSelection = dataSelection.map((n) => ({
       ...n,
       perspective,
       filters: perspective === n.perspective ? n.filters : initialFilters,
       dynamicFrom: perspective === n.perspective ? n.dynamicFrom : emptyFilterGroup,
       dynamicTo: perspective === n.perspective ? n.dynamicTo : emptyFilterGroup,
+      columns: perspective === n.perspective ? n.columns : initialColumns,
     }
     ));
     setConfigWidget({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

To test : I have a list of entities, I have selected certain columns. I switch to knowledge perspective, I don't have the “default” knowledge perspective columns, but only those that match my previous selection.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Close https://github.com/OpenCTI-Platform/opencti/issues/7295

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
