### PR TITLE
[frontend] Title tag correction. Icon swap to be the Label tag used elsewhere in platform

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceHeader.jsx
@@ -16,7 +16,7 @@ import Select from '@mui/material/Select';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Slide from '@mui/material/Slide';
-import { AddOutlined, CloseOutlined, Delete, LockPersonOutlined, MoveToInboxOutlined } from '@mui/icons-material';
+import { CloseOutlined, Delete, LabelOutlined, LockPersonOutlined, MoveToInboxOutlined } from '@mui/icons-material';
 import { DotsHorizontalCircleOutline } from 'mdi-material-ui';
 import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
@@ -391,7 +391,7 @@ const WorkspaceHeader = ({
                 <DotsHorizontalCircleOutline fontSize="small" />
               </IconButton>
             ) : (
-              <Tooltip title={t_i18n('Add tag')}>
+              <Tooltip title={openTag ? t_i18n('Cancel') : t_i18n('Add tag')}>
                 <IconButton
                   style={{ float: 'left', marginTop: '-5px', marginRight: '3px' }}
                   color="primary"
@@ -402,7 +402,7 @@ const WorkspaceHeader = ({
                   {openTag ? (
                     <CloseOutlined fontSize="small" />
                   ) : (
-                    <AddOutlined fontSize="small" />
+                    <LabelOutlined fontSize="small" />
                   )}
                 </IconButton>
               </Tooltip>


### PR DESCRIPTION
Investigations - at top the (+) icon for “Add label”, matches/very similar to the (+) at bottom for add new entity… confusing new users, and possibly existing users. Proposed correction is in this PR swapping the “Add Label” icon to match the existing Label icon. Additionally, the "Title" text when the slideout to add a Tag is open - it still says "Add Tag" when it should say "Cancel".

### Proposed changes

![image](https://github.com/user-attachments/assets/4ace99ee-a934-4e95-ad47-59c039870273)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] N/A - I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] N/A - I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
