### PR TITLE
[frontend] action on 'No label' click in 'Add entities' panel (#8985)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -368,6 +368,7 @@ const ContainerAddStixCoreObjects = (props) => {
               mapping={mapping}
               containerRef={containerRef}
               enableReferences={enableReferences}
+              onLabelClick={helpers.handleAddFilter}
             />
           )}
         />

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsInLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsInLine.tsx
@@ -106,6 +106,7 @@ const ContainerAddStixCreObjectsInLineLoader: FunctionComponent<ContainerAddStix
       setNumberOfElements={helpers.handleSetNumberOfElements}
       containerRef={{ current: containerRef }}
       enableReferences={enableReferences}
+      onLabelClick={helpers.handleAddFilter}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
@@ -316,11 +316,8 @@ class ContainerAddStixCoreObjectsLinesComponent extends Component {
           hasMore={relay.hasMore.bind(this)}
           isLoading={relay.isLoading.bind(this)}
           dataList={dataList}
-          globalCount={R.pathOr(
-            nbOfRowsToLoad,
-            ['stixCoreObjects', 'pageInfo', 'globalCount'],
-            this.props.data,
-          )}
+          globalCount={this.props.data?.stixCoreObjects?.pageInfo?.globalCount ?? nbOfRowsToLoad}
+          onLabelClick={this.props.onLabelClick}
           LineComponent={<ContainerAddStixCoreObjectsLine />}
           DummyLineComponent={<ContainerAddStixCoreObjecstLineDummy />}
           dataColumns={dataColumns}
@@ -376,6 +373,7 @@ ContainerAddStixCoreObjectsLinesComponent.propTypes = {
   mapping: PropTypes.bool,
   containerRef: PropTypes.object,
   enableReferences: PropTypes.bool,
+  onLabelClick: PropTypes.func,
 };
 
 export const containerAddStixCoreObjectsLinesQuery = graphql`


### PR DESCRIPTION
### Proposed changes
In the 'Add entities' panel, add the filter 'label is empty' when clicking on the 'No label' chip instead of doing nothing

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8985
