### PR TITLE
[frontend] Limit number of results to 100 in list widgets (#9508)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "Das maximale Konfidenzniveau wird derzeit auf Benutzerebene definiert. Sie hat Vorrang vor dem Max Confidence Level der Benutzergruppen.",
   "The Max Confidence Level is currently inherited from...": "Die maximale Konfidenzstufe wird derzeit von der Gruppe {link} geerbt.",
   "The min value cannot be greater than max value": "Der Minimalwert kann nicht größer als der Maximalwert sein",
+  "The number of results should be lower than 100": "Die Anzahl der Ergebnisse sollte weniger als 100 betragen",
   "The operators and modes are restricted for these filters.": "Die Operatoren und Modi sind für diese Filter eingeschränkt.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Die Meinungen haben keinen in Ihrem Wortschatz definierten Wert. Bitte fügen Sie sie erst hinzu, um Meinungen hinzufügen zu können.",
   "The password has been updated": "Das Passwort wurde aktualisiert",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.",
   "The Max Confidence Level is currently inherited from...": "The Max Confidence Level is currently inherited from the group {link}.",
   "The min value cannot be greater than max value": "The min value cannot be greater than max value",
+  "The number of results should be lower than 100": "The number of results should be lower than 100",
   "The operators and modes are restricted for these filters.": "The operators and modes are restricted for these filters.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.",
   "The password has been updated": "The password has been updated",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "El Nivel de Confianza Máximo se define actualmente a nivel de usuario. Anula el Nivel de Confianza Máximo de los grupos de usuarios.",
   "The Max Confidence Level is currently inherited from...": "El nivel de confianza máximo se hereda actualmente del grupo {link}.",
   "The min value cannot be greater than max value": "El valor mínimo no puede ser mayor que el valor máximo",
+  "The number of results should be lower than 100": "El número de resultados debe ser inferior a 100",
   "The operators and modes are restricted for these filters.": "Los operadores y modos están restringidos para estos filtros.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Las opiniones no tienen ningún valor definido en su vocabulario. Por favor, añádelas primero para poder añadir opiniones.",
   "The password has been updated": "La contraseña se ha modificado",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "Le niveau de confiance maximal est actuellement défini au niveau de l'utilisateur. Il remplace le niveau de confiance maximal des groupes d'utilisateurs.",
   "The Max Confidence Level is currently inherited from...": "Le niveau de confiance maximum est actuellement hérité du groupe {link}.",
   "The min value cannot be greater than max value": "La valeur min ne peut pas être supérieure à la valeur max",
+  "The number of results should be lower than 100": "Le nombre de résultats doit être inférieur à 100",
   "The operators and modes are restricted for these filters.": "Les opérateurs et les modes sont restreints pour ces filtres.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Les opinions n'ont pas de valeur définie dans votre vocabulaire. Veuillez d'abord les ajouter pour pouvoir ajouter des opinions.",
   "The password has been updated": "Le mot de passe a été modifié",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "現在、最大信頼度はユーザーレベルで定義されています。これはユーザーグループのMax Confidence Levelを上書きします。",
   "The Max Confidence Level is currently inherited from...": "最大信頼度は現在グループ{link}から継承されています。",
   "The min value cannot be greater than max value": "最小値を最大値より大きくすることはできません",
+  "The number of results should be lower than 100": "結果の数は100以下でなければならない",
   "The operators and modes are restricted for these filters.": "これらのフィルタには演算子とモードの制限があります。",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意見には、あなたの語彙で定義された価値はありません。意見を追加できるようにするには、まずそれらを追加してください。",
   "The password has been updated": "パスワードを変更しました",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "최대 신뢰 수준이 현재 사용자 수준에서 정의되어 있습니다. 사용자 그룹의 최대 신뢰 수준을 재정의합니다.",
   "The Max Confidence Level is currently inherited from...": "최대 신뢰 수준은 현재 {link} 그룹에서 상속됩니다.",
   "The min value cannot be greater than max value": "최소 값은 최대 값보다 클 수 없습니다",
+  "The number of results should be lower than 100": "결과 수는 100보다 작아야 합니다",
   "The operators and modes are restricted for these filters.": "이 필터의 연산자 및 모드는 제한됩니다.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "의견에 대한 값이 정의되어 있지 않습니다. 의견을 추가할 수 있도록 먼저 추가하십시오.",
   "The password has been updated": "비밀번호가 업데이트되었습니다",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2917,6 +2917,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "最大置信度目前是在用户级别定义的。它覆盖用户组的最大置信度。",
   "The Max Confidence Level is currently inherited from...": "当前最大置信度是从组 {link} 继承的。",
   "The min value cannot be greater than max value": "最小值不能大于最大值",
+  "The number of results should be lower than 100": "结果数量应少于 100",
   "The operators and modes are restricted for these filters.": "这些过滤器的运算符和模式受到限制。",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意见在您的词汇中没有定义值。请先添加意见，才能添加观点。",
   "The password has been updated": "密码已更新",

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -226,6 +226,7 @@ const WidgetCreationParameters = () => {
           .fill(0)
           .map((_, i) => {
             const currentInstanceId = dataSelection[i].instance_id;
+            const isNumberError = (dataSelection[i].number ?? 10) > 100;
             return (
               <div key={i}>
                 {type === 'attribute' && (
@@ -284,6 +285,8 @@ const WidgetCreationParameters = () => {
                     label={t_i18n('Number of results')}
                     fullWidth={true}
                     type="number"
+                    error={isNumberError}
+                    helperText={t_i18n('The number of results should be lower than 100')}
                     value={dataSelection[i].number ?? 10}
                     onChange={(event) => handleChangeDataValidationParameter(
                       i,

--- a/opencti-platform/opencti-front/src/private/components/widgets/useWidgetConfigValidateForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/useWidgetConfigValidateForm.tsx
@@ -34,6 +34,9 @@ const useWidgetConfigValidateForm = () => {
   // Check there is a type
   const isTypeFilled = !!type && type !== '';
 
+  // Check the number of results is lower than 100 for lists
+  const isDataSelectionNumberValid = dataSelection.every((selection) => !selection.number || selection.number <= 100);
+
   // Check all data selections has an attribute filled if  widget type requires it
   const isDataSelectionAttributesFilled = !getCurrentAvailableParameters(type).includes('attribute')
     || (getCurrentAvailableParameters(type).includes('attribute') && isDataSelectionAttributesValid());
@@ -60,6 +63,7 @@ const useWidgetConfigValidateForm = () => {
   return {
     isFormValid: (
       isLastStep
+      && isDataSelectionNumberValid
       && isDataSelectionAttributesFilled
       && isVariableNameFilled
       && isVariableNameValid

--- a/opencti-platform/opencti-front/src/utils/outcome_template/engine/stix_core_objects/useBuildListOutcome.tsx
+++ b/opencti-platform/opencti-front/src/utils/outcome_template/engine/stix_core_objects/useBuildListOutcome.tsx
@@ -18,7 +18,7 @@ const useBuildListOutcome = () => {
     const dateAttribute = dataSelection.date_attribute || 'created_at';
     const variables = {
       types: ['Stix-Core-Object'],
-      first: dataSelection.number ?? 1000,
+      first: dataSelection.number ?? 10,
       orderBy: dateAttribute,
       orderMode: 'desc',
       filters: dataSelection.filters,


### PR DESCRIPTION
### Proposed changes
In frontend UI of list widgets, limit the number of results to 100

![image](https://github.com/user-attachments/assets/5b163d65-36f0-4a9a-8384-fcdca5ae671b)


### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9508