### PR TITLE
[backend] now also send event_id for events sent to worker coming from stream (#9824)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1870,6 +1870,10 @@ const updateAttributeRaw = async (context, user, instance, inputs, opts = {}) =>
   };
 };
 
+const computeDateFromEventId = (context) => {
+  return utcDate(parseInt(context.eventId.split('-')[0], 10)).toISOString();
+};
+
 export const updateAttributeMetaResolved = async (context, user, initial, inputs, opts = {}) => {
   const { locks = [], impactStandardId = true } = opts;
   const updates = Array.isArray(inputs) ? inputs : [inputs];
@@ -2143,7 +2147,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
         const uniqImpactKey = uniqImpactKeys[i];
         attributesMap.set(uniqImpactKey, {
           name: uniqImpactKey,
-          updated_at: now(),
+          updated_at: context.eventId ? computeDateFromEventId(context) : now(),
           confidence: confidenceLevelToApply,
           user_id: user.internal_id,
         });
@@ -2509,7 +2513,7 @@ const isOutdatedUpdate = (context, element, attributeKey) => {
     const { updated_at: lastAttributeUpdateDate } = attributesMap.get(attributeKey) ?? {};
     if (lastAttributeUpdateDate) {
       try {
-        const eventDate = utcDate(parseInt(context.eventId.split('-')[0], 10)).toISOString();
+        const eventDate = computeDateFromEventId(context);
         return utcDate(lastAttributeUpdateDate).isAfter(eventDate);
       } catch (e) {
         logApp.error('Error evaluating event id', { key: attributeKey, event_id: context.eventId });

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2147,7 +2147,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
         const uniqImpactKey = uniqImpactKeys[i];
         attributesMap.set(uniqImpactKey, {
           name: uniqImpactKey,
-          updated_at: context.eventId ? computeDateFromEventId(context) : now(),
+          updated_at: context?.eventId ? computeDateFromEventId(context) : now(),
           confidence: confidenceLevelToApply,
           user_id: user.internal_id,
         });

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -454,12 +454,13 @@ const mapJSToStream = (event: any) => {
 };
 const pushToStream = async (context: AuthContext, user: AuthUser, client: Cluster | Redis, event: BaseEvent, opts: EventOpts = {}) => {
   const draftContext = getDraftContext(context, user);
+  const eventToPush = { ...event, event_id: context.eventId };
   if (!draftContext && isStreamPublishable(opts)) {
     const pushToStreamFn = async () => {
       if (streamTrimming) {
-        await client.call('XADD', REDIS_STREAM_NAME, 'MAXLEN', '~', streamTrimming, '*', ...mapJSToStream(event));
+        await client.call('XADD', REDIS_STREAM_NAME, 'MAXLEN', '~', streamTrimming, '*', ...mapJSToStream(eventToPush));
       } else {
-        await client.call('XADD', REDIS_STREAM_NAME, '*', ...mapJSToStream(event));
+        await client.call('XADD', REDIS_STREAM_NAME, '*', ...mapJSToStream(eventToPush));
       }
     };
     telemetry(context, user, 'INSERT STREAM', {

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -389,8 +389,6 @@ const createSseMiddleware = () => {
         const message = generateCreateMessage(missingInstance);
         const origin = { referer: EVENT_TYPE_DEPENDENCIES };
         const content = { data: missingData, message, origin, version: EVENT_CURRENT_VERSION };
-        const eventTime = missingData.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
-        content.event_id = `${utcDate(eventTime).toDate().getTime()}-${missingIndex}`;
         channel.sendEvent(eventId, EVENT_TYPE_CREATE, content);
         cache.set(missingData.id, 'hit');
         await wait(channel.delay);
@@ -417,8 +415,6 @@ const createSseMiddleware = () => {
             const message = generateCreateMessage(missingRelation);
             const origin = { referer: EVENT_TYPE_DEPENDENCIES };
             const content = { data: stixRelation, message, origin, version: EVENT_CURRENT_VERSION };
-            const eventTime = stixRelation.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
-            content.event_id = `${utcDate(eventTime).toDate().getTime()}-${relIndex}`;
             channel.sendEvent(eventId, EVENT_TYPE_CREATE, content);
             cache.set(stixRelation.id, 'hit');
           }
@@ -582,9 +578,9 @@ const createSseMiddleware = () => {
           for (let index = 0; index < elements.length; index += 1) {
             const element = elements[index];
             const { id: eventId, event, data: eventData } = element;
+            const { type, data: stix, version: eventVersion, context: evenContext, event_id } = eventData;
             const eventTime = eventData?.data?.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
-            eventData.event_id = `${utcDate(eventTime).toDate().getTime()}-${index}`;
-            const { type, data: stix, version: eventVersion, context: evenContext } = eventData;
+            eventData.event_id = event_id ?? `${utcDate(eventTime).toDate().getTime()}-${index}`;
             const isRelation = stix.type === 'relationship' || stix.type === 'sighting';
             // New stream support only v4+ events.
             const isCompatibleVersion = parseInt(eventVersion ?? '0', 10) >= 4;

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -34,7 +34,7 @@ import {
   KNOWLEDGE_ORGANIZATION_RESTRICT,
   SYSTEM_USER
 } from '../utils/access';
-import { FROM_START_STR, utcDate } from '../utils/format';
+import { streamEventId, FROM_START_STR, utcDate } from '../utils/format';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, buildRefRelationKey, ENTITY_TYPE_CONTAINER, STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
 import { convertStoreToStix } from '../database/stix-converter';
@@ -579,8 +579,8 @@ const createSseMiddleware = () => {
             const element = elements[index];
             const { id: eventId, event, data: eventData } = element;
             const { type, data: stix, version: eventVersion, context: evenContext, event_id } = eventData;
-            const eventTime = stix.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
-            eventData.event_id = event_id ?? `${utcDate(eventTime).toDate().getTime()}-${index}`;
+            const updateTime = stix.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
+            eventData.event_id = event_id ?? streamEventId(updateTime, index);
             const isRelation = stix.type === 'relationship' || stix.type === 'sighting';
             // New stream support only v4+ events.
             const isCompatibleVersion = parseInt(eventVersion ?? '0', 10) >= 4;
@@ -675,7 +675,7 @@ const createSseMiddleware = () => {
             const instance = instances[index];
             const stixData = convertStoreToStix(instance);
             const stixUpdatedAt = stixData.extensions[STIX_EXT_OCTI].updated_at;
-            const eventId = `${utcDate(stixUpdatedAt).toDate().getTime()}-0`;
+            const eventId = streamEventId(stixUpdatedAt);
             if (channel.connected()) {
               // publish missing dependencies if needed
               const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stixData);

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -579,7 +579,7 @@ const createSseMiddleware = () => {
             const element = elements[index];
             const { id: eventId, event, data: eventData } = element;
             const { type, data: stix, version: eventVersion, context: evenContext, event_id } = eventData;
-            const eventTime = eventData?.data?.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
+            const eventTime = stix.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
             eventData.event_id = event_id ?? `${utcDate(eventTime).toDate().getTime()}-${index}`;
             const isRelation = stix.type === 'relationship' || stix.type === 'sighting';
             // New stream support only v4+ events.

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -389,7 +389,7 @@ const createSseMiddleware = () => {
         const message = generateCreateMessage(missingInstance);
         const origin = { referer: EVENT_TYPE_DEPENDENCIES };
         const content = { data: missingData, message, origin, version: EVENT_CURRENT_VERSION };
-        const eventTime = missingData.extensions[STIX_EXT_OCTI].updated_at ?? now();
+        const eventTime = missingData.extensions[STIX_EXT_OCTI]?.updated_at ?? now();
         content.event_id = `${utcDate(eventTime).toDate().getTime()}-${missingIndex}`;
         channel.sendEvent(eventId, EVENT_TYPE_CREATE, content);
         cache.set(missingData.id, 'hit');

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -25,7 +25,7 @@ import { FunctionalError, TYPE_LOCK_ERROR, UnsupportedError } from '../config/er
 import { executionContext, RETENTION_MANAGER_USER, SYSTEM_USER } from '../utils/access';
 import type { SseEvent, StreamDataEvent } from '../types/event';
 import type { StixBundle } from '../types/stix-common';
-import { utcDate } from '../utils/format';
+import { streamEventId, utcDate } from '../utils/format';
 import { findById } from '../modules/playbook/playbook-domain';
 import { type CronConfiguration, PLAYBOOK_INTERNAL_DATA_CRON, type StreamConfiguration } from '../modules/playbook/playbook-components';
 import { PLAYBOOK_COMPONENTS } from '../modules/playbook/playbook-components';
@@ -326,7 +326,7 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
       const data = await stixLoadById(context, RETENTION_MANAGER_USER, entityId);
       if (data) {
         try {
-          const eventId = `${utcDate().toDate().getTime()}-0`;
+          const eventId = streamEventId();
           const nextStep = { component: connector, instance };
           const bundle: StixBundle = {
             id: uuidv4(),
@@ -465,7 +465,7 @@ const initPlaybookManager = () => {
               const data = await stixLoadById(context, RETENTION_MANAGER_USER, node.internal_id);
               if (data) {
                 try {
-                  const eventId = `${utcDate().toDate().getTime()}-${index}`;
+                  const eventId = streamEventId(null, index);
                   const nextStep = { component: connector, instance };
                   const bundle: StixBundle = {
                     id: uuidv4(),

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -33,9 +33,9 @@ const syncManagerInstance = (syncId) => {
   let lastStateSaveTime;
   const handleEvent = (event) => {
     const { type, data, lastEventId } = event;
-    const { data: stixData, context, version } = JSON.parse(data);
+    const { data: stixData, context, version, event_id } = JSON.parse(data);
     if (version === EVENT_CURRENT_VERSION) {
-      eventsQueue.enqueue({ id: lastEventId, type, data: stixData, context });
+      eventsQueue.enqueue({ id: lastEventId, type, data: stixData, context, event_id });
     }
   };
   const startStreamListening = (sseUri, syncElement) => {
@@ -137,7 +137,7 @@ const syncManagerInstance = (syncId) => {
         if (event) {
           try {
             currentDelay = await manageBackPressure(httpClient, sync, currentDelay);
-            const { id: eventId, type: eventType, data, context: eventContext } = event;
+            const { id: eventId, type: eventType, data, context: eventContext, event_id } = event;
             if (eventType === 'heartbeat') {
               await saveCurrentState(context, eventType, sync, eventId);
             } else {
@@ -147,6 +147,7 @@ const syncManagerInstance = (syncId) => {
               // Applicant_id should be a userId coming from synchronizer
               await pushToWorkerForConnector(sync.internal_id, {
                 type: 'event',
+                event_id,
                 synchronized,
                 previous_standard,
                 update: true,

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -57,4 +57,5 @@ interface AuthContext {
   tracing: TracingContext
   user: AuthUser | undefined
   draft_context?: string | undefined
+  eventId?: string | undefined
 }

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -36,6 +36,8 @@ export const UNTIL_END_STR = '5138-11-16T09:46:40.000Z';
 const dateFormat = 'YYYY-MM-DDTHH:mm:ss.SSS';
 
 export const utcDate = (date) => (date ? moment(date).utc() : moment().utc());
+export const utcEpochTime = (date = null) => utcDate(date).toDate().getTime();
+export const streamEventId = (date = null, index = 0) => `${utcEpochTime(date)}-${index}`;
 export const now = () => utcDate().toISOString();
 export const nowTime = () => timeFormat(now());
 export const sinceNowInMinutes = (lastModified) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* out of date events coming from stream could be processed even if they should be ignored
* now send originating eventId in streams if current event resulted from an external event

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9824


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
