### PR TITLE
[frontend] Modified left padding for submenus to align with parent text

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -142,12 +142,13 @@ const useStyles = makeStyles((theme) => createStyles({
     fontSize: 14,
   },
   menuSubItem: {
+    paddingLeft: 44,
     height: 25,
     fontWeight: 500,
     fontSize: 12,
   },
   menuSubItemWithIcon: {
-    paddingLeft: 20,
+    paddingLeft: 40,
     height: 25,
     fontWeight: 500,
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -148,7 +148,7 @@ const useStyles = makeStyles((theme) => createStyles({
     fontSize: 12,
   },
   menuSubItemWithIcon: {
-    paddingLeft: 40,
+    paddingLeft: 20,
     height: 25,
     fontWeight: 500,
     fontSize: 12,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Modifies submenus to align with the left side of the parent menu text. Easier to navigate and scan quickly.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] ~~I wrote test cases for the relevant uses case (coverage and e2e)~~
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Several users complained about the ambiguity of the submenus and that it was difficult to quickly read and scan the submenus. Left-aligning the submenus with the text of the parent helps users differentiate what is a top-level menu item, and what is a submenu item.


https://github.com/user-attachments/assets/63b02047-ced8-43c8-9b7e-e86d06f0f144
