### PR TITLE
[backend/frontend] update API disseminationListSend inputs (#5551)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesDissemination.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesDissemination.tsx
@@ -72,9 +72,9 @@ const StixCoreObjectContentFilesDissemination: FunctionComponent<StixCoreObjectC
     const emailBodyFormatted = sanitizedEmailBody.replace(/(\r\n|\n|\r)/g, '<br/>');
     commitMutation({
       variables: {
-        id: entityId,
+        id: values.disseminationListId,
         input: {
-          dissemination_list_id: values.disseminationListId,
+          entity_id: entityId,
           email_object: values.emailObject,
           email_body: emailBodyFormatted,
           email_attachment_ids: [fileId],

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -12626,7 +12626,7 @@ input DisseminationListAddInput {
 }
 
 input DisseminationListSendInput {
-  dissemination_list_id: ID!
+  entity_id: ID!
   email_object: String!
   email_body: String!
   email_attachment_ids: [ID!]!

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6330,10 +6330,10 @@ export enum DisseminationListOrdering {
 }
 
 export type DisseminationListSendInput = {
-  dissemination_list_id: Scalars['ID']['input'];
   email_attachment_ids: Array<Scalars['ID']['input']>;
   email_body: Scalars['String']['input'];
   email_object: Scalars['String']['input'];
+  entity_id: Scalars['ID']['input'];
 };
 
 export type Distribution = {

--- a/opencti-platform/opencti-graphql/src/modules/disseminationList/disseminationList.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/disseminationList/disseminationList.graphql
@@ -47,7 +47,7 @@ input DisseminationListAddInput {
 }
 
 input DisseminationListSendInput {
-  dissemination_list_id: ID!
+  entity_id: ID!
   email_object: String!
   email_body: String!
   email_attachment_ids: [ID!]!


### PR DESCRIPTION
follow-up for #5551 

We decide to update the api for `disseminationListSend` to be more consistent with the rest.

* The `id` is the di of the list, like in other mutation of this module
* the entity_id is passed in the dissemination input (it's a mandatory context).
* improved error handling and checks