### PR TITLE
[frontend] fix file name in fintel template export form (#8336)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -142,16 +142,6 @@ const StixCoreObjectFileExportForm = ({
     [defaultTemplate] = templates ?? [];
   }
   const defaultFileToExport = fileOptions?.find((f) => f.value === defaultValues?.fileToExport);
-  let defaultExportFileName = null;
-  if (defaultTemplate) defaultExportFileName = defaultTemplate.label;
-  if (defaultFileToExport) {
-    defaultExportFileName = defaultFileToExport.value === 'mappableContent' && scoName
-      ? scoName
-      : defaultFileToExport.label.split('.')[0];
-  }
-  if (defaultTemplate || defaultFileToExport) {
-    defaultExportFileName = `${defaultExportFileName}_${now()}`;
-  }
   let defaultFormat = '';
   if (defaultValues?.format) {
     defaultFormat = defaultValues.format;
@@ -164,7 +154,7 @@ const StixCoreObjectFileExportForm = ({
     type: null,
     template: defaultTemplate ?? null,
     fileToExport: defaultFileToExport ?? null,
-    exportFileName: defaultExportFileName,
+    exportFileName: null,
     contentMaxMarkings: [],
     fileMarkings: defaultFileToExport?.fileMarkings.map(({ id, name }) => ({ label: name, value: id })) ?? [],
   };

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePopover.tsx
@@ -57,7 +57,7 @@ const FintelTemplatePopover = ({
   const onHandleCloseDelete = (e: UIEvent) => {
     stopEvent(e);
     handleCloseDelete();
-    setAnchorEl(null);
+    setAnchorEl(undefined);
   };
 
   const update = (e: UIEvent) => {
@@ -84,6 +84,7 @@ const FintelTemplatePopover = ({
 
   const onExport = async (e: UIEvent) => {
     stopEvent(e);
+    setAnchorEl(undefined);
     await exportFintel(templateId);
   };
 

--- a/opencti-platform/opencti-graphql/src/utils/fintelTemplate/__executiveSummary.template.ts
+++ b/opencti-platform/opencti-graphql/src/utils/fintelTemplate/__executiveSummary.template.ts
@@ -87,11 +87,11 @@ const executiveSummaryContent = (containerType: string) => {
         <ul>
           <li>The timeline of the incident/risk </li>
           <li>The attribution of the incident/risk: pick the main threats from this list.</li>
-          <div>$threats</div>
           <li>The main victims of the incident/risk: pick the main form the list.</li>
-          <div>$victims</div>
         </ul>
       </blockquote>
+      <div>$threats</div>
+      <div>$victims</div>
       
       <div class="page-break" style="page-break-after:always;">
         <span style="display:none;">&nbsp;</span>


### PR DESCRIPTION
Last fixes for Fintel templates
- fix export file name at fintel template export generation (from Content tab of a container)
- changes in the Executive Summary built-in template

To test: be able to change the export file name when generating an html/pdf file from a fintel template
