### PR TITLE
[backend] Internal cache performance improvements (#9805)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -62,7 +62,7 @@ export const partialRefreshCacheForEntity = async (instance: StoreEntity | Store
     logApp.debug('Partial refresh cache for entity', { type: instance.entity_type, id: instance.id });
     const instanceToStore = await instanceCache.refresh(instance.id);
     const cacheWithoutInstance = instanceCache.values.filter((v: any) => v.id !== instanceToStore.id);
-    if (cacheWithoutInstance) {
+    if (instanceToStore) {
       instanceCache.values = [...cacheWithoutInstance, instanceToStore];
     } else { // instance not found (deleted)
       instanceCache.values = [...cacheWithoutInstance];

--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -61,7 +61,7 @@ export const partialRefreshCacheForEntity = async (instance: StoreEntity | Store
   if (instanceCache && instanceCache.values && instanceCache.refresh) {
     logApp.debug('Partial refresh cache for entity', { type: instance.entity_type, id: instance.id });
     const instanceToStore = await instanceCache.refresh(instance.id);
-    const cacheWithoutInstance = instanceCache.values.filter((v: any) => v.id !== instanceToStore.id);
+    const cacheWithoutInstance = instanceCache.values.filter((v: any) => v.id !== instance.id);
     if (instanceToStore) {
       instanceCache.values = [...cacheWithoutInstance, instanceToStore];
     } else { // instance not found (deleted)

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1683,6 +1683,7 @@ const buildCompleteUserFromCacheOrDb = async (context, user, userToLoad, cachedU
     // we need groups and capabilities to compute user effective confidence level, which are accurate in cache.
     completeUser = {
       ...userToLoad,
+      effective_confidence_level: cachedUser.effective_confidence_level, // already in cache (buildCompleteUser)
       groups: cachedUser.groups,
       capabilities: cachedUser.capabilities,
     };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1683,7 +1683,6 @@ const buildCompleteUserFromCacheOrDb = async (context, user, userToLoad, cachedU
     // we need groups and capabilities to compute user effective confidence level, which are accurate in cache.
     completeUser = {
       ...userToLoad,
-      effective_confidence_level: cachedUser.effective_confidence_level, // already in cache (buildCompleteUser)
       groups: cachedUser.groups,
       capabilities: cachedUser.capabilities,
     };

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -24,6 +24,8 @@ type ConfidenceOverride = {
 };
 
 export const computeUserEffectiveConfidenceLevel = (user: AuthUser) => {
+  // already computed (in buildCompleteUser)
+  if (user.effective_confidence_level) { return user.effective_confidence_level; }
   // if a user has BYPASS capability, we consider a level 100
   if (isBypassUser(user)) {
     return {

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/cacheManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/cacheManager-test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { addUser, userDelete, userEditField } from '../../../src/domain/user';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { generateStandardId } from '../../../src/schema/identifier';
+import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+import { getEntitiesListFromCache, refreshCacheForEntity } from '../../../src/database/cache';
+import type { AuthUser } from '../../../src/types/user';
+import type { StoreEntity } from '../../../src/types/store';
+
+const USERS_CACHE_LENGTH = 7;
+
+describe('CacheManager refresh and reset test', () => {
+  const testUser = {
+    password: 'testuserpass',
+    user_email: 'test-user-cache@opencti.io',
+    name: 'test user cache',
+  };
+  const testUserId: string = generateStandardId(ENTITY_TYPE_USER, testUser);
+  let userInstance: StoreEntity | null = null;
+  it('CacheManager should refresh one user after create', async () => {
+    const usersCacheInitial = await getEntitiesListFromCache<AuthUser>(testContext, ADMIN_USER, ENTITY_TYPE_USER);
+    expect(usersCacheInitial.length).toEqual(USERS_CACHE_LENGTH);
+    // create user
+    const addedUser = await addUser(testContext, ADMIN_USER, testUser);
+    userInstance = addedUser;
+    expect(addedUser).toBeDefined();
+    expect(addedUser.standard_id).toEqual(testUserId);
+    // refresh cache
+    await refreshCacheForEntity(addedUser);
+    // test cache
+    const usersCache = await getEntitiesListFromCache<AuthUser>(testContext, ADMIN_USER, ENTITY_TYPE_USER);
+    expect(usersCache.length).toEqual(USERS_CACHE_LENGTH + 1);
+    const userInCache = usersCache.find((u) => u.standard_id === testUserId);
+    expect(userInCache).toBeDefined();
+    expect(userInCache?.user_email).toEqual(testUser.user_email);
+  });
+  it('CacheManager should refresh one user after update', async () => {
+    const userNameEdit = 'test user cache edit';
+    const inputs = [{ key: 'name', value: [userNameEdit] }];
+    const editedUser = await userEditField(testContext, ADMIN_USER, testUserId, inputs);
+    // refresh cache
+    await refreshCacheForEntity(editedUser);
+    // test cache
+    const usersCache = await getEntitiesListFromCache<AuthUser>(testContext, ADMIN_USER, ENTITY_TYPE_USER);
+    const userInCache = usersCache.find((u) => u.standard_id === testUserId);
+    expect(userInCache).toBeDefined();
+    expect(userInCache?.user_email).toEqual(testUser.user_email);
+    expect(userInCache?.name).toEqual(userNameEdit);
+  });
+  it('CacheManager should refresh one user after delete', async () => {
+    // delete user
+    await userDelete(testContext, ADMIN_USER, testUserId);
+    // refresh cache
+    await refreshCacheForEntity(userInstance as StoreEntity);
+    // test cache
+    const usersCache = await getEntitiesListFromCache<AuthUser>(testContext, ADMIN_USER, ENTITY_TYPE_USER);
+    expect(usersCache.length).toEqual(USERS_CACHE_LENGTH);
+    const userInCache = usersCache.find((u) => u.standard_id === testUserId);
+    expect(userInCache).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Partial refresh of cache, working only for users for now (need a refresh function to be set on the cache)
* Minor improvement in computeUserEffectiveConfidenceLevel to return effective_confidence_level if it's already present (from buildCompleteUser)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
cache reload can take a lot of time, especially for users (~15s if you have 100 users)
* #9805 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
