### PR TITLE
[frontend] Fix border-radius on triggers in groups overview (#9788)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLine.tsx
@@ -55,6 +55,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     float: 'left',
     width: 100,
     marginRight: 10,
+    borderRadius: 4,
   },
   chipInList2: {
     fontSize: 12,
@@ -69,6 +70,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     height: 20,
     float: 'left',
     marginRight: 10,
+    borderRadius: 4,
   },
 }));
 


### PR DESCRIPTION
### Proposed changes

* Add missing border-radius to triggers icons

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9788