### PR TITLE
[frontend] correctly display observable types in filters list (#9857)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -902,9 +902,9 @@ const useSearchEntities = ({
                 (data as useSearchEntitiesSchemaSCOSearchQuery$data)?.schemaSCOs
                   ?.edges ?? []
               ).map((n) => ({
-                label: n?.node.label,
+                label: t_i18n(`entity_${n?.node.id}`),
                 value: n?.node.id,
-                type: 'Vocabulary',
+                type: n?.node.id,
               }));
               unionSetEntities(
                 filterKey,


### PR DESCRIPTION
### Proposed changes
In filters of type 'main observable type', the list of possible values should be observables types that are:
- translated
- with correct icon before

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9857