### PR TITLE
Knowledge graph labels are either black or white only, depending on platform theme.

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeCorrelation.jsx
@@ -1154,6 +1154,7 @@ class GroupingKnowledgeCorrelationComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                         )

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledgeGraph.jsx
@@ -1271,6 +1271,7 @@ class GroupingKnowledgeGraphComponent extends Component {
                         },
                         node,
                         node.color,
+                        theme.palette.chip.main,
                         ctx,
                         this.selectedNodes.has(node),
                         node.isNestedInferred,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeCorrelation.jsx
@@ -1155,6 +1155,7 @@ class ReportKnowledgeCorrelationComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                           false,

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeGraph.jsx
@@ -166,21 +166,19 @@ class ReportKnowledgeGraphComponent extends Component {
 
   initialize() {
     if (this.initialized) return;
-    if (this.graph && this.graph.current) {
+    if (this.graph?.current) {
       this.graph.current.d3Force('link').distance(50);
       if (this.state.modeTree !== '') {
         this.graph.current.d3Force('charge').strength(-1000);
       }
       if (this.zoomed < 2) {
-        if (this.zoom && this.zoom.k && !this.state.mode3D) {
+        if (this.zoom?.k && !this.state.mode3D) {
           this.graph.current.zoom(this.zoom.k, 400);
         } else {
           // eslint-disable-next-line @typescript-eslint/no-this-alias
           const currentContext = this;
           setTimeout(
-            () => currentContext.graph
-              && currentContext.graph.current
-              && currentContext.graph.current.zoomToFit(0, 150),
+            () => currentContext.graph?.current?.zoomToFit(0, 150),
             1200,
           );
         }
@@ -222,15 +220,15 @@ class ReportKnowledgeGraphComponent extends Component {
       { zoom: this.zoom, ...this.state },
     );
     if (refreshGraphData) {
-      this.setState({
+      this.setState((prevState) => ({
         graphData: applyFilters(
           this.graphData,
-          this.state.stixCoreObjectsTypes,
-          this.state.markedBy,
-          this.state.createdBy,
+          prevState.stixCoreObjectsTypes,
+          prevState.markedBy,
+          prevState.createdBy,
           ignoredStixCoreObjectsTypes,
         ),
-      });
+      }));
     }
   }
 
@@ -267,15 +265,18 @@ class ReportKnowledgeGraphComponent extends Component {
   }
 
   handleToggle3DMode() {
-    this.setState({ mode3D: !this.state.mode3D }, () => this.saveParameters());
+    this.setState(
+      (prevState) => ({ mode3D: !prevState.mode3D }),
+      () => this.saveParameters(),
+    );
   }
 
   handleToggleRectangleSelectModeFree() {
     this.setState(
-      {
-        selectRectangleModeFree: !this.state.selectRectangleModeFree,
+      (prevState) => ({
+        selectRectangleModeFree: !prevState.selectRectangleModeFree,
         selectModeFree: false,
-      },
+      }),
       () => {
         this.saveParameters();
       },
@@ -284,10 +285,10 @@ class ReportKnowledgeGraphComponent extends Component {
 
   handleToggleSelectModeFree() {
     this.setState(
-      {
-        selectModeFree: !this.state.selectModeFree,
+      (prevState) => ({
+        selectModeFree: !prevState.selectModeFree,
         selectRectangleModeFree: false,
-      },
+      }),
       () => {
         this.saveParameters();
       },
@@ -297,9 +298,9 @@ class ReportKnowledgeGraphComponent extends Component {
   handleToggleTreeMode(modeTree) {
     if (modeTree === 'horizontal') {
       this.setState(
-        {
-          modeTree: this.state.modeTree === 'horizontal' ? '' : 'horizontal',
-        },
+        (prevState) => ({
+          modeTree: prevState.modeTree === 'horizontal' ? '' : 'horizontal',
+        }),
         () => {
           if (this.state.modeTree === 'horizontal') {
             this.graph.current.d3Force('charge').strength(-1000);
@@ -311,9 +312,9 @@ class ReportKnowledgeGraphComponent extends Component {
       );
     } else if (modeTree === 'vertical') {
       this.setState(
-        {
-          modeTree: this.state.modeTree === 'vertical' ? '' : 'vertical',
-        },
+        (prevState) => ({
+          modeTree: prevState.modeTree === 'vertical' ? '' : 'vertical',
+        }),
         () => {
           if (this.state.modeTree === 'vertical') {
             this.graph.current.d3Force('charge').strength(-1000);
@@ -341,7 +342,12 @@ class ReportKnowledgeGraphComponent extends Component {
   }
 
   handleToggleDisplayTimeRange() {
-    this.setState({ displayTimeRange: !this.state.displayTimeRange }, () => this.saveParameters());
+    this.setState(
+      (prevState) => ({
+        displayTimeRange: !prevState.displayTimeRange,
+      }),
+      () => this.saveParameters(),
+    );
   }
 
   handleToggleStixCoreObjectType(type) {
@@ -547,17 +553,17 @@ class ReportKnowledgeGraphComponent extends Component {
       this.graphObjects,
     );
     this.setState(
-      {
+      (prevState) => ({
         selectedTimeRangeInterval,
         graphData: applyFilters(
           this.graphData,
-          this.state.stixCoreObjectsTypes,
-          this.state.markedBy,
-          this.state.createdBy,
+          prevState.stixCoreObjectsTypes,
+          prevState.markedBy,
+          prevState.createdBy,
           ignoredStixCoreObjectsTypes,
           selectedTimeRangeInterval,
         ),
-      },
+      }),
       () => {
         setTimeout(() => this.handleZoomToFit(), 1500);
       },
@@ -587,17 +593,17 @@ class ReportKnowledgeGraphComponent extends Component {
           const selectedTimeRangeInterval = computeTimeRangeInterval(
             this.graphObjects,
           );
-          this.setState({
+          this.setState((prevState) => ({
             selectedTimeRangeInterval,
             graphData: applyFilters(
               this.graphData,
-              this.state.stixCoreObjectsTypes,
-              this.state.markedBy,
-              this.state.createdBy,
+              prevState.stixCoreObjectsTypes,
+              prevState.markedBy,
+              prevState.createdBy,
               ignoredStixCoreObjectsTypes,
               selectedTimeRangeInterval,
             ),
-          });
+          }));
         }
       },
     });
@@ -630,16 +636,16 @@ class ReportKnowledgeGraphComponent extends Component {
         },
       });
     }, relationshipsToRemove);
-    this.setState({
+    this.setState((prevState) => ({
       graphData: applyFilters(
         this.graphData,
-        this.state.stixCoreObjectsTypes,
-        this.state.markedBy,
-        this.state.createdBy,
+        prevState.stixCoreObjectsTypes,
+        prevState.markedBy,
+        prevState.createdBy,
         ignoredStixCoreObjectsTypes,
-        this.state.selectedTimeRangeInterval,
+        prevState.selectedTimeRangeInterval,
       ),
-    });
+    }));
   }
 
   async handleDeleteSelected(deleteObject = false, commitMessage = '', references = [], setSubmitting = null, resetForm = null) {
@@ -755,18 +761,18 @@ class ReportKnowledgeGraphComponent extends Component {
       this.props.t,
     );
     await this.resetAllFilters();
-    this.setState({
+    this.setState((prevState) => ({
       graphData: applyFilters(
         this.graphData,
-        this.state.stixCoreObjectsTypes,
-        this.state.markedBy,
-        this.state.createdBy,
+        prevState.stixCoreObjectsTypes,
+        prevState.markedBy,
+        prevState.createdBy,
         ignoredStixCoreObjectsTypes,
-        this.state.selectedTimeRangeInterval,
+        prevState.selectedTimeRangeInterval,
       ),
       numberOfSelectedNodes: this.selectedNodes.size,
       numberOfSelectedLinks: this.selectedLinks.size,
-    });
+    }));
     if (setSubmitting) setSubmitting(false);
     if (resetForm) resetForm(true);
   }
@@ -788,16 +794,16 @@ class ReportKnowledgeGraphComponent extends Component {
             decodeGraphData(this.props.report.x_opencti_graph_data),
             this.props.t,
           );
-          this.setState({
+          this.setState((prevState) => ({
             graphData: applyFilters(
               this.graphData,
-              this.state.stixCoreObjectsTypes,
-              this.state.markedBy,
-              this.state.createdBy,
+              prevState.stixCoreObjectsTypes,
+              prevState.markedBy,
+              prevState.createdBy,
               ignoredStixCoreObjectsTypes,
-              this.state.selectedTimeRangeInterval,
+              prevState.selectedTimeRangeInterval,
             ),
-          });
+          }));
         });
     }, 1500);
   }
@@ -819,16 +825,16 @@ class ReportKnowledgeGraphComponent extends Component {
             decodeGraphData(this.props.report.x_opencti_graph_data),
             this.props.t,
           );
-          this.setState({
+          this.setState((prevState) => ({
             graphData: applyFilters(
               this.graphData,
-              this.state.stixCoreObjectsTypes,
-              this.state.markedBy,
-              this.state.createdBy,
+              prevState.stixCoreObjectsTypes,
+              prevState.markedBy,
+              prevState.createdBy,
               ignoredStixCoreObjectsTypes,
-              this.state.selectedTimeRangeInterval,
+              prevState.selectedTimeRangeInterval,
             ),
-          });
+          }));
         });
     }, 1500);
   }
@@ -951,16 +957,16 @@ class ReportKnowledgeGraphComponent extends Component {
   handleResetLayout() {
     this.graphData = buildGraphData(this.graphObjects, {}, this.props.t);
     this.setState(
-      {
+      (prevState) => ({
         graphData: applyFilters(
           this.graphData,
-          this.state.stixCoreObjectsTypes,
-          this.state.markedBy,
-          this.state.createdBy,
+          prevState.stixCoreObjectsTypes,
+          prevState.markedBy,
+          prevState.createdBy,
           ignoredStixCoreObjectsTypes,
-          this.state.selectedTimeRangeInterval,
+          prevState.selectedTimeRangeInterval,
         ),
-      },
+      }),
       () => {
         this.handleDragEnd();
         this.forceUpdate();
@@ -981,31 +987,31 @@ class ReportKnowledgeGraphComponent extends Component {
     const selectedTimeRangeInterval = computeTimeRangeInterval(
       this.graphObjects,
     );
-    this.setState({
+    this.setState((prevState) => ({
       selectedTimeRangeInterval,
       graphData: applyFilters(
         this.graphData,
-        this.state.stixCoreObjectsTypes,
-        this.state.markedBy,
-        this.state.createdBy,
+        prevState.stixCoreObjectsTypes,
+        prevState.markedBy,
+        prevState.createdBy,
         ignoredStixCoreObjectsTypes,
         selectedTimeRangeInterval,
       ),
-    });
+    }));
   }
 
   handleTimeRangeChange(selectedTimeRangeInterval) {
-    this.setState({
+    this.setState((prevState) => ({
       selectedTimeRangeInterval,
       graphData: applyFilters(
         this.graphData,
-        this.state.stixCoreObjectsTypes,
-        this.state.markedBy,
-        this.state.createdBy,
+        prevState.stixCoreObjectsTypes,
+        prevState.markedBy,
+        prevState.createdBy,
         [],
         selectedTimeRangeInterval,
       ),
-    });
+    }));
   }
 
   handleSearch(keyword) {
@@ -1314,6 +1320,7 @@ class ReportKnowledgeGraphComponent extends Component {
                         },
                         node,
                         node.color,
+                        theme.palette.chip.main,
                         ctx,
                         this.selectedNodes.has(node),
                         node.isNestedInferred,
@@ -1419,10 +1426,10 @@ class ReportKnowledgeGraphComponent extends Component {
 
 ReportKnowledgeGraphComponent.propTypes = {
   report: PropTypes.object,
-  classes: PropTypes.object,
   theme: PropTypes.object,
   mode: PropTypes.string,
   t: PropTypes.func,
+  enableReferences: PropTypes.bool,
 };
 
 const ReportKnowledgeGraph = createFragmentContainer(

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeCorrelation.jsx
@@ -1155,6 +1155,7 @@ class IncidentKnowledgeCorrelationComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                           false,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeGraph.jsx
@@ -1283,6 +1283,7 @@ class IncidentKnowledgeGraphComponent extends Component {
                         },
                         node,
                         node.color,
+                        theme.palette.chip.main,
                         ctx,
                         this.selectedNodes.has(node),
                         node.isNestedInferred,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeCorrelation.jsx
@@ -1154,6 +1154,7 @@ class CaseRfiKnowledgeCorrelationComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                           false,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeGraph.jsx
@@ -1283,6 +1283,7 @@ class CaseRfiKnowledgeGraphComponent extends Component {
                         },
                         node,
                         node.color,
+                        theme.palette.chip.main,
                         ctx,
                         this.selectedNodes.has(node),
                         node.isNestedInferred,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeCorrelation.jsx
@@ -1156,6 +1156,7 @@ class CaseRftKnowledgeCorrelationComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                           false,

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeGraph.jsx
@@ -1282,6 +1282,7 @@ class CaseRftKnowledgeGraphComponent extends Component {
                         },
                         node,
                         node.color,
+                        theme.palette.chip.main,
                         ctx,
                         this.selectedNodes.has(node),
                         node.isNestedInferred,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.jsx
@@ -666,6 +666,7 @@ class StixCoreObjectOrStixCoreRelationshipContainersGraphComponent extends Compo
                     },
                     node,
                     node.color,
+                    theme.palette.chip.main,
                     ctx,
                     this.selectedNodes.has(node),
                     false,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
@@ -149,6 +149,7 @@ class StixCoreRelationshipInference extends Component {
             },
             node,
             node.color,
+            theme.palette.chip.main,
             ctx,
             false,
           )

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipInference.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipInference.jsx
@@ -155,6 +155,7 @@ class StixSightingRelationshipInference extends Component {
             },
             node,
             node.color,
+            theme.palette.chip.main,
             ctx,
             false,
             node.disabled,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.jsx
@@ -2358,6 +2358,7 @@ class InvestigationGraphComponent extends Component {
                           },
                           node,
                           node.color,
+                          theme.palette.chip.main,
                           ctx,
                           this.selectedNodes.has(node),
                           false,

--- a/opencti-platform/opencti-front/src/utils/Graph.js
+++ b/opencti-platform/opencti-front/src/utils/Graph.js
@@ -890,6 +890,7 @@ export const nodePaint = (
   colors,
   { label, img, x, y, numberOfConnectedElement },
   color,
+  labelColor,
   ctx,
   selected = false,
   inferred = false,
@@ -916,7 +917,9 @@ export const nodePaint = (
   ctx.font = '4px IBM Plex Sans';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
+  ctx.fillStyle = disabled ? colors.disabled : labelColor;
   ctx.fillText(label, x, y + 9);
+  ctx.fillStyle = disabled ? colors.disabled : color;
 
   const validConnectedElements = numberOfConnectedElement === undefined || numberOfConnectedElement > 0;
   if (showNbConnectedElements && validConnectedElements) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Node labels in knowledge graphs are now black or white, depending on the platform theme. Improves accessibility and makes the knowledge graphs more readable.
![image](https://github.com/user-attachments/assets/1e2dd4d9-c680-4090-93c4-81143e16ba00)
![image](https://github.com/user-attachments/assets/c7779274-a0b0-4bc0-aa52-a8ea69bac19d)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Could be added as a setting in custom themes (#9456).
* Cherry-picked commit from #8239.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

e2e tests are not necessary; only changed label colors
