### PR TITLE
[frontend] merge icon available in global search for entities with same type (#9894)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1625,7 +1625,7 @@ class DataTableToolBar extends Component {
           const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes, stixDomainObjectSubTypes);
           // Some filter types are high level, we do not want to check them as "Different"
           // We might need to add some other types here before refactoring the toolbar
-          const typesAreDifferent = (selectedTypes.filter((type) => !['Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type))).length > 1;
+          const typesAreDifferent = (selectedTypes.filter((type) => !['Stix-Core-Object', 'Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type))).length > 1;
           const preventMerge = selectedTypes.at(0) === 'Vocabulary'
               && Object.values(selectedElements).some(({ builtIn }) => Boolean(builtIn));
           // region update


### PR DESCRIPTION
### Proposed changes
Merge icon of tool bar should be available if I select 2 entities of the same type in the Global Search results list

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9894