### PR TITLE
[backend] Fix CSV mapper creation if name exists (#9962)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.ts
@@ -1,12 +1,12 @@
+import { v4 as uuidv4 } from 'uuid';
 import type { ModuleDefinition } from '../../../schema/module';
 import { registerDefinition } from '../../../schema/module';
 import type { StixCsvMapper, StoreEntityCsvMapper } from './csvMapper-types';
 import { ENTITY_TYPE_CSV_MAPPER } from './csvMapper-types';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../../schema/general';
-import { NAME_FIELD, normalizeName } from '../../../schema/identifier';
+import { normalizeName } from '../../../schema/identifier';
 import convertCsvMapperToStix from './csvMapper-converter';
 import './deprecated/csvMapper-deprecated';
-import { v4 as uuidv4 } from 'uuid';
 
 const CSV_MAPPER_DEFINITION: ModuleDefinition<StoreEntityCsvMapper, StixCsvMapper> = {
   type: {

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper.ts
@@ -6,6 +6,7 @@ import { ABSTRACT_INTERNAL_OBJECT } from '../../../schema/general';
 import { NAME_FIELD, normalizeName } from '../../../schema/identifier';
 import convertCsvMapperToStix from './csvMapper-converter';
 import './deprecated/csvMapper-deprecated';
+import { v4 as uuidv4 } from 'uuid';
 
 const CSV_MAPPER_DEFINITION: ModuleDefinition<StoreEntityCsvMapper, StixCsvMapper> = {
   type: {
@@ -16,7 +17,7 @@ const CSV_MAPPER_DEFINITION: ModuleDefinition<StoreEntityCsvMapper, StixCsvMappe
   },
   identifier: {
     definition: {
-      [ENTITY_TYPE_CSV_MAPPER]: [{ src: NAME_FIELD }]
+      [ENTITY_TYPE_CSV_MAPPER]: () => uuidv4()
     },
     resolvers: {
       name(data: object) {


### PR DESCRIPTION
### Proposed changes
When creating a CSV mapper with name already used for another csv, the csv is well created (before: nothing happened with no error message)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9962