### PR TITLE
[backend] Allow OpenBAS API URL to be overriden (#9994)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
+++ b/opencti-platform/opencti-graphql/src/database/xtm-obas.ts
@@ -11,12 +11,13 @@ import { ENTITY_TYPE_CONTAINER_CASE_RFT } from '../modules/case/case-rft/case-rf
 import { ENTITY_TYPE_THREAT_ACTOR_INDIVIDUAL } from '../modules/threatActorIndividual/threatActorIndividual-types';
 
 const XTM_OPENBAS_URL = conf.get('xtm:openbas_url');
+const XTM_OPENBAS_API_OVERRIDE_URL = conf.get('xtm:openbas_api_override_url');
 const XTM_OPENBAS_TOKEN = conf.get('xtm:openbas_token');
 const XTM_OPENBAS_REJECT_UNAUTHORIZED = conf.get('xtm:openbas_reject_unauthorized');
 
 export const buildXTmOpenBasHttpClient = () => {
   const httpClientOptions: GetHttpClient = {
-    baseURL: `${XTM_OPENBAS_URL}/api`,
+    baseURL: XTM_OPENBAS_API_OVERRIDE_URL || `${XTM_OPENBAS_URL}/api`,
     responseType: 'json',
     rejectUnauthorized: XTM_OPENBAS_REJECT_UNAUTHORIZED,
     headers: {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add `xtm:openbas_api_url` to allow overriding the base URL used in `buildXTmOpenBasHttpClient`

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/9994

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
I have tested this does not break the existing behavior. I haven't added it to the `default.json` config file to avoid causing potential confusion with the documentation.