### PR TITLE
[frontend] Align the height between EnterpriseEdition and Danger zone labels

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
@@ -13,7 +13,7 @@ import useAuth from '../../../../utils/hooks/useAuth';
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     fontSize: 'xx-small',
-    height: 14,
+    height: 18,
     display: 'inline-flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -29,7 +29,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   containerFloating: {
     float: 'left',
     fontSize: 'xx-small',
-    height: 14,
+    height: 18,
     display: 'inline-flex',
     justifyContent: 'center',
     alignItems: 'center',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change the EEchip height

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9569 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
