### PR TITLE
[frontend] Redirect to the All view for each diamond model view with the needed filters

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
@@ -4,7 +4,7 @@ export enum DiamondNodeType {
   capabilities = 'capabilities',
 }
 
-enum DiamondEntityType {
+export enum DiamondEntityType {
   threatActorGroup = 'Threat-Actor-Group',
   threatActorIndividual = 'Threat-Actor-Individual',
   intrusionSet = 'Intrusion-Set',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
@@ -9,6 +9,10 @@ enum DiamondEntityType {
   threatActorIndividual = 'Threat-Actor-Group',
   intrusionSet = 'Intrusion-Set',
   campaign = 'Campaign',
+  malware = 'Malware',
+  channel = 'Channel',
+  tool = 'Tool',
+  incident = 'Incident',
 }
 
 const filterContentFromEntityTypeAndNodeType = {
@@ -62,6 +66,62 @@ const filterContentFromEntityTypeAndNodeType = {
     [DiamondNodeType.infrastructure]: {
       entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
       relationships: ['uses', 'hosts', 'owns', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],
+      relationships: ['uses'],
+    },
+  },
+  [DiamondEntityType.malware]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      relationships: ['authored-by'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'exfiltrates-to', 'beacons-to', 'communicates-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Tool'],
+      relationships: ['uses', 'downloads', 'drops'],
+    },
+  },
+  [DiamondEntityType.channel]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      relationships: ['uses'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Tool', 'Malware'],
+      relationships: ['uses', 'delivers', 'drops'],
+    },
+  },
+  [DiamondEntityType.tool]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual', 'Incident'],
+      relationships: ['uses'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware'],
+      relationships: ['uses', 'delivers', 'drops'],
+    },
+  },
+  [DiamondEntityType.incident]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual', 'Campaign'],
+      relationships: ['attributed-to'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['related-to', 'uses'],
     },
     [DiamondNodeType.capabilities]: {
       entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
@@ -14,7 +14,7 @@ enum DiamondEntityType {
 const filterContentFromEntityTypeAndNodeType = {
   [DiamondEntityType.threatActorGroup]: {
     [DiamondNodeType.adversary]: {
-      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group'],
+      entityType: ['Campaign', 'Intrusion-Set', 'Incident'],
       relationships: ['attributed-to'],
     },
     [DiamondNodeType.infrastructure]: {
@@ -28,7 +28,7 @@ const filterContentFromEntityTypeAndNodeType = {
   },
   [DiamondEntityType.threatActorIndividual]: {
     [DiamondNodeType.adversary]: {
-      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Individual'],
+      entityType: ['Campaign', 'Intrusion-Set', 'Incident'],
       relationships: ['attributed-to'],
     },
     [DiamondNodeType.infrastructure]: {
@@ -42,7 +42,7 @@ const filterContentFromEntityTypeAndNodeType = {
   },
   [DiamondEntityType.intrusionSet]: {
     [DiamondNodeType.adversary]: {
-      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      entityType: ['Campaign', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
       relationships: ['attributed-to'],
     },
     [DiamondNodeType.infrastructure]: {
@@ -56,7 +56,7 @@ const filterContentFromEntityTypeAndNodeType = {
   },
   [DiamondEntityType.campaign]: {
     [DiamondNodeType.adversary]: {
-      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      entityType: ['Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual', 'Incident'],
       relationships: ['attributed-to'],
     },
     [DiamondNodeType.infrastructure]: {
@@ -94,14 +94,10 @@ const getFilterFromEntityTypeAndNodeType = (entity_type: DiamondEntityType, node
         mode: 'or',
       },
     ],
+    filterGroups: [],
   };
 
-  return JSON.stringify({
-    mode: 'and',
-    filters: [],
-    filterGroups: [filterGroups],
-  });
-  // return JSON.stringify(filterGroups);
+  return encodeURIComponent(JSON.stringify(filterGroups));
 };
 
 export default getFilterFromEntityTypeAndNodeType;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
@@ -1,0 +1,107 @@
+export enum DiamondNodeType {
+  adversary = 'adversary',
+  infrastructure = 'infrastructure',
+  capabilities = 'capabilities',
+}
+
+enum DiamondEntityType {
+  threatActorGroup = 'Threat-Actor-Group',
+  threatActorIndividual = 'Threat-Actor-Group',
+  intrusionSet = 'Intrusion-Set',
+  campaign = 'Campaign',
+}
+
+const filterContentFromEntityTypeAndNodeType = {
+  [DiamondEntityType.threatActorGroup]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group'],
+      relationships: ['attributed-to'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'hosts', 'owns', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],
+      relationships: ['uses'],
+    },
+  },
+  [DiamondEntityType.threatActorIndividual]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Individual'],
+      relationships: ['attributed-to'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'hosts', 'owns', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],
+      relationships: ['uses'],
+    },
+  },
+  [DiamondEntityType.intrusionSet]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      relationships: ['attributed-to'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'hosts', 'owns', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],
+      relationships: ['uses'],
+    },
+  },
+  [DiamondEntityType.campaign]: {
+    [DiamondNodeType.adversary]: {
+      entityType: ['Campaign', 'Intrusion-Set', 'Threat-Actor-Group', 'Threat-Actor-Individual'],
+      relationships: ['attributed-to'],
+    },
+    [DiamondNodeType.infrastructure]: {
+      entityType: ['IPv4-Addr', 'IPv6-Addr', 'Infrastructure', 'Domain-Name'],
+      relationships: ['uses', 'hosts', 'owns', 'related-to'],
+    },
+    [DiamondNodeType.capabilities]: {
+      entityType: ['Attack-Pattern', 'Malware', 'Tool', 'Channel'],
+      relationships: ['uses'],
+    },
+  },
+};
+
+const getFilterFromEntityTypeAndNodeType = (entity_type: DiamondEntityType, nodeType: DiamondNodeType) => {
+  const filterContent = filterContentFromEntityTypeAndNodeType[entity_type][nodeType];
+
+  const filterGroups = {
+    mode: 'and',
+    filters: [
+      {
+        key: 'entity_type',
+        operator: 'eq',
+        values: [...filterContent.entityType],
+        mode: 'or',
+      },
+      {
+        key: 'regardingOf',
+        operator: 'eq',
+        values: [
+          {
+            key: 'relationship_type',
+            values: [...filterContent.relationships],
+          },
+        ],
+        mode: 'or',
+      },
+    ],
+  };
+
+  return JSON.stringify({
+    mode: 'and',
+    filters: [],
+    filterGroups: [filterGroups],
+  });
+  // return JSON.stringify(filterGroups);
+};
+
+export default getFilterFromEntityTypeAndNodeType;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType.ts
@@ -6,7 +6,7 @@ export enum DiamondNodeType {
 
 enum DiamondEntityType {
   threatActorGroup = 'Threat-Actor-Group',
-  threatActorIndividual = 'Threat-Actor-Group',
+  threatActorIndividual = 'Threat-Actor-Individual',
   intrusionSet = 'Intrusion-Set',
   campaign = 'Campaign',
   malware = 'Malware',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
@@ -78,3 +78,81 @@ describe('get the filters from Threat-actor-group, containing a diamond ', () =>
     expect(results).toEqual(encodedFilters);
   });
 });
+
+describe('get the filters from Malware, containing a diamond ', () => {
+  const entityType = 'Malware' as DiamondEntityType;
+  it('should list filter for adversary', () => {
+    const nodeType = 'adversary' as DiamondNodeType;
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: 'entity_type',
+          operator: 'eq',
+          values: [
+            'Intrusion-Set',
+            'Threat-Actor-Group',
+            'Threat-Actor-Individual',
+          ],
+          mode: 'or',
+        },
+        {
+          key: 'regardingOf',
+          operator: 'eq',
+          values: [
+            {
+              key: 'relationship_type',
+              values: [
+                'authored-by',
+              ],
+            },
+          ],
+          mode: 'or',
+        },
+      ],
+      filterGroups: [],
+    };
+    const encodedFilters = encodeURIComponent(JSON.stringify(expectedFilters));
+    const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
+    expect(results).toEqual(encodedFilters);
+  });
+  it('should list filter for infrastructure', () => {
+    const nodeType = 'infrastructure' as DiamondNodeType;
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: 'entity_type',
+          operator: 'eq',
+          values: [
+            'IPv4-Addr',
+            'IPv6-Addr',
+            'Infrastructure',
+            'Domain-Name',
+          ],
+          mode: 'or',
+        },
+        {
+          key: 'regardingOf',
+          operator: 'eq',
+          values: [
+            {
+              key: 'relationship_type',
+              values: [
+                'uses',
+                'exfiltrates-to',
+                'beacons-to',
+                'communicates-to',
+              ],
+            },
+          ],
+          mode: 'or',
+        },
+      ],
+      filterGroups: [],
+    };
+    const encodedFilters = encodeURIComponent(JSON.stringify(expectedFilters));
+    const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
+    expect(results).toEqual(encodedFilters);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import getFilterFromEntityTypeAndNodeType, { DiamondEntityType, DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
+
+describe('get the filters from Threat-actor-group, containing a diamond ', () => {
+  const entityType = 'Threat-Actor-Group' as DiamondEntityType;
+  it('should list filter for adversary', () => {
+    const nodeType = 'adversary' as DiamondNodeType;
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: 'entity_type',
+          operator: 'eq',
+          values: [
+            'Campaign',
+            'Intrusion-Set',
+            'Incident',
+          ],
+          mode: 'or',
+        },
+        {
+          key: 'regardingOf',
+          operator: 'eq',
+          values: [
+            {
+              key: 'relationship_type',
+              values: [
+                'attributed-to',
+              ],
+            },
+          ],
+          mode: 'or',
+        },
+      ],
+      filterGroups: [],
+    };
+    const encodedFilters = encodeURIComponent(JSON.stringify(expectedFilters));
+    const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
+    expect(results).toEqual(encodedFilters);
+  });
+  it('should list filter for infrastructure', () => {
+    const nodeType = 'infrastructure' as DiamondNodeType;
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: 'entity_type',
+          operator: 'eq',
+          values: [
+            'IPv4-Addr',
+            'IPv6-Addr',
+            'Infrastructure',
+            'Domain-Name',
+          ],
+          mode: 'or',
+        },
+        {
+          key: 'regardingOf',
+          operator: 'eq',
+          values: [
+            {
+              key: 'relationship_type',
+              values: [
+                'uses',
+                'hosts',
+                'owns',
+                'related-to',
+              ],
+            },
+          ],
+          mode: 'or',
+        },
+      ],
+      filterGroups: [],
+    };
+    const encodedFilters = encodeURIComponent(JSON.stringify(expectedFilters));
+    const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
+    expect(results).toEqual(encodedFilters);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/test/getFilterFromEntity.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest';
 import getFilterFromEntityTypeAndNodeType, { DiamondEntityType, DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
 
 describe('get the filters from Threat-actor-group, containing a diamond ', () => {
-  const entityType = 'Threat-Actor-Group' as DiamondEntityType;
+  const entityType = DiamondEntityType.threatActorGroup;
+
   it('should list filter for adversary', () => {
-    const nodeType = 'adversary' as DiamondNodeType;
+    const nodeType = DiamondNodeType.adversary;
     const expectedFilters = {
       mode: 'and',
       filters: [
@@ -38,8 +39,9 @@ describe('get the filters from Threat-actor-group, containing a diamond ', () =>
     const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
     expect(results).toEqual(encodedFilters);
   });
+
   it('should list filter for infrastructure', () => {
-    const nodeType = 'infrastructure' as DiamondNodeType;
+    const nodeType = DiamondNodeType.infrastructure;
     const expectedFilters = {
       mode: 'and',
       filters: [
@@ -80,9 +82,10 @@ describe('get the filters from Threat-actor-group, containing a diamond ', () =>
 });
 
 describe('get the filters from Malware, containing a diamond ', () => {
-  const entityType = 'Malware' as DiamondEntityType;
+  const entityType = DiamondEntityType.malware;
+
   it('should list filter for adversary', () => {
-    const nodeType = 'adversary' as DiamondNodeType;
+    const nodeType = DiamondNodeType.adversary;
     const expectedFilters = {
       mode: 'and',
       filters: [
@@ -116,8 +119,9 @@ describe('get the filters from Malware, containing a diamond ', () => {
     const results = getFilterFromEntityTypeAndNodeType(entityType, nodeType);
     expect(results).toEqual(encodedFilters);
   });
+
   it('should list filter for infrastructure', () => {
-    const nodeType = 'infrastructure' as DiamondNodeType;
+    const nodeType = DiamondNodeType.infrastructure;
     const expectedFilters = {
       mode: 'and',
       filters: [

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -10,58 +10,12 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-const getStyles = ((theme: Theme) => ({
-  node: {
-    position: 'relative',
-    border:
-        theme.palette.mode === 'dark'
-          ? '1px solid rgba(255, 255, 255, 0.12)'
-          : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
-    backgroundColor: theme.palette.background.paper,
-    width: 400,
-    height: 200,
-    paddingBottom: 25,
-  },
-  nodeContent: {
-    width: '100%',
-    height: '100%',
-    overflowY: 'auto',
-    padding: 20,
-  },
-  handle: {
-    visibility: 'hidden',
-  },
-  label: {
-    marginTop: 20,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
-    '&:hover': {
-      backgroundColor:
-          theme.palette.mode === 'dark'
-            ? 'rgba(255, 255, 255, .2)'
-            : 'rgba(0, 0, 0, .2)',
-    },
-  },
-}));
-
 const NodeAdversary = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
-  const styles = getStyles(theme);
+
   const { stixDomainObject, entityLink } = data;
+
   const isArsenal = ['Malware', 'Tool', 'Channel'].includes(stixDomainObject.entity_type);
   const aliases = stixDomainObject.aliases?.slice(0, 5).join(', ');
   const attributedTo = R.uniq((stixDomainObject.attributedTo?.edges ?? [])
@@ -74,13 +28,31 @@ const NodeAdversary = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div style={styles.node} >
-      <div style={styles.nodeContent}>
+    <div style={{
+      position: 'relative',
+      border:
+        theme.palette.mode === 'dark'
+          ? '1px solid rgba(255, 255, 255, 0.12)'
+          : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: 4,
+      backgroundColor: theme.palette.background.paper,
+      width: '400px',
+      height: '200px',
+      paddingBottom: '25px',
+    }}
+    >
+      <div style={{
+        width: '100%',
+        height: '100%',
+        overflowY: 'auto',
+        padding: '20px',
+      }}
+      >
         <Typography variant="h3" gutterBottom={true}>
           {t_i18n('Aliases')}
         </Typography>
         {emptyFilled(aliases)}
-        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
+        <Typography variant="h3" gutterBottom={true} sx={{ marginTop: 20 }}>
           {isArsenal ? t_i18n('Last used by') : t_i18n('Last attributions')}
         </Typography>
         {isArsenal ? emptyFilled(usedBy) : emptyFilled(attributedTo)}
@@ -90,13 +62,32 @@ const NodeAdversary = ({ data }: NodeProps) => {
         to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
-        sx={styles.buttonExpand}
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          height: '25px',
+          color: theme.palette.primary.main,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, .1)'
+              : 'rgba(0, 0, 0, .1)',
+          '&:hover': {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .2)'
+                : 'rgba(0, 0, 0, .2)',
+          },
+        }}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={styles.handle}
+        sx={{ visibility: 'hidden' }}
         type="target"
         position={Position.Bottom}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -27,7 +27,7 @@ const NodeAdversary = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.adversary);
 
   return (
-    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Bottom} height={200}>
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}&view=entities`} position={Position.Bottom} height={200}>
       <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Aliases')}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -1,26 +1,25 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
-import { Handle, NodeProps, Position } from 'reactflow';
+import { NodeProps, Position } from 'reactflow';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
-import { useTheme } from '@mui/styles';
-import type { Theme } from '../../../../../../../components/Theme';
+import NodeContainer from '@components/common/stix_domain_objects/diamond/types/nodes/NodeContainer';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
 const NodeAdversary = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const theme = useTheme<Theme>();
 
   const { stixDomainObject, entityLink } = data;
 
   const isArsenal = ['Malware', 'Tool', 'Channel'].includes(stixDomainObject.entity_type);
+
   const aliases = stixDomainObject.aliases?.slice(0, 5).join(', ');
+
   const attributedTo = R.uniq((stixDomainObject.attributedTo?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
+
   const usedBy = R.uniq((stixDomainObject.usedBy?.edges ?? [])
     .map((n: { node: { from: { name: string } } }) => n?.node?.from?.name))
     .join(', ');
@@ -28,26 +27,8 @@ const NodeAdversary = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.adversary);
 
   return (
-    <div style={{
-      position: 'relative',
-      border:
-        theme.palette.mode === 'dark'
-          ? '1px solid rgba(255, 255, 255, 0.12)'
-          : '1px solid rgba(0, 0, 0, 0.12)',
-      borderRadius: 4,
-      backgroundColor: theme.palette.background.paper,
-      width: '400px',
-      height: '200px',
-      paddingBottom: '25px',
-    }}
-    >
-      <div style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        padding: '20px',
-      }}
-      >
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Bottom} height={200}>
+      <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Aliases')}
         </Typography>
@@ -56,43 +37,8 @@ const NodeAdversary = ({ data }: NodeProps) => {
           {isArsenal ? t_i18n('Last used by') : t_i18n('Last attributions')}
         </Typography>
         {isArsenal ? emptyFilled(usedBy) : emptyFilled(attributedTo)}
-      </div>
-      <Button
-        component={Link}
-        to={`${entityLink}/all?filters=${generatedFilters}`}
-        variant="contained"
-        size="small"
-        sx={{
-          position: 'absolute',
-          left: 0,
-          bottom: 0,
-          width: '100%',
-          height: '25px',
-          color: theme.palette.primary.main,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          backgroundColor:
-            theme.palette.mode === 'dark'
-              ? 'rgba(255, 255, 255, .1)'
-              : 'rgba(0, 0, 0, .1)',
-          '&:hover': {
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .2)'
-                : 'rgba(0, 0, 0, .2)',
-          },
-        }}
-        className="nodrag nopan"
-      >
-        {t_i18n('View all')}
-      </Button>
-      <Handle
-        style={{ visibility: 'hidden' }}
-        type="target"
-        position={Position.Bottom}
-        isConnectable={false}
-      />
-    </div>
+      </>
+    </NodeContainer>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -25,7 +25,7 @@ const NodeAdversary = ({ data }: NodeProps) => {
     .map((n: { node: { from: { name: string } } }) => n?.node?.from?.name))
     .join(', ');
 
-  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
+  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.adversary);
 
   return (
     <div style={{
@@ -48,11 +48,11 @@ const NodeAdversary = ({ data }: NodeProps) => {
         padding: '20px',
       }}
       >
-        <Typography variant="h3" gutterBottom={true}>
+        <Typography variant="h3" gutterBottom>
           {t_i18n('Aliases')}
         </Typography>
         {emptyFilled(aliases)}
-        <Typography variant="h3" gutterBottom={true} sx={{ marginTop: 20 }}>
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '20px' }}>
           {isArsenal ? t_i18n('Last used by') : t_i18n('Last attributions')}
         </Typography>
         {isArsenal ? emptyFilled(usedBy) : emptyFilled(attributedTo)}
@@ -87,7 +87,7 @@ const NodeAdversary = ({ data }: NodeProps) => {
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={{ visibility: 'hidden' }}
+        style={{ visibility: 'hidden' }}
         type="target"
         position={Position.Bottom}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -84,7 +84,7 @@ const NodeAdversary = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={isArsenal ? `${entityLink}/threats` : `${entityLink}/attribution`}
+        to={`${entityLink}/all`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
+import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
@@ -59,6 +60,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 }));
 
 const NodeAdversary = ({ data }: NodeProps) => {
+  const { t_i18n } = useFormatter();
   const classes = useStyles();
   const { stixDomainObject, entityLink } = data;
   const isArsenal = ['Malware', 'Tool', 'Channel'].includes(stixDomainObject.entity_type);
@@ -69,7 +71,9 @@ const NodeAdversary = ({ data }: NodeProps) => {
   const usedBy = R.uniq((stixDomainObject.usedBy?.edges ?? [])
     .map((n: { node: { from: { name: string } } }) => n?.node?.from?.name))
     .join(', ');
-  const { t_i18n } = useFormatter();
+
+  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
+
   return (
     <div className={classes.node} >
       <div className={classes.nodeContent}>
@@ -84,7 +88,7 @@ const NodeAdversary = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/all`}
+        to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeAdversary.tsx
@@ -1,18 +1,16 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { makeStyles } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
+import { useTheme } from '@mui/styles';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
+const getStyles = ((theme: Theme) => ({
   node: {
     position: 'relative',
     border:
@@ -61,7 +59,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 const NodeAdversary = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const styles = getStyles(theme);
   const { stixDomainObject, entityLink } = data;
   const isArsenal = ['Malware', 'Tool', 'Channel'].includes(stixDomainObject.entity_type);
   const aliases = stixDomainObject.aliases?.slice(0, 5).join(', ');
@@ -75,13 +74,13 @@ const NodeAdversary = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div className={classes.node} >
-      <div className={classes.nodeContent}>
+    <div style={styles.node} >
+      <div style={styles.nodeContent}>
         <Typography variant="h3" gutterBottom={true}>
           {t_i18n('Aliases')}
         </Typography>
         {emptyFilled(aliases)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
           {isArsenal ? t_i18n('Last used by') : t_i18n('Last attributions')}
         </Typography>
         {isArsenal ? emptyFilled(usedBy) : emptyFilled(attributedTo)}
@@ -91,13 +90,13 @@ const NodeAdversary = ({ data }: NodeProps) => {
         to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
-        classes={{ root: classes.buttonExpand }}
+        sx={styles.buttonExpand}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        className={classes.handle}
+        sx={styles.handle}
         type="target"
         position={Position.Bottom}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -10,59 +10,9 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const getStyles = ((theme: Theme) => ({
-  node: {
-    position: 'relative',
-    border:
-      theme.palette.mode === 'dark'
-        ? '1px solid rgba(255, 255, 255, 0.12)'
-        : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
-    backgroundColor: theme.palette.background.paper,
-    width: 400,
-    height: 300,
-    paddingBottom: 25,
-  },
-  nodeContent: {
-    width: '100%',
-    height: '100%',
-    overflowY: 'auto',
-    padding: 20,
-  },
-  handle: {
-    visibility: 'hidden',
-  },
-  label: {
-    marginTop: 20,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
-    '&:hover': {
-      backgroundColor:
-          theme.palette.mode === 'dark'
-            ? 'rgba(255, 255, 255, .2)'
-            : 'rgba(0, 0, 0, .2)',
-    },
-  },
-}));
-
 const NodeCapabilities = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
-  const styles = getStyles(theme);
 
   const { stixDomainObject, entityLink } = data;
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
+import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
@@ -59,6 +60,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
 }));
 
 const NodeCapabilities = ({ data }: NodeProps) => {
+  const { t_i18n } = useFormatter();
   const classes = useStyles();
   const { stixDomainObject, entityLink } = data;
   const usedAttackPatterns = R.uniq((stixDomainObject.attackPatternsUsed?.edges ?? [])
@@ -70,7 +72,9 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const usedToolsAndChannels = R.uniq((stixDomainObject.toolsAndChannelsUsed?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
-  const { t_i18n } = useFormatter();
+
+  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
+
   return (
     <div className={classes.node}>
       <div className={classes.nodeContent}>
@@ -89,7 +93,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/all`}
+        to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -10,9 +10,59 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
+const getStyles = ((theme: Theme) => ({
+  node: {
+    position: 'relative',
+    border:
+      theme.palette.mode === 'dark'
+        ? '1px solid rgba(255, 255, 255, 0.12)'
+        : '1px solid rgba(0, 0, 0, 0.12)',
+    borderRadius: 4,
+    backgroundColor: theme.palette.background.paper,
+    width: 400,
+    height: 300,
+    paddingBottom: 25,
+  },
+  nodeContent: {
+    width: '100%',
+    height: '100%',
+    overflowY: 'auto',
+    padding: 20,
+  },
+  handle: {
+    visibility: 'hidden',
+  },
+  label: {
+    marginTop: 20,
+  },
+  buttonExpand: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: '100%',
+    height: 25,
+    color: theme.palette.primary.main,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    backgroundColor:
+        theme.palette.mode === 'dark'
+          ? 'rgba(255, 255, 255, .1)'
+          : 'rgba(0, 0, 0, .1)',
+    '&:hover': {
+      backgroundColor:
+          theme.palette.mode === 'dark'
+            ? 'rgba(255, 255, 255, .2)'
+            : 'rgba(0, 0, 0, .2)',
+    },
+  },
+}));
+
 const NodeCapabilities = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
+  const styles = getStyles(theme);
 
   const { stixDomainObject, entityLink } = data;
 
@@ -26,7 +76,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
 
-  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
+  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.capabilities);
 
   return (
     <div style={{
@@ -49,15 +99,21 @@ const NodeCapabilities = ({ data }: NodeProps) => {
         padding: '20px',
       }}
       >
-        <Typography variant="h3" gutterBottom={true}>
+        <Typography variant="h3" gutterBottom>
           {t_i18n('Last used attack patterns')}
         </Typography>
         {emptyFilled(usedAttackPatterns)}
-        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{
+          marginTop: '20px',
+        }}
+        >
           {t_i18n('Last used malwares')}
         </Typography>
         {emptyFilled(usedMalwares)}
-        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{
+          marginTop: '20px',
+        }}
+        >
           {t_i18n('Last used tools and channels')}
         </Typography>
         {emptyFilled(usedToolsAndChannels)}
@@ -92,9 +148,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={{
-          visibility: 'hidden',
-        }}
+        style={{ visibility: 'hidden' }}
         type="target"
         position={Position.Right}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -1,18 +1,18 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { makeStyles } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
+import { useTheme } from '@mui/styles';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
+const getStyles = ((theme: Theme) => ({
   node: {
     position: 'relative',
     border:
@@ -61,8 +61,11 @@ const useStyles = makeStyles<Theme>((theme) => ({
 
 const NodeCapabilities = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const styles = getStyles(theme);
+
   const { stixDomainObject, entityLink } = data;
+
   const usedAttackPatterns = R.uniq((stixDomainObject.attackPatternsUsed?.edges ?? [])
     .map((n: { node: { to: { name: string, x_mitre_id: string } } }) => (n?.node?.to?.x_mitre_id ? `[${n?.node?.to?.x_mitre_id}] ${n?.node?.to?.name}` : n?.node?.to?.name)))
     .join(', ');
@@ -76,17 +79,17 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div className={classes.node}>
-      <div className={classes.nodeContent}>
+    <div style={styles.node}>
+      <div style={styles.nodeContent}>
         <Typography variant="h3" gutterBottom={true}>
           {t_i18n('Last used attack patterns')}
         </Typography>
         {emptyFilled(usedAttackPatterns)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
           {t_i18n('Last used malwares')}
         </Typography>
         {emptyFilled(usedMalwares)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom={true} sx={styles.label}>
           {t_i18n('Last used tools and channels')}
         </Typography>
         {emptyFilled(usedToolsAndChannels)}
@@ -96,13 +99,13 @@ const NodeCapabilities = ({ data }: NodeProps) => {
         to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
-        classes={{ root: classes.buttonExpand }}
+        sx={styles.buttonExpand}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        className={classes.handle}
+        sx={styles.handle}
         type="target"
         position={Position.Right}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
 import { useTheme } from '@mui/styles';
+import NodeContainer from '@components/common/stix_domain_objects/diamond/types/nodes/NodeContainer';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
@@ -29,81 +30,58 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.capabilities);
 
   return (
-    <div style={{
-      position: 'relative',
-      border:
-        theme.palette.mode === 'dark'
-          ? '1px solid rgba(255, 255, 255, 0.12)'
-          : '1px solid rgba(0, 0, 0, 0.12)',
-      borderRadius: 4,
-      backgroundColor: theme.palette.background.paper,
-      width: '400px',
-      height: '300px',
-      paddingBottom: '25px',
-    }}
-    >
-      <div style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        padding: '20px',
-      }}
-      >
+    <NodeContainer content={
+      <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used attack patterns')}
         </Typography>
         {emptyFilled(usedAttackPatterns)}
-        <Typography variant="h3" gutterBottom sx={{
-          marginTop: '20px',
-        }}
-        >
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '20px' }}>
           {t_i18n('Last used malwares')}
         </Typography>
         {emptyFilled(usedMalwares)}
-        <Typography variant="h3" gutterBottom sx={{
-          marginTop: '20px',
-        }}
-        >
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '20px' }}>
           {t_i18n('Last used tools and channels')}
         </Typography>
         {emptyFilled(usedToolsAndChannels)}
-      </div>
-      <Button
-        component={Link}
-        to={`${entityLink}/all?filters=${generatedFilters}`}
-        variant="contained"
-        size="small"
-        sx={{
-          position: 'absolute',
-          left: 0,
-          bottom: 0,
-          width: '100%',
-          height: '25px',
-          color: theme.palette.primary.main,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          backgroundColor:
-            theme.palette.mode === 'dark'
-              ? 'rgba(255, 255, 255, .1)'
-              : 'rgba(0, 0, 0, .1)',
-          '&:hover': {
+        <Button
+          component={Link}
+          to={`${entityLink}/all?filters=${generatedFilters}`}
+          variant="contained"
+          size="small"
+          sx={{
+            position: 'absolute',
+            left: 0,
+            bottom: 0,
+            width: '100%',
+            height: '25px',
+            color: theme.palette.primary.main,
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
             backgroundColor:
               theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .2)'
-                : 'rgba(0, 0, 0, .2)',
-          },
-        }}
-        className="nodrag nopan"
-      >
-        {t_i18n('View all')}
-      </Button>
-      <Handle
-        style={{ visibility: 'hidden' }}
-        type="target"
-        position={Position.Right}
-        isConnectable={false}
-      />
-    </div>
+                ? 'rgba(255, 255, 255, .1)'
+                : 'rgba(0, 0, 0, .1)',
+            '&:hover': {
+              backgroundColor:
+                theme.palette.mode === 'dark'
+                  ? 'rgba(255, 255, 255, .2)'
+                  : 'rgba(0, 0, 0, .2)',
+            },
+          }}
+          className="nodrag nopan"
+        >
+          {t_i18n('View all')}
+        </Button>
+        <Handle
+          style={{ visibility: 'hidden' }}
+          type="target"
+          position={Position.Right}
+          isConnectable={false}
+        />
+      </>
+    }
+    />
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -1,19 +1,14 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
-import { Handle, NodeProps, Position } from 'reactflow';
+import { NodeProps, Position } from 'reactflow';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
-import { useTheme } from '@mui/styles';
-import NodeContainer from '@components/common/stix_domain_objects/diamond/types/nodes/NodeContainer';
-import type { Theme } from '../../../../../../../components/Theme';
+import NodeContainer from './NodeContainer';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
 const NodeCapabilities = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const theme = useTheme<Theme>();
 
   const { stixDomainObject, entityLink } = data;
 
@@ -30,7 +25,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.capabilities);
 
   return (
-    <NodeContainer content={
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Right}>
       <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used attack patterns')}
@@ -44,44 +39,8 @@ const NodeCapabilities = ({ data }: NodeProps) => {
           {t_i18n('Last used tools and channels')}
         </Typography>
         {emptyFilled(usedToolsAndChannels)}
-        <Button
-          component={Link}
-          to={`${entityLink}/all?filters=${generatedFilters}`}
-          variant="contained"
-          size="small"
-          sx={{
-            position: 'absolute',
-            left: 0,
-            bottom: 0,
-            width: '100%',
-            height: '25px',
-            color: theme.palette.primary.main,
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .1)'
-                : 'rgba(0, 0, 0, .1)',
-            '&:hover': {
-              backgroundColor:
-                theme.palette.mode === 'dark'
-                  ? 'rgba(255, 255, 255, .2)'
-                  : 'rgba(0, 0, 0, .2)',
-            },
-          }}
-          className="nodrag nopan"
-        >
-          {t_i18n('View all')}
-        </Button>
-        <Handle
-          style={{ visibility: 'hidden' }}
-          type="target"
-          position={Position.Right}
-          isConnectable={false}
-        />
       </>
-    }
-    />
+    </NodeContainer>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -25,7 +25,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.capabilities);
 
   return (
-    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Right}>
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}&view=entities`} position={Position.Right}>
       <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used attack patterns')}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -10,59 +10,9 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const getStyles = ((theme: Theme) => ({
-  node: {
-    position: 'relative',
-    border:
-      theme.palette.mode === 'dark'
-        ? '1px solid rgba(255, 255, 255, 0.12)'
-        : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
-    backgroundColor: theme.palette.background.paper,
-    width: 400,
-    height: 300,
-    paddingBottom: 25,
-  },
-  nodeContent: {
-    width: '100%',
-    height: '100%',
-    overflowY: 'auto',
-    padding: 20,
-  },
-  handle: {
-    visibility: 'hidden',
-  },
-  label: {
-    marginTop: 20,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
-    '&:hover': {
-      backgroundColor:
-          theme.palette.mode === 'dark'
-            ? 'rgba(255, 255, 255, .2)'
-            : 'rgba(0, 0, 0, .2)',
-    },
-  },
-}));
-
 const NodeCapabilities = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
-  const styles = getStyles(theme);
 
   const { stixDomainObject, entityLink } = data;
 
@@ -79,8 +29,26 @@ const NodeCapabilities = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div style={styles.node}>
-      <div style={styles.nodeContent}>
+    <div style={{
+      position: 'relative',
+      border:
+        theme.palette.mode === 'dark'
+          ? '1px solid rgba(255, 255, 255, 0.12)'
+          : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: 4,
+      backgroundColor: theme.palette.background.paper,
+      width: '400px',
+      height: '300px',
+      paddingBottom: '25px',
+    }}
+    >
+      <div style={{
+        width: '100%',
+        height: '100%',
+        overflowY: 'auto',
+        padding: '20px',
+      }}
+      >
         <Typography variant="h3" gutterBottom={true}>
           {t_i18n('Last used attack patterns')}
         </Typography>
@@ -99,13 +67,34 @@ const NodeCapabilities = ({ data }: NodeProps) => {
         to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
-        sx={styles.buttonExpand}
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          height: '25px',
+          color: theme.palette.primary.main,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, .1)'
+              : 'rgba(0, 0, 0, .1)',
+          '&:hover': {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .2)'
+                : 'rgba(0, 0, 0, .2)',
+          },
+        }}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={styles.handle}
+        sx={{
+          visibility: 'hidden',
+        }}
         type="target"
         position={Position.Right}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeCapabilities.tsx
@@ -89,7 +89,7 @@ const NodeCapabilities = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/attack_patterns`}
+        to={`${entityLink}/all`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
@@ -1,12 +1,25 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import { useTheme } from '@mui/styles';
+import Button from '@mui/material/Button';
+import { Link } from 'react-router-dom';
+import { Handle, Position } from 'reactflow';
+import { useFormatter } from 'src/components/i18n';
 import type { Theme } from '../../../../../../../components/Theme';
 
 interface NodeContainerProps {
-  content: React.ReactNode;
+  children: ReactNode;
+  height?: number;
+  link: string;
+  position: Position;
 }
 
-const NodeContainer: FunctionComponent<NodeContainerProps> = ({ content }) => {
+const NodeContainer: FunctionComponent<NodeContainerProps> = ({
+  children,
+  height = 300,
+  link,
+  position,
+}) => {
+  const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
 
   return (
@@ -18,7 +31,7 @@ const NodeContainer: FunctionComponent<NodeContainerProps> = ({ content }) => {
       borderRadius: '4px',
       backgroundColor: theme.palette.background.paper,
       width: '400px',
-      height: '300px',
+      height: `${height}px`,
       paddingBottom: '25px',
     }}
     >
@@ -29,8 +42,43 @@ const NodeContainer: FunctionComponent<NodeContainerProps> = ({ content }) => {
         padding: '20px',
       }}
       >
-        {content}
+        {children}
       </div>
+      <Button
+        component={Link}
+        to={link}
+        variant="contained"
+        size="small"
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          height: '25px',
+          color: theme.palette.primary.main,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, .1)'
+              : 'rgba(0, 0, 0, .1)',
+          '&:hover': {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .2)'
+                : 'rgba(0, 0, 0, .2)',
+          },
+        }}
+        className="nodrag nopan"
+      >
+        {t_i18n('View all')}
+      </Button>
+      <Handle
+        style={{ visibility: 'hidden' }}
+        type="target"
+        position={position}
+        isConnectable={false}
+      />
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from 'react';
+import { useTheme } from '@mui/styles';
+import type { Theme } from '../../../../../../../components/Theme';
+
+interface NodeContainerProps {
+  content: React.ReactNode;
+}
+
+const NodeContainer: FunctionComponent<NodeContainerProps> = ({ content }) => {
+  const theme = useTheme<Theme>();
+
+  return (
+    <div style={{
+      position: 'relative',
+      border: theme.palette.mode === 'dark'
+        ? '1px solid rgba(255, 255, 255, 0.12)'
+        : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: '4px',
+      backgroundColor: theme.palette.background.paper,
+      width: '400px',
+      height: '300px',
+      paddingBottom: '25px',
+    }}
+    >
+      <div style={{
+        width: '100%',
+        height: '100%',
+        overflowY: 'auto',
+        padding: '20px',
+      }}
+      >
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default NodeContainer;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -10,57 +10,9 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-const getStyles = (theme: Theme) => ({
-  node: {
-    position: 'relative',
-    border:
-      theme.palette.mode === 'dark'
-        ? '1px solid rgba(255, 255, 255, 0.12)'
-        : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: '4px',
-    backgroundColor: theme.palette.background.paper,
-    width: '400px',
-    height: '300px',
-    paddingBottom: '25px',
-  },
-  nodeContent: {
-    width: '100%',
-    height: '100%',
-    overflowY: 'auto',
-    padding: '20px',
-  },
-  handle: {
-    visibility: 'hidden',
-  },
-  label: {
-    marginTop: '20px',
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: '25px',
-    color: theme.palette.primary.main,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-});
-
 const NodeInfrastructure = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
-  const styles = getStyles(theme);
 
   const { stixDomainObject, entityLink } = data;
 
@@ -79,17 +31,41 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div style={styles.node}>
-      <div style={styles.nodeContent}>
+    <div style={{
+      position: 'relative',
+      border:
+        theme.palette.mode === 'dark'
+          ? '1px solid rgba(255, 255, 255, 0.12)'
+          : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: '4px',
+      backgroundColor: theme.palette.background.paper,
+      width: '400px',
+      height: '300px',
+      paddingBottom: '25px',
+    }}
+    >
+      <div style={{
+        width: '100%',
+        height: '100%',
+        overflowY: 'auto',
+        padding: '20px',
+      }}
+      >
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used IP addresses')}
         </Typography>
         {emptyFilled(usedIPs)}
-        <Typography variant="h3" gutterBottom sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{
+          marginTop: '20px',
+        }}
+        >
           {t_i18n('Last used domains')}
         </Typography>
         {emptyFilled(usedDomains)}
-        <Typography variant="h3" gutterBottom sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{
+          marginTop: '20px',
+        }}
+        >
           {t_i18n('Last used infrastructures')}
         </Typography>
         {emptyFilled(usedInfrastructures)}
@@ -99,13 +75,32 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
         to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
-        sx={styles.buttonExpand}
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          height: '25px',
+          color: theme.palette.primary.main,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, .1)'
+              : 'rgba(0, 0, 0, .1)',
+          '&:hover': {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .2)'
+                : 'rgba(0, 0, 0, .2)',
+          },
+        }}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={styles.handle}
+        sx={{ visibility: 'hidden' }}
         type="target"
         position={Position.Left}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -100,7 +100,7 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={{ visibility: 'hidden' }}
+        style={{ visibility: 'hidden' }}
         type="target"
         position={Position.Left}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -27,7 +27,7 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Left}>
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}&view=entities`} position={Position.Left}>
       <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used IP addresses')}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -89,7 +89,7 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/observables`}
+        to={`${entityLink}/all`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -1,88 +1,98 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { makeStyles } from '@mui/styles';
+import { useTheme } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
+import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
 import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
+const getStyles = (theme: Theme) => ({
   node: {
     position: 'relative',
     border:
       theme.palette.mode === 'dark'
         ? '1px solid rgba(255, 255, 255, 0.12)'
         : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
+    borderRadius: '4px',
     backgroundColor: theme.palette.background.paper,
-    width: 400,
-    height: 300,
-    paddingBottom: 25,
+    width: '400px',
+    height: '300px',
+    paddingBottom: '25px',
   },
   nodeContent: {
     width: '100%',
     height: '100%',
     overflowY: 'auto',
-    padding: 20,
+    padding: '20px',
   },
   handle: {
     visibility: 'hidden',
   },
   label: {
-    marginTop: 20,
+    marginTop: '20px',
   },
   buttonExpand: {
     position: 'absolute',
     left: 0,
     bottom: 0,
     width: '100%',
-    height: 25,
+    height: '25px',
     color: theme.palette.primary.main,
     borderTopLeftRadius: 0,
     borderTopRightRadius: 0,
     backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, .1)'
+        : 'rgba(0, 0, 0, .1)',
     '&:hover': {
       backgroundColor:
-          theme.palette.mode === 'dark'
-            ? 'rgba(255, 255, 255, .2)'
-            : 'rgba(0, 0, 0, .2)',
+        theme.palette.mode === 'dark'
+          ? 'rgba(255, 255, 255, .2)'
+          : 'rgba(0, 0, 0, .2)',
     },
   },
-}));
+});
 
 const NodeInfrastructure = ({ data }: NodeProps) => {
-  const classes = useStyles();
+  const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
+  const styles = getStyles(theme);
+
   const { stixDomainObject, entityLink } = data;
+
   const usedIPs = R.uniq((stixDomainObject.relatedIPs?.edges ?? [])
     .map((n: { node: { from: { representative: { main: string } } } }) => n?.node?.from?.representative?.main))
     .join(', ');
+
   const usedDomains = R.uniq((stixDomainObject.relatedDomains?.edges ?? [])
     .map((n: { node: { from: { representative: { main: string } } } }) => n?.node?.from?.representative?.main))
     .join(', ');
+
   const usedInfrastructures = R.uniq((stixDomainObject.infrastructuresUsed?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
-  const { t_i18n } = useFormatter();
+
+  console.log('stixDomainObject : ', stixDomainObject);
+  const generatedFilter = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
+
+  const encoded = encodeURIComponent(generatedFilter);
+
   return (
-    <div className={classes.node}>
-      <div className={classes.nodeContent}>
-        <Typography variant="h3" gutterBottom={true}>
+    <div style={styles.node}>
+      <div style={styles.nodeContent}>
+        <Typography variant="h3" gutterBottom>
           {t_i18n('Last used IP addresses')}
         </Typography>
         {emptyFilled(usedIPs)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom sx={styles.label}>
           {t_i18n('Last used domains')}
         </Typography>
         {emptyFilled(usedDomains)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom sx={styles.label}>
           {t_i18n('Last used infrastructures')}
         </Typography>
         {emptyFilled(usedInfrastructures)}
@@ -90,15 +100,16 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
       <Button
         component={Link}
         to={`${entityLink}/all`}
+        // to={`${entityLink}/all?filters=${encoded}`}
         variant="contained"
         size="small"
-        classes={{ root: classes.buttonExpand }}
+        sx={styles.buttonExpand}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        className={classes.handle}
+        sx={styles.handle}
         type="target"
         position={Position.Left}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -1,18 +1,14 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
-import { Handle, NodeProps, Position } from 'reactflow';
-import { useTheme } from '@mui/styles';
+import { NodeProps, Position } from 'reactflow';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import { Link } from 'react-router-dom';
 import getFilterFromEntityTypeAndNodeType, { DiamondNodeType } from '@components/common/stix_domain_objects/diamond/getFilterFromEntityTypeAndNodeType';
-import type { Theme } from '../../../../../../../components/Theme';
+import NodeContainer from '@components/common/stix_domain_objects/diamond/types/nodes/NodeContainer';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
 const NodeInfrastructure = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const theme = useTheme<Theme>();
 
   const { stixDomainObject, entityLink } = data;
 
@@ -31,26 +27,8 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
   const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
-    <div style={{
-      position: 'relative',
-      border:
-        theme.palette.mode === 'dark'
-          ? '1px solid rgba(255, 255, 255, 0.12)'
-          : '1px solid rgba(0, 0, 0, 0.12)',
-      borderRadius: '4px',
-      backgroundColor: theme.palette.background.paper,
-      width: '400px',
-      height: '300px',
-      paddingBottom: '25px',
-    }}
-    >
-      <div style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        padding: '20px',
-      }}
-      >
+    <NodeContainer link={`${entityLink}/all?filters=${generatedFilters}`} position={Position.Left}>
+      <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last used IP addresses')}
         </Typography>
@@ -69,43 +47,8 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
           {t_i18n('Last used infrastructures')}
         </Typography>
         {emptyFilled(usedInfrastructures)}
-      </div>
-      <Button
-        component={Link}
-        to={`${entityLink}/all?filters=${generatedFilters}`}
-        variant="contained"
-        size="small"
-        sx={{
-          position: 'absolute',
-          left: 0,
-          bottom: 0,
-          width: '100%',
-          height: '25px',
-          color: theme.palette.primary.main,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          backgroundColor:
-            theme.palette.mode === 'dark'
-              ? 'rgba(255, 255, 255, .1)'
-              : 'rgba(0, 0, 0, .1)',
-          '&:hover': {
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .2)'
-                : 'rgba(0, 0, 0, .2)',
-          },
-        }}
-        className="nodrag nopan"
-      >
-        {t_i18n('View all')}
-      </Button>
-      <Handle
-        style={{ visibility: 'hidden' }}
-        type="target"
-        position={Position.Left}
-        isConnectable={false}
-      />
-    </div>
+      </>
+    </NodeContainer>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeInfrastructure.tsx
@@ -76,10 +76,7 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
 
-  console.log('stixDomainObject : ', stixDomainObject);
-  const generatedFilter = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
-
-  const encoded = encodeURIComponent(generatedFilter);
+  const generatedFilters = getFilterFromEntityTypeAndNodeType(stixDomainObject.entity_type, DiamondNodeType.infrastructure);
 
   return (
     <div style={styles.node}>
@@ -99,8 +96,7 @@ const NodeInfrastructure = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/all`}
-        // to={`${entityLink}/all?filters=${encoded}`}
+        to={`${entityLink}/all?filters=${generatedFilters}`}
         variant="contained"
         size="small"
         sx={styles.buttonExpand}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -93,7 +93,7 @@ const NodeVictimology = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/all`}
+        to={`${entityLink}/victimology`}
         variant="contained"
         size="small"
         sx={styles.buttonExpand}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -91,7 +91,7 @@ const NodeVictimology = ({ data }: NodeProps) => {
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={{ visibility: 'hidden' }}
+        style={{ visibility: 'hidden' }}
         type="target"
         position={Position.Top}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -1,17 +1,13 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
-import { Handle, NodeProps, Position } from 'reactflow';
-import { useTheme } from '@mui/styles';
+import { NodeProps, Position } from 'reactflow';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import { Link } from 'react-router-dom';
-import type { Theme } from '../../../../../../../components/Theme';
+import NodeContainer from './NodeContainer';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
 const NodeVictimology = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
-  const theme = useTheme<Theme>();
 
   const { stixDomainObject, entityLink } = data;
 
@@ -28,26 +24,8 @@ const NodeVictimology = ({ data }: NodeProps) => {
     .join(', ');
 
   return (
-    <div style={{
-      position: 'relative',
-      border:
-        theme.palette.mode === 'dark'
-          ? '1px solid rgba(255, 255, 255, 0.12)'
-          : '1px solid rgba(0, 0, 0, 0.12)',
-      borderRadius: '4px',
-      backgroundColor: theme.palette.background.paper,
-      width: '400px',
-      height: '300px',
-      paddingBottom: '25px',
-    }}
-    >
-      <div style={{
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        padding: '20px',
-      }}
-      >
+    <NodeContainer link={`${entityLink}/victimology`} position={Position.Top}>
+      <>
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last targeted countries')}
         </Typography>
@@ -60,43 +38,8 @@ const NodeVictimology = ({ data }: NodeProps) => {
           {t_i18n('Last targeted organizations')}
         </Typography>
         {emptyFilled(targetedOrganizations)}
-      </div>
-      <Button
-        component={Link}
-        to={`${entityLink}/victimology`}
-        variant="contained"
-        size="small"
-        sx={{
-          position: 'absolute',
-          left: 0,
-          bottom: 0,
-          width: '100%',
-          height: '25px',
-          color: theme.palette.primary.main,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          backgroundColor:
-            theme.palette.mode === 'dark'
-              ? 'rgba(255, 255, 255, .1)'
-              : 'rgba(0, 0, 0, .1)',
-          '&:hover': {
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, .2)'
-                : 'rgba(0, 0, 0, .2)',
-          },
-        }}
-        className="nodrag nopan"
-      >
-        {t_i18n('View all')}
-      </Button>
-      <Handle
-        style={{ visibility: 'hidden' }}
-        type="target"
-        position={Position.Top}
-        isConnectable={false}
-      />
-    </div>
+      </>
+    </NodeContainer>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -89,7 +89,7 @@ const NodeVictimology = ({ data }: NodeProps) => {
       </div>
       <Button
         component={Link}
-        to={`${entityLink}/victimology`}
+        to={`${entityLink}/all`}
         variant="contained"
         size="small"
         classes={{ root: classes.buttonExpand }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import * as R from 'ramda';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { makeStyles } from '@mui/styles';
+import { useTheme } from '@mui/styles';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
@@ -9,80 +9,84 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
+const getStyles = (theme: Theme) => ({
   node: {
     position: 'relative',
     border:
       theme.palette.mode === 'dark'
         ? '1px solid rgba(255, 255, 255, 0.12)'
         : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
+    borderRadius: '4px',
     backgroundColor: theme.palette.background.paper,
-    width: 400,
-    height: 300,
-    paddingBottom: 25,
+    width: '400px',
+    height: '300px',
+    paddingBottom: '25px',
   },
   nodeContent: {
     width: '100%',
     height: '100%',
     overflowY: 'auto',
-    padding: 20,
+    padding: '20px',
   },
   handle: {
     visibility: 'hidden',
   },
   label: {
-    marginTop: 20,
+    marginTop: '20px',
   },
   buttonExpand: {
     position: 'absolute',
     left: 0,
     bottom: 0,
     width: '100%',
-    height: 25,
+    height: '25px',
     color: theme.palette.primary.main,
     borderTopLeftRadius: 0,
     borderTopRightRadius: 0,
     backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .1)'
-          : 'rgba(0, 0, 0, .1)',
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, .1)'
+        : 'rgba(0, 0, 0, .1)',
     '&:hover': {
       backgroundColor:
-          theme.palette.mode === 'dark'
-            ? 'rgba(255, 255, 255, .2)'
-            : 'rgba(0, 0, 0, .2)',
+        theme.palette.mode === 'dark'
+          ? 'rgba(255, 255, 255, .2)'
+          : 'rgba(0, 0, 0, .2)',
     },
   },
-}));
+});
 
 const NodeVictimology = ({ data }: NodeProps) => {
-  const classes = useStyles();
+  const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
+  const styles = getStyles(theme);
+
   const { stixDomainObject, entityLink } = data;
+
   const targetedCountries = R.uniq((stixDomainObject.targetedCountries?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
+
   const targetedSectors = R.uniq((stixDomainObject.targetedSectors?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
+
   const targetedOrganizations = R.uniq((stixDomainObject.targetedOrganizations?.edges ?? [])
     .map((n: { node: { to: { name: string } } }) => n?.node?.to?.name))
     .join(', ');
-  const { t_i18n } = useFormatter();
+
   return (
-    <div className={classes.node}>
-      <div className={classes.nodeContent}>
-        <Typography variant="h3" gutterBottom={true}>
+    <div style={styles.node}>
+      <div style={styles.nodeContent}>
+        <Typography variant="h3" gutterBottom>
           {t_i18n('Last targeted countries')}
         </Typography>
         {emptyFilled(targetedCountries)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom sx={styles.label}>
           {t_i18n('Last targeted sectors')}
         </Typography>
         {emptyFilled(targetedSectors)}
-        <Typography variant="h3" gutterBottom={true} className={classes.label}>
+        <Typography variant="h3" gutterBottom sx={styles.label}>
           {t_i18n('Last targeted organizations')}
         </Typography>
         {emptyFilled(targetedOrganizations)}
@@ -92,13 +96,13 @@ const NodeVictimology = ({ data }: NodeProps) => {
         to={`${entityLink}/all`}
         variant="contained"
         size="small"
-        classes={{ root: classes.buttonExpand }}
+        sx={styles.buttonExpand}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        className={classes.handle}
+        sx={styles.handle}
         type="target"
         position={Position.Top}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeVictimology.tsx
@@ -9,57 +9,9 @@ import type { Theme } from '../../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { emptyFilled } from '../../../../../../../utils/String';
 
-const getStyles = (theme: Theme) => ({
-  node: {
-    position: 'relative',
-    border:
-      theme.palette.mode === 'dark'
-        ? '1px solid rgba(255, 255, 255, 0.12)'
-        : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: '4px',
-    backgroundColor: theme.palette.background.paper,
-    width: '400px',
-    height: '300px',
-    paddingBottom: '25px',
-  },
-  nodeContent: {
-    width: '100%',
-    height: '100%',
-    overflowY: 'auto',
-    padding: '20px',
-  },
-  handle: {
-    visibility: 'hidden',
-  },
-  label: {
-    marginTop: '20px',
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: '25px',
-    color: theme.palette.primary.main,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-});
-
 const NodeVictimology = ({ data }: NodeProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
-  const styles = getStyles(theme);
 
   const { stixDomainObject, entityLink } = data;
 
@@ -76,17 +28,35 @@ const NodeVictimology = ({ data }: NodeProps) => {
     .join(', ');
 
   return (
-    <div style={styles.node}>
-      <div style={styles.nodeContent}>
+    <div style={{
+      position: 'relative',
+      border:
+        theme.palette.mode === 'dark'
+          ? '1px solid rgba(255, 255, 255, 0.12)'
+          : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: '4px',
+      backgroundColor: theme.palette.background.paper,
+      width: '400px',
+      height: '300px',
+      paddingBottom: '25px',
+    }}
+    >
+      <div style={{
+        width: '100%',
+        height: '100%',
+        overflowY: 'auto',
+        padding: '20px',
+      }}
+      >
         <Typography variant="h3" gutterBottom>
           {t_i18n('Last targeted countries')}
         </Typography>
         {emptyFilled(targetedCountries)}
-        <Typography variant="h3" gutterBottom sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '20px' }}>
           {t_i18n('Last targeted sectors')}
         </Typography>
         {emptyFilled(targetedSectors)}
-        <Typography variant="h3" gutterBottom sx={styles.label}>
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '20px' }}>
           {t_i18n('Last targeted organizations')}
         </Typography>
         {emptyFilled(targetedOrganizations)}
@@ -96,13 +66,32 @@ const NodeVictimology = ({ data }: NodeProps) => {
         to={`${entityLink}/victimology`}
         variant="contained"
         size="small"
-        sx={styles.buttonExpand}
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          height: '25px',
+          color: theme.palette.primary.main,
+          borderTopLeftRadius: 0,
+          borderTopRightRadius: 0,
+          backgroundColor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, .1)'
+              : 'rgba(0, 0, 0, .1)',
+          '&:hover': {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, .2)'
+                : 'rgba(0, 0, 0, .2)',
+          },
+        }}
         className="nodrag nopan"
       >
         {t_i18n('View all')}
       </Button>
       <Handle
-        sx={styles.handle}
+        sx={{ visibility: 'hidden' }}
         type="target"
         position={Position.Top}
         isConnectable={false}

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -34,6 +34,7 @@ const IntrusionSetKnowledgeComponent = ({
   const link = `/dashboard/threats/intrusion_sets/${intrusionSet.id}/knowledge`;
   const { schema } = useAuth();
   const allRelationshipsTypes = getRelationshipTypesForEntityType(intrusionSet.entity_type, schema);
+
   return (
     <>
       <Routes>

--- a/opencti-platform/opencti-front/src/utils/Relation.ts
+++ b/opencti-platform/opencti-front/src/utils/Relation.ts
@@ -151,5 +151,7 @@ export const getRelationshipTypesForEntityType = (entityType: string, schema: Sc
     .filter(([key, _]) => key.startsWith(`${entityType}_`) || key.endsWith(`_${entityType}`))
     .flatMap(([_, values]) => values);
 
-  return [...new Set(relationshipList), DEFAULT_RELATION];
+  const uniqRelationshipList = new Set(relationshipList);
+  uniqRelationshipList.add(DEFAULT_RELATION);
+  return Array.from(uniqRelationshipList);
 };

--- a/opencti-platform/opencti-front/src/utils/Relation.ts
+++ b/opencti-platform/opencti-front/src/utils/Relation.ts
@@ -151,5 +151,5 @@ export const getRelationshipTypesForEntityType = (entityType: string, schema: Sc
     .filter(([key, _]) => key.startsWith(`${entityType}_`) || key.endsWith(`_${entityType}`))
     .flatMap(([_, values]) => values);
 
-  return [...relationshipList, DEFAULT_RELATION];
+  return [...new Set(relationshipList), DEFAULT_RELATION];
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change redirection links

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7879 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
