### PR TITLE
[frontend] Fix spacing before search bar of 'Rules engine' (#9972)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Rules.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Rules.jsx
@@ -29,7 +29,6 @@ const useStyles = makeStyles(() => ({
   },
   parameters: {
     float: 'left',
-    marginTop: -10,
   },
 }));
 


### PR DESCRIPTION
### Proposed changes

* Fix margin

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9972