### PR TITLE
[backend] Retrieve RabbitMQ metrics of vhost only

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/WorkersStatus.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/WorkersStatus.jsx
@@ -107,7 +107,7 @@ class WorkersStatusComponent extends Component {
             <Grid item xs={2} style={{ height: '25%' }}>
               <div className={classes.metric}>
                 <div className={classes.number}>
-                  {n(pathOr(0, ['queue_totals', 'messages'], overview))}
+                  {n(pathOr(0, ['messages'], overview))}
                 </div>
                 <div className={classes.title}>{t('Queued bundles')}</div>
               </div>
@@ -192,11 +192,9 @@ const WorkersStatus = createRefetchContainer(
         rabbitMQMetrics {
           consumers
           overview {
-            queue_totals {
-              messages
-              messages_ready
-              messages_unacknowledged
-            }
+            messages
+            messages_ready
+            messages_unacknowledged
             message_stats {
               ack
               ack_details {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -285,21 +285,10 @@ type QueueMetrics {
   message_stats: MessagesStats
 }
 
-type QueueTotals {
+type OverviewMetrics {
   messages: String
   messages_ready: String
   messages_unacknowledged: String
-}
-
-type ObjectTotals {
-  channels: String
-  consumers: String
-  queues: String
-}
-
-type OverviewMetrics {
-  object_totals: ObjectTotals
-  queue_totals: QueueTotals
   message_stats: MessagesStats
 }
 

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -282,19 +282,10 @@ type QueueMetrics {
   idle_since: DateTime
   message_stats: MessagesStats
 }
-type QueueTotals {
+type OverviewMetrics {
   messages: String
   messages_ready: String
   messages_unacknowledged: String
-}
-type ObjectTotals {
-  channels: String
-  consumers: String
-  queues: String
-}
-type OverviewMetrics {
-  object_totals: ObjectTotals
-  queue_totals: QueueTotals
   message_stats: MessagesStats
 }
 type RabbitMQMetrics {

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -164,8 +164,8 @@ export const metrics = async (context, user) => {
   const metricApi = async () => {
     const httpClient = await amqpHttpClient();
     const overview = await httpClient.get(`/api/vhosts${VHOST_PATH}`).then((response) => response.data);
-    const version = await httpClient.get(`/api/version`).then((response) => response.data);
-    overview.rabbitmq_version = version;
+    const version = await httpClient.get(`/api/overview`).then((response) => response.data);
+    overview.rabbitmq_version = version.rabbitmq_version;
     const queues = await httpClient.get(`/api/queues${VHOST_PATH}`).then((response) => response.data);
     // Compute number of push queues
     const platformQueues = queues.filter((q) => q.name.startsWith(RABBIT_QUEUE_PREFIX));

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -32,7 +32,7 @@ const PORT = conf.get('rabbitmq:port');
 const USERNAME = conf.get('rabbitmq:username');
 const PASSWORD = conf.get('rabbitmq:password');
 const VHOST = conf.get('rabbitmq:vhost');
-const VHOST_PATH = VHOST === '/' ? '' : `/${VHOST}`;
+const VHOST_PATH = VHOST === '/' ? '/%2f' : `/${VHOST}`;
 const USE_SSL_MGMT = booleanConf('rabbitmq:management_ssl', false);
 const HOSTNAME_MGMT = conf.get('rabbitmq:hostname_management') || HOSTNAME;
 const PORT_MGMT = conf.get('rabbitmq:port_management');
@@ -163,7 +163,9 @@ export const send = (exchangeName, routingKey, message) => {
 export const metrics = async (context, user) => {
   const metricApi = async () => {
     const httpClient = await amqpHttpClient();
-    const overview = await httpClient.get('/api/overview').then((response) => response.data);
+    const overview = await httpClient.get(`/api/vhosts${VHOST_PATH}`).then((response) => response.data);
+    const version = await httpClient.get(`/api/version`).then((response) => response.data);
+    overview.rabbitmq_version = version;
     const queues = await httpClient.get(`/api/queues${VHOST_PATH}`).then((response) => response.data);
     // Compute number of push queues
     const platformQueues = queues.filter((q) => q.name.startsWith(RABBIT_QUEUE_PREFIX));

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -164,7 +164,7 @@ export const metrics = async (context, user) => {
   const metricApi = async () => {
     const httpClient = await amqpHttpClient();
     const overview = await httpClient.get(`/api/vhosts${VHOST_PATH}`).then((response) => response.data);
-    const version = await httpClient.get(`/api/overview`).then((response) => response.data);
+    const version = await httpClient.get('/api/overview').then((response) => response.data);
     overview.rabbitmq_version = version.rabbitmq_version;
     const queues = await httpClient.get(`/api/queues${VHOST_PATH}`).then((response) => response.data);
     // Compute number of push queues


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix the `WorkersStatus` to retrieve only statistics on vhost used by OpenCTI. 

In order to do so, replace the use of the `api/overview` query with `api/vhosts/${VHOST}` to retrieve statistics on all the queues of the vhost; and the use of ~`api/version`~ `api/overview` to retrieve the version of RabbitMQ (used in the settings). Edit: use `api/overview` for the version, `api/version` is only available to rabbitmq >=4.0

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10036 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

As visible on the snapshot, number of messages from the `test` vhost are not taken into account when using root vhost for opencti (contrary to the one in the issue):
![image](https://github.com/user-attachments/assets/178c69c0-4bf4-4e7e-a994-4b6daac84a2a)

And when using another vhost, e.g. `opencti`, other vhost are not taken into account:
![image](https://github.com/user-attachments/assets/04660746-ac07-4f2d-8b8a-ffca278c9ce5)


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
