### PR TITLE
[frontend] replace APP_SCRIPT_SNIPPET in dev mode

### DIFF
--- a/opencti-platform/opencti-front/builder/dev/dev.js
+++ b/opencti-platform/opencti-front/builder/dev/dev.js
@@ -120,6 +120,7 @@ esbuild.context({
     const data = readFileSync(`${__dirname}/index.html`, "utf8");
     const withOptionValued = data
       .replace(/%BASE_PATH%/g, basePath)
+      .replace(/%APP_SCRIPT_SNIPPET%/g,  '')
       .replace(/%APP_TITLE%/g, "OpenCTI Dev")
       .replace(/%APP_DESCRIPTION%/g, "OpenCTI Development platform")
       .replace(/%APP_FAVICON%/g, `${basePath}/static/ext/favicon.png`)

--- a/opencti-platform/opencti-front/vite.config.mts
+++ b/opencti-platform/opencti-front/vite.config.mts
@@ -224,6 +224,7 @@ export default defineConfig({
       apply: 'serve',
       transformIndexHtml(html) {
         return html.replace(/%BASE_PATH%/g, basePath)
+          .replace(/%APP_SCRIPT_SNIPPET%/g,  '')
           .replace(/%APP_TITLE%/g, "OpenCTI Dev")
           .replace(/%APP_DESCRIPTION%/g, "OpenCTI Development platform")
           .replace(/%APP_FAVICON%/g, `${basePath}/static/ext/favicon.png`)


### PR DESCRIPTION
`%APP_SCRIPT_SNIPPET%` was not correctly replaced in dev mode.