### PR TITLE
[frontend/backend] add new filter capabilities to playbooks

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -96,6 +96,11 @@ export const stixFilters = [
   'x_opencti_cvss_base_score',
   'x_opencti_cvss_base_severity',
   'report_types',
+  'response_types',
+  'information_types',
+  'takedown_types',
+  'note_types',
+  'incident_type',
 ];
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -50,6 +50,12 @@ export const EPSS_SCORE_FILTER = 'x_opencti_epss_score';
 export const CVSS_BASE_SCORE_FILTER = 'x_opencti_cvss_base_score';
 export const CVSS_BASE_SEVERITY_FILTER = 'x_opencti_cvss_base_severity';
 export const REPORT_TYPES_FILTER = 'report_types';
+export const INCIDENT_RESPONSE_TYPES_FILTER = 'response_types';
+export const REQUEST_FOR_INFORMATION_TYPES_FILTER = 'information_types';
+export const REQUEST_FOR_TAKEDOWN_TYPES_FILTER = 'takedown_types';
+export const NOTE_TYPES_FILTER = 'note_types';
+export const INCIDENT_TYPE_FILTER = 'incident_type';
+
 // special cases
 export const IDS_FILTER = 'ids';
 export const SIGHTED_BY_FILTER = 'sightedBy';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -36,7 +36,12 @@ import {
   EPSS_SCORE_FILTER,
   CVSS_BASE_SCORE_FILTER,
   CVSS_BASE_SEVERITY_FILTER,
-  REPORT_TYPES_FILTER
+  REPORT_TYPES_FILTER,
+  INCIDENT_RESPONSE_TYPES_FILTER,
+  REQUEST_FOR_INFORMATION_TYPES_FILTER,
+  REQUEST_FOR_TAKEDOWN_TYPES_FILTER,
+  INCIDENT_TYPE_FILTER,
+  NOTE_TYPES_FILTER
 } from '../filtering-constants';
 import type { Filter } from '../../../generated/graphql';
 import { STIX_RESOLUTION_MAP_PATHS } from '../filtering-resolution';
@@ -84,6 +89,51 @@ export const testIndicatorTypes = (stix: any, filter: Filter) => {
 export const testReportTypes = (stix: any, filter: Filter) => {
   const stixValue: string[] = stix.report_types ?? [];
   return testStringFilter(filter, stixValue);
+};
+
+/**
+ * IR
+ * - incident response types is response_types in stix
+ */
+export const testResponseTypes = (stix: any, filter: Filter) => {
+  const stixValue: string[] = stix.response_types ?? [];
+  return testStringFilter(filter, stixValue);
+};
+
+/**
+ * RFI
+ * - RFI types is information_types in stix
+ */
+export const testRFITypes = (stix: any, filter: Filter) => {
+  const stixValue: string[] = stix.information_types ?? [];
+  return testStringFilter(filter, stixValue);
+};
+
+/**
+ * RFT
+ * - RFT types is takedown_types in stix
+ */
+export const testRFTTypes = (stix: any, filter: Filter) => {
+  const stixValue: string[] = stix.takedown_types ?? [];
+  return testStringFilter(filter, stixValue);
+};
+
+/**
+ * NOTE
+ * - note types is note_types in stix
+ */
+export const testNoteTypes = (stix: any, filter: Filter) => {
+  const stixValue: string[] = stix.note_types ?? [];
+  return testStringFilter(filter, stixValue);
+};
+
+/**
+ * INCIDENT
+ * - incident type is incident_type in stix
+ */
+export const testIncidentType = (stix: any, filter: Filter) => {
+  const stixValue: string | null = stix.incident_type;
+  return testStringFilter(filter, toValidArray(stixValue));
 };
 
 /**
@@ -381,6 +431,11 @@ export const FILTER_KEY_TESTERS_MAP: Record<string, TesterFunction> = {
   [DETECTION_FILTER]: testDetection,
   [INDICATOR_FILTER]: testIndicatorTypes,
   [REPORT_TYPES_FILTER]: testReportTypes,
+  [INCIDENT_RESPONSE_TYPES_FILTER]: testResponseTypes,
+  [REQUEST_FOR_INFORMATION_TYPES_FILTER]: testRFITypes,
+  [REQUEST_FOR_TAKEDOWN_TYPES_FILTER]: testRFTTypes,
+  [NOTE_TYPES_FILTER]: testNoteTypes,
+  [INCIDENT_TYPE_FILTER]: testIncidentType,
   [LABEL_FILTER]: testLabel,
   [MAIN_OBSERVABLE_TYPE_FILTER]: testMainObservableType,
   [MARKING_FILTER]: testMarkingFilter,


### PR DESCRIPTION
Closes #9144 

Added STIX filtering for fields `response_types`, `information_types`, `takedown_types`, `note_types`, `incident_type`