### PR TITLE
[frontend] Bad margin/padding on some pages with an information section (#10053)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
@@ -93,7 +93,6 @@ const Sync = () => {
       <PageContainer withRightMenu>
         <Breadcrumbs
           elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('OpenCTI Streams'), current: true }]}
-          noMargin
         />
         <AlertInfo content={
           <>
@@ -109,6 +108,7 @@ const Sync = () => {
             .
           </>
         }
+          style={{ marginBottom: theme.spacing(2) }}
         />
         <ListLines
           sortBy={viewStorage.sortBy}


### PR DESCRIPTION
### Proposed changes

* Remove "noMargin" props in breadcrumbs
* Add a marginBottom to alert component

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10053