### PR TITLE
[frontend] Markings default values switching in Customization (#10107)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingAttributes.tsx
@@ -94,7 +94,15 @@ const EntitySettingAttributes = ({
       width: '25%',
       isSortable: false,
       render: (data: EntitySettingAttributeLine_attribute$data) => {
-        return isNotEmptyField(data.defaultValues) ? (
+        let isDefaultValuesSet = isNotEmptyField(data.defaultValues);
+        if (data.name === 'objectMarking') {
+          if (isNotEmptyField(data.defaultValues)) {
+            if (data.defaultValues.every((v) => v.id === 'false')) {
+              isDefaultValuesSet = false;
+            }
+          }
+        }
+        return isDefaultValuesSet ? (
           <CheckCircleOutlined
             fontSize="small"
             color={data.editDefault ? 'success' : 'disabled'}

--- a/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDefaultValues.ts
@@ -34,6 +34,9 @@ export const useComputeDefaultValues = () => {
 
     // Handle object marking specific case : activate or deactivate default values (handle in access)
     if (attributeName === 'objectMarking') {
+      if (defaultValues[0]?.id === 'false') {
+        return false;
+      }
       return defaultValues[0]?.id ?? false;
     }
 


### PR DESCRIPTION
### Proposed changes
In customization > an entity type : be able to switch between enabling or not markings default values 

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10107