### PR TITLE
[backend] Bug correction for setting x_opencti_score on SCO. Uses confidence factor value from User/Group

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3156,10 +3156,6 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   const input = { ...rawInput };
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input, type);
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
-  // StixCyberObservables use x_opencti_score versus having a confidence value field. Creates will not
-  // default populate this field, unless x_opencti_score is set. Connectors cannot set this value based on
-  // default user it is running due to PR#3526 in OpenCTI Connectors removed the passing of these settings.
-  input.x_opencti_score = confidenceLevelToApply; // x_opencti_score of new entity will be capped to user's confidence
   // authorized_members renaming
   if (input.authorized_members?.length > 0) {
     input.restricted_members = input.authorized_members;

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3156,6 +3156,10 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   const input = { ...rawInput };
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input, type);
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
+  // StixCyberObservables use x_opencti_score versus having a confidence value field. Creates will not
+  // default populate this field, unless x_opencti_score is set. Connectors cannot set this value based on
+  // default user it is running due to PR#3526 in OpenCTI Connectors removed the passing of these settings.
+  input.x_opencti_score = confidenceLevelToApply; // x_opencti_score of new entity will be capped to user's confidence
   // authorized_members renaming
   if (input.authorized_members?.length > 0) {
     input.restricted_members = input.authorized_members;

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -212,7 +212,7 @@ export const observableValue = (stixCyberObservable) => {
 export const checkScore = (newScore) => {
   if (newScore) {
     const parsedScore = parseFloat(newScore);
-    if (parsedScore < 0 || parsedScore > 100 || !Number.isInteger(parsedScore)) {
+    if (!Number.isInteger(parsedScore) || parsedScore < 0 || parsedScore > 100) {
       throw ValidationError('The score should be an integer between 0 and 100', 'x_opencti_score');
     }
   }


### PR DESCRIPTION
Maybe x_opencti_score isn't a direct corollary to "confidence" for an SCO, however it is required for decay rules, so just in case:

The new PR#(https://github.com/OpenCTI-Platform/connectors/pull/3526) removes the setting of confidence value directly via a connector. It is expected to inherit the value via the User/Group setting of the users running the connector. However, SCO objects use `x_opencti_score` and not `confidence` value as the key in the DB that tracks this "similar" value. Thus, all SCOs would not be created with a "confidence" value (x_opencti_score) (i.e. would be set to None). This PR seeks to create a similar behavior for `x_opencti_score`, based on the confidence level that the User/Group creating the record is rated.

`opencti-graphql/src/domain/stixCyberObservable.js` has been updated to account for this difference.

### Impact

#### Platform UI Front Level
NOTE: The Artifact create drawer within the Frontend off - `/dashboard/observations/artifacts` - does **not** have a score field on it, so artifacts created via this panel will now inherit the score of the creator. However, the drawer off - `/dashboard/observations/observables` - to create and select Artifact - does have a score field, defaulted to 50.

Previous behavior would be a score of `None` set off  `/dashboard/observations/artifacts` and a score of 50 (or whatever the user defined) set off `/dashboard/observations/observables`. I believe the `None` is a bug in itself, since the docs seem to indicate all should have 50 to start at a minimum. (https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay)

To fix / make the behavior the same (setting to 50 or a selected value) - **artifactImport** would require the support of `x_opencti_score`, which it currently doesn't support. This is viewed as a separate tech debt PR should this behavior correction be required. They system will now off this screen (`/dashboard/observations/artifacts`) set the score to that of the user creating versus `None`

#### Connector Level
Connectors that pass bundles that do **not** have an `x_opencti_score` in them will set the `x_opencti_score` to the `confidence level` of the user that the connector is currently running under. So, if the connector has a `confidence level` of `90` and **no** `x_opencti_score` is passed, the observable will be created with an `x_opencti_score` of `90`. The previous behavior would be that the `x_opencti_score` would be empty. This empty behavior is a violation of the intended documentation pattern which indicates all should have `50` to start at a minimum. (https://docs.opencti.io/latest/usage/indicators-lifecycle/#score-decay)

 If an `x_opencti_score` is passed, the value passed will be the setting upon creation of the observable.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

See Issue - https://github.com/OpenCTI-Platform/opencti/issues/10153


