### PR TITLE
[frontend] fix call to widget horizontal bar for relationships

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardEntitiesViz.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardEntitiesViz.tsx
@@ -74,7 +74,7 @@ const DashboardEntitiesViz = ({
           dataSelection={dataSelection}
           parameters={widget.parameters as object} // because calling js component in ts
           height={undefined} // because calling js component in ts
-          withoutTitle={false} // because calling js component in ts
+          withoutTitle={undefined} // because calling js component in ts
         />
       );
     case 'list':

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardRelationshipsViz.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardRelationshipsViz.tsx
@@ -191,9 +191,9 @@ const DashboardRelationshipsViz = ({
           height={undefined} // because calling js component in ts
           title={undefined} // because calling js component in ts
           field={undefined} // because calling js component in ts
-          withoutTitle={false} // because calling js component in ts
-          fromId={false} // because calling js component in ts
-          relationshipType={false} // because calling js component in ts
+          withoutTitle={undefined} // because calling js component in ts
+          fromId={undefined} // because calling js component in ts
+          relationshipType={undefined} // because calling js component in ts
         />
       );
     case 'radar':


### PR DESCRIPTION
### Proposed changes

* Fix default props that need to be passed because of TS to JS

Why passing a lot of props as undefined ? Because the component called is written in JS so there is no props type defined. When using this component in a TS file, Typescript is not happy when the props is not specified.

### Related issues

* #10159 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality