### PR TITLE
[frontend/backend] Dynamic 'me' filter value (#9128)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -37,6 +37,8 @@ export const emptyFilterGroup = {
 export const SELF_ID = 'SELF_ID';
 export const SELF_ID_VALUE = 'CURRENT ENTITY';
 
+export const ME_FILTER_VALUE = '@me';
+
 // 'within' operator filter constants
 export const DEFAULT_WITHIN_FILTER_VALUES = ['now-1d', 'now'];
 

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -505,7 +505,7 @@ const useSearchEntities = ({
       type: string,
       data: IdentitySearchCreatorsSearchQuery$data['creators'], // this type is actually the same for the different queries we use, not only creators
     ) => {
-      const newOptions: { label: string, value: string, type: string, color?: string }[] = (data?.edges ?? []).map((n) => ({
+      const newOptions: EntityValue[] = (data?.edges ?? []).map((n) => ({
         label: n?.node.name ?? '',
         value: n?.node.id ?? '',
         type,

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -2928,7 +2928,7 @@ const elQueryBodyBuilder = async (context, user, options) => {
   const { ids = [], after, orderBy = null, orderMode = 'asc', noSize = false, noSort = false, intervalInclude = false } = options;
   const first = options.first ?? ES_DEFAULT_PAGINATION;
   const { types = null, search = null } = options;
-  const filters = checkAndConvertFilters(options.filters, { noFiltersChecking: options.noFiltersChecking });
+  const filters = checkAndConvertFilters(options.filters, user.id, { noFiltersChecking: options.noFiltersChecking });
   const { startDate = null, endDate = null, dateAttribute = null } = options;
   const searchAfter = after ? cursorToOffset(after) : undefined;
   let ordering = [];

--- a/opencti-platform/opencti-graphql/src/domain/basicObject.ts
+++ b/opencti-platform/opencti-graphql/src/domain/basicObject.ts
@@ -1,6 +1,6 @@
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { STIX_CORE_RELATIONSHIPS } from '../schema/stixCoreRelationship';
-import { specialFilterKeysWhoseValueToResolve } from '../utils/filtering/filtering-constants';
+import { ME_FILTER_VALUE, specialFilterKeysWhoseValueToResolve } from '../utils/filtering/filtering-constants';
 import { extractFilterGroupValues } from '../utils/filtering/filtering-utils';
 import { storeLoadByIds } from '../database/middleware-loader';
 import { ABSTRACT_BASIC_OBJECT } from '../schema/general';
@@ -65,6 +65,15 @@ export const findFiltersRepresentatives = async (context: AuthContext, user: Aut
       id: SELF_ID,
       value: SELF_ID_VALUE,
       entity_type: 'Instance',
+      color: null,
+    });
+  }
+  // resolve ME_FILTER_VALUE differently
+  if (idsToResolve.includes(ME_FILTER_VALUE)) {
+    filtersRepresentatives.push({
+      id: ME_FILTER_VALUE,
+      value: ME_FILTER_VALUE,
+      entity_type: 'User',
       color: null,
     });
   }

--- a/opencti-platform/opencti-graphql/src/domain/stix.js
+++ b/opencti-platform/opencti-graphql/src/domain/stix.js
@@ -237,7 +237,7 @@ export const askEntityExport = async (context, user, format, entity, type, conte
   return worksForExport;
 };
 
-export const exportTransformFilters = (filteringArgs, orderOptions) => {
+export const exportTransformFilters = (filteringArgs, orderOptions, userId) => {
   const orderingInversed = invertObj(orderOptions);
   const { filters } = filteringArgs;
   return {
@@ -245,7 +245,7 @@ export const exportTransformFilters = (filteringArgs, orderOptions) => {
     orderBy: filteringArgs.orderBy in orderingInversed
       ? orderingInversed[filteringArgs.orderBy]
       : filteringArgs.orderBy,
-    filters: checkAndConvertFilters(filters),
+    filters: checkAndConvertFilters(filters, userId),
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -423,7 +423,7 @@ export const stixCoreObjectsExportAsk = async (context, user, args) => {
   const { search, orderBy, orderMode, filters } = args;
   const argsFilters = { search, orderBy, orderMode, filters };
   const ordersOpts = stixCoreObjectOptions.StixCoreObjectsOrdering;
-  const listParams = exportTransformFilters(argsFilters, ordersOpts);
+  const listParams = exportTransformFilters(argsFilters, ordersOpts, user.id);
   const works = await askListExport(context, user, exportContext, format, selectedIds, listParams, exportType, contentMaxMarkings, fileMarkings);
   return works.map((w) => workToExportFile(w));
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -87,7 +87,7 @@ export const stixCoreRelationshipsExportAsk = async (context, user, args) => {
   const argsFilters = { search, orderBy, orderMode, filters };
   const ordersOpts = stixCoreRelationshipOptions.StixCoreRelationshipsOrdering;
   const initialParams = { fromOrToId, elementWithTargetTypes, fromId, fromRole, fromTypes, toId, toRole, toTypes, relationship_type };
-  const listParams = { ...initialParams, ...exportTransformFilters(argsFilters, ordersOpts) };
+  const listParams = { ...initialParams, ...exportTransformFilters(argsFilters, ordersOpts, user.id) };
   const works = await askListExport(context, user, exportContext, format, selectedIds, listParams, exportType, contentMaxMarkings, fileMarkings);
   return works.map((w) => workToExportFile(w));
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -326,7 +326,7 @@ export const stixCyberObservablesExportAsk = async (context, user, args) => {
   const { search, orderBy, orderMode, filters, types } = args;
   const argsFilters = { search, orderBy, orderMode, filters, types };
   const ordersOpts = stixCyberObservableOptions.StixCyberObservablesOrdering;
-  const listParams = exportTransformFilters(argsFilters, ordersOpts);
+  const listParams = exportTransformFilters(argsFilters, ordersOpts, user.id);
   const observableContext = { ...exportContext, entity_type: exportContext.entity_type ?? 'Stix-Cyber-Observable' };
   const works = await askListExport(context, user, observableContext, format, selectedIds, listParams, exportType, contentMaxMarkings, fileMarkings);
   return works.map((w) => workToExportFile(w));

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -104,7 +104,7 @@ export const stixDomainObjectsExportAsk = async (context, user, args) => {
   const { search, orderBy, orderMode, filters } = args;
   const filteringArgs = { search, orderBy, orderMode, filters };
   const ordersOpts = stixDomainObjectOptions.StixDomainObjectsOrdering;
-  const listParams = exportTransformFilters(filteringArgs, ordersOpts);
+  const listParams = exportTransformFilters(filteringArgs, ordersOpts, user.id);
   const works = await askListExport(context, user, exportContext, format, selectedIds, listParams, exportType, contentMaxMarkings, fileMarkings);
   return works.map((w) => workToExportFile(w));
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -116,7 +116,7 @@ export const getPlaybookDefinition = async (context: AuthContext, playbook: Basi
   return playbook.playbook_definition;
 };
 
-const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = (input: PlaybookAddNodeInput) => {
+const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = (input: PlaybookAddNodeInput, userId: string) => {
   if (!input.configuration) {
     return '{}';
   }
@@ -125,7 +125,7 @@ const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = (input: PlaybookAdd
   if (config.filters) {
     const filterGroup = JSON.parse(config.filters) as FilterGroup;
     if (input.component_id === PLAYBOOK_INTERNAL_DATA_CRON.id) {
-      stringifiedFilters = JSON.stringify(checkAndConvertFilters(filterGroup));
+      stringifiedFilters = JSON.stringify(checkAndConvertFilters(filterGroup, userId));
     } else { // our stix matching is currently limited, we need to validate the input filters
       validateFilterGroupForStixMatch(filterGroup);
       stringifiedFilters = config.filters;
@@ -135,7 +135,7 @@ const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = (input: PlaybookAdd
 };
 
 export const playbookAddNode = async (context: AuthContext, user: AuthUser, id: string, input: PlaybookAddNodeInput) => {
-  const configuration = checkPlaybookFiltersAndBuildConfigWithCorrectFilters(input);
+  const configuration = checkPlaybookFiltersAndBuildConfigWithCorrectFilters(input, user.id);
 
   const playbook = await findById(context, user, id);
   const definition = JSON.parse(playbook.playbook_definition ?? '{}') as ComponentDefinition;
@@ -212,7 +212,7 @@ export const playbookUpdatePositions = async (context: AuthContext, user: AuthUs
 };
 
 export const playbookReplaceNode = async (context: AuthContext, user: AuthUser, id: string, nodeId: string, input: PlaybookAddNodeInput) => {
-  const configuration = checkPlaybookFiltersAndBuildConfigWithCorrectFilters(input);
+  const configuration = checkPlaybookFiltersAndBuildConfigWithCorrectFilters(input, user.id);
 
   const playbook = await findById(context, user, id);
   const definition = JSON.parse(playbook.playbook_definition) as ComponentDefinition;

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -155,3 +155,14 @@ export const specialFilterKeysWhoseValueToResolve = [
   RELATION_FROM_FILTER,
   RELATION_TO_FILTER
 ];
+
+// special filter values
+export const ME_FILTER_VALUE = '@me';
+export const filterKeysWithMeValue = [
+  ASSIGNEE_FILTER,
+  PARTICIPANT_FILTER,
+  CONTEXT_CREATOR_FILTER,
+  CREATOR_FILTER,
+  CONTEXT_ENTITY_ID_FILTER,
+  MEMBERS_USER_FILTER,
+];

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
@@ -6,10 +6,12 @@ import {
   CONNECTED_TO_INSTANCE_FILTER,
   CONNECTED_TO_INSTANCE_SIDE_EVENTS_FILTER,
   CREATED_BY_FILTER,
+  filterKeysWithMeValue,
   INDICATOR_FILTER,
   INSTANCE_REGARDING_OF,
   LABEL_FILTER,
   MARKING_FILTER,
+  ME_FILTER_VALUE,
   OBJECT_CONTAINS_FILTER,
   PARTICIPANT_FILTER,
   RELATION_FROM_FILTER,
@@ -96,6 +98,14 @@ const resolveFilter = async (
     // !!! it works to do the mode/operator filter on the status (and not on the template)
     // because a status can only have a single template and because the operators are full-match operators (eq/not_eq) !!!
     newFilterValues = statusIds;
+  }
+
+  // 3. handle the special case of dynamic @me value
+  if (key.some((k) => filterKeysWithMeValue.includes(k))) {
+    if (filter.values.includes(ME_FILTER_VALUE)) {
+      // eslint-disable-next-line no-param-reassign
+      filter.values = filter.values.map((v) => (v === ME_FILTER_VALUE ? user.id : v));
+    }
   }
 
   return {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -353,13 +353,13 @@ export const checkAndConvertFilters = (inputFilterGroup: FilterGroup | null | un
   if (!inputFilterGroup) {
     return undefined;
   }
-  // 01. replace dynamic @me value
-  const filterGroup = replaceMeValuesInFilters(inputFilterGroup, userId);
-  // 02. check filters validity
+  // 01. check filters validity
   const { noFiltersChecking = false } = opts;
+  checkFiltersValidity(inputFilterGroup, noFiltersChecking);
+  // 02. replace dynamic @me value
+  const filterGroup = replaceMeValuesInFilters(inputFilterGroup, userId);
+  // 03. convert relation refs
   if (!noFiltersChecking && isFilterGroupNotEmpty(inputFilterGroup)) {
-    checkFiltersValidity(inputFilterGroup, noFiltersChecking);
-    // 03. convert relation refs
     return convertRelationRefsFilterKeys(filterGroup);
   }
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -353,12 +353,13 @@ export const checkAndConvertFilters = (inputFilterGroup: FilterGroup | null | un
   if (!inputFilterGroup) {
     return undefined;
   }
-  // 01. check filters validity
-  const { noFiltersChecking = false } = opts;
-  checkFiltersValidity(inputFilterGroup, noFiltersChecking);
+  // 01. replace dynamic @me value
   const filterGroup = replaceMeValuesInFilters(inputFilterGroup, userId);
-  // 03. translate the filter keys on relation refs and return the converted filters
-  if (!noFiltersChecking && isFilterGroupNotEmpty(filterGroup)) {
+  // 02. check filters validity
+  const { noFiltersChecking = false } = opts;
+  if (!noFiltersChecking && isFilterGroupNotEmpty(inputFilterGroup)) {
+    checkFiltersValidity(inputFilterGroup, noFiltersChecking);
+    // 03. convert relation refs
     return convertRelationRefsFilterKeys(filterGroup);
   }
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -10,7 +10,9 @@ import {
   CONTEXT_ENTITY_TYPE_FILTER,
   CONTEXT_OBJECT_LABEL_FILTER,
   CONTEXT_OBJECT_MARKING_FILTER,
+  filterKeysWithMeValue,
   INSTANCE_REGARDING_OF,
+  ME_FILTER_VALUE,
   MEMBERS_GROUP_FILTER,
   MEMBERS_ORGANIZATION_FILTER,
   MEMBERS_USER_FILTER,
@@ -280,6 +282,26 @@ const getConvertedRelationsNames = (relationNames: string[]) => {
 };
 
 /**
+ * Replace @me by the user id in filter whose values can contain user ids
+ */
+export const replaceMeValuesInFilters = (filterGroup: FilterGroup, userId: string) => {
+  const filtersResult = { ...filterGroup };
+  filtersResult.filters.forEach((filter) => {
+    const { key } = filter;
+    const arrayKeys = Array.isArray(key) ? key : [key];
+    if (arrayKeys.some((filterKey) => filterKeysWithMeValue.includes(filterKey))) {
+      // replace ME_FILTER_VALUE with the id of the user
+      if (filter.values.includes(ME_FILTER_VALUE)) {
+        // eslint-disable-next-line no-param-reassign
+        filter.values = filter.values.map((v) => (v === ME_FILTER_VALUE ? userId : v));
+      }
+    }
+  });
+  filtersResult.filterGroups.forEach((fg) => replaceMeValuesInFilters(fg, userId));
+  return filtersResult;
+};
+
+/**
  * Check the filter keys exist in the schema
  */
 const checkFilterKeys = (filterGroup: FilterGroup) => {
@@ -327,14 +349,15 @@ export const checkFiltersValidity = (filterGroup: FilterGroup, noFiltersChecking
  * - check that the key is available with respect to the schema, throws an Error if not
  * - convert relation refs key if any
  */
-export const checkAndConvertFilters = (filterGroup: FilterGroup | null | undefined, opts: { noFiltersChecking?: boolean } = {}) => {
-  if (!filterGroup) {
+export const checkAndConvertFilters = (inputFilterGroup: FilterGroup | null | undefined, userId: string, opts: { noFiltersChecking?: boolean } = {}) => {
+  if (!inputFilterGroup) {
     return undefined;
   }
   // 01. check filters validity
   const { noFiltersChecking = false } = opts;
-  checkFiltersValidity(filterGroup, noFiltersChecking);
-  // 02. translate the filter keys on relation refs and return the converted filters
+  checkFiltersValidity(inputFilterGroup, noFiltersChecking);
+  const filterGroup = replaceMeValuesInFilters(inputFilterGroup, userId);
+  // 03. translate the filter keys on relation refs and return the converted filters
   if (!noFiltersChecking && isFilterGroupNotEmpty(filterGroup)) {
     return convertRelationRefsFilterKeys(filterGroup);
   }


### PR DESCRIPTION
### Proposed changes
For filters involving users id as value, add the possibility to set a dynamic value @me representing the current user

to test:
- dynamic filtering (lists, exports, fintel templates, widgets, public dashboards)
- stix filtering (triggers, stream, feed, playbook etc)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9128