### PR TITLE
[frontend] avoid duplicate relationship types in relationship creation form (#10151)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.jsx
@@ -369,11 +369,11 @@ class StixCoreRelationshipCreation extends Component {
     return (
       <UserContext.Consumer>
         {({ schema }) => {
-          const relationshipTypes = resolveRelationsTypes(
+          const relationshipTypes = R.uniq(resolveRelationsTypes(
             fromObjects[0].entity_type,
             toObjects[0].entity_type,
             schema.schemaRelationsTypesMapping,
-          );
+          ));
           return (
             <>
               <div className={classes.header}>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -937,16 +937,15 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
     return (
       <UserContext.Consumer>
         {({ schema }) => {
-          const relationshipTypes = R.uniq(R.filter(
+          const relationshipTypes = R.uniq(resolveRelationsTypes(
+            fromEntities[0].entity_type,
+            toEntities[0].entity_type,
+            schema?.schemaRelationsTypesMapping ?? new Map(),
+          ).filter(
             (n) => R.isNil(allowedRelationshipTypes)
               || allowedRelationshipTypes.length === 0
               || allowedRelationshipTypes.includes('stix-core-relationship')
               || allowedRelationshipTypes.includes(n),
-            resolveRelationsTypes(
-              fromEntities[0].entity_type,
-              toEntities[0].entity_type,
-              schema?.schemaRelationsTypesMapping ?? new Map(),
-            ),
           ));
           return (
             <StixCoreRelationshipCreationForm

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
@@ -501,18 +501,17 @@ class StixCoreRelationshipCreationFromRelation extends Component {
     return (
       <UserContext.Consumer>
         {({ schema }) => {
-          const relationshipTypes = R.filter(
+          const relationshipTypes = R.uniq(resolveRelationsTypes(
+            fromEntity.parent_types.includes('Stix-Cyber-Observable')
+              ? 'observable'
+              : fromEntity.entity_type,
+            toEntity.entity_type,
+            schema.schemaRelationsTypesMapping,
+          ).filter(
             (n) => R.isNil(allowedRelationshipTypes)
                     || allowedRelationshipTypes.length === 0
                     || allowedRelationshipTypes.includes(n),
-            resolveRelationsTypes(
-              R.includes('Stix-Cyber-Observable', fromEntity.parent_types)
-                ? 'observable'
-                : fromEntity.entity_type,
-              toEntity.entity_type,
-              schema.schemaRelationsTypesMapping,
-            ),
-          );
+          ));
           return (
             <>
               <div className={classes.header}>


### PR DESCRIPTION
### Proposed changes
In relationship creation from Graph, avoid duplicate relationship types in relationship types list

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10151