### PR TITLE
[backend] Live stream consuming can crash when inferences and specific filters are used (#10201)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -34,9 +34,9 @@ import {
   KNOWLEDGE_ORGANIZATION_RESTRICT,
   SYSTEM_USER
 } from '../utils/access';
-import { streamEventId, FROM_START_STR, utcDate } from '../utils/format';
+import { FROM_START_STR, streamEventId, utcDate } from '../utils/format';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
-import { ABSTRACT_STIX_CORE_RELATIONSHIP, buildRefRelationKey, ENTITY_TYPE_CONTAINER, STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
+import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_OBJECT, buildRefRelationKey, ENTITY_TYPE_CONTAINER, STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
 import { convertStoreToStix } from '../database/stix-converter';
 import { UnsupportedError } from '../config/errors';
 import { MARKING_FILTER } from '../utils/filtering/filtering-constants';
@@ -52,6 +52,7 @@ import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { generateCreateMessage } from '../database/generate-message';
 import { isStixMatchFilterGroup } from '../utils/filtering/filtering-stix/stix-filtering';
+import { STIX_CORE_RELATIONSHIPS } from '../schema/stixCoreRelationship';
 
 const broadcastClients = {};
 const queryIndices = [...READ_STIX_INDICES, READ_INDEX_STIX_META_OBJECTS];
@@ -260,7 +261,7 @@ const createSseMiddleware = () => {
       setLastEventId: (id) => { lastEventId = id; },
       connected: () => !req.finished,
       sendEvent: (eventId, topic, event) => {
-        if (req.finished) {
+        if (!res.writable) {
           // Write on an already terminated response
           return;
         }
@@ -695,6 +696,7 @@ const createSseMiddleware = () => {
           return channel.connected();
         };
         const queryOptions = await convertFiltersToQueryOptions(streamFilters, {
+          defaultTypes: [STIX_CORE_RELATIONSHIPS, STIX_SIGHTING_RELATIONSHIP, ABSTRACT_STIX_OBJECT],
           after: startIsoDate,
           before: recoverIsoDate
         });


### PR DESCRIPTION
See #10201