### PR TITLE
[backend] Check date filters values validity (#9751)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -111,7 +111,7 @@ import {
   REL_INDEX_PREFIX,
   RULE_PREFIX
 } from '../schema/general';
-import { isAnId, isValidDate } from '../schema/schemaUtils';
+import { isAnId, isValidISODate } from '../schema/schemaUtils';
 import {
   isStixRefRelationship,
   RELATION_CREATED_BY,
@@ -509,7 +509,7 @@ export const stixLoadByFilters = async (context, user, types, args) => {
 // used to get a "restricted" value of a current attribute value depending on the value type
 const restrictValue = (entityValue) => {
   if (Array.isArray((entityValue))) return [];
-  if (isValidDate(entityValue)) return FROM_START_STR;
+  if (isValidISODate(entityValue)) return FROM_START_STR;
   const type = typeof entityValue;
   switch (type) {
     case 'string': return 'Restricted';

--- a/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
@@ -225,6 +225,12 @@ export const schemaAttributesDefinition = {
   getAttributeByName(name: string): AttributeDefinition | undefined {
     return this.allAttributes.get(name);
   },
+  getAttributesNamesByType(entityType: string, type: string) {
+    const attributes = this.attributes[this.selectEntityType(entityType)] ?? new Map();
+    return Array.from(attributes.values())
+      .filter((a) => a.type === type)
+      .map((a) => a.name);
+  },
   isMultipleAttribute(entityType: string, attributeName: string): boolean {
     return this.getAttribute(entityType, attributeName)?.multiple ?? false;
   },

--- a/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
@@ -225,11 +225,13 @@ export const schemaAttributesDefinition = {
   getAttributeByName(name: string): AttributeDefinition | undefined {
     return this.allAttributes.get(name);
   },
-  getAttributesNamesByType(entityType: string, type: string) {
-    const attributes = this.attributes[this.selectEntityType(entityType)] ?? new Map();
-    return Array.from(attributes.values())
-      .filter((a) => a.type === type)
-      .map((a) => a.name);
+  getAttributesNamesByTypes(entityTypes: string[], type: string) {
+    return R.uniq(entityTypes.flatMap((entityType) => {
+      const attributes = this.attributes[this.selectEntityType(entityType)] ?? new Map();
+      return Array.from(attributes.values())
+        .filter((a) => a.type === type)
+        .map((a) => a.name);
+    }));
   },
   isMultipleAttribute(entityType: string, attributeName: string): boolean {
     return this.getAttribute(entityType, attributeName)?.multiple ?? false;

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -60,7 +60,7 @@ export const isValidISODate = (stringDate) => {
   return dateInstance.toISOString() === stringDate;
 };
 
-export const isValidDate = (stringDate) => {
+export const isValidStringDate = (stringDate) => {
   const dateParsed = Date.parse(stringDate);
   if (!dateParsed) return false;
   try {

--- a/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
+++ b/opencti-platform/opencti-graphql/src/schema/schemaUtils.js
@@ -53,11 +53,23 @@ export const shortHash = (element) => {
   return hash.slice(0, 8);
 };
 
-export const isValidDate = (stringDate) => {
+export const isValidISODate = (stringDate) => {
   const dateParsed = Date.parse(stringDate);
   if (!dateParsed) return false;
   const dateInstance = new Date(dateParsed);
   return dateInstance.toISOString() === stringDate;
+};
+
+export const isValidDate = (stringDate) => {
+  const dateParsed = Date.parse(stringDate);
+  if (!dateParsed) return false;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const dateInstance = new Date(dateParsed);
+  } catch (e) {
+    return false;
+  }
+  return true;
 };
 
 const pascalize = (str) => {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -1,5 +1,10 @@
 import { uniq } from 'ramda';
-import { ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT, buildRefRelationKey, RULE_PREFIX } from '../../schema/general';
+import {
+  ABSTRACT_STIX_CYBER_OBSERVABLE,
+  ABSTRACT_STIX_DOMAIN_OBJECT,
+  buildRefRelationKey,
+  RULE_PREFIX
+} from '../../schema/general';
 import { schemaAttributesDefinition } from '../../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../schema/schema-relationsRef';
 import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../../generated/graphql';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -1,10 +1,5 @@
 import { uniq } from 'ramda';
-import {
-  ABSTRACT_STIX_CYBER_OBSERVABLE,
-  ABSTRACT_STIX_DOMAIN_OBJECT,
-  buildRefRelationKey,
-  RULE_PREFIX
-} from '../../schema/general';
+import { ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT, buildRefRelationKey, RULE_PREFIX } from '../../schema/general';
 import { schemaAttributesDefinition } from '../../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../schema/schema-relationsRef';
 import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../../generated/graphql';

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/modelConsistency-test.js
@@ -109,7 +109,7 @@ import { stixRefsExtractor } from '../../../src/schema/stixEmbeddedRelationship'
 import { schemaRelationsRefDefinition } from '../../../src/schema/schema-relationsRef';
 import { confidence, created, entityType, xOpenctiStixIds } from '../../../src/schema/attribute-definition';
 import { getParentTypes } from '../../../src/schema/schemaUtils';
-import {ENTITY_TYPE_RULE, ENTITY_TYPE_WORK} from '../../../src/schema/internalObject';
+import { ENTITY_TYPE_RULE, ENTITY_TYPE_WORK } from '../../../src/schema/internalObject';
 import { RELATION_MIGRATES } from '../../../src/schema/internalRelationship';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../../src/schema/stixSightingRelationship';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../src/modules/organization/organization-types';

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
@@ -29,7 +29,7 @@ describe('Filtering utils', () => {
     } as FilterGroup;
     expect(() => checkFiltersValidity(filterGroup2)).toThrowError('Incorrect filters format');
   });
-  it('should check a filter syntax for filter with "within" operator', async () => {
+  it('should check filter values syntax for date filters', async () => {
     const filterGroup1 = {
       mode: 'or',
       filters: [
@@ -53,7 +53,7 @@ describe('Filtering utils', () => {
       ],
       filterGroups: [],
     } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup3)).toThrowError('The values for filter with "within" operator are not valid: you should provide a datetime or a valid relative date.');
+    expect(() => checkFiltersValidity(filterGroup3)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
     const filterGroup4 = {
       mode: 'or',
       filters: [
@@ -69,7 +69,7 @@ describe('Filtering utils', () => {
       ],
       filterGroups: [],
     } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup5)).toThrowError('The values for filter with "within" operator are not valid: you should provide a datetime or a valid relative date.');
+    expect(() => checkFiltersValidity(filterGroup5)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
     const filterGroup6 = {
       mode: 'or',
       filters: [
@@ -102,6 +102,22 @@ describe('Filtering utils', () => {
       filterGroups: [],
     } as FilterGroup;
     expect(() => checkFiltersValidity(filterGroup9)).toThrowError();
+    const filterGroup10 = {
+      mode: 'or',
+      filters: [
+        { key: ['created_at'], values: ['now3'], operator: 'gt' },
+      ],
+      filterGroups: [],
+    } as FilterGroup;
+    expect(() => checkFiltersValidity(filterGroup10)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    const filterGroup11 = {
+      mode: 'or',
+      filters: [
+        { key: ['modified'], values: ['now'], operator: 'gt' },
+      ],
+      filterGroups: [],
+    } as FilterGroup;
+    expect(() => checkFiltersValidity(filterGroup11)).not.toThrowError();
   });
   it('should add a filter to a filter group and separate them with the AND mode', async () => {
     const filterGroup = {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { now } from 'moment';
 import { addFilter, checkFiltersValidity, convertRelationRefsFilterKeys, extractFilterGroupValues, replaceFilterKey } from '../../../src/utils/filtering/filtering-utils';
 import type { FilterGroup } from '../../../src/generated/graphql';
+import { utcDate } from '../../../src/utils/format';
 
 describe('Filtering utils', () => {
   it('should check a filter syntax', async () => {
@@ -54,7 +56,21 @@ describe('Filtering utils', () => {
     expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
-        { key: ['published'], values: ['now-1y', 'now'], operator: 'within' },
+        { key: ['published'], values: ['now-1y', utcDate()], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['now-1d/d', 'now'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: [new Date(now()), 'now+18M'], operator: 'within' },
       ],
       filterGroups: [],
     } as FilterGroup)).not.toThrowError();
@@ -104,13 +120,6 @@ describe('Filtering utils', () => {
       mode: 'or',
       filters: [
         { key: ['published'], values: ['-3563', '245289'], operator: 'within' },
-      ],
-      filterGroups: [],
-    } as FilterGroup)).not.toThrowError();
-    expect(() => checkFiltersValidity({
-      mode: 'or',
-      filters: [
-        { key: ['published'], values: ['now-1d/d', 'now'], operator: 'within' },
       ],
       filterGroups: [],
     } as FilterGroup)).not.toThrowError();

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
@@ -30,94 +30,118 @@ describe('Filtering utils', () => {
     expect(() => checkFiltersValidity(filterGroup2)).toThrowError('Incorrect filters format');
   });
   it('should check filter values syntax for date filters', async () => {
-    const filterGroup1 = {
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['now'], operator: 'within' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup1)).toThrowError('A filter with "within" operator must have 2 values');
-    const filterGroup2 = {
+    } as FilterGroup)).toThrowError('A filter with "within" operator must have 2 values');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['now', ''], operator: 'within' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup2)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup3 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['now-1y', 'now3'], operator: 'within' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup3)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup4 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['now-1y', 'now'], operator: 'within' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup4)).not.toThrowError();
-    const filterGroup5 = {
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['2039-09-T00:51:35.000Z'], operator: 'lt' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup5)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup6 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
-        { key: ['published'], values: ['2023-09-01T00:51:35.000Z', '2023-09-30T00:51:35.000Z'], operator: 'within' },
+        { key: ['modified'], values: ['<=', 'now'], operator: 'eq' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup6)).not.toThrowError();
-    const filterGroup7 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['2023-09-01T00:51:35.000Z', '2025-03-09'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['2023-09-01T00:51:35.000', '2025-03-09T00:51'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['2023-09-01T00:51:35', '2025-03-09T00:51:35.8'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['2024', '2025-03'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
+      mode: 'or',
+      filters: [
+        { key: ['published'], values: ['-3563', '245289'], operator: 'within' },
+      ],
+      filterGroups: [],
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['published'], values: ['now-1d/d', 'now'], operator: 'within' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup7)).not.toThrowError();
-    const filterGroup8 = {
+    } as FilterGroup)).not.toThrowError();
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['first_observed'], values: ['now-1d/'], operator: 'gt' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup8)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup9 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['last_seen'], values: ['10y/y'], operator: 'gte' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup9)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup10 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
         { key: ['created_at'], values: ['now3'], operator: 'gt' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup10)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
-    const filterGroup11 = {
+    } as FilterGroup)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
+    expect(() => checkFiltersValidity({
       mode: 'or',
       filters: [
-        { key: ['modified'], values: ['now'], operator: 'gt' },
+        { key: ['created_at'], values: ['now'], operator: 'gt' },
       ],
       filterGroups: [],
-    } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup11)).not.toThrowError();
+    } as FilterGroup)).not.toThrowError();
   });
   it('should add a filter to a filter group and separate them with the AND mode', async () => {
     const filterGroup = {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
@@ -45,7 +45,7 @@ describe('Filtering utils', () => {
       ],
       filterGroups: [],
     } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup2)).toThrowError('A filter with "within" operator must have 2 values');
+    expect(() => checkFiltersValidity(filterGroup2)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
     const filterGroup3 = {
       mode: 'or',
       filters: [
@@ -65,7 +65,7 @@ describe('Filtering utils', () => {
     const filterGroup5 = {
       mode: 'or',
       filters: [
-        { key: ['published'], values: ['now', '2039-09-T00:51:35.000Z'], operator: 'within' },
+        { key: ['published'], values: ['2039-09-T00:51:35.000Z'], operator: 'lt' },
       ],
       filterGroups: [],
     } as FilterGroup;
@@ -89,19 +89,19 @@ describe('Filtering utils', () => {
     const filterGroup8 = {
       mode: 'or',
       filters: [
-        { key: ['published'], values: ['now-1d/', 'now'], operator: 'within' },
+        { key: ['first_observed'], values: ['now-1d/'], operator: 'gt' },
       ],
       filterGroups: [],
     } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup8)).toThrowError();
+    expect(() => checkFiltersValidity(filterGroup8)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
     const filterGroup9 = {
       mode: 'or',
       filters: [
-        { key: ['published'], values: ['10y/y', 'now'], operator: 'within' },
+        { key: ['last_seen'], values: ['10y/y'], operator: 'gte' },
       ],
       filterGroups: [],
     } as FilterGroup;
-    expect(() => checkFiltersValidity(filterGroup9)).toThrowError();
+    expect(() => checkFiltersValidity(filterGroup9)).toThrowError('The values for a date filter are not valid: you should provide a datetime or a relative date expressed in date math.');
     const filterGroup10 = {
       mode: 'or',
       filters: [


### PR DESCRIPTION
### Proposed changes
Improve filters validity checking in backend:
- date filters values should be either in relative date math format, either a valid date understood by elastic

Enables not to make the screen crashes when doing a NLQ search returning filters with a date filter in bad format


Exemple: 
Do a NLQ search with the question: 'Give me the 10 most recent reports'
--> The screen should not throw an error anymore. You should now have a message like this : 
![image](https://github.com/user-attachments/assets/8f46ea88-38ca-4e2e-be15-9a3f4289c895)
