### PR TITLE
[frontend] feat: Hide XTM Hub CTA button if platform_xtmhub_url variable is empty

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -78,7 +78,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   const FAB_REPLACED = isFeatureEnable('FAB_REPLACEMENT');
   const isXTMHubFeatureEnabled = isFeatureEnable('XTM_HUB_INTEGRATION');
   const { settings } = useContext(UserContext);
-  const importFromHubUrl = isNotEmptyField(settings) ? `${settings.platform_xtmhub_url}/redirect/custom_dashboards?octi_instance_id=${settings.id}` : '';
+  const importFromHubUrl = isNotEmptyField(settings) && isNotEmptyField(settings.platform_xtmhub_url) ? `${settings.platform_xtmhub_url}/redirect/custom_dashboards?octi_instance_id=${settings.id}` : '';
 
   const [commitImportMutation] = useApiMutation(importMutation);
   const [commitCreationMutation] = useApiMutation(workspaceMutation);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request includes a minor update to the `WorkspaceCreation` component in the `opencti-platform/opencti-front` project. The change ensures that the `importFromHubUrl` is only constructed if both `settings` and `settings.platform_xtmhub_url` are not empty.
If `importFromHubUrl` is empty, the button will be hidden.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10027

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
