### PR TITLE
[frontend] Scrollable User History

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -608,7 +608,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
                 </Security>
                 <div className="clearfix" />
                 <FieldOrEmpty source={orderedSessions}>
-                  <List style={{ marginTop: -2 }}>
+                  <List style={{ marginTop: -2, width: '100%', maxHeight: 400, overflowY: 'auto'}}>
                     {orderedSessions
                       && orderedSessions.map((session: Session) => (
                         <ListItem
@@ -669,7 +669,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         </Grid>
         <Triggers recipientId={user.id} filterKey="authorized_members.id" />
         <Grid item xs={6} style={{ marginTop: 10 }}>
-          <Typography variant="h4" gutterBottom={true}>
+          <Typography variant="h4" gutterBottom={true} style={{ paddingBottom: '22px' }}>
             {t_i18n('Operations')}
           </Typography>
           <Paper

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -608,7 +608,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
                 </Security>
                 <div className="clearfix" />
                 <FieldOrEmpty source={orderedSessions}>
-                  <List style={{ marginTop: -2, width: '100%', maxHeight: 400, overflowY: 'auto'}}>
+                  <List style={{ marginTop: -2, width: '100%', maxHeight: 400, overflowY: 'auto' }}>
                     {orderedSessions
                       && orderedSessions.map((session: Session) => (
                         <ListItem

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
@@ -51,7 +51,7 @@ const UserHistory: FunctionComponent<UserHistoryProps> = ({
         { key: ['context_data.id'], values: [userId], operator: 'wildcard', mode: 'or' },
       ],
     } as GqlFilterGroup,
-    first: 10,
+    first: 500,
     orderBy: 'timestamp' as LogsOrdering,
     orderMode: 'desc' as OrderingMode,
     search: entitySearchTerm,

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
@@ -20,6 +20,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
     marginTop: theme.spacing(1.5),
     padding: '10px 20px 10px 20px',
     borderRadius: 4,
+    maxHeight: 600,
+    overflowY: 'auto',
   },
 }));
 
@@ -106,7 +108,7 @@ const UserHistoryLines: FunctionComponent<UserHistoryLinesProps> = ({
     <Paper
       classes={{ root: classes.paper }}
       variant="outlined"
-      style={{ marginTop: 0 }}
+      style={{ marginTop: 0, minHeight: 500 }}
       className={'paper-for-grid'}
     >
       {audits.length > 0 ? (


### PR DESCRIPTION
The current User profile view could use two improvements for display purposes:

First, it does not support fetching and listing more than 10 Activity History entries which isn't really enough history to determine what the user has been doing recently. [ENHANCEMENT]

Secondly, the Session History display area is not bounded, so if you have say 10-20 session entries they make the form expand in height, versus just limiting a height and making the area scrollable. [BUG]

Here is an example of a user with a "large amount" of active sessions to demonstrate this issue.
![image](https://github.com/user-attachments/assets/e29d5bff-67a3-491b-9ed8-49065a9941f5)

### Proposed changes

* **Fetch the user's last 500 actions to display in a scrollable (if needed) Activity History Area after 13 entries (Aligned to left Operations widget in same row):**

`**User that requires Scrolling History**`
![image](https://github.com/user-attachments/assets/48ff2f19-3452-44fb-8bed-e78a69bda63d)


`**User not requiring scrolling**`
![image](https://github.com/user-attachments/assets/db498ef4-2f33-4a1a-98b1-5ed34712b712)



* **Allow Session History to display as scrollable, if required:**

`**Example requiring scrolling:**`

![image](https://github.com/user-attachments/assets/35599073-d40b-4119-a9da-5c38a0335efb)


`**Example not requiring scrolling:**`

![image](https://github.com/user-attachments/assets/898fe42d-c375-4d84-add4-2c65324f042a)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

