### PR TITLE
[backend] Relationship representative in email notifications (#10208)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix-representative.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-representative.ts
@@ -73,7 +73,8 @@ import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
 
 export const extractStixRepresentative = (
   stix: S.StixObject,
-  { fromRestricted = false, toRestricted = false }: { fromRestricted: boolean, toRestricted: boolean } = { fromRestricted: false, toRestricted: false }
+  { fromRestricted = false, toRestricted = false }: { fromRestricted: boolean, toRestricted: boolean } = { fromRestricted: false, toRestricted: false },
+  withArrowForRelationships = false,
 ): string => {
   const entityType = stix.extensions[STIX_EXT_OCTI].type;
   // region Modules
@@ -99,7 +100,8 @@ export const extractStixRepresentative = (
     const relation = stix as SRO.StixRelation;
     const fromValue = fromRestricted ? 'Restricted' : relation.extensions[STIX_EXT_OCTI].source_value;
     const targetValue = toRestricted ? 'Restricted' : relation.extensions[STIX_EXT_OCTI].target_value;
-    return `${fromValue} ${relation.relationship_type} ${targetValue}`;
+    const separator = withArrowForRelationships ? '➡️' : relation.relationship_type;
+    return `${fromValue} ${separator} ${targetValue}`;
   }
   // endregion
   // region Entities
@@ -340,9 +342,10 @@ export const extractStixRepresentativeForUser = async (
   context: AuthContext,
   user: AuthUser,
   stix: S.StixObject,
+  withArrowForRelationships = false,
 ) => {
   const [from, to] = extractUserAccessPropertiesFromStixObject(stix);
   const fromRestricted = from ? !(await isUserCanAccessStoreElement(context, user, from)) : false;
   const toRestricted = to ? !(await isUserCanAccessStoreElement(context, user, to)) : false;
-  return extractStixRepresentative(stix, { fromRestricted, toRestricted });
+  return extractStixRepresentative(stix, { fromRestricted, toRestricted }, withArrowForRelationships);
 };

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -7,7 +7,7 @@ import { createStreamProcessor, fetchRangeNotifications, storeNotificationEvent,
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';
-import { executionContext, INTERNAL_USERS, isUserCanAccessStixElement, isUserCanAccessStoreElement, SYSTEM_USER } from '../utils/access';
+import { executionContext, INTERNAL_USERS, isUserCanAccessStixElement, SYSTEM_USER } from '../utils/access';
 import type { DataEvent, SseEvent, StreamNotifEvent, UpdateEvent } from '../types/event';
 import type { AuthContext, AuthUser, UserOrigin } from '../types/user';
 import { utcDate } from '../utils/format';
@@ -25,7 +25,7 @@ import { ENTITY_TYPE_USER } from '../schema/internalObject';
 import { STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
 import { STIX_EXT_OCTI } from '../types/stix-extensions';
-import { extractStixRepresentative } from '../database/stix-representative';
+import { extractStixRepresentative, extractStixRepresentativeForUser } from '../database/stix-representative';
 import { RELATION_GRANTED_TO, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
 import type { BasicStoreCommon } from '../types/store';
@@ -359,10 +359,7 @@ export const generateNotificationMessageForInstance = async (
   user: AuthUser,
   instance: StixObject | StixRelationshipObject,
 ) => {
-  const [from, to] = extractUserAccessPropertiesFromStixObject(instance);
-  const fromRestricted = from ? !(await isUserCanAccessStoreElement(context, user, from)) : false;
-  const toRestricted = to ? !(await isUserCanAccessStoreElement(context, user, to)) : false;
-  const instanceRepresentative = extractStixRepresentative(instance, { fromRestricted, toRestricted });
+  const instanceRepresentative = await extractStixRepresentativeForUser(context, user, instance);
   return `[${instance.type.toLowerCase()}] ${instanceRepresentative}`;
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -1,5 +1,4 @@
 import * as R from 'ramda';
-import { head } from 'ramda';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import type { Moment } from 'moment';
@@ -24,13 +23,8 @@ import { getEntitiesListFromCache } from '../database/cache';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
 import { STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
-import { STIX_EXT_OCTI } from '../types/stix-extensions';
 import { extractStixRepresentative, extractStixRepresentativeForUser } from '../database/stix-representative';
-import { RELATION_GRANTED_TO, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
-import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
-import type { BasicStoreCommon } from '../types/store';
 import type { StixRelation, StixSighting } from '../types/stix-sro';
-import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 import { isStixMatchFilterGroup } from '../utils/filtering/filtering-stix/stix-filtering';
 import { replaceFilterKey } from '../utils/filtering/filtering-utils';
 import { CONNECTED_TO_INSTANCE_FILTER, CONNECTED_TO_INSTANCE_SIDE_EVENTS_FILTER } from '../utils/filtering/filtering-constants';
@@ -89,55 +83,6 @@ export interface DigestEvent extends StreamNotifEvent {
   playbook_source?: string
   data: Array<{ notification_id: string, instance: StixObject, type: string, message: string }>
 }
-
-// region: user access information extractors
-// extract information from a sighting to have all the elements to check if a user has access to the from/to of the sighting
-const extractUserAccessPropertiesFromSighting = (sighting: StixSighting) => {
-  return [
-    {
-      [RELATION_OBJECT_MARKING]: sighting.extensions[STIX_EXT_OCTI].sighting_of_ref_object_marking_refs,
-      [RELATION_GRANTED_TO]: sighting.extensions[STIX_EXT_OCTI].sighting_of_ref_granted_refs,
-      entity_type: sighting.extensions[STIX_EXT_OCTI].sighting_of_type,
-    } as BasicStoreCommon,
-    {
-      [RELATION_OBJECT_MARKING]: sighting.extensions[STIX_EXT_OCTI].where_sighted_refs_object_marking_refs,
-      [RELATION_GRANTED_TO]: sighting.extensions[STIX_EXT_OCTI].where_sighted_refs_granted_refs,
-      entity_type: head(sighting.extensions[STIX_EXT_OCTI].where_sighted_types),
-    } as BasicStoreCommon
-  ];
-};
-
-// extract information from a relationship to have all the elements to check if a user has access to the from/to of the relationship
-const extractUserAccessPropertiesFromRelationship = (relation: StixRelation) => {
-  return [
-    {
-      [RELATION_OBJECT_MARKING]: relation.extensions[STIX_EXT_OCTI].source_ref_object_marking_refs,
-      [RELATION_GRANTED_TO]: relation.extensions[STIX_EXT_OCTI].source_ref_granted_refs,
-      entity_type: relation.extensions[STIX_EXT_OCTI].source_type,
-    } as BasicStoreCommon,
-    {
-      [RELATION_OBJECT_MARKING]: relation.extensions[STIX_EXT_OCTI].target_ref_object_marking_refs,
-      [RELATION_GRANTED_TO]: relation.extensions[STIX_EXT_OCTI].target_ref_granted_refs,
-      entity_type: relation.extensions[STIX_EXT_OCTI].target_type,
-    } as BasicStoreCommon
-  ];
-};
-
-// extract information from a stix object to have all the elements to check if a user has access to the object
-const extractUserAccessPropertiesFromStixObject = (
-  instance: StixObject | StixRelationshipObject
-) => {
-  if (isStixSightingRelationship(instance.extensions[STIX_EXT_OCTI].type)) {
-    const sighting = instance as StixSighting;
-    return extractUserAccessPropertiesFromSighting(sighting);
-  }
-  if (isStixCoreRelationship(instance.extensions[STIX_EXT_OCTI].type)) {
-    const relation = instance as StixRelation;
-    return extractUserAccessPropertiesFromRelationship(relation);
-  }
-  return [];
-};
-// endregion
 
 export const isLiveKnowledge = (n: ResolvedTrigger): n is ResolvedLive => {
   return n.trigger.trigger_scope === 'knowledge' && n.trigger.trigger_type === 'live';

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -58,7 +58,7 @@ export const internalProcessNotification = async (
       const eventNotification = notificationMap.get(notification_id);
       if (eventNotification) {
         const notificationUser = await findById(context, SYSTEM_USER, user.user_id);
-        const main = 'extensions' in instance ? await extractStixRepresentativeForUser(context, notificationUser, instance) : extractRepresentative(instance)?.main;
+        const main = 'extensions' in instance ? await extractStixRepresentativeForUser(context, notificationUser, instance, true) : extractRepresentative(instance)?.main;
         const notificationName = main;
         if (generatedContent[notificationName]) {
           generatedContent[notificationName] = [...generatedContent[notificationName], event];

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -57,10 +57,8 @@ export const internalProcessNotification = async (
       const event = { operation: type, message, instance_id: instance.id };
       const eventNotification = notificationMap.get(notification_id);
       if (eventNotification) {
-        console.log('instance', instance);
         const notificationUser = await findById(context, SYSTEM_USER, user.user_id);
         const main = 'extensions' in instance ? await extractStixRepresentativeForUser(context, notificationUser, instance) : extractRepresentative(instance)?.main;
-        console.log('main', main);
         const notificationName = main;
         if (generatedContent[notificationName]) {
           generatedContent[notificationName] = [...generatedContent[notificationName], event];
@@ -93,8 +91,6 @@ export const internalProcessNotification = async (
       });
     } else if (notifier_connector_id === NOTIFIER_CONNECTOR_EMAIL) {
       const { title, template, url_suffix: urlSuffix } = JSON.parse(configuration ?? '{}') as NOTIFIER_CONNECTOR_EMAIL_INTERFACE;
-      console.log('title', title);
-      console.log('templateData', templateData);
       const generatedTitle = ejs.render(title, templateData);
       const generatedEmail = ejs.render(template, { ...templateData, url_suffix: urlSuffix });
       const mail = { from: settings.platform_email, to: user.user_email, subject: generatedTitle, html: generatedEmail };

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-representative-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-representative-test.ts
@@ -72,4 +72,21 @@ describe('Stix representative tests', () => {
     expect(extractStixRepresentative(relationship, { fromRestricted: false, toRestricted: true })).toEqual('T234 located-at Restricted');
     expect(extractStixRepresentative(relationship, { fromRestricted: true, toRestricted: true })).toEqual('Restricted located-at Restricted');
   });
+  it('Should return the representative of a stix relationship with relationship arrow option', async () => {
+    const relationship = {
+      name: 'My relationship',
+      relationship_type: 'located-at',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ABSTRACT_STIX_CORE_RELATIONSHIP,
+            source_value: 'T234',
+            target_value: 'My City',
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(relationship, { fromRestricted: true, toRestricted: false }, true)).toEqual('Restricted ➡️ My City');
+    expect(extractStixRepresentative(relationship, { fromRestricted: false, toRestricted: true }, true)).toEqual('T234 ➡️ Restricted');
+    expect(extractStixRepresentative(relationship, { fromRestricted: true, toRestricted: true }, true)).toEqual('Restricted ➡️ Restricted');
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-representative-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-representative-test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { extractStixRepresentative } from '../../../src/database/stix-representative';
+import type { StixObject } from '../../../src/types/stix-common';
+import { STIX_EXT_OCTI } from '../../../src/types/stix-extensions';
+import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_LOCATION_CITY } from '../../../src/schema/stixDomainObject';
+import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../../../src/schema/stixMetaObject';
+import { ABSTRACT_STIX_CORE_RELATIONSHIP } from '../../../src/schema/general';
+
+describe('Stix representative tests', () => {
+  it('Should return the representative of a stix object', async () => {
+    const report = {
+      name: 'My Report',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ENTITY_TYPE_CONTAINER_REPORT,
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(report)).toEqual('My Report');
+    const city = {
+      name: 'My City',
+      id: 'city--MyCity',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ENTITY_TYPE_LOCATION_CITY,
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(city)).toEqual('My City');
+    const externalReference = {
+      name: 'My External Reference',
+      source_name: 'source',
+      external_id: '23',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ENTITY_TYPE_EXTERNAL_REFERENCE,
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(externalReference)).toEqual('source (23)');
+    const relationship = {
+      name: 'My relationship',
+      relationship_type: 'located-at',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ABSTRACT_STIX_CORE_RELATIONSHIP,
+            source_value: 'T234',
+            target_value: 'My City',
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(relationship)).toEqual('T234 located-at My City');
+  });
+  it('Should return the representative of a stix relationship with restricted source/target', async () => {
+    const relationship = {
+      name: 'My relationship',
+      relationship_type: 'located-at',
+      extensions: {
+        [STIX_EXT_OCTI]:
+          {
+            type: ABSTRACT_STIX_CORE_RELATIONSHIP,
+            source_value: 'T234',
+            target_value: 'My City',
+          },
+      }
+    } as unknown as StixObject;
+    expect(extractStixRepresentative(relationship, { fromRestricted: true, toRestricted: false })).toEqual('Restricted located-at My City');
+    expect(extractStixRepresentative(relationship, { fromRestricted: false, toRestricted: true })).toEqual('T234 located-at Restricted');
+    expect(extractStixRepresentative(relationship, { fromRestricted: true, toRestricted: true })).toEqual('Restricted located-at Restricted');
+  });
+});


### PR DESCRIPTION
### Proposed changes
- In email notifications, if the entity concerned is a relationship, display the stix representative instead of the entity representative (to avoid having undefined>undefined instead of the relationship representative)
- add tests for extractStixRepresentative

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10208
https://github.com/OpenCTI-Platform/opencti/issues/9243