### PR TITLE
[frontend/renovate] Upgrade react-markdown to v10

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -74,7 +74,7 @@
     "react-grid-layout": "1.5.0",
     "react-intl": "7.1.6",
     "react-leaflet": "4.2.1",
-    "react-markdown": "9.1.0",
+    "react-markdown": "10.1.0",
     "react-material-ui-carousel": "3.4.2",
     "react-mde": "11.5.0",
     "react-otp-input": "3.1.1",

--- a/opencti-platform/opencti-front/src/components/MarkdownDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/MarkdownDisplay.tsx
@@ -92,58 +92,63 @@ MarkdownWithRedirectionWarningProps
   }
   const markdownElement = () => {
     return (
-      <Markdown
-        className="markdown"
-        disallowedElements={disallowedElements}
-        unwrapDisallowed={true}
-      >
-        {limit ? truncate(content, limit) : content}
-      </Markdown>
+      <div className="markdown">
+        <Markdown
+          disallowedElements={disallowedElements}
+          unwrapDisallowed={true}
+        >
+          {limit ? truncate(content, limit) : content}
+        </Markdown>
+      </div>
     );
   };
   const remarkGfmMarkdownElement = () => {
     if (remarkPlugins) {
       return (
-        <Markdown
-          className="markdown"
-          remarkPlugins={remarkPlugins}
-          disallowedElements={disallowedElements}
-          unwrapDisallowed={true}
-        >
-          {expand || !limit ? content : truncate(content, limit)}
-        </Markdown>
+        <div className="markdown">
+          <Markdown
+            remarkPlugins={remarkPlugins}
+            disallowedElements={disallowedElements}
+            unwrapDisallowed={true}
+          >
+            {expand || !limit ? content : truncate(content, limit)}
+          </Markdown>
+        </div>
+
       );
     }
     if (markdownComponents) {
       return (
+        <div className="markdown">
+          <Markdown
+            remarkPlugins={[
+              remarkGfm,
+              remarkFlexibleMarkers,
+              [remarkParse, { commonmark: !!commonmark }],
+            ]}
+            components={MarkDownComponents(theme)}
+            disallowedElements={disallowedElements}
+            unwrapDisallowed={true}
+          >
+            {expand || !limit ? content : truncate(content, limit)}
+          </Markdown>
+        </div>
+      );
+    }
+    return (
+      <div className="markdown">
         <Markdown
-          className="markdown"
           remarkPlugins={[
             remarkGfm,
             remarkFlexibleMarkers,
             [remarkParse, { commonmark: !!commonmark }],
           ]}
-          components={MarkDownComponents(theme)}
           disallowedElements={disallowedElements}
           unwrapDisallowed={true}
         >
-          {expand || !limit ? content : truncate(content, limit)}
+          {limit ? truncate(content, limit) : content}
         </Markdown>
-      );
-    }
-    return (
-      <Markdown
-        className="markdown"
-        remarkPlugins={[
-          remarkGfm,
-          remarkFlexibleMarkers,
-          [remarkParse, { commonmark: !!commonmark }],
-        ]}
-        disallowedElements={disallowedElements}
-        unwrapDisallowed={true}
-      >
-        {limit ? truncate(content, limit) : content}
-      </Markdown>
+      </div>
     );
   };
   const browseLinkWarning = (

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -17017,7 +17017,7 @@ __metadata:
     react-grid-layout: "npm:1.5.0"
     react-intl: "npm:7.1.6"
     react-leaflet: "npm:4.2.1"
-    react-markdown: "npm:9.1.0"
+    react-markdown: "npm:10.1.0"
     react-material-ui-carousel: "npm:3.4.2"
     react-mde: "npm:11.5.0"
     react-otp-input: "npm:3.1.1"
@@ -18030,9 +18030,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-markdown@npm:9.1.0":
-  version: 9.1.0
-  resolution: "react-markdown@npm:9.1.0"
+"react-markdown@npm:10.1.0":
+  version: 10.1.0
+  resolution: "react-markdown@npm:10.1.0"
   dependencies:
     "@types/hast": "npm:^3.0.0"
     "@types/mdast": "npm:^4.0.0"
@@ -18048,7 +18048,7 @@ __metadata:
   peerDependencies:
     "@types/react": ">=18"
     react: ">=18"
-  checksum: 10/07045797b926afafc6aff692c9ee7d1cb9b12bc0e2d2b9f22ab17f2d1036dd807034a58565d67cfcfe94fe43961452a977496a175cbc9028ed51f2eec823c2f4
+  checksum: 10/886c037d18266e94750abbc00c6096435bccd4da5f2d1727984bcbdf83e9f2a5cc9a6b0eecfe6c30456dc26546fee41c7f6aecbf176e6d7453963df4abefd7df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Proposed changes

* remove className props has it's no longer available for Markdown component
* add previous className to a div to wrap Markdown

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/pull/10126