### PR TITLE
[frontend/backend] Entities ids mapping by entity type for NLQ filters result (#9751)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "Das maximale Konfidenzniveau wird derzeit auf Benutzerebene definiert. Sie hat Vorrang vor dem Max Confidence Level der Benutzergruppen.",
   "The Max Confidence Level is currently inherited from...": "Die maximale Konfidenzstufe wird derzeit von der Gruppe {link} geerbt.",
   "The min value cannot be greater than max value": "Der Minimalwert kann nicht größer als der Maximalwert sein",
+  "The NLQ model didn't find filters corresponding to your question": "Das NLQ-Modell hat keine Filter gefunden, die Ihrer Frage entsprechen",
   "The number of results should be lower than 100": "Die Anzahl der Ergebnisse sollte weniger als 100 betragen",
   "The operators and modes are restricted for these filters.": "Die Operatoren und Modi sind für diese Filter eingeschränkt.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Die Meinungen haben keinen in Ihrem Wortschatz definierten Wert. Bitte fügen Sie sie erst hinzu, um Meinungen hinzufügen zu können.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.",
   "The Max Confidence Level is currently inherited from...": "The Max Confidence Level is currently inherited from the group {link}.",
   "The min value cannot be greater than max value": "The min value cannot be greater than max value",
+  "The NLQ model didn't find filters corresponding to your question": "The NLQ model didn't find filters corresponding to your question",
   "The number of results should be lower than 100": "The number of results should be lower than 100",
   "The operators and modes are restricted for these filters.": "The operators and modes are restricted for these filters.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "El Nivel de Confianza Máximo se define actualmente a nivel de usuario. Anula el Nivel de Confianza Máximo de los grupos de usuarios.",
   "The Max Confidence Level is currently inherited from...": "El nivel de confianza máximo se hereda actualmente del grupo {link}.",
   "The min value cannot be greater than max value": "El valor mínimo no puede ser mayor que el valor máximo",
+  "The NLQ model didn't find filters corresponding to your question": "El modelo NLQ no ha encontrado los filtros correspondientes a su pregunta",
   "The number of results should be lower than 100": "El número de resultados debe ser inferior a 100",
   "The operators and modes are restricted for these filters.": "Los operadores y modos están restringidos para estos filtros.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Las opiniones no tienen ningún valor definido en su vocabulario. Por favor, añádelas primero para poder añadir opiniones.",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "Le niveau de confiance maximal est actuellement défini au niveau de l'utilisateur. Il remplace le niveau de confiance maximal des groupes d'utilisateurs.",
   "The Max Confidence Level is currently inherited from...": "Le niveau de confiance maximum est actuellement hérité du groupe {link}.",
   "The min value cannot be greater than max value": "La valeur min ne peut pas être supérieure à la valeur max",
+  "The NLQ model didn't find filters corresponding to your question": "Le modèle NLQ n'a pas trouvé de filtres correspondant à votre question",
   "The number of results should be lower than 100": "Le nombre de résultats doit être inférieur à 100",
   "The operators and modes are restricted for these filters.": "Les opérateurs et les modes sont restreints pour ces filtres.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "Les opinions n'ont pas de valeur définie dans votre vocabulaire. Veuillez d'abord les ajouter pour pouvoir ajouter des opinions.",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "現在、最大信頼度はユーザーレベルで定義されています。これはユーザーグループのMax Confidence Levelを上書きします。",
   "The Max Confidence Level is currently inherited from...": "最大信頼度は現在グループ{link}から継承されています。",
   "The min value cannot be greater than max value": "最小値を最大値より大きくすることはできません",
+  "The NLQ model didn't find filters corresponding to your question": "NLQモデルは、あなたの質問に対応するフィルタを見つけられませんでした。",
   "The number of results should be lower than 100": "結果の数は100以下でなければならない",
   "The operators and modes are restricted for these filters.": "これらのフィルタには演算子とモードの制限があります。",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意見には、あなたの語彙で定義された価値はありません。意見を追加できるようにするには、まずそれらを追加してください。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "최대 신뢰 수준이 현재 사용자 수준에서 정의되어 있습니다. 사용자 그룹의 최대 신뢰 수준을 재정의합니다.",
   "The Max Confidence Level is currently inherited from...": "최대 신뢰 수준은 현재 {link} 그룹에서 상속됩니다.",
   "The min value cannot be greater than max value": "최소 값은 최대 값보다 클 수 없습니다",
+  "The NLQ model didn't find filters corresponding to your question": "NLQ 모델에서 질문에 해당하는 필터를 찾지 못했습니다",
   "The number of results should be lower than 100": "결과 수는 100보다 작아야 합니다",
   "The operators and modes are restricted for these filters.": "이 필터의 연산자 및 모드는 제한됩니다.",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "의견에 대한 값이 정의되어 있지 않습니다. 의견을 추가할 수 있도록 먼저 추가하십시오.",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2982,6 +2982,7 @@
   "The Max Confidence Level is currently defined at the user level. It overrides Max Confidence Level from user's groups.": "最大置信度目前是在用户级别定义的。它覆盖用户组的最大置信度。",
   "The Max Confidence Level is currently inherited from...": "当前最大置信度是从组 {link} 继承的。",
   "The min value cannot be greater than max value": "最小值不能大于最大值",
+  "The NLQ model didn't find filters corresponding to your question": "NLQ 模型未找到与您的问题相对应的过滤器",
   "The number of results should be lower than 100": "结果数量应少于 100",
   "The operators and modes are restricted for these filters.": "这些过滤器的运算符和模式受到限制。",
   "The opinions has no value defined in your vocabulary. Please add them first to be able to add opinions.": "意见在您的词汇中没有定义值。请先添加意见，才能添加观点。",

--- a/opencti-platform/opencti-front/src/components/SearchInput.jsx
+++ b/opencti-platform/opencti-front/src/components/SearchInput.jsx
@@ -93,6 +93,11 @@ const SearchInput = (props) => {
       setDisplayEEDialog(true);
     }
   };
+  const handleRemoveAskAI = () => {
+    if (isEnterpriseEdition && askAI) {
+      setAskAI(false);
+    }
+  };
   const isAIEnabled = variant === 'topBar' && isEnterpriseEdition && askAI;
   const isAdmin = useGranted([SETTINGS_SETPARAMETERS]);
   const { settings: { id: settingsId } } = useAuth();
@@ -170,26 +175,29 @@ const SearchInput = (props) => {
             }
             <Tooltip title={t_i18n('Advanced search')}>
               <IconButton
+                onClick={handleRemoveAskAI}
                 component={Link}
                 to="/dashboard/search"
                 size="medium"
                 color={
-                   location.pathname.includes('/dashboard/search')
-                    && !location.pathname.includes('/dashboard/search_bulk')
-                     ? 'primary'
-                     : 'inherit'
-                    }
+                  location.pathname.includes('/dashboard/search')
+                   && !location.pathname.includes('/dashboard/search_bulk')
+                   && !askAI
+                    ? 'primary'
+                    : 'inherit'
+                  }
               >
                 <BiotechOutlined fontSize='medium'/>
               </IconButton>
             </Tooltip>
             <Tooltip title={t_i18n('Bulk search')}>
               <IconButton
+                onClick={handleRemoveAskAI}
                 component={Link}
                 to="/dashboard/search_bulk"
                 size="medium"
                 color={
-                location.pathname.includes('/dashboard/search_bulk')
+                location.pathname.includes('/dashboard/search_bulk') && !askAI
                   ? 'primary'
                   : 'inherit'
               }

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -46,6 +46,7 @@ import ItemBoolean from '../../../components/ItemBoolean';
 import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
 import { RelayError } from '../../../relay/relayTypes';
+import { isFilterGroupNotEmpty } from '../../../utils/filters/filtersUtils';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -244,8 +245,11 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
         onCompleted: (response: TopBarAskAINLQMutation$data) => {
           setIsNLQLoading(false);
           const notResolvedValues = response.aiNLQ?.notResolvedValues ?? [];
+          const filters = response.aiNLQ?.filters;
           if (notResolvedValues.length > 0) {
             MESSAGING$.notifyNLQ(`${t_i18n('Some entities you mentioned have not been found in the platform')}: ${notResolvedValues}`);
+          } else if (!filters || !isFilterGroupNotEmpty(JSON.parse(filters))) {
+            MESSAGING$.notifyNLQ(t_i18n('The NLQ model didn\'t find filters corresponding to your question'));
           }
           handleSearchByFilter(searchKeyword, 'nlq', navigate, response.aiNLQ?.filters);
         },

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -400,10 +400,8 @@ export const filtersEntityIdsMapping = async (context: AuthContext, user: AuthUs
     n.valuesToResolve,
     n.entityTypes,
   )));
-  console.log('others', otherIdsResolution);
   const valuesIdsMap = new Map(scosMapContent.concat(otherIdsResolution.flatMap((n) => n.mapContent)));
   const notResolvedValues = notResolvedScos.concat(otherIdsResolution.flatMap((n) => n.notResolvedValues));
-  console.log('valuesIdsMap', valuesIdsMap);
   // 04. replace the values in filters with their corresponding ids
   return {
     filters: filtersEntityIdsMappingResult(filters, idsFilterKeys, valuesIdsMap),


### PR DESCRIPTION
### Proposed changes
Improvement of the values mapping for ids filters applied on NLQ filters result:
- take the filter key entity types ids into account in the values mapping search
- enables to look only for users for the filters creators, assignee and participants
- enables to resolve stix meta objects values (like the one for the Markings filter)

Add a message if no filters have been found for a NLQ search in frontend

### Examples of resolution that are now possible

![image](https://github.com/user-attachments/assets/53713b99-46e0-48aa-88ab-ec5604a77262)

![image](https://github.com/user-attachments/assets/3a8ccb49-64d8-4237-87e1-06c7d024cafc)



### Related issues
#9751 