### PR TITLE
[e2e] Verifiy that background task popup is gone away before continue.

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2074,6 +2074,7 @@ class DataTableToolBar extends Component {
                 onClose={this.handleCloseTask.bind(this)}
                 fullWidth={true}
                 maxWidth="md"
+                data-testid="background-task-popup"
               >
                 <DialogTitle>
                   <div style={{ float: 'left' }}>

--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -41,16 +41,23 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
   // Select all
   await dataTable.getCheckAll().click();
   await taskPopup.launchAddLabel('background-task-filter-add-label', true);
+
+  // Need to wait after click on "Launch" that the popup goes away.
+  await expect(taskPopup.getPage().getByText('Launch a background task')).not.toBeVisible({ timeout: 3000 });
+
   await expect(incidentPage.getPage()).toBeVisible();
 
-  // Clear filter on label
+  // Clear filter on label 'background-task'
   await filter.removeLastFilter();
 
   // Filter with a search
-  await search.addSearch('"Find this incident in test please"');
-  await expect(dataTable.getNumberElements(1)).toBeVisible();
+  await search.addSearch('findMeWithSearchID');
+  await expect(dataTable.getNumberElements(1), 'An exact search with no label should match only one incident.').toBeVisible();
   await dataTable.getCheckAll().click();
   await taskPopup.launchAddLabel('background-task-search-add-label', false);
+  // Need to wait after click on "Launch" that the popup goes away.
+  await expect(taskPopup.getPage().getByText('Launch a background task')).not.toBeVisible({ timeout: 3000 });
+
   await sleep(3000); // Wait 3 secs for task creation
   await tasksPage.goto();
   await expect(tasksPage.getPage()).toBeVisible();

--- a/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
@@ -3,6 +3,10 @@ import { Page } from '@playwright/test';
 export default class TaskPopup {
   constructor(private page: Page) {}
 
+  getPage() {
+    return this.page.getByTestId('background-task-popup');
+  }
+
   async launchAddLabel(labelName: string, firstTime: boolean) {
     // Launch background task on selected
     await this.page.getByLabel('Update', { exact: true }).getByLabel('update').click();

--- a/opencti-platform/opencti-graphql/tests/data/data-test-stix-e2e.json
+++ b/opencti-platform/opencti-graphql/tests/data/data-test-stix-e2e.json
@@ -871,7 +871,7 @@
       "created": "2024-07-22T11:34:27.675Z",
       "modified": "2024-07-22T11:34:27.680Z",
       "name": "Incident for background task test - search by text 1",
-      "description": "Find this incident in test please.",
+      "description": "Find this incident in test please findMeWithSearchID.",
       "x_opencti_id": "2f7b477c-41c2-4d27-854b-99ed35dd5403",
       "x_opencti_type": "Incident",
       "type": "incident"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Verifiy that background task popup is gone away before continue.
* Add a 'background-task-popup' id on frontend source code
* Use a search without space

### Related issues
![image](https://github.com/user-attachments/assets/214ddb0f-3f24-4296-8873-fb841628eec6)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
