### PR TITLE
[backend] upsert indicator score if revoked (#10298)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2603,7 +2603,7 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
       updatePatch.valid_from = element.valid_from;
       updatePatch.valid_until = element.valid_until;
       // don't reset decay attributes
-      updatePatch.decay_base_score = element.decay_base_score;
+      // updatePatch.decay_base_score = element.decay_base_score; // no need since it's the same score
       updatePatch.revoked = element.revoked;
       updatePatch.decay_base_score_date = element.decay_base_score_date;
       updatePatch.decay_applied_rule = element.decay_applied_rule;

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2592,28 +2592,7 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
       updatePatch.number_observed = element.number_observed + updatePatch.number_observed;
     }
   }
-  if (type === ENTITY_TYPE_INDICATOR) {
-    // Do not compute decay again when base score does not change
-    // if the element was revoked, we need to update the score to reactivate the indicator
-    if (!element.revoked && updatePatch.decay_applied_rule
-      && (updatePatch.decay_base_score === element.decay_base_score || updatePatch.decay_base_score === element.x_opencti_score)) {
-      logApp.debug('UPSERT INDICATOR -- no decay reset because no score change', { element, basePatch });
-      // don't reset score, valid_from & valid_until
-      updatePatch.x_opencti_score = element.x_opencti_score; // don't change the score
-      updatePatch.valid_from = element.valid_from;
-      updatePatch.valid_until = element.valid_until;
-      // don't reset decay attributes
-      updatePatch.decay_base_score = element.decay_base_score;
-      updatePatch.revoked = element.revoked;
-      updatePatch.decay_base_score_date = element.decay_base_score_date;
-      updatePatch.decay_applied_rule = element.decay_applied_rule;
-      updatePatch.decay_history = []; // History is multiple, forcing to empty array will prevent any modification
-      updatePatch.decay_next_reaction_date = element.decay_next_reaction_date;
-    } else {
-      // As base_score as change, decay will be reset by upsert
-      logApp.debug('UPSERT INDICATOR -- Decay is reset', { element, basePatch });
-    }
-  }
+
   // Upsert relations with times extensions
   if (isStixCoreRelationship(type)) {
     const { date: cStartTime } = computeExtendedDateValues(updatePatch.start_time, element.start_time, ALIGN_OLDEST);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2594,7 +2594,9 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
   }
   if (type === ENTITY_TYPE_INDICATOR) {
     // Do not compute decay again when base score does not change
-    if (updatePatch.decay_applied_rule && (updatePatch.decay_base_score === element.decay_base_score || updatePatch.decay_base_score === element.x_opencti_score)) {
+    // if the element was revoked, we need to update the score to reactivate the indicator
+    if (!element.revoked && updatePatch.decay_applied_rule
+      && (updatePatch.decay_base_score === element.decay_base_score || updatePatch.decay_base_score === element.x_opencti_score)) {
       logApp.debug('UPSERT INDICATOR -- no decay reset because no score change', { element, basePatch });
       // don't reset score, valid_from & valid_until
       updatePatch.x_opencti_score = element.x_opencti_score; // don't change the score


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* if indicator has been revoked, decay score needs to be reset during upsert
* Change the upsert condition to : if the indicator present in db has been revoked, or if it has a different decay base score, or if it has a different score, we upsert the indicator fully with decay. Otherwise we don't change the score & decay attributes.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10298 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
