### PR TITLE
[frontend] fix crash when using search in knowledge/victimology relationship creation drawer (#9449, #10156, #10214, 10186, #10289)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "Viktimologie (Länder)",
   "Victimology (regions)": "Viktimologie (Regionen)",
   "Victimology (sectors)": "Viktimologie (Sektoren)",
+  "Victimology map": "Viktimologische Karte",
   "View": "Ansicht",
   "View all": "Alle anzeigen",
   "View all entities created by user": "Alle vom Benutzer erstellten Organisationen anzeigen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "Victimology (countries)",
   "Victimology (regions)": "Victimology (regions)",
   "Victimology (sectors)": "Victimology (sectors)",
+  "Victimology map": "Victimology map",
   "View": "View",
   "View all": "View all",
   "View all entities created by user": "View all entities created by user",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "Victimología (países)",
   "Victimology (regions)": "Victimología (regiones)",
   "Victimology (sectors)": "Victimología (sectores)",
+  "Victimology map": "Mapa victimológico",
   "View": "Vista",
   "View all": "Ver todos",
   "View all entities created by user": "Ver todas las entidades creadas por el usuario",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "Victimologie (pays)",
   "Victimology (regions)": "Victimologie (régions)",
   "Victimology (sectors)": "Victimologie (secteurs)",
+  "Victimology map": "Carte de victimologie",
   "View": "Aperçu",
   "View all": "Tout voir",
   "View all entities created by user": "Voir toutes les entités créées par l'utilisateur",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "被害者学（国）",
   "Victimology (regions)": "被害者学（地域）",
   "Victimology (sectors)": "被害者学（セクター）",
+  "Victimology map": "被害者マップ",
   "View": "表示",
   "View all": "全てを見る",
   "View all entities created by user": "ユーザーによって作成されたすべてのエンティティを表示する",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "피해자학 (국가)",
   "Victimology (regions)": "피해자학 (지역)",
   "Victimology (sectors)": "피해자학 (부문)",
+  "Victimology map": "피해자학 지도",
   "View": "보기",
   "View all": "모두 보기",
   "View all entities created by user": "사용자가 생성한 모든 엔터티 보기",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3329,6 +3329,7 @@
   "Victimology (countries)": "受害者研究（国家）",
   "Victimology (regions)": "受害者研究（地区）)",
   "Victimology (sectors)": "受害者研究（部门）",
+  "Victimology map": "受害者地图",
   "View": "视图",
   "View all": "查看全部",
   "View all entities created by user": "查看用户创建的所有实体",

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import React, { FunctionComponent, useEffect, useRef, useState, Suspense } from 'react';
 import { graphql } from 'react-relay';
 import * as R from 'ramda';
 import IconButton from '@mui/material/IconButton';
@@ -26,6 +26,7 @@ import {
 import { PaginationOptions } from 'src/components/list_lines';
 import Drawer from '@components/common/drawer/Drawer';
 import { getMainRepresentative } from 'src/utils/defaultRepresentatives';
+import Loader, { LoaderVariant } from 'src/components/Loader';
 import { commitMutation, handleErrorInForm, QueryRenderer } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';
 import { formatDate } from '../../../../utils/Time';
@@ -1019,22 +1020,24 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
         title={t_i18n('Create a relationship')}
         ref={containerRef}
       >
-        <QueryRenderer
-          query={stixCoreRelationshipCreationFromEntityQuery}
-          variables={{ id: entityId }}
-          render={({ props: renderProps }: ({ props: StixCoreRelationshipCreationFromEntityQuery$data })) => {
-            if (renderProps && renderProps.stixCoreObject) {
-              const { name, entity_type, observable_value } = renderProps.stixCoreObject;
-              return (
-                <>
-                  {step === 0 ? renderSelectEntity(entity_type, name || observable_value) : null}
-                  {step === 1 ? renderForm(renderProps.stixCoreObject) : null}
-                </>
-              );
-            }
-            return renderLoader();
-          }}
-        />
+        <Suspense fallback={<Loader variant={LoaderVariant.container} />}>
+          <QueryRenderer
+            query={stixCoreRelationshipCreationFromEntityQuery}
+            variables={{ id: entityId }}
+            render={({ props: renderProps }: ({ props: StixCoreRelationshipCreationFromEntityQuery$data })) => {
+              if (renderProps && renderProps.stixCoreObject) {
+                const { name, entity_type, observable_value } = renderProps.stixCoreObject;
+                return (
+                  <>
+                    {step === 0 ? renderSelectEntity(entity_type, name || observable_value) : null}
+                    {step === 1 ? renderForm(renderProps.stixCoreObject) : null}
+                  </>
+                );
+              }
+              return renderLoader();
+            }}
+          />
+        </Suspense>
       </Drawer>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -44,6 +44,7 @@ import { ModuleHelper } from '../../../../utils/platformModulesHelper';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import DataTable from '../../../../components/dataGrid/DataTable';
+import { DataTableVariant } from '../../../../components/dataGrid/dataTableTypes';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -567,6 +568,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
   const { viewStorage, helpers } = usePaginationLocalStorage<StixCoreRelationshipCreationFromEntityStixCoreObjectsLinesQuery$variables>(
     getLocalStorageKey(entityId),
     {},
+    true,
   );
   const { searchTerm = '', orderAsc: storageOrderAsc, sortBy: storageSortBy, filters } = viewStorage;
 
@@ -793,6 +795,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                       disableSelectAll
                       disableNavigation
                       selectOnLineClick
+                      variant={DataTableVariant.inline}
                       rootRef={tableRootRef ?? undefined}
                       dataColumns={buildColumns(platformModuleHelpers)}
                       resolvePath={(data: StixCoreRelationshipCreationFromEntityStixCoreObjectsLines_data$data) => data.stixCoreObjects?.edges?.map((n) => n?.node)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
@@ -1,160 +1,107 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
-import withStyles from '@mui/styles/withStyles';
 import Grid from '@mui/material/Grid';
 import Divider from '@mui/material/Divider';
+import { useTheme } from '@mui/material/styles';
 import StixDomainObjectVictimologySectors, { stixDomainObjectVictimologySectorsStixCoreRelationshipsQuery } from './StixDomainObjectVictimologySectors';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import EntityStixCoreRelationships from '../stix_core_relationships/EntityStixCoreRelationships';
 import EntityStixCoreRelationshipsHorizontalBars from '../stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars';
 import StixDomainObjectVictimologyMap from './StixDomainObjectVictimologyMap';
 
-const styles = (theme) => ({
-  container: {
-    marginTop: theme.spacing(3),
-  },
-  bottomNav: {
-    zIndex: 1,
-    padding: '0 200px 0 205px',
-    display: 'flex',
-    height: 50,
-  },
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: 0,
-    overflow: 'hidden',
-  },
-});
+const StixDomainObjectVictimology = ({
+  stixDomainObjectId,
+  entityLink,
+  defaultStartTime,
+  defaultStopTime,
+}) => {
+  const theme = useTheme();
+  const { t_i18n } = useFormatter();
+  const [viewMode, setViewMode] = useState('relationships');
 
-class StixDomainObjectVictimology extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      viewMode: 'relationships',
-    };
-  }
+  const paginationOptionsSectors = {
+    fromId: stixDomainObjectId,
+    toTypes: ['Sector', 'Organization', 'Individual'],
+    relationship_type: 'targets',
+  };
 
-  handleChangeView(viewMode) {
-    this.setState({ viewMode });
-  }
+  const gridItemSize = { height: 300, minHeight: 300 };
 
-  render() {
-    const { viewMode } = this.state;
-    const {
-      classes,
-      stixDomainObjectId,
-      entityLink,
-      t,
-      defaultStartTime,
-      defaultStopTime,
-    } = this.props;
-    const paginationOptionsSectors = {
-      fromId: stixDomainObjectId,
-      toTypes: ['Sector', 'Organization', 'Individual'],
-      relationship_type: 'targets',
-    };
-    return (
-      <>
-        <Grid container={true} spacing={3} style={{ marginTop: 15 }}>
-          <Grid
-            item
-            xs={6}
-            style={{ height: 300, minHeight: 300, paddingTop: 0 }}
-          >
-            <EntityStixCoreRelationshipsHorizontalBars
-              title={t('Victimology (sectors)')}
-              fromId={stixDomainObjectId}
-              toTypes={['Sector']}
-              relationshipType="targets"
-              field="internal_id"
-              isTo={true}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={6}
-            style={{ height: 300, minHeight: 300, paddingTop: 0 }}
-          >
-            <EntityStixCoreRelationshipsHorizontalBars
-              title={t('Victimology (regions)')}
-              fromId={stixDomainObjectId}
-              toTypes={['Region']}
-              relationshipType="targets"
-              field="internal_id"
-              isTo={true}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={6}
-            style={{
-              marginTop: 45,
-              height: 300,
-              minHeight: 300,
-              paddingTop: 0,
-            }}
-          >
-            <EntityStixCoreRelationshipsHorizontalBars
-              title={t('Victimology (countries)')}
-              fromId={stixDomainObjectId}
-              toTypes={['Country']}
-              relationshipType="targets"
-              field="internal_id"
-              isTo={true}
-            />
-          </Grid>
-          <Grid
-            item
-            xs={6}
-            style={{
-              marginTop: 45,
-              height: 300,
-              minHeight: 300,
-              paddingTop: 0,
-            }}
-          >
-            <StixDomainObjectVictimologyMap
-              title={t('Victimology (countries)')}
-              stixDomainObjectId={stixDomainObjectId}
-            />
-          </Grid>
+  return (
+    <>
+      <Grid container={true} spacing={3} rowSpacing={6}>
+        <Grid item xs={6} style={gridItemSize}>
+          <EntityStixCoreRelationshipsHorizontalBars
+            title={t_i18n('Victimology (sectors)')}
+            fromId={stixDomainObjectId}
+            toTypes={['Sector']}
+            relationshipType="targets"
+            field="internal_id"
+            isTo={true}
+          />
         </Grid>
-        <Divider style={{ marginTop: 50 }} />
-        <div className={classes.container} id="container">
-          {(viewMode === 'entities' || viewMode === 'relationships') && (
-            <EntityStixCoreRelationships
-              entityLink={entityLink}
-              entityId={stixDomainObjectId}
-              stixCoreObjectTypes={[
-                'System',
-                'Individual',
-                'Organization',
-                'Sector',
-                'City',
-                'Country',
-                'Region',
-                'Position',
-                'Event',
-                'Administrative-Area',
-              ]}
-              relationshipTypes={['targets']}
-              isRelationReversed={false}
-              enableExport={true}
-              currentView={viewMode}
-              handleChangeView={this.handleChangeView.bind(this)}
-              enableNestedView={true}
-              enableEntitiesView={false}
-              defaultStartTime={defaultStartTime}
-              defaultStopTime={defaultStopTime}
-            />
-          )}
-          {viewMode === 'nested' && (
+        <Grid item xs={6} style={gridItemSize}>
+          <EntityStixCoreRelationshipsHorizontalBars
+            title={t_i18n('Victimology (regions)')}
+            fromId={stixDomainObjectId}
+            toTypes={['Region']}
+            relationshipType="targets"
+            field="internal_id"
+            isTo={true}
+          />
+        </Grid>
+        <Grid item xs={6} style={gridItemSize}>
+          <EntityStixCoreRelationshipsHorizontalBars
+            title={t_i18n('Victimology (countries)')}
+            fromId={stixDomainObjectId}
+            toTypes={['Country']}
+            relationshipType="targets"
+            field="internal_id"
+            isTo={true}
+          />
+        </Grid>
+        <Grid item xs={6} style={gridItemSize}>
+          <StixDomainObjectVictimologyMap
+            title={t_i18n('Victimology (countries)')}
+            stixDomainObjectId={stixDomainObjectId}
+          />
+        </Grid>
+      </Grid>
+
+      <Divider style={{ marginTop: 50 }} />
+
+      <div style={{ marginTop: theme.spacing(3) }} id="container">
+        {(viewMode === 'entities' || viewMode === 'relationships') && (
+          <EntityStixCoreRelationships
+            entityLink={entityLink}
+            entityId={stixDomainObjectId}
+            stixCoreObjectTypes={[
+              'System',
+              'Individual',
+              'Organization',
+              'Sector',
+              'City',
+              'Country',
+              'Region',
+              'Position',
+              'Event',
+              'Administrative-Area',
+            ]}
+            relationshipTypes={['targets']}
+            isRelationReversed={false}
+            enableExport={true}
+            currentView={viewMode}
+            handleChangeView={setViewMode}
+            enableNestedView={true}
+            enableEntitiesView={false}
+            defaultStartTime={defaultStartTime}
+            defaultStopTime={defaultStopTime}
+          />
+        )}
+        {viewMode === 'nested' && (
           <QueryRenderer
-            query={
-              stixDomainObjectVictimologySectorsStixCoreRelationshipsQuery
-            }
+            query={stixDomainObjectVictimologySectorsStixCoreRelationshipsQuery}
             variables={{ first: 500, ...paginationOptionsSectors }}
             render={({ props }) => {
               if (props) {
@@ -164,31 +111,25 @@ class StixDomainObjectVictimology extends Component {
                     entityLink={entityLink}
                     paginationOptions={paginationOptionsSectors}
                     stixDomainObjectId={stixDomainObjectId}
-                    handleChangeView={this.handleChangeView.bind(this)}
+                    handleChangeView={setViewMode}
                   />
                 );
               }
               return <div />;
             }}
           />
-          )}
-        </div>
-      </>
-    );
-  }
-}
+        )}
+      </div>
+    </>
+  );
+};
 
 StixDomainObjectVictimology.propTypes = {
   stixDomainObjectId: PropTypes.string,
   entityLink: PropTypes.string,
   paginationOptions: PropTypes.object,
-  classes: PropTypes.object,
-  t: PropTypes.func,
   defaultStartTime: PropTypes.string,
   defaultStopTime: PropTypes.string,
 };
 
-export default R.compose(
-  inject18n,
-  withStyles(styles),
-)(StixDomainObjectVictimology);
+export default StixDomainObjectVictimology;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimology.jsx
@@ -26,7 +26,7 @@ const StixDomainObjectVictimology = ({
     relationship_type: 'targets',
   };
 
-  const gridItemSize = { height: 300, minHeight: 300 };
+  const gridItemSize = { height: 350, minHeight: 350 };
 
   return (
     <>


### PR DESCRIPTION
### Proposed changes

* Do not use URI filters for Drawer "Create a relationship"

> /!\ To fix the issue, a change in how filters are saved has been made. Before, filters made by the user inside the Drawer to create relationship were saved in the URI. Now they are not. Anyway it seems weird that filters from a Drawer for a specific use case were saved in the URI of the entity in the first place, discussed with product. But still, please double check that this new behavior is ok.

### Related issues

* closes #9449 
* closes #10156 
* closes #10214
* closes #10186
* closes #10289

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The fix of the issue is in the file `StixCoreRelationshipCreationFromEntity.tsx`. Other files it's refactoring


# EDIT AFTER ADDITIONAL INVESTIGATIONS

Due to a lack of `<Supense>` in the rendering tree, making the whole knowledge view re-render when searching in the drawer.

Bug was hard to reproduce because depends on network speed. With simulated throttling it's reproduced easily.
