### PR TITLE
[frontend] Spacing of left submenu without icons is incorrect (#10296)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -169,6 +169,14 @@ const useStyles = makeStyles((theme) => createStyles({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    padding: '1px 0 0 0px',
+    fontWeight: 500,
+    fontSize: 12,
+  },
+  menuSubItemTextWithoutIconCollapseOpen: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     padding: '1px 0 0 20px',
     fontWeight: 500,
     fontSize: 12,
@@ -389,7 +397,7 @@ const LeftBar = () => {
                     </ListItemIcon>
                   )}
                   <ListItemText
-                    classes={{ primary: (submenu_show_icons && entry.icon) ? classes.menuSubItemText : classes.menuSubItemTextWithoutIcon }}
+                    classes={{ primary: (submenu_show_icons && entry.icon) ? classes.menuSubItemText : classes.menuSubItemTextWithoutIconCollapseOpen }}
                     primary={t_i18n(entry.label)}
                   />
                 </MenuItem>

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -169,7 +169,7 @@ const useStyles = makeStyles((theme) => createStyles({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    padding: '1px 0 0 0',
+    padding: '1px 0 0 20px',
     fontWeight: 500,
     fontSize: 12,
   },

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -173,14 +173,6 @@ const useStyles = makeStyles((theme) => createStyles({
     fontWeight: 500,
     fontSize: 12,
   },
-  menuSubItemTextWithoutIconCollapseOpen: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    padding: '1px 0 0 20px',
-    fontWeight: 500,
-    fontSize: 12,
-  },
   menuCollapseOpen: {
     width: OPEN_BAR_WIDTH,
     height: 35,
@@ -397,7 +389,10 @@ const LeftBar = () => {
                     </ListItemIcon>
                   )}
                   <ListItemText
-                    classes={{ primary: (submenu_show_icons && entry.icon) ? classes.menuSubItemText : classes.menuSubItemTextWithoutIconCollapseOpen }}
+                    classes={{ primary: (submenu_show_icons && entry.icon) ? classes.menuSubItemText : classes.menuSubItemTextWithoutIcon }}
+                    sx={{
+                      paddingLeft: (submenu_show_icons && entry.icon) ? '0px' : '20px',
+                    }}
                     primary={t_i18n(entry.label)}
                   />
                 </MenuItem>


### PR DESCRIPTION
### Proposed changes

* Add a padding left

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [Spacing of left submenu without icons is incorrect
](https://github.com/OpenCTI-Platform/opencti/issues/10296)
