### PR TITLE
[backend] Indicator when revoked is updated, compute score and valid until with decay rules (#10299)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
@@ -68,6 +68,10 @@ export const dayToMs = (days: number) => {
   return days * 24 * 60 * 60 * 1000;
 };
 
+export const msToDay = (milliseconds: number) => {
+  return milliseconds / 1000 / 24 / 60 / 60;
+};
+
 export const findById = (context: AuthContext, user: AuthUser, id: string) => {
   return storeLoadById<BasicStoreEntityDecayRule>(context, user, id, ENTITY_TYPE_DECAY_RULE);
 };

--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
@@ -392,8 +392,8 @@ export const computeScoreFromValidUntil = (revokeInDaysFromNow: number, rule: De
     return rule.decay_revoke_score;
   }
 
-  const baseScore: number = rule.decay_revoke_score === 0 ? 1 : rule.decay_revoke_score;
-  return baseScore / (1 - ((revokeInDaysFromNow / rule.decay_lifetime) ** (1 / (DECAY_FACTOR * rule.decay_pound))));
+  const revokeScore: number = rule.decay_revoke_score === 0 ? 1 : rule.decay_revoke_score;
+  return revokeScore / (1 - ((revokeInDaysFromNow / rule.decay_lifetime) ** (1 / (DECAY_FACTOR * rule.decay_pound))));
 };
 
 export const computeDecayPointReactionDate = (initialScore: number, model: DecayModel, startDate: Moment, decayPoint: number) => {

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -340,7 +340,7 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
 
 /**
  * Compute decay data when it's needed from indicator updates.
- * Return keys for 'decay_history', 'decay_next_reaction_date', 'valid_until', 'valid_from'
+ * Return keys for 'decay_history', 'decay_next_reaction_date', 'valid_until'
  * @param fromScore
  * @param indicatorBeforeUpdate
  */
@@ -364,7 +364,6 @@ export const restartDecayComputationOnEdit = (fromScore: number, indicatorBefore
   }
   const newValidUntilDate = computeDecayPointReactionDate(fromScore, indicatorDecayRule, updateDate, revokeScore);
   inputToAdd.push({ key: VALID_UNTIL, value: [newValidUntilDate.toISOString()] });
-  inputToAdd.push({ key: VALID_FROM, value: [nowDate.toISOString()] });
   return inputToAdd;
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -404,7 +404,8 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   let hasRevokedChangedToFalse: boolean = false;
   logApp.info('Before decay computation: scoreEditInput:', { scoreEditInput, revokedEditInput, validUntilEditInput, isDecayEnabledOnIndicator });
 
-  if (revokedEditInput) {
+  // Revoke value is taken only if valid until and score are not updated at the same time too.
+  if (revokedEditInput && !validUntilEditInput && !scoreEditInput) {
     hasRevokedChangedToTrue = revokedEditInput.value[0] === true && !indicatorBeforeUpdate.revoked;
     hasRevokedChangedToFalse = revokedEditInput.value[0] === false && indicatorBeforeUpdate.revoked;
   }

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -26,34 +26,39 @@ import { addFilter } from '../../utils/filtering/filtering-utils';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { type BasicStoreEntityIndicator, ENTITY_TYPE_INDICATOR, type StoreEntityIndicator } from './indicator-types';
 import {
-  type EditInput,
-  FilterMode,
-  FilterOperator,
   type IndicatorAddInput,
-  OrderingMode,
   type QueryIndicatorsArgs,
   type QueryIndicatorsNumberArgs,
-  type StixCyberObservable
+  type EditInput,
+  type StixCyberObservable,
+  FilterMode,
+  FilterOperator,
+  OrderingMode
 } from '../../generated/graphql';
 import type { BasicStoreCommon, NumberResult } from '../../types/store';
 import {
-  computeChartDecayAlgoSerie,
-  type ComputeDecayChartInput,
-  computeDecayPointReactionDate,
+  findDecayRuleForIndicator,
   computeNextScoreReactionDate,
-  computeScoreFromExpectedTime,
-  computeScoreList,
-  computeTimeFromExpectedScore,
-  type DecayChartData,
   type DecayHistory,
   type DecayLiveDetails,
-  findDecayRuleForIndicator
+  computeScoreList,
+  computeChartDecayAlgoSerie,
+  type DecayChartData,
+  type ComputeDecayChartInput,
+  computeScoreFromExpectedTime,
+  computeTimeFromExpectedScore,
+  computeDecayPointReactionDate,
+  dayToMs
 } from '../decayRule/decayRule-domain';
 import { isModuleActivated } from '../../domain/settings';
 import { stixDomainObjectEditField } from '../../domain/stixDomainObject';
 import { prepareDate, utcDate } from '../../utils/format';
 import { checkObservableValue, isCacheEmpty } from '../../database/exclusionListCache';
-import { stixHashesToInput } from '../../schema/fieldDataAdapter';
+import { REVOKED, VALID_FROM, VALID_UNTIL, X_DETECTION, X_SCORE } from '../../schema/identifier';
+
+export const INDICATOR_DEFAULT_SCORE: number = 50;
+export const NO_DECAY_DEFAULT_VALID_PERIOD: number = dayToMs(90);
+export const NO_DECAY_DEFAULT_REVOKED_SCORE: number = 0;
 
 export const findById = (context: AuthContext, user: AuthUser, indicatorId: string) => {
   return storeLoadById<BasicStoreEntityIndicator>(context, user, indicatorId, ENTITY_TYPE_INDICATOR);
@@ -212,10 +217,7 @@ export const promoteIndicatorToObservables = async (context: AuthContext, user: 
   return createObservablesFromIndicator(context, user, input, indicator);
 };
 
-export const getObservableValuesFromPattern = (pattern: string) => {
-  const observableValues = extractObservablesFromIndicatorPattern(pattern);
-  return observableValues.map((o) => (o.hashes ? { ...o, hashes: stixHashesToInput(o) } : o));
-};
+export const getObservableValuesFromPattern = (pattern: string) => extractObservablesFromIndicatorPattern(pattern);
 
 const validateIndicatorPattern = async (context: AuthContext, user: AuthUser, patternType: string, patternValue: string) => {
   // check indicator syntax
@@ -259,7 +261,7 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
 
   const indicatorBaseScore = indicator.x_opencti_score ?? 50;
   if (indicatorBaseScore < 0 || indicatorBaseScore > 100) {
-    throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
+    throw ValidationError('The score should be between 0 and 100', X_SCORE);
   }
 
   const isDecayActivated = await isModuleActivated('INDICATOR_DECAY_MANAGER');
@@ -271,7 +273,7 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
     R.dissoc('basedOn'),
     R.assoc('pattern', formattedPattern),
     R.assoc('x_opencti_main_observable_type', observableType),
-    R.assoc('x_opencti_score', indicatorBaseScore),
+    R.assoc(X_SCORE, indicatorBaseScore),
     R.assoc('x_opencti_detection', indicator.x_opencti_detection ?? false),
     R.assoc('valid_from', validFrom.toISOString()),
     R.assoc('valid_until', validUntil.toISOString()),
@@ -334,53 +336,143 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   return notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC, created, user);
 };
 
+/**
+ * Compute decay data when it's needed from indicator updates.
+ * @param fromScore
+ * @param indicatorBeforeUpdate
+ */
+export const restartDecayComputationOnEdit = (fromScore: number, indicatorBeforeUpdate: BasicStoreEntityIndicator): EditInput[] => {
+  const indicatorDecayRule = indicatorBeforeUpdate.decay_applied_rule;
+  const revokeScore = indicatorBeforeUpdate.decay_applied_rule.decay_revoke_score;
+  const nowDate = new Date();
+  const inputToAdd: EditInput[] = [];
+  const updateDate = utcDate();
+  inputToAdd.push({ key: 'decay_base_score', value: [fromScore] });
+  inputToAdd.push({ key: 'decay_base_score_date', value: [updateDate.toISOString()] });
+  const decayHistory: DecayHistory[] = [...(indicatorBeforeUpdate.decay_history ?? [])];
+  decayHistory.push({
+    updated_at: nowDate,
+    score: fromScore,
+  });
+  inputToAdd.push({ key: 'decay_history', value: decayHistory });
+  const nextScoreReactionDate = computeNextScoreReactionDate(fromScore, fromScore, indicatorDecayRule, updateDate);
+  if (nextScoreReactionDate) {
+    inputToAdd.push({ key: 'decay_next_reaction_date', value: [nextScoreReactionDate.toISOString()] });
+  }
+  const newValidUntilDate = computeDecayPointReactionDate(fromScore, indicatorDecayRule, updateDate, revokeScore);
+  inputToAdd.push({ key: VALID_UNTIL, value: [newValidUntilDate.toISOString()] });
+  return inputToAdd;
+};
+
 export const indicatorEditField = async (context: AuthContext, user: AuthUser, id: string, input: EditInput[], opts = {}) => {
   const finalInput = [...input];
-  const indicator = await findById(context, user, id);
-  if (!indicator) {
+  const indicatorBeforeUpdate = await findById(context, user, id);
+  if (!indicatorBeforeUpdate) {
     throw FunctionalError('Cannot edit the field, Indicator cannot be found.');
   }
+  // Region Validation
   // validation check because according to STIX 2.1 specification the valid_until must be greater than the valid_from
-  let { valid_from, valid_until } = indicator;
+  let { valid_from, valid_until } = indicatorBeforeUpdate;
   input.forEach((e) => {
-    if (e.key === 'valid_from') [valid_from] = e.value;
-    if (e.key === 'valid_until') [valid_until] = e.value;
+    if (e.key === VALID_FROM) [valid_from] = e.value;
+    if (e.key === VALID_UNTIL) [valid_until] = e.value;
   });
   if (new Date(valid_until) <= new Date(valid_from)) {
-    throw ValidationError('The valid until date must be greater than the valid from date', 'valid_from');
-  }
-  const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
-  if (scoreEditInput) {
-    const newScore = scoreEditInput.value[0];
-    if (newScore < 0 || newScore > 100) {
-      throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
-    }
-    if (indicator.decay_applied_rule && !scoreEditInput.value.includes(indicator.decay_base_score)) {
-      const updateDate = utcDate();
-      finalInput.push({ key: 'decay_base_score', value: [newScore] });
-      finalInput.push({ key: 'decay_base_score_date', value: [updateDate.toISOString()] });
-      const decayHistory: DecayHistory[] = [...(indicator.decay_history ?? [])];
-      decayHistory.push({
-        updated_at: updateDate.toDate(),
-        score: newScore,
-      });
-      finalInput.push({ key: 'decay_history', value: decayHistory });
-      const model = indicator.decay_applied_rule;
-      const nextScoreReactionDate = computeNextScoreReactionDate(newScore, newScore, model, updateDate);
-      if (nextScoreReactionDate) {
-        finalInput.push({ key: 'decay_next_reaction_date', value: [nextScoreReactionDate.toISOString()] });
-      }
-      const newValidUntilDate = computeDecayPointReactionDate(newScore, model, updateDate, model.decay_revoke_score);
-      finalInput.push({ key: 'valid_until', value: [newValidUntilDate.toISOString()] });
-    }
+    throw ValidationError('The valid until date must be greater than the valid from date', VALID_FROM, input);
   }
   // check indicator pattern syntax
   const patternEditInput = input.find((e) => e.key === 'pattern');
   if (patternEditInput) {
-    await validateIndicatorPattern(context, user, indicator.pattern_type, patternEditInput.value[0]);
+    await validateIndicatorPattern(context, user, indicatorBeforeUpdate.pattern_type, patternEditInput.value[0]);
+  }
+  const scoreEditInput = input.find((e) => e.key === X_SCORE);
+  logApp.info('scoreEditInput:', { scoreEditInput });
+  if (scoreEditInput) {
+    const newScore = scoreEditInput.value[0];
+    if (newScore < 0 || newScore > 100) {
+      throw ValidationError('The score should be between 0 and 100', X_SCORE, input);
+    }
+  }
+  // END Region Validation
+
+  // Region {Score, Valid until, Revoke} computation
+  const isDecayEnabledOnindicator: boolean = indicatorBeforeUpdate.decay_applied_rule !== undefined && indicatorBeforeUpdate.decay_applied_rule.decay_revoke_score !== undefined;
+  const validUntilEditInput = input.find((e) => e.key === VALID_UNTIL);
+  const revokedEditInput = input.find((e) => e.key === REVOKED);
+  const nowDate = new Date();
+  let hasRevokedChangedToTrue: boolean = false;
+  let hasRevokedChangedToFalse: boolean = false;
+  if (revokedEditInput) {
+    hasRevokedChangedToTrue = revokedEditInput.value[0] === true && !indicatorBeforeUpdate.revoked;
+    hasRevokedChangedToFalse = revokedEditInput.value[0] === false && indicatorBeforeUpdate.revoked;
   }
 
-  logApp.info('indicatorEditField finalInput', { finalInput });
+  if (validUntilEditInput) {
+    const untilDateTime = utcDate(validUntilEditInput?.value[0]).toDate();
+    if (untilDateTime < nowDate && !indicatorBeforeUpdate.revoked) {
+      finalInput.push({ key: REVOKED, value: [true] });
+      hasRevokedChangedToTrue = true;
+    }
+
+    if (untilDateTime > nowDate && indicatorBeforeUpdate.revoked) {
+      finalInput.push({ key: REVOKED, value: [false] });
+      hasRevokedChangedToFalse = true;
+    }
+  }
+
+  if (isDecayEnabledOnindicator) {
+    const revokeScore = indicatorBeforeUpdate.decay_applied_rule.decay_revoke_score;
+    const baseScore = indicatorBeforeUpdate.decay_base_score;
+
+    // Check if score is in input, unless it's the original score
+    if (scoreEditInput && !scoreEditInput.value.includes(baseScore)) {
+      const newScore = scoreEditInput.value[0];
+      const allChanges = restartDecayComputationOnEdit(newScore, indicatorBeforeUpdate);
+      logApp.info('Computed changes because score updated manually:', finalInput);
+      finalInput.push(...allChanges);
+    }
+
+    if (!scoreEditInput) {
+      if (hasRevokedChangedToTrue) {
+        finalInput.push({ key: X_SCORE, value: [revokeScore] });
+        finalInput.push({ key: X_DETECTION, value: [false] });
+        finalInput.push({ key: VALID_UNTIL, value: [nowDate.toISOString()] });
+
+        const decayHistory: DecayHistory[] = [...(indicatorBeforeUpdate.decay_history ?? [])];
+        decayHistory.push({
+          updated_at: nowDate,
+          score: revokeScore,
+        });
+        finalInput.push({ key: 'decay_history', value: decayHistory });
+      }
+
+      if (hasRevokedChangedToFalse) {
+        // Restart decay as if the score has been put to decay_base_score manually.
+        const newScore = indicatorBeforeUpdate.decay_base_score;
+        const allChanges = restartDecayComputationOnEdit(newScore, indicatorBeforeUpdate);
+        logApp.info('Computed changes because revoked moved from true to false:', finalInput);
+        finalInput.push(...allChanges);
+        finalInput.push({ key: X_SCORE, value: [newScore] });
+      }
+    }
+  } else {
+    // No decay on indicator
+    if (hasRevokedChangedToTrue) {
+      finalInput.push({ key: X_SCORE, value: [NO_DECAY_DEFAULT_REVOKED_SCORE] });
+      finalInput.push({ key: X_DETECTION, value: [false] });
+      finalInput.push({ key: VALID_UNTIL, value: [nowDate.toISOString()] });
+    }
+
+    if (hasRevokedChangedToFalse) {
+      const in90Days = new Date(nowDate.getTime() + NO_DECAY_DEFAULT_VALID_PERIOD);
+      finalInput.push({ key: X_SCORE, value: [INDICATOR_DEFAULT_SCORE] });
+      finalInput.push({ key: VALID_UNTIL, value: [in90Days.toISOString()] });
+    }
+  }
+
+  // END Region {Score, Valid until, Revoke} computation
+  logApp.info('All changes to apply:', finalInput);
+
   return stixDomainObjectEditField(context, user, id, finalInput, opts);
 };
 

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -50,6 +50,7 @@ export const REVOKED = 'revoked';
 export const X_MITRE_ID_FIELD = 'x_mitre_id';
 export const X_DETECTION = 'x_opencti_detection';
 export const X_WORKFLOW_ID = 'x_opencti_workflow_id';
+export const X_SCORE = 'x_opencti_score';
 // endregion
 
 export const normalizeName = (name) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
@@ -10,7 +10,8 @@ import {
   computeTimeFromExpectedScore,
   computeScoreList,
   computeChartDecayAlgoSerie,
-  type ComputeDecayChartInput
+  type ComputeDecayChartInput,
+  computeScoreFromValidUntil
 } from '../../../src/modules/decayRule/decayRule-domain';
 
 const indicator_fallback_applied_rule: IndicatorDecayRule = {
@@ -29,6 +30,19 @@ const TEST_DEFAULT_DECAY_RULE: DecayRuleConfiguration = {
   decay_pound: 1.0,
   decay_points: [80, 60, 40, 20],
   decay_revoke_score: 0,
+  decay_observable_types: [], // no observable means any
+  order: 0,
+  active: true,
+};
+
+const TEST_DEFAULT_LINEAR_DECAY_RULE: DecayRuleConfiguration = {
+  id: 'test-defaut-rule',
+  name: 'Default Decay Rule',
+  description: 'Built-in decay rule for all indicators',
+  decay_lifetime: 100,
+  decay_pound: 0.3333,
+  decay_points: [80, 60, 40, 20],
+  decay_revoke_score: 10,
   decay_observable_types: [], // no observable means any
   order: 0,
   active: true,
@@ -61,6 +75,26 @@ export const TEST_IP_DECAY_RULE: DecayRuleConfiguration = {
 };
 
 const BUILT_IN_DECAY_RULES_FOR_TEST = [TEST_DEFAULT_DECAY_RULE, TEST_IP_DECAY_RULE, TEST_URL_DECAY_RULE];
+
+describe.only('Decay formula testing', () => {
+  it.only('should compute today score from valid until input in days', () => {
+    const computeTodayScore = computeScoreFromValidUntil(0, TEST_DEFAULT_LINEAR_DECAY_RULE);
+    expect(computeTodayScore).toBe(10);
+
+    const computeFiveDaysScore = computeScoreFromValidUntil(TEST_DEFAULT_LINEAR_DECAY_RULE.decay_lifetime, TEST_DEFAULT_LINEAR_DECAY_RULE);
+    expect(computeFiveDaysScore).toBe(100);
+
+    // const computeHalfLifetimeDaysScore2 = computeScoreFromValidUntil(50, TEST_DEFAULT_LINEAR_DECAY_RULE);
+
+    console.log(`expire in 10d => ${computeScoreFromValidUntil(10, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+    console.log(`expire in 30d => ${computeScoreFromValidUntil(30, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+    console.log(`expire in 50d => ${computeScoreFromValidUntil(50, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+    console.log(`expire in 70d => ${computeScoreFromValidUntil(70, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+
+    console.log(`score at 50d => ${computeScoreFromExpectedTime(100, 50, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+    console.log(`score at 50d => ${computeScoreFromExpectedTime(50, 50, TEST_DEFAULT_LINEAR_DECAY_RULE)}`);
+  });
+});
 
 describe('Decay formula testing', () => {
   it('should compute score', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
@@ -48,6 +48,32 @@ const TEST_DEFAULT_LINEAR_DECAY_RULE: DecayRuleConfiguration = {
   active: true,
 };
 
+const TEST_DECAY_RULE_FAST: DecayRuleConfiguration = {
+  id: 'test-decay-fast',
+  name: 'Default Decay Rule fast',
+  description: 'Built-in decay rule for all indicators',
+  decay_lifetime: 200,
+  decay_pound: 0.1,
+  decay_points: [80, 60, 40, 20],
+  decay_revoke_score: 20,
+  decay_observable_types: [], // no observable means any
+  order: 0,
+  active: true,
+};
+
+const TEST_DECAY_RULE_SLOW: DecayRuleConfiguration = {
+  id: 'test-decay-fast',
+  name: 'Default Decay Rule slow',
+  description: 'Built-in decay rule for all indicators',
+  decay_lifetime: 50,
+  decay_pound: 2,
+  decay_points: [80, 60, 40, 20],
+  decay_revoke_score: 25,
+  decay_observable_types: [], // no observable means any
+  order: 0,
+  active: true,
+};
+
 export const TEST_URL_DECAY_RULE: DecayRuleConfiguration = {
   id: 'test-url-rule',
   name: 'URL Decay Rule',
@@ -79,13 +105,13 @@ const BUILT_IN_DECAY_RULES_FOR_TEST = [TEST_DEFAULT_DECAY_RULE, TEST_IP_DECAY_RU
 describe('Decay formula testing', () => {
   it('should compute today score from valid until input in days', () => {
     const computeTodayScore = computeScoreFromValidUntil(0, TEST_DEFAULT_LINEAR_DECAY_RULE);
-    expect(computeTodayScore).toBe(10);
+    expect(computeTodayScore).toBe(TEST_DEFAULT_LINEAR_DECAY_RULE.decay_revoke_score);
 
     const computeFiveDaysScore = computeScoreFromValidUntil(TEST_DEFAULT_LINEAR_DECAY_RULE.decay_lifetime, TEST_DEFAULT_LINEAR_DECAY_RULE);
     expect(computeFiveDaysScore).toBe(100);
 
     // Validate that the mathematical function and the reverse one works well together.
-    const allRulesToTest = [TEST_DEFAULT_LINEAR_DECAY_RULE, TEST_DEFAULT_DECAY_RULE, TEST_IP_DECAY_RULE, TEST_URL_DECAY_RULE];
+    const allRulesToTest = [TEST_DEFAULT_LINEAR_DECAY_RULE, TEST_DEFAULT_DECAY_RULE, TEST_IP_DECAY_RULE, TEST_URL_DECAY_RULE, TEST_DECAY_RULE_SLOW, TEST_DECAY_RULE_FAST];
     for (let ruleI = 0; ruleI < allRulesToTest.length; ruleI += 1) {
       const rule = allRulesToTest[ruleI];
       const step = rule.decay_lifetime / 10;

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
@@ -20,10 +20,12 @@ import { logApp } from '../../../src/config/conf';
 
 describe('Testing field patch on indicator for trio {score, valid until, revoked}', () => {
   const indicatorCreatedIds : string[] = [];
-  const inPast90Days = new Date(new Date().getTime() - NO_DECAY_DEFAULT_VALID_PERIOD);
-  const tomorrow = new Date(new Date().getTime() + dayToMs(1));
-  const yesterday: Date = new Date(utcDate().toDate().getTime() - dayToMs(1));
-  const twoDaysAgo: Date = new Date(utcDate().toDate().getTime() - dayToMs(2));
+  const todayMorning = new Date();
+  todayMorning.setUTCHours(0, 0, 0, 0);
+  const inPast90Days = new Date(todayMorning.getTime() - NO_DECAY_DEFAULT_VALID_PERIOD);
+  const tomorrow = new Date(todayMorning.getTime() + dayToMs(1));
+  const yesterday: Date = new Date(todayMorning.getTime() - dayToMs(1));
+  const twoDaysAgo: Date = new Date(todayMorning.getTime() - dayToMs(2));
 
   const createIndicator = async (input: IndicatorAddInput, withDecay: boolean): Promise<BasicStoreEntityIndicator> => {
     if (withDecay) {
@@ -295,8 +297,8 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
     const indicatorWithDecay = await createIndicator(indicatorAddInput, true);
 
     const inputWithEverything: EditInput[] = [
-      { key: VALID_FROM, value: [twoDaysAgo.toISOString()] },
-      { key: VALID_UNTIL, value: [tomorrow.toISOString()] },
+      { key: VALID_FROM, value: [twoDaysAgo] },
+      { key: VALID_UNTIL, value: [tomorrow] },
       { key: X_SCORE, value: [12] },
       { key: 'revoked', value: [false] },
     ];

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import {
+  addIndicator,
+  findById,
+  INDICATOR_DEFAULT_SCORE,
+  indicatorEditField,
+  NO_DECAY_DEFAULT_REVOKED_SCORE,
+  NO_DECAY_DEFAULT_VALID_PERIOD
+} from '../../../src/modules/indicator/indicator-domain';
+import type { EditInput, IndicatorAddInput } from '../../../src/generated/graphql';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { stixDomainObjectDelete } from '../../../src/domain/stixDomainObject';
+import { type BasicStoreEntityIndicator, ENTITY_TYPE_INDICATOR } from '../../../src/modules/indicator/indicator-types';
+import { STIX_PATTERN_TYPE } from '../../../src/utils/syntax';
+import { VALID_FROM, VALID_UNTIL, X_SCORE } from '../../../src/schema/identifier';
+import { utcDate } from '../../../src/utils/format';
+import { createEntity } from '../../../src/database/middleware';
+import { dayToMs } from '../../../src/modules/decayRule/decayRule-domain';
+import { logApp } from '../../../src/config/conf';
+
+describe('Testing field patch on indicator for trio {score, valid until, revoked}', () => {
+  let indicatorWithDecay: BasicStoreEntityIndicator;
+  let indicatorWithDecay2: BasicStoreEntityIndicator;
+  let indicatorWithoutDecay: BasicStoreEntityIndicator;
+  let indicatorWithoutDecay2: BasicStoreEntityIndicator;
+
+  beforeAll(async () => {
+    const indicatorAddInput: IndicatorAddInput = {
+      name: 'Indicator domain test with decay',
+      pattern: '[file:hashes.\'SHA-256\' = \'4bac27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f877\']',
+      pattern_type: STIX_PATTERN_TYPE,
+      x_opencti_score: 87,
+    };
+    indicatorWithDecay = await addIndicator(testContext, ADMIN_USER, indicatorAddInput);
+    expect(indicatorWithDecay.revoked).toBeFalsy();
+    expect(indicatorWithDecay.decay_applied_rule).toBeDefined();
+    expect(indicatorWithDecay.decay_applied_rule.decay_revoke_score).toBeDefined();
+    expect(indicatorWithDecay.x_opencti_score).toBeGreaterThan(indicatorWithDecay.decay_applied_rule.decay_revoke_score);
+    expect(new Date(indicatorWithDecay.valid_until).getTime()).toBeGreaterThan(new Date().getTime());
+
+    const indicatorAddInput2: IndicatorAddInput = {
+      name: 'Indicator domain test with decay 2',
+      pattern: '[file:hashes.\'SHA-256\' = \'4bac27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f666\']',
+      pattern_type: STIX_PATTERN_TYPE,
+      x_opencti_score: 91,
+    };
+    indicatorWithDecay2 = await addIndicator(testContext, ADMIN_USER, indicatorAddInput2);
+    expect(indicatorWithDecay2.revoked).toBeFalsy();
+    expect(indicatorWithDecay2.decay_applied_rule).toBeDefined();
+    expect(indicatorWithDecay2.decay_applied_rule.decay_revoke_score).toBeDefined();
+    expect(indicatorWithDecay2.x_opencti_score).toBeGreaterThan(indicatorWithDecay2.decay_applied_rule.decay_revoke_score);
+    expect(new Date(indicatorWithDecay2.valid_until).getTime()).toBeGreaterThan(new Date().getTime());
+
+    const inPast90Days = new Date(new Date().getTime() - NO_DECAY_DEFAULT_VALID_PERIOD);
+    const tomorow = new Date(new Date().getTime() + dayToMs(1));
+    const indicatorNoDecayInput = {
+      name: 'Indicator domain test without decay',
+      pattern: '[file:hashes.\'SHA-256\' = \'aaa27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f666\']',
+      pattern_type: STIX_PATTERN_TYPE,
+      x_opencti_score: 85,
+      valid_from: inPast90Days,
+      valid_until: tomorow
+    };
+    // bypass addIndicator to have one without decay rules
+    indicatorWithoutDecay = await createEntity(testContext, ADMIN_USER, indicatorNoDecayInput, ENTITY_TYPE_INDICATOR);
+
+    const indicatorNoDecayInput2 = {
+      name: 'Indicator domain test without decay',
+      pattern: '[file:hashes.\'SHA-256\' = \'bbb27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f666\']',
+      pattern_type: STIX_PATTERN_TYPE,
+      x_opencti_score: 92,
+      valid_from: inPast90Days,
+      valid_until: tomorow
+    };
+    // bypass addIndicator to have one without decay rules
+    indicatorWithoutDecay2 = await createEntity(testContext, ADMIN_USER, indicatorNoDecayInput2, ENTITY_TYPE_INDICATOR);
+  });
+
+  afterAll(async () => {
+    await stixDomainObjectDelete(testContext, ADMIN_USER, indicatorWithDecay.id);
+    await stixDomainObjectDelete(testContext, ADMIN_USER, indicatorWithDecay2.id);
+    await stixDomainObjectDelete(testContext, ADMIN_USER, indicatorWithoutDecay.id);
+    await stixDomainObjectDelete(testContext, ADMIN_USER, indicatorWithoutDecay2.id);
+  });
+
+  it('valid until and valid from should be in right order', async () => {
+    const futureValidFrom = new Date(new Date(indicatorWithDecay.valid_until).getTime() + dayToMs(1));
+    const input: EditInput[] = [{ key: VALID_FROM, value: [futureValidFrom.toUTCString()] }];
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, input)).rejects.toThrowError('The valid until date must be greater than the valid from date');
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, input)).rejects.toThrowError('The valid until date must be greater than the valid from date');
+
+    const pastValidUntil = new Date(new Date(indicatorWithDecay.valid_from).getTime() - dayToMs(1));
+    const input2: EditInput[] = [{ key: VALID_UNTIL, value: [pastValidUntil.toUTCString()] }];
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, input2)).rejects.toThrowError('The valid until date must be greater than the valid from date');
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, input)).rejects.toThrowError('The valid until date must be greater than the valid from date');
+  });
+
+  it('On update, input score should be between 0 and 100', async () => {
+    const inputBelow: EditInput[] = [{ key: X_SCORE, value: [-12] }];
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputBelow)).rejects.toThrowError('The score should be between 0 and 100');
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, inputBelow)).rejects.toThrowError('The score should be between 0 and 100');
+
+    const inputAbove: EditInput[] = [{ key: X_SCORE, value: [305] }];
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputAbove)).rejects.toThrowError('The score should be between 0 and 100');
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, inputAbove)).rejects.toThrowError('The score should be between 0 and 100');
+
+    const inputWeird: EditInput[] = [{ key: X_SCORE, value: ['coucou'] }];
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputWeird)).rejects.toThrowError('Attribute must be a numeric/string');
+    await expect(() => indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, inputWeird)).rejects.toThrowError('Attribute must be a numeric/string');
+  });
+
+  it('decay enabled - revoke=true compute new score and new valid until', async () => {
+    // --------------------
+    // Move revoke to true
+    // score should be set to the revoke number
+    // indicator should have a valid until date in the past
+    const inputToRevoke: EditInput[] = [{ key: 'revoked', value: [true] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputToRevoke);
+
+    const indicatorUpdatedRevoked = await findById(testContext, ADMIN_USER, indicatorWithDecay.id);
+    expect(indicatorUpdatedRevoked.revoked).toBeTruthy();
+    expect(indicatorUpdatedRevoked.x_opencti_score).toBe(indicatorWithDecay.decay_applied_rule.decay_revoke_score);
+    expect(new Date(indicatorUpdatedRevoked.valid_until).getTime()).toBeLessThan(new Date().getTime());
+    const history = indicatorUpdatedRevoked.decay_history;
+    history.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+    const lastHistoryEntry = history[0];
+    logApp.info('Indicator lastHistoryEntry', lastHistoryEntry);
+    expect(
+      lastHistoryEntry?.score,
+      'The lifecycle history should have a new entry with the score set to revoke score'
+    ).toBe(indicatorWithDecay.decay_applied_rule.decay_revoke_score);
+  });
+
+  it('decay enabled - revoke=false compute new score and new valid until', async () => {
+    // --------------------
+    // Reverse: move revoke to false
+    // score should be back to base score
+    // indicator should have a valid until date in the future
+    const inputToUnrevoke: EditInput[] = [{ key: 'revoked', value: [false] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputToUnrevoke);
+
+    const indicatorUpdatedUnRevoked = await findById(testContext, ADMIN_USER, indicatorWithDecay.id);
+    logApp.info('Indicator after revoke true then false ICI', indicatorUpdatedUnRevoked);
+    expect(indicatorUpdatedUnRevoked.revoked).toBeFalsy();
+    expect(indicatorUpdatedUnRevoked.x_opencti_score).toBeGreaterThan(indicatorWithDecay.decay_applied_rule.decay_revoke_score);
+    expect(new Date(indicatorUpdatedUnRevoked.valid_until).getTime()).toBeGreaterThan(new Date().getTime());
+    const history = indicatorUpdatedUnRevoked.decay_history;
+    history.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+    const lastHistoryEntry = history[0];
+    logApp.info('Indicator lastHistoryEntry ICI', lastHistoryEntry);
+    expect(
+      lastHistoryEntry.score,
+      'The lifecycle history should have a new entry with the score updated'
+    ).toBe(indicatorWithDecay.decay_base_score);
+  });
+
+  it('decay enabled - valid until is moved to past date, indicator should be revoked', async () => {
+    const yesterday: Date = new Date(utcDate().toDate().getTime() - dayToMs(1));
+    const twoDaysAgo: Date = new Date(utcDate().toDate().getTime() - dayToMs(2));
+    const inputToRevoke: EditInput[] = [
+      { key: VALID_FROM, value: [twoDaysAgo] },
+      { key: VALID_UNTIL, value: [yesterday] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay2.id, inputToRevoke);
+
+    const indicatorValidUntilYesterday = await findById(testContext, ADMIN_USER, indicatorWithDecay2.id);
+    expect(indicatorValidUntilYesterday.revoked).toBeTruthy();
+    expect(indicatorValidUntilYesterday.x_opencti_score).toBe(indicatorWithDecay2.decay_applied_rule.decay_revoke_score);
+    expect(new Date(indicatorValidUntilYesterday.valid_until).getTime()).toBeLessThan(new Date().getTime());
+    expect(
+      indicatorValidUntilYesterday.decay_history.pop()?.score,
+      'The lifecycle history should have a new entry with the score updated'
+    ).toBe(indicatorWithDecay2.decay_applied_rule.decay_revoke_score);
+  });
+
+  it('no decay - revoke=true compute new score and new valid until', async () => {
+    const inputToRevoke: EditInput[] = [{ key: 'revoked', value: [true] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, inputToRevoke);
+
+    const indicatorUpdatedRevoked = await findById(testContext, ADMIN_USER, indicatorWithoutDecay.id);
+    expect(indicatorUpdatedRevoked.revoked).toBeTruthy();
+    expect(indicatorUpdatedRevoked.x_opencti_score).toBe(NO_DECAY_DEFAULT_REVOKED_SCORE);
+    expect(new Date(indicatorUpdatedRevoked.valid_until).getTime()).toBeLessThan(new Date().getTime());
+  });
+
+  it('no decay - revoke=false compute new score and new valid until', async () => {
+    // Reverse: move revoke to false
+    const inputToUnrevoke: EditInput[] = [{ key: 'revoked', value: [false] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay.id, inputToUnrevoke);
+
+    const indicatorUpdatedUnRevoked = await findById(testContext, ADMIN_USER, indicatorWithoutDecay.id);
+    expect(indicatorUpdatedUnRevoked.revoked).toBeFalsy();
+    expect(indicatorUpdatedUnRevoked.x_opencti_score).toBe(INDICATOR_DEFAULT_SCORE);
+    expect(new Date(indicatorUpdatedUnRevoked.valid_until).getTime()).toBeGreaterThan(new Date().getTime());
+  });
+
+  it('no decay - valid until is moved to past date, indicator should be revoked', async () => {
+    const yesterday: Date = new Date(utcDate().toDate().getTime() - dayToMs(1));
+    const twoDaysAgo: Date = new Date(utcDate().toDate().getTime() - dayToMs(2));
+    const inputToRevoke: EditInput[] = [
+      { key: VALID_FROM, value: [twoDaysAgo] },
+      { key: VALID_UNTIL, value: [yesterday] }];
+    await indicatorEditField(testContext, ADMIN_USER, indicatorWithoutDecay2.id, inputToRevoke);
+
+    const indicatorValidUntilYesterday = await findById(testContext, ADMIN_USER, indicatorWithoutDecay2.id);
+    expect(indicatorValidUntilYesterday.revoked).toBeTruthy();
+    expect(indicatorValidUntilYesterday.x_opencti_score).toBe(NO_DECAY_DEFAULT_REVOKED_SCORE);
+    expect(new Date(indicatorValidUntilYesterday.valid_until).getTime()).toBeLessThan(new Date().getTime());
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
@@ -234,10 +234,22 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
     await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay3.id, inputWithEverything);
 
     const indicatorWithAllChanges = await findById(testContext, ADMIN_USER, indicatorWithDecay3.id);
-    expect(indicatorWithAllChanges.valid_until.getTime()).toBeCloseTo(tomorrow.getTime());
+    expect(new Date(indicatorWithAllChanges.valid_until).toDateString()).toBe(tomorrow.toDateString()); // precision to day is enough
     expect(indicatorWithAllChanges.x_opencti_score).toBeGreaterThan(indicatorWithAllChanges.decay_applied_rule.decay_revoke_score);
     expect(indicatorWithAllChanges.revoked).toBeFalsy();
 
     console.log('indicatorWithAllChanges:', indicatorWithAllChanges);
+  });
+
+  it.todo('decay enabled - updating valid until and score should valid until wins', async () => {
+
+  });
+
+  it.todo('decay enabled - updating valid until and revoke should valid until wins', async () => {
+
+  });
+
+  it.todo('decay enabled - updating score and revoke should revoke wins', async () => {
+
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
@@ -222,7 +222,7 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
     expect(new Date(indicatorValidUntilYesterday.valid_until).getTime()).toBeLessThan(new Date().getTime());
   });
 
-  it.only('decay enabled - updating revoke and valid until and score should ??? what', async () => {
+  it.only('decay enabled - updating revoke and valid until and score should valid until wins', async () => {
     const tomorrow: Date = new Date(utcDate().toDate().getTime() + dayToMs(1));
     const twoDaysAgo: Date = new Date(utcDate().toDate().getTime() - dayToMs(2));
     const inputWithEverything: EditInput[] = [
@@ -234,6 +234,10 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
     await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay3.id, inputWithEverything);
 
     const indicatorWithAllChanges = await findById(testContext, ADMIN_USER, indicatorWithDecay3.id);
+    expect(indicatorWithAllChanges.valid_until.getTime()).toBeCloseTo(tomorrow.getTime());
+    expect(indicatorWithAllChanges.x_opencti_score).toBeGreaterThan(indicatorWithAllChanges.decay_applied_rule.decay_revoke_score);
+    expect(indicatorWithAllChanges.revoked).toBeFalsy();
+
     console.log('indicatorWithAllChanges:', indicatorWithAllChanges);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/indicator-domain-test.ts
@@ -24,6 +24,7 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
   todayMorning.setUTCHours(0, 0, 0, 0);
   const inPast90Days = new Date(todayMorning.getTime() - NO_DECAY_DEFAULT_VALID_PERIOD);
   const tomorrow = new Date(todayMorning.getTime() + dayToMs(1));
+  const in300Days = new Date(todayMorning.getTime() + dayToMs(300));
   const yesterday: Date = new Date(todayMorning.getTime() - dayToMs(1));
   const twoDaysAgo: Date = new Date(todayMorning.getTime() - dayToMs(2));
 
@@ -297,15 +298,14 @@ describe('Testing field patch on indicator for trio {score, valid until, revoked
     const indicatorWithDecay = await createIndicator(indicatorAddInput, true);
 
     const inputWithEverything: EditInput[] = [
-      { key: VALID_FROM, value: [twoDaysAgo] },
-      { key: VALID_UNTIL, value: [tomorrow] },
+      { key: VALID_UNTIL, value: [in300Days] },
       { key: X_SCORE, value: [12] },
-      { key: 'revoked', value: [false] },
+      { key: 'revoked', value: [true] },
     ];
     await indicatorEditField(testContext, ADMIN_USER, indicatorWithDecay.id, inputWithEverything);
 
     const indicatorWithAllChanges = await findById(testContext, ADMIN_USER, indicatorWithDecay.id);
-    expect(new Date(indicatorWithAllChanges.valid_until).toDateString()).toBe(tomorrow.toDateString()); // precision to day is enough
+    expect(new Date(indicatorWithAllChanges.valid_until).toDateString()).toBe(in300Days.toDateString()); // precision to day is enough
     expect(indicatorWithAllChanges.x_opencti_score).toBeGreaterThan(indicatorWithAllChanges.decay_applied_rule.decay_revoke_score);
     expect(indicatorWithAllChanges.revoked).toBeFalsy();
 

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -30,7 +30,7 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.location.length).toBe(16);
       expect(createEventsByTypes.relationship.length).toBe(138);
       expect(createEventsByTypes.sighting.length).toBe(4);
-      expect(createEventsByTypes.indicator.length).toBe(38);
+      expect(createEventsByTypes.indicator.length).toBe(42);
       expect(createEventsByTypes['attack-pattern'].length).toBe(9);
       expect(createEventsByTypes['threat-actor'].length).toBe(17);
       expect(createEventsByTypes['observed-data'].length).toBe(1);
@@ -50,7 +50,7 @@ describe('Raw streams tests', () => {
       // 328 created at init + 1 request access + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vocabulary.length).toBe(VOCABULARY_NUMBERS);
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(827);
+      expect(createEvents.length).toBe(831);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -74,7 +74,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['external-reference'].length).toBe(1);
       expect(updateEventsByTypes['grouping'].length).toBe(3);
       expect(updateEventsByTypes['incident'].length).toBe(3);
-      expect(updateEventsByTypes['indicator'].length).toBe(6);
+      expect(updateEventsByTypes['indicator'].length).toBe(12);
       expect(updateEventsByTypes['label'].length).toBe(1);
       expect(updateEventsByTypes['malware-analysis'].length).toBe(3);
       expect(updateEventsByTypes['note'].length).toBe(3);
@@ -86,7 +86,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(198);
+      expect(updateEvents.length).toBe(204);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;
@@ -99,7 +99,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(170);
+      expect(deleteEvents.length).toBe(174);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
@@ -40,7 +40,7 @@ describe('Database sync raw', () => {
   it(
     'Should python raw sync succeed',
     async () => {
-      const queryResultBefore = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 350 } });
+      const queryResultBefore = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 500 } });
 
       // Pre check
       const { objectMap, relMap, initStixReport } = await checkPreSyncContent();
@@ -50,9 +50,9 @@ describe('Database sync raw', () => {
       expect(execution).not.toBeNull();
       expect(execution.status).toEqual('success');
       // to uncomment for debug if counters are failing
-      // expect(execution.messages.length, `Execution messages ${JSON.stringify(execution.messages)}`).toEqual(0);
+      expect(execution.messages.length, `Execution messages ${JSON.stringify(execution.messages)}`).toEqual(0);
 
-      const queryResultAfter = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 350 } });
+      const queryResultAfter = await queryAsAdmin({ query: LIST_QUERY, variables: { first: 500 } });
 
       const vocabBefore = queryResultBefore.data.vocabularies.edges.map((e) => e.node);
       const vocabAfter = queryResultAfter.data.vocabularies.edges.map((e) => e.node);

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1203;
+export const RAW_EVENTS_SIZE = 1217;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* On indicator update, resync one of {score, valid until, valid from, revoke} field when needed.
* For both indicator under decay and without decay

Rules:
- on move to revoke = true
⇒ (decay enabled) put score to revoke score + update valid until to now()
⇒ (decay disabled) put score 0 + update valid until to now()

- on move to revoke = false
⇒ (decay enabled) put score “Initial score” + compute valid until
⇒ (decay disabled) put score 50 if no score + update valid until to 3 months

*Test counter*
- created 4 indicators
- updated => 6
- deleted 4 indicators

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #10299
* closes #10300
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
