### PR TITLE
[frontend] list widgets sortable values according to runtime mapping enabled (#10338)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -41,13 +41,13 @@ const WidgetCreationParameters = () => {
   const [selectedTab, setSelectedTab] = useState<'write' | 'preview' | undefined>('write');
 
   const isRuntimeSort = isRuntimeFieldEnable() ?? false;
-  const runtimeSortByValues = [ // values sortable only if runtime mapping is enabled
+  const runtimeSortByValues = isRuntimeSort ? [ // values sortable only if runtime mapping is enabled
     'createdBy',
     'creator',
     'objectMarking',
     'observable_value',
-  ];
-  let sortByValues = [
+  ] : [];
+  const sortByValues = [
     'created',
     'created_at',
     'modified',
@@ -56,6 +56,7 @@ const WidgetCreationParameters = () => {
     'valid_from',
     'valid_until',
     'entity_type',
+    ...runtimeSortByValues,
     'value',
     'x_opencti_workflow_id',
     'opinions_metrics_mean',
@@ -63,9 +64,6 @@ const WidgetCreationParameters = () => {
     'opinions_metrics_min',
     'opinions_metrics_total',
   ];
-  if (isRuntimeSort) {
-    sortByValues = sortByValues.concat(runtimeSortByValues);
-  }
 
   const {
     config,

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -30,11 +30,42 @@ import type { WidgetColumn, WidgetParameters } from '../../../utils/widget/widge
 import { getCurrentAvailableParameters, getCurrentCategory, getCurrentIsRelationships, isWidgetListOrTimeline } from '../../../utils/widget/widgetUtils';
 import EntitySelectWithTypes from '../../../components/fields/EntitySelectWithTypes';
 import { FilterGroup } from '../../../utils/filters/filtersHelpers-types';
+import useAuth from '../../../utils/hooks/useAuth';
 
 const WidgetCreationParameters = () => {
   const { t_i18n } = useFormatter();
+  const {
+    platformModuleHelpers: { isRuntimeFieldEnable },
+  } = useAuth();
   const { ignoredAttributesInDashboards } = useAttributes();
   const [selectedTab, setSelectedTab] = useState<'write' | 'preview' | undefined>('write');
+
+  const isRuntimeSort = isRuntimeFieldEnable() ?? false;
+  const runtimeSortByValues = [ // values sortable only if runtime sorting is enabled
+    'createdBy',
+    'creator',
+    'objectMarking',
+    'observable_value',
+  ];
+  let sortByValues = [
+    'created',
+    'created_at',
+    'modified',
+    'updated_at',
+    'name',
+    'valid_from',
+    'valid_until',
+    'entity_type',
+    'value',
+    'x_opencti_workflow_id',
+    'opinions_metrics_mean',
+    'opinions_metrics_max',
+    'opinions_metrics_min',
+    'opinions_metrics_total',
+  ];
+  if (isRuntimeSort) {
+    sortByValues = sortByValues.concat(runtimeSortByValues);
+  }
 
   const {
     config,
@@ -322,26 +353,7 @@ const WidgetCreationParameters = () => {
                         )
                         }
                       >
-                        {[
-                          'created',
-                          'created_at',
-                          'modified',
-                          'updated_at',
-                          'name',
-                          'valid_from',
-                          'valid_until',
-                          'entity_type',
-                          'createdBy',
-                          'creator',
-                          'objectMarking',
-                          'observable_value',
-                          'value',
-                          'x_opencti_workflow_id',
-                          'opinions_metrics_mean',
-                          'opinions_metrics_max',
-                          'opinions_metrics_min',
-                          'opinions_metrics_total',
-                        ].map((value) => (
+                        {sortByValues.map((value) => (
                           <MenuItem
                             key={value}
                             value={value}

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -41,7 +41,7 @@ const WidgetCreationParameters = () => {
   const [selectedTab, setSelectedTab] = useState<'write' | 'preview' | undefined>('write');
 
   const isRuntimeSort = isRuntimeFieldEnable() ?? false;
-  const runtimeSortByValues = [ // values sortable only if runtime sorting is enabled
+  const runtimeSortByValues = [ // values sortable only if runtime mapping is enabled
     'createdBy',
     'creator',
     'objectMarking',


### PR DESCRIPTION
### Proposed changes
In list widget creation form, the possible sortable values should be limited to sortable values if runtime mapping is disabled

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10338