### PR TITLE
[e2e] some changes on background tasks test (#9147)

### DIFF
--- a/opencti-platform/opencti-front/playwright.config.ts
+++ b/opencti-platform/opencti-front/playwright.config.ts
@@ -14,7 +14,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests_e2e',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: 0,
@@ -113,7 +113,7 @@ export default defineConfig({
    webServer: {
      command: 'yarn start',
      url: 'http://localhost:3000',
-     reuseExistingServer: false,
+     reuseExistingServer: !process.env.CI,
    },
 
 });

--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -82,7 +82,7 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
     loopCurrent += 1;
   }
   await expect(page.getByText('Waiting')).toBeHidden();
-  await expect(page.getByText('Complete')).toBeVisible();
+  await expect(page.getByText('Complete').first()).toBeVisible();
   // END Region Background task page
 
   // Go on the general Data > entities

--- a/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/taskPopup.pageModel.ts
@@ -7,7 +7,7 @@ export default class TaskPopup {
     return this.page.getByTestId('background-task-popup');
   }
 
-  async launchAddLabel(labelName: string, firstTime: boolean) {
+  async launchAddLabel(labelName: string) {
     // Launch background task on selected
     await this.page.getByLabel('Update', { exact: true }).getByLabel('update').click();
     await this.page.getByRole('combobox').first().click();
@@ -16,12 +16,7 @@ export default class TaskPopup {
     await this.page.getByRole('option', { name: 'Labels' }).click();
     await this.page.getByLabel('Values').click();
 
-    // Need to wait the request that fetch labels (in background task popup) - but only on the first call...
-    if (firstTime) {
-      await this.page.waitForResponse((resp) => resp.url().includes('/graphql') && resp.status() === 200);
-    }
-
-    await this.page.getByText(labelName).click();
+    await this.page.getByText(labelName).click({ timeout: 5000 });
     await this.page.getByRole('button', { name: 'Update' }).click();
     await this.page.getByRole('button', { name: 'Launch' }).click();
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change the way to wait until all background task are complete.
* remove the wait for graphql call on label selection, seems useless
* add possibility to use frontend server locally, it's way faster for e2e execution locally

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* relates to #9147

![image](https://github.com/user-attachments/assets/e8dec5f4-e518-43bc-9820-5cf57ddeaee2)


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
