### PR TITLE
[frontend] dynamic @me filter value at top of the list (#9128)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
@@ -1,5 +1,5 @@
 import { OptionValue } from '@components/common/lists/FilterAutocomplete';
-import { isStixObjectTypes } from './filtersUtils';
+import { isStixObjectTypes, ME_FILTER_VALUE } from './filtersUtils';
 
 // eslint-disable-next-line import/prefer-default-export
 export const getOptionsFromEntities = (
@@ -28,13 +28,19 @@ export const getOptionsFromEntities = (
     return f;
   })
     .sort((a, b) => {
-    // In case value is null, for "no label" case we want it at the top of the list
+      // In case value is null, for "no label" case we want it at the top of the list
       if (!b.value) {
         return 1;
       }
+      // In case value is dynamic @me filter, for user id filter we want it at the top of the list
+      if (a.value === ME_FILTER_VALUE) {
+        return -1;
+      }
+      // order by group
       if (a.group && b.group && a.group !== b.group) {
         return a.group.localeCompare(b.group);
       }
+      // order by label
       return a.label.localeCompare(b.label);
     });
 };


### PR DESCRIPTION
### Proposed changes

The dynamic @me filter value (for use id filters) should always be at the top of the list

Enable to fix such behaviors when they are technical creators : 
![image](https://github.com/user-attachments/assets/b2f2fad6-3c47-4313-b842-a92ed0934284)
