### PR TITLE
[backend] Fix cache refresh multiple times (#8877)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1160,7 +1160,6 @@ export const userAddIndividual = async (context, user) => {
   const individualInput = { name: targetUser.name, contact_information: targetUser.user_email };
   // We need to bypass validation here has we maybe not setup all require fields
   const individual = await addIndividual(context, targetUser, individualInput, { bypassValidation: true });
-  // await refreshCacheForEntity(targetUser); // Auto add must reset the local cache directly
   return notify(BUS_TOPICS[ENTITY_TYPE_USER].EDIT_TOPIC, targetUser, user).then(() => individual);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -729,9 +729,9 @@ export const userEditField = async (context, user, userId, rawInputs) => {
     message: `updates \`${inputs.map((i) => i.key).join(', ')}\` for ${personalUpdate ? '`themselves`' : `user \`${actionEmail}\``}`,
     context_data: { id: userId, entity_type: ENTITY_TYPE_USER, input }
   });
-  if (refreshUserNeeded) {
+  /* if (refreshUserNeeded) { // TODO remove ?
     await refreshCacheForEntity(element); // Me edit must reset the local cache directly
-  }
+  } */
   return notify(BUS_TOPICS[ENTITY_TYPE_USER].EDIT_TOPIC, element, user);
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* cache is refreshed multiple times : once when editing a user, once in notify, then another time in cache manager. For user cache refresh this can lead to perf issues (when entering a draft for ex) => we keep the direct cache refresh in notify

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8877 
* #9300 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
