### PR TITLE
[frontend] filter entity types values in Relationship view (#10375)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationships.tsx
@@ -53,9 +53,7 @@ EntityStixCoreRelationshipsProps
   handleChangeView,
 }) => {
   const classes = useStyles();
-  const LOCAL_STORAGE_KEY = `relationships-${entityId}-${stixCoreObjectTypes?.join(
-    '-',
-  )}-${relationshipTypes?.join('-')}`;
+  const LOCAL_STORAGE_KEY = `relationships-${entityId}-${stixCoreObjectTypes?.join('-')}-${relationshipTypes?.join('-')}`;
   const localStorage = usePaginationLocalStorage<PaginationOptions>(
     LOCAL_STORAGE_KEY,
     {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
@@ -185,7 +185,7 @@ const EntityStixCoreRelationshipsRelationshipsView: FunctionComponent<EntityStix
         selectAll={selectAll}
         numberOfElements={numberOfElements}
         filters={filters}
-        availableEntityTypes={stixCoreObjectTypes}
+        availableEntityTypes={relationshipTypes}
         availableRelationshipTypes={relationshipTypes}
         handleToggleExports={storageHelpers.handleToggleExports}
         openExports={openExports}


### PR DESCRIPTION
### Proposed changes
In Knowledge view > Relationship view, the possible values for the entity types filter should be the possible relationships types values

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10375