### PR TITLE
[frontend] fix export of Indicators in Knowledge tab (#10381)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -19,6 +19,7 @@ import { useDataTableContext } from './components/DataTableContext';
 
 type DataTableInternalFiltersProps = Pick<DataTableProps,
 | 'additionalFilterKeys'
+| 'additionalFilters'
 | 'entityTypes'> & {
   hideSearch?: boolean
   hideFilters?: boolean
@@ -33,6 +34,7 @@ type DataTableInternalFiltersProps = Pick<DataTableProps,
 
 const DataTableInternalFilters = ({
   additionalFilterKeys,
+  additionalFilters,
   entityTypes,
   hideSearch,
   hideFilters,
@@ -75,6 +77,7 @@ const DataTableInternalFilters = ({
 
         {!hideFilters && (
           <DataTableFilters
+            additionalFilters={additionalFilters}
             availableFilterKeys={availableFilterKeys}
             searchContextFinal={searchContextFinal}
             availableEntityTypes={availableEntityTypes}
@@ -163,6 +166,7 @@ type OCTIDataTableProps = Pick<DataTableProps,
 | 'availableFilterKeys'
 | 'redirectionModeEnabled'
 | 'additionalFilterKeys'
+| 'additionalFilters'
 | 'variant'
 | 'actions'
 | 'icon'
@@ -194,6 +198,7 @@ const DataTable = (props: OCTIDataTableProps) => {
     availableRelationFilterTypes,
     preloadedPaginationProps: dataQueryArgs,
     additionalFilterKeys,
+    additionalFilters,
     lineFragment,
     exportContext,
     entityTypes,
@@ -238,6 +243,7 @@ const DataTable = (props: OCTIDataTableProps) => {
         filtersComponent={(
           <DataTableInternalFilters
             entityTypes={entityTypes}
+            additionalFilters={additionalFilters}
             additionalFilterKeys={additionalFilterKeys}
             additionalHeaderButtons={additionalHeaderButtons}
             availableEntityTypes={availableEntityTypes}

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -72,6 +72,7 @@ export const DataTableDisplayFilters = ({
 };
 
 const DataTableFilters = ({
+  additionalFilters,
   availableFilterKeys,
   searchContextFinal,
   availableEntityTypes,
@@ -110,6 +111,22 @@ const DataTableFilters = ({
   const hasFilters = availableFilterKeys && availableFilterKeys.length > 0;
 
   const hasToggleGroup = additionalHeaderButtons || redirectionModeEnabled || !exportDisabled;
+
+  const exportFilterGroups = [];
+  if (isFilterGroupNotEmpty(additionalFilters)) {
+    exportFilterGroups.push(additionalFilters);
+  }
+  if (isFilterGroupNotEmpty(paginationOptions.filters)) {
+    exportFilterGroups.push(paginationOptions.filters);
+  }
+  const exportPaginationOptions = {
+    ...paginationOptions,
+    filters: {
+      mode: 'and',
+      filters: [],
+      filterGroups: exportFilterGroups,
+    },
+  };
 
   return (
     <ExportContext.Provider value={{ selectedIds: Object.keys(selectedElements) }}>
@@ -194,7 +211,7 @@ const DataTableFilters = ({
             <StixDomainObjectsExports
               open={!!openExports}
               handleToggle={helpers.handleToggleExports}
-              paginationOptions={paginationOptions}
+              paginationOptions={exportPaginationOptions}
               exportContext={exportContext}
             />
           </Security>
@@ -205,7 +222,7 @@ const DataTableFilters = ({
             <StixCoreRelationshipsExports
               open={openExports}
               handleToggle={helpers.handleToggleExports}
-              paginationOptions={paginationOptions}
+              paginationOptions={exportPaginationOptions}
               exportContext={exportContext}
             />
           </Security>
@@ -216,7 +233,7 @@ const DataTableFilters = ({
             <StixCoreObjectsExports
               open={openExports}
               handleToggle={helpers.handleToggleExports}
-              paginationOptions={paginationOptions}
+              paginationOptions={exportPaginationOptions}
               exportContext={exportContext}
             />
           </Security>
@@ -227,7 +244,7 @@ const DataTableFilters = ({
             <StixCyberObservablesExports
               open={openExports}
               handleToggle={helpers.handleToggleExports}
-              paginationOptions={paginationOptions}
+              paginationOptions={exportPaginationOptions}
               exportContext={exportContext}
             />
           </Security>

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -88,6 +88,7 @@ export interface DataTableProps {
   dataQueryArgs: any
   availableFilterKeys?: string[] | undefined;
   redirectionModeEnabled?: boolean
+  additionalFilters?: FilterGroup
   additionalFilterKeys?: string[]
   entityTypes?: string[]
   settingsMessagesBannerHeight?: number
@@ -163,6 +164,7 @@ export interface DataTableDisplayFiltersProps {
 }
 
 export interface DataTableFiltersProps {
+  additionalFilters?: DataTableProps['additionalFilters'];
   availableFilterKeys?: string[] | undefined;
   availableRelationFilterTypes?: Record<string, string[]> | undefined
   availableEntityTypes?: string[]

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
@@ -244,9 +244,10 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
         storageKey={localStorageKey}
         initialValues={initialValues}
         toolbarFilters={contextFilters}
+        additionalFilters={contextFilters}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={entityStixCoreRelationshipsIndicatorsEntitiesViewLineFragment}
-        exportContext={{ entity_type: 'Indicator' }}
+        exportContext={{ entity_id: entityId, entity_type: 'Indicator' }}
         additionalHeaderButtons={[...viewButtons]}
       />
       )}


### PR DESCRIPTION
### Proposed changes

* Add a new props in DataTable to be able to pass extra filters that are not saved in local storage. Those extra filter are for example used by the export components when we are in a context of entities inside a container to specify which container it is. 

### Related issues

* #10008 
* #10381 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
