### PR TITLE
[worker] fix starting pingAlive thread once

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -103,7 +103,6 @@ class ApiConsumer(Thread):  # pylint: disable=too-many-instance-attributes
         super().__init__()
         self.logger_class = logger(self.log_level.upper(), self.json_logging)
         self.worker_logger = self.logger_class("worker")
-        self.worker_logger.info(self.connector)
         self.queue_name = self.connector["config"]["listen"]
         self.connector_token = self.connector["connector_user"]["api_token"]
         self.pika_credentials = pika.PlainCredentials(
@@ -222,7 +221,6 @@ class ApiConsumer(Thread):  # pylint: disable=too-many-instance-attributes
                 connection.add_callback_threadsafe(cb)
 
     def stop(self):
-        self.worker_logger.info('stop called')
         self._is_interrupted = True
 
     def run(self) -> None:


### PR DESCRIPTION
### Proposed changes

* Start pingAlive once in the main loop
* Use consume() generator instead of callable + basic_consume to handle graceful stops
* handle graceful stops for sigint (control-c) or sigterm
* improved exception handling
* rejection of faulty messages in AMQP listening mode (if message is not json)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Before this change, a worker would create a pingAlive thread per rabbitmq queue, which is useless & consumes resources.
Also, on exceptions (eg. a message which is not valid json), the consuption would fail and restart, creating a new pingAlive thread. Exceptions during ingestion would then lead to an ever increasing number of these pingAlive threads.
A comment suggested graceful stop was handled but it was incomplete/incorrect.