### PR TITLE
[backend/frontend] Request access - fix workflow status and fix popup organization (#9657)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "Du benötigst ein Vertrauensniveau, um Objekte auf der Plattform zu bearbeiten.",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "Sie müssen eine Zwei-Faktor-Authentifizierung aktivieren. Bitte geben Sie den in Ihrer Anwendung generierten Code ein.",
   "You need to activate OpenCTI enterprise edition to use this feature.": "Um diese Funktion nutzen zu können, müssen Sie die OpenCTI Enterprise Edition aktivieren.",
+  "You need to be able to edit the RFI and share knowledge": "Sie müssen in der Lage sein, die RFI zu bearbeiten und Wissen zu teilen",
   "You need to enable EE License to use this feature": "Sie müssen die EE-Lizenz aktivieren, um diese Funktion nutzen zu können",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "Sie müssen Ihre Zwei-Faktor-Authentifizierung validieren. Bitte geben Sie den in Ihrer Anwendung generierten Code ein.",
   "You see only marking definitions that can be shared (defined by the admin)": "Sie sehen nur Markierungsdefinitionen, die freigegeben werden können (vom Administrator definiert)",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "You need a confidence level to edit objects in the platform.",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "You need to activate a two-factor authentication. Please type the code generated in your application.",
   "You need to activate OpenCTI enterprise edition to use this feature.": "You need to activate OpenCTI enterprise edition to use this feature.",
+  "You need to be able to edit the RFI and share knowledge": "You need to be able to edit the RFI and share knowledge",
   "You need to enable EE License to use this feature": "You need to enable EE License to use this feature",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "You need to validate your two-factor authentication. Please type the code generated in your application.",
   "You see only marking definitions that can be shared (defined by the admin)": "You see only marking definitions that can be shared (defined by the admin)",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "Necesitas un nivel de confianza para editar objetos en la plataforma.",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "Necesitas activar una autenticación de dos factores. Por favor, escriba el código generado en su aplicación.",
   "You need to activate OpenCTI enterprise edition to use this feature.": "Es necesario activar la edición empresarial de OpenCTI para utilizar esta función.",
+  "You need to be able to edit the RFI and share knowledge": "Debe ser capaz de editar el RFI y compartir conocimientos",
   "You need to enable EE License to use this feature": "Debe activar la licencia EE para utilizar esta función",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "Debe validar su autenticación de dos factores. Por favor, escriba el código generado en su aplicación.",
   "You see only marking definitions that can be shared (defined by the admin)": "Sólo se ven las definiciones de marcado que se pueden compartir (definidas por el administrador)",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "Vous avez besoin d'un niveau de confiance pour éditer des objets sur la plateforme.",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "Vous devez activer une authentification à deux facteurs. Veuillez saisir le code généré dans votre application.",
   "You need to activate OpenCTI enterprise edition to use this feature.": "Vous devez activer OpenCTI enterprise edition pour utiliser cette fonctionnalité.",
+  "You need to be able to edit the RFI and share knowledge": "Vous devez être en mesure d'éditer le RFI et de partager les connaissances",
   "You need to enable EE License to use this feature": "Vous devez activer la licence EE pour utiliser cette fonction",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "Vous devez valider votre authentification à deux facteurs. Veuillez saisir le code généré dans votre application.",
   "You see only marking definitions that can be shared (defined by the admin)": "Vous ne voyez que les définitions de marquage qui peuvent être partagées (définies par l'administrateur)",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "プラットフォーム上でオブジェクトを編集するには、最大の自信レベルが必要です。",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "二要素認証を有効にする必要があります。アプリケーションで生成されたコードを入力してください。",
   "You need to activate OpenCTI enterprise edition to use this feature.": "この機能を使用するには、OpenCTI エンタープライズ版を有効にする必要があります。",
+  "You need to be able to edit the RFI and share knowledge": "RFIを編集し、知識を共有できる必要がある。",
   "You need to enable EE License to use this feature": "この機能を使用するには、EEライセンスを有効にする必要があります。",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "二要素認証を検証する必要があります。アプリケーションで生成されたコードを入力してください。",
   "You see only marking definitions that can be shared (defined by the admin)": "共有可能な（管理者によって定義された）マーキング定義のみが表示されます。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "플랫폼에서 객체를 편집하려면 신뢰 수준이 필요합니다.",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "이중 인증을 활성화해야 합니다. 애플리케이션에서 생성된 코드를 입력하십시오.",
   "You need to activate OpenCTI enterprise edition to use this feature.": "이 기능을 사용하려면 OpenCTI 엔터프라이즈 에디션을 활성화해야 합니다.",
+  "You need to be able to edit the RFI and share knowledge": "RFI를 편집하고 지식을 공유할 수 있어야 합니다",
   "You need to enable EE License to use this feature": "이 기능을 사용하려면 EE 라이선스를 활성화해야 합니다",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "이중 인증을 검증해야 합니다. 애플리케이션에서 생성된 코드를 입력하십시오",
   "You see only marking definitions that can be shared (defined by the admin)": "공유할 수 있는 마킹 정의만 표시됩니다 (관리자가 정의한 것)",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3564,6 +3564,7 @@
   "You need a confidence level to edit objects in the platform.": "编辑平台中的对象需要信任级别。",
   "You need to activate a two-factor authentication. Please type the code generated in your application.": "您需要激活双因素身份验证。请输入在您的应用程序中生成的代码。",
   "You need to activate OpenCTI enterprise edition to use this feature.": "您需要激活 OpenCTI 企业版才能使用此功能。",
+  "You need to be able to edit the RFI and share knowledge": "您需要能够编辑《索取资料书》并分享知识",
   "You need to enable EE License to use this feature": "您需要启用 EE 许可才能使用此功能",
   "You need to validate your two-factor authentication. Please type the code generated in your application": "您需要验证您的双因素身份验证。请输入在您的应用程序中生成的代码。",
   "You see only marking definitions that can be shared (defined by the admin)": "您只能看到可以共享的标记定义（由管理员定义）",

--- a/opencti-platform/opencti-front/src/components/RequestAccessDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/RequestAccessDialog.tsx
@@ -9,6 +9,7 @@ import ObjectOrganizationField from '@components/common/form/ObjectOrganizationF
 import { Field, Form, Formik, FormikConfig } from 'formik';
 import { graphql } from 'react-relay';
 import { useTheme } from '@mui/styles';
+import * as Yup from 'yup';
 import { useFormatter } from './i18n';
 import TextField from './TextField';
 import useApiMutation from '../utils/hooks/useApiMutation';
@@ -48,6 +49,12 @@ const RequestAccessDialog: React.FC<RequestAccessDialogProps> = ({ open, onClose
   const theme = useTheme<Theme>();
   const { me } = useAuth();
   const meResolvedId = me.id;
+
+  const requestAccessValidation = (t: (v: string) => string) => Yup.object().shape({
+    organizations: Yup.object().shape({
+      value: Yup.string().trim().required(t('This field is required')),
+    }),
+  });
 
   const [commit] = useApiMutation(requestAccessDialogMutation, undefined, {
     successMessage: `${t_i18n('Your request for access has been successfully taken into account')}`,
@@ -98,6 +105,7 @@ const RequestAccessDialog: React.FC<RequestAccessDialogProps> = ({ open, onClose
           <Formik
             initialValues={initialValues}
             onSubmit={onSubmit}
+            validationSchema={requestAccessValidation(t_i18n)}
           >
             {({ isSubmitting, submitForm }) => {
               return (

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -182,6 +182,14 @@ const meUserFragment = graphql`
       name
       authorized_authorities
     }
+    objectOrganization {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
     allowed_marking {
       id
       entity_type

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -251,6 +251,7 @@ export const ReportCreationForm: FunctionComponent<ReportFormProps> = ({
           <Field
             component={DateTimePickerField}
             name="published"
+            withSeconds
             textFieldProps={{
               label: t_i18n('Publication date'),
               required: mandatoryAttributes.includes('published'),

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -238,6 +238,7 @@ const ReportEditionOverviewComponent = (props) => {
           <Field
             component={DateTimePickerField}
             name="published"
+            withSeconds
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             textFieldProps={{

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
@@ -94,11 +94,13 @@ const caseRfiFragment = graphql`
       isUserCanAction
       configuration {
         approved_status {
+          id
           template {
             color
           }
         }
         declined_status {
+          id
           template {
             color
           }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfi.tsx
@@ -88,16 +88,20 @@ const caseRfiFragment = graphql`
       }
     }
     workflowEnabled
+    revoked
     x_opencti_request_access
     requestAccessConfiguration {
-      approved_status {
-        template {
-          color
+      isUserCanAction
+      configuration {
+        approved_status {
+          template {
+            color
+          }
         }
-      }
-      declined_status {
-        template {
-          color
+        declined_status {
+          template {
+            color
+          }
         }
       }
     }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/ProcessingStatusOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/ProcessingStatusOverview.tsx
@@ -20,29 +20,15 @@ export interface RequestAccessActionStatus {
   actionStatus: string,
 }
 
-interface RequestAccessAction {
-  reason?: string
-  entities?: string[]
-  members?: string[]
-  type?: string,
-  status: string,
-  executionDate?: Date,
-  workflowMapping: RequestAccessActionStatus[],
-}
-
 const ProcessingStatusOverview = ({ data }: CaseRfiRequestAccessOverviewProps) => {
   const { t_i18n } = useFormatter();
-  let requestAccessData = null;
   const approvedStatus = data.requestAccessConfiguration?.configuration?.approved_status;
   const approvedButtonColor = approvedStatus?.template?.color;
   const declinedStatus = data.requestAccessConfiguration?.configuration?.declined_status;
   const declineButtonColor = declinedStatus?.template?.color;
-  const requestAccess = data.x_opencti_request_access;
-  if (requestAccess) {
-    requestAccessData = JSON.parse(requestAccess) as RequestAccessAction;
-  }
-  const isDecisionNotTaken = requestAccessData?.status === 'NEW'; // Action Status (NEW/DECLINED/ACCEPTED)
-
+  const rfiStatus = data.status?.id;
+  const isDecisionNotTaken = rfiStatus !== approvedStatus?.id && rfiStatus !== declinedStatus?.id;
+  const requestAccessData = data.x_opencti_request_access;
   const onSubmitValidateRequestAccess = () => {
     commitMutation({
       mutation: validateRequestAccessMutation,

--- a/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
@@ -1,22 +1,18 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { Field } from 'formik';
 import AutocompleteField from '../../../../components/AutocompleteField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import useAuth from '../../../../utils/hooks/useAuth';
-
-export interface OrganizationOption {
-  value: string;
-  label: string ;
-}
+import { AutoCompleteOption } from '../../../../utils/field';
 
 interface MyOrganizationFieldProps {
   name: string;
   label: string;
   disabled:boolean;
   multiple:boolean;
-  style:any;
-  onChange:any;
+  style:CSSProperties;
+  onChange:(name: string, value: AutoCompleteOption)=>void;
 }
 
 const MyOrganizationField = (props: MyOrganizationFieldProps) => {
@@ -30,7 +26,7 @@ const MyOrganizationField = (props: MyOrganizationFieldProps) => {
   } = props;
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
-  const myOrganizationList: OrganizationOption[] = [];
+  const myOrganizationList: AutoCompleteOption[] = [];
   if (me.objectOrganization) {
     for (let i = 0; i < me.objectOrganization?.edges.length; i += 1) {
       const org = me.objectOrganization?.edges[i];
@@ -40,6 +36,7 @@ const MyOrganizationField = (props: MyOrganizationFieldProps) => {
   return (
     <Field
       component={AutocompleteField}
+      required
       name={name}
       multiple={multiple}
       disabled={disabled}

--- a/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
@@ -49,7 +49,7 @@ const MyOrganizationField = (props: MyOrganizationFieldProps) => {
         label: t_i18n(label) ?? '',
       }}
       noOptionsText={t_i18n('No available options')}
-      options={myOrganizationList ?? []}
+      options={myOrganizationList}
       onChange={typeof onChange === 'function' ? onChange : null}
       renderOption={(
         renderProps: React.HTMLAttributes<HTMLLIElement>,

--- a/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
@@ -11,8 +11,8 @@ interface MyOrganizationFieldProps {
   label: string;
   disabled:boolean;
   multiple:boolean;
-  style:CSSProperties;
-  onChange:(name: string, value: AutoCompleteOption)=>void;
+  style?: CSSProperties;
+  onChange?: (name: string, value: AutoCompleteOption) => void;
 }
 
 const MyOrganizationField = (props: MyOrganizationFieldProps) => {
@@ -21,8 +21,8 @@ const MyOrganizationField = (props: MyOrganizationFieldProps) => {
     label,
     disabled,
     multiple = true,
-    style,
-    onChange,
+    style = {},
+    onChange = null,
   } = props;
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
@@ -47,7 +47,7 @@ const MyOrganizationField = (props: MyOrganizationFieldProps) => {
       }}
       noOptionsText={t_i18n('No available options')}
       options={myOrganizationList}
-      onChange={typeof onChange === 'function' ? onChange : null}
+      onChange={onChange}
       renderOption={(
         renderProps: React.HTMLAttributes<HTMLLIElement>,
         option: { value: string; label: string },

--- a/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/MyOrganizationField.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Field } from 'formik';
+import AutocompleteField from '../../../../components/AutocompleteField';
+import { useFormatter } from '../../../../components/i18n';
+import ItemIcon from '../../../../components/ItemIcon';
+import useAuth from '../../../../utils/hooks/useAuth';
+
+export interface OrganizationOption {
+  value: string;
+  label: string ;
+}
+
+interface MyOrganizationFieldProps {
+  name: string;
+  label: string;
+  disabled:boolean;
+  multiple:boolean;
+  style:any;
+  onChange:any;
+}
+
+const MyOrganizationField = (props: MyOrganizationFieldProps) => {
+  const {
+    name,
+    label,
+    disabled,
+    multiple = true,
+    style,
+    onChange,
+  } = props;
+  const { t_i18n } = useFormatter();
+  const { me } = useAuth();
+  const myOrganizationList: OrganizationOption[] = [];
+  if (me.objectOrganization) {
+    for (let i = 0; i < me.objectOrganization?.edges.length; i += 1) {
+      const org = me.objectOrganization?.edges[i];
+      myOrganizationList.push({ value: org?.node.id, label: org?.node.name });
+    }
+  }
+  return (
+    <Field
+      component={AutocompleteField}
+      name={name}
+      multiple={multiple}
+      disabled={disabled}
+      style={style}
+      textfieldprops={{
+        variant: 'standard',
+        label: t_i18n(label) ?? '',
+      }}
+      noOptionsText={t_i18n('No available options')}
+      options={myOrganizationList ?? []}
+      onChange={typeof onChange === 'function' ? onChange : null}
+      renderOption={(
+        renderProps: React.HTMLAttributes<HTMLLIElement>,
+        option: { value: string; label: string },
+      ) => (
+        <li {...renderProps}>
+          <div style={{ paddingTop: 4, display: 'inline-block' }}>
+            <ItemIcon type="Organization"/>
+          </div>
+          <div style={{ display: 'inline-block', flexGrow: 1, marginLeft: 10 }}>{option.label ?? ''}</div>
+        </li>
+      )}
+    />
+  );
+};
+
+export default MyOrganizationField;

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/RequestAccessConfigurationEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/RequestAccessConfigurationEdition.tsx
@@ -152,6 +152,8 @@ const RequestAccessConfigurationEdition: FunctionComponent<RequestAccessWorkflow
                 style={fieldSpacingContainerStyle}
                 scope='REQUEST_ACCESS'
               />
+              {/* When multiple is moved to true, need to change access.canRequestAccess method,
+                search for request_access_workflow.approval_admin */}
               <GroupField
                 name="approvalAdmin"
                 label={t_i18n('Validator group membership:')}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10595,6 +10595,11 @@ input CaseIncidentAddInput {
   authorized_members: [MemberAccessInput!]
 }
 
+type RfiRequestAccessConfiguration {
+  configuration: RequestAccessConfiguration
+  isUserCanAction: Boolean!
+}
+
 type CaseRfi implements BasicObject & StixObject & StixCoreObject & StixDomainObject & Container & Case {
   id: ID!
   standard_id: String!
@@ -10661,7 +10666,7 @@ type CaseRfi implements BasicObject & StixObject & StixCoreObject & StixDomainOb
   severity: String
   priority: String
   x_opencti_request_access: String
-  requestAccessConfiguration: RequestAccessConfiguration
+  requestAccessConfiguration: RfiRequestAccessConfiguration
   x_opencti_workflow_id: String
 }
 

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -77,7 +77,7 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation'] }, async ({ pa
   await expect(page.getByText('This field is required')).toBeVisible();
   await reportForm.publicationDateField.fill('2023-12-05');
   await expect(page.getByText('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')).toBeVisible();
-  await reportForm.publicationDateField.fill('2023-12-05 12:00 AM');
+  await reportForm.publicationDateField.fill('2023-12-05 12:00:00 AM');
   await expect(page.getByText('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')).toBeHidden();
 
   await reportForm.reportTypesAutocomplete.selectOption('malware');

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -55,7 +55,7 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation'] }, async ({ pa
   // region Check default values in the form
   // ---------------------------------------
 
-  await expect(reportForm.publicationDateField.getInput()).toHaveValue('2024-04-01 12:00 PM');
+  await expect(reportForm.publicationDateField.getInput()).toHaveValue('2024-04-01 12:00:00 PM');
   await expect(reportForm.confidenceLevelField.getInput()).toHaveValue('100');
 
   // ---------

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -245,7 +245,6 @@ export const createInitialRequestAccessFlow = async (context) => {
   const statusTemplateDeclined = await createStatusTemplate(context, SYSTEM_USER, { name: 'DECLINED', color: '#b83f13' });
   const statusTemplateApproved = await createStatusTemplate(context, SYSTEM_USER, { name: 'APPROVED', color: '#4caf50' });
 
-  // TODO exclude scope request-access from search first status and order can be 0.
   const statusEntityRFIDeclined = await createStatus(
     context,
     SYSTEM_USER,
@@ -269,7 +268,6 @@ export const createInitialRequestAccessFlow = async (context) => {
     const editInput = [
       { key: 'request_access_workflow', value: [initialConfig] }
     ];
-    // TODO use updateAttribute instead
     await updateAttribute(context, SYSTEM_USER, rfiEntitySettings.id, ENTITY_TYPE_ENTITY_SETTING, editInput);
   }
 };

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -270,9 +270,7 @@ export const createInitialRequestAccessFlow = async (context) => {
       { key: 'request_access_workflow', value: [initialConfig] }
     ];
     // TODO use updateAttribute instead
-    // await updateAttribute(context, user, rfiEntitySettings.id, ENTITY_TYPE_ENTITY_SETTING, {request_access_workflow});
     await updateAttribute(context, SYSTEM_USER, rfiEntitySettings.id, ENTITY_TYPE_ENTITY_SETTING, editInput);
-    // await entitySettingEditField(context, SYSTEM_USER, rfiEntitySettings.id, editInput);
   }
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -239,26 +239,7 @@ export const statusTemplateUsagesNumber = async (context: AuthContext, user: Aut
 };
 
 export const isGlobalWorkflowEnabled = async (context: AuthContext, user: AuthUser, subTypeId: string) => {
-  // FIXME cache issue here
-  // const entityStatusFromCache = await findByType(context, user, subTypeId);
-
-  const args: QueryStatusesArgs = {
-    filters: {
-      mode: FilterMode.And,
-      filterGroups: [],
-      filters: [
-        { key: ['type'], values: [subTypeId] },
-        { key: ['scope'], values: [StatusScope.Global] },
-      ],
-    },
-    orderBy: StatusOrdering.Order,
-    orderMode: OrderingMode.Asc,
-  };
-
-  const entityStatusFromDB = await findAll(context, user, args);
-
-  // TODO remove this filter if we don't use cache
-  const globalStatuses = entityStatusFromDB.edges.filter((status) => status.node.scope === StatusScope.Global);
-  logApp.info('isGlobalWorkflowEnabled - current:', { subTypeId, globalStatuses, entityStatusFromDB, args });
+  const entityStatusFromCache = await findByType(context, user, subTypeId);
+  const globalStatuses = entityStatusFromCache.filter((status) => status.scope === StatusScope.Global);
   return globalStatuses.length > 0;
 };

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -30,8 +30,8 @@ import { publishUserAction } from '../listener/UserActionListener';
 import { validateSetting } from '../modules/entitySetting/entitySetting-validators';
 import { telemetry } from '../config/tracing';
 
-export const findTemplateById = (context: AuthContext, user: AuthUser, statusTemplateId: string): StatusTemplate => {
-  return storeLoadById(context, user, statusTemplateId, ENTITY_TYPE_STATUS_TEMPLATE) as unknown as StatusTemplate;
+export const findTemplateById = async (context: AuthContext, user: AuthUser, statusTemplateId: string) => {
+  return await storeLoadById(context, user, statusTemplateId, ENTITY_TYPE_STATUS_TEMPLATE) as unknown as StatusTemplate;
 };
 export const findAllTemplates = async (context: AuthContext, user: AuthUser, args: QueryStatusTemplatesArgs) => {
   return listEntitiesPaginated<BasicStoreEntity>(context, user, [ENTITY_TYPE_STATUS_TEMPLATE], args);

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -21,7 +21,7 @@ import {
 } from '../generated/graphql';
 import type { AuthContext, AuthUser } from '../types/user';
 import { delEditContext, notify, setEditContext } from '../database/redis';
-import { BUS_TOPICS } from '../config/conf';
+import { BUS_TOPICS, logApp } from '../config/conf';
 import type { BasicStoreEntity, BasicWorkflowStatus } from '../types/store';
 import { getEntitiesListFromCache } from '../database/cache';
 import { READ_INDEX_INTERNAL_OBJECTS } from '../database/utils';
@@ -140,6 +140,8 @@ export const createStatusTemplate = async (context: AuthContext, user: AuthUser,
 export const createStatus = async (context: AuthContext, user: AuthUser, subTypeId: string, input: StatusAddInput) => {
   validateSetting(subTypeId, 'workflow_configuration');
   const data = await createEntity(context, user, { type: subTypeId, ...input }, ENTITY_TYPE_STATUS);
+  logApp.info('Create status:', { subTypeId, input });
+  // FIXME Status cache is not invalidated here, and should
   await publishUserAction({
     user,
     event_type: 'mutation',
@@ -234,4 +236,29 @@ export const statusTemplateUsagesNumber = async (context: AuthContext, user: Aut
   const result = elCount(context, user, READ_INDEX_INTERNAL_OBJECTS, options);
   const count = await Promise.all([result]);
   return count[0];
+};
+
+export const isGlobalWorkflowEnabled = async (context: AuthContext, user: AuthUser, subTypeId: string) => {
+  // FIXME cache issue here
+  // const entityStatusFromCache = await findByType(context, user, subTypeId);
+
+  const args: QueryStatusesArgs = {
+    filters: {
+      mode: FilterMode.And,
+      filterGroups: [],
+      filters: [
+        { key: ['type'], values: [subTypeId] },
+        { key: ['scope'], values: [StatusScope.Global] },
+      ],
+    },
+    orderBy: StatusOrdering.Order,
+    orderMode: OrderingMode.Asc,
+  };
+
+  const entityStatusFromDB = await findAll(context, user, args);
+
+  // TODO remove this filter if we don't use cache
+  const globalStatuses = entityStatusFromDB.edges.filter((status) => status.node.scope === StatusScope.Global);
+  logApp.info('isGlobalWorkflowEnabled - current:', { subTypeId, globalStatuses, entityStatusFromDB, args });
+  return globalStatuses.length > 0;
 };

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -30,8 +30,8 @@ import { publishUserAction } from '../listener/UserActionListener';
 import { validateSetting } from '../modules/entitySetting/entitySetting-validators';
 import { telemetry } from '../config/tracing';
 
-export const findTemplateById = async (context: AuthContext, user: AuthUser, statusTemplateId: string) => {
-  return await storeLoadById(context, user, statusTemplateId, ENTITY_TYPE_STATUS_TEMPLATE) as unknown as StatusTemplate;
+export const findTemplateById = (context: AuthContext, user: AuthUser, statusTemplateId: string): StatusTemplate => {
+  return storeLoadById(context, user, statusTemplateId, ENTITY_TYPE_STATUS_TEMPLATE) as unknown as StatusTemplate;
 };
 export const findAllTemplates = async (context: AuthContext, user: AuthUser, args: QueryStatusTemplatesArgs) => {
   return listEntitiesPaginated<BasicStoreEntity>(context, user, [ENTITY_TYPE_STATUS_TEMPLATE], args);

--- a/opencti-platform/opencti-graphql/src/domain/status.ts
+++ b/opencti-platform/opencti-graphql/src/domain/status.ts
@@ -21,7 +21,7 @@ import {
 } from '../generated/graphql';
 import type { AuthContext, AuthUser } from '../types/user';
 import { delEditContext, notify, setEditContext } from '../database/redis';
-import { BUS_TOPICS, logApp } from '../config/conf';
+import { BUS_TOPICS } from '../config/conf';
 import type { BasicStoreEntity, BasicWorkflowStatus } from '../types/store';
 import { getEntitiesListFromCache } from '../database/cache';
 import { READ_INDEX_INTERNAL_OBJECTS } from '../database/utils';
@@ -140,8 +140,6 @@ export const createStatusTemplate = async (context: AuthContext, user: AuthUser,
 export const createStatus = async (context: AuthContext, user: AuthUser, subTypeId: string, input: StatusAddInput) => {
   validateSetting(subTypeId, 'workflow_configuration');
   const data = await createEntity(context, user, { type: subTypeId, ...input }, ENTITY_TYPE_STATUS);
-  logApp.info('Create status:', { subTypeId, input });
-  // FIXME Status cache is not invalidated here, and should
   await publishUserAction({
     user,
     event_type: 'mutation',

--- a/opencti-platform/opencti-graphql/src/domain/subType.ts
+++ b/opencti-platform/opencti-graphql/src/domain/subType.ts
@@ -11,6 +11,7 @@ import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../schema/stixCyberObservable
 import { telemetry } from '../config/tracing';
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
+
 // -- ENTITY TYPES --
 
 export const queryDefaultSubTypes = async (context: AuthContext, user: AuthUser, search : string | null = null) => {

--- a/opencti-platform/opencti-graphql/src/domain/subType.ts
+++ b/opencti-platform/opencti-graphql/src/domain/subType.ts
@@ -11,7 +11,6 @@ import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../schema/stixCyberObservable
 import { telemetry } from '../config/tracing';
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
-
 // -- ENTITY TYPES --
 
 export const queryDefaultSubTypes = async (context: AuthContext, user: AuthUser, search : string | null = null) => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -2564,7 +2564,7 @@ export type CaseRfi = BasicObject & Case & Container & StixCoreObject & StixDoma
   relatedContainers?: Maybe<ContainerConnection>;
   reports?: Maybe<ReportConnection>;
   representative: Representative;
-  requestAccessConfiguration?: Maybe<RequestAccessConfiguration>;
+  requestAccessConfiguration?: Maybe<RfiRequestAccessConfiguration>;
   revoked: Scalars['Boolean']['output'];
   severity?: Maybe<Scalars['String']['output']>;
   spec_version: Scalars['String']['output'];
@@ -23545,6 +23545,12 @@ export enum RetentionUnit {
   Minutes = 'minutes'
 }
 
+export type RfiRequestAccessConfiguration = {
+  __typename?: 'RfiRequestAccessConfiguration';
+  configuration?: Maybe<RequestAccessConfiguration>;
+  isUserCanAction: Scalars['Boolean']['output'];
+};
+
 export type Role = BasicObject & InternalObject & {
   __typename?: 'Role';
   can_manage_sensitive_config?: Maybe<Scalars['Boolean']['output']>;
@@ -32033,6 +32039,7 @@ export type ResolversTypes = ResolversObject<{
   RetentionRuleOrdering: RetentionRuleOrdering;
   RetentionRuleScope: RetentionRuleScope;
   RetentionUnit: RetentionUnit;
+  RfiRequestAccessConfiguration: ResolverTypeWrapper<Omit<RfiRequestAccessConfiguration, 'configuration'> & { configuration?: Maybe<ResolversTypes['RequestAccessConfiguration']> }>;
   Role: ResolverTypeWrapper<Omit<Role, 'capabilities' | 'editContext'> & { capabilities?: Maybe<Array<Maybe<ResolversTypes['Capability']>>>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>> }>;
   RoleAddInput: RoleAddInput;
   RoleConnection: ResolverTypeWrapper<Omit<RoleConnection, 'edges'> & { edges?: Maybe<Array<ResolversTypes['RoleEdge']>> }>;
@@ -32840,6 +32847,7 @@ export type ResolversParentTypes = ResolversObject<{
   RetentionRuleConnection: RetentionRuleConnection;
   RetentionRuleEdge: RetentionRuleEdge;
   RetentionRuleEditMutations: RetentionRuleEditMutations;
+  RfiRequestAccessConfiguration: Omit<RfiRequestAccessConfiguration, 'configuration'> & { configuration?: Maybe<ResolversParentTypes['RequestAccessConfiguration']> };
   Role: Omit<Role, 'capabilities' | 'editContext'> & { capabilities?: Maybe<Array<Maybe<ResolversParentTypes['Capability']>>>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>> };
   RoleAddInput: RoleAddInput;
   RoleConnection: Omit<RoleConnection, 'edges'> & { edges?: Maybe<Array<ResolversParentTypes['RoleEdge']>> };
@@ -33966,7 +33974,7 @@ export type CaseRfiResolvers<ContextType = any, ParentType extends ResolversPare
   relatedContainers?: Resolver<Maybe<ResolversTypes['ContainerConnection']>, ParentType, ContextType, Partial<CaseRfiRelatedContainersArgs>>;
   reports?: Resolver<Maybe<ResolversTypes['ReportConnection']>, ParentType, ContextType, Partial<CaseRfiReportsArgs>>;
   representative?: Resolver<ResolversTypes['Representative'], ParentType, ContextType>;
-  requestAccessConfiguration?: Resolver<Maybe<ResolversTypes['RequestAccessConfiguration']>, ParentType, ContextType>;
+  requestAccessConfiguration?: Resolver<Maybe<ResolversTypes['RfiRequestAccessConfiguration']>, ParentType, ContextType>;
   revoked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   severity?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   spec_version?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -39974,6 +39982,12 @@ export type RetentionRuleEditMutationsResolvers<ContextType = any, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type RfiRequestAccessConfigurationResolvers<ContextType = any, ParentType extends ResolversParentTypes['RfiRequestAccessConfiguration'] = ResolversParentTypes['RfiRequestAccessConfiguration']> = ResolversObject<{
+  configuration?: Resolver<Maybe<ResolversTypes['RequestAccessConfiguration']>, ParentType, ContextType>;
+  isUserCanAction?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type RoleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Role'] = ResolversParentTypes['Role']> = ResolversObject<{
   can_manage_sensitive_config?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   capabilities?: Resolver<Maybe<Array<Maybe<ResolversTypes['Capability']>>>, ParentType, ContextType>;
@@ -43039,6 +43053,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   RetentionRuleConnection?: RetentionRuleConnectionResolvers<ContextType>;
   RetentionRuleEdge?: RetentionRuleEdgeResolvers<ContextType>;
   RetentionRuleEditMutations?: RetentionRuleEditMutationsResolvers<ContextType>;
+  RfiRequestAccessConfiguration?: RfiRequestAccessConfigurationResolvers<ContextType>;
   Role?: RoleResolvers<ContextType>;
   RoleConnection?: RoleConnectionResolvers<ContextType>;
   RoleEdge?: RoleEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi-resolvers.ts
@@ -3,8 +3,7 @@ import { buildRefRelationKey } from '../../../schema/general';
 import { RELATION_OBJECT_ASSIGNEE } from '../../../schema/stixRefRelationship';
 import { stixDomainObjectDelete } from '../../../domain/stixDomainObject';
 import { addCaseRfi, caseRfiContainsStixObjectOrStixRelationship, findAll, findById } from './case-rfi-domain';
-import { approveRequestAccess, declineRequestAccess, getRequestAccessConfiguration } from '../../requestAccess/requestAccess-domain';
-import type { BasicStoreEntityEntitySetting } from '../../entitySetting/entitySetting-types';
+import { approveRequestAccess, declineRequestAccess, getRfiAccessConfiguration } from '../../requestAccess/requestAccess-domain';
 
 const caseRfiResolvers: Resolvers = {
   Query: {
@@ -15,7 +14,7 @@ const caseRfiResolvers: Resolvers = {
     },
   },
   CaseRfi: {
-    requestAccessConfiguration: (entitySetting, _, context) => getRequestAccessConfiguration(context, context.user, entitySetting as unknown as BasicStoreEntityEntitySetting),
+    requestAccessConfiguration: (caseRfi, _, context) => getRfiAccessConfiguration(context, context.user, caseRfi),
   },
   CaseRfisOrdering: {
     creator: 'creator_id',

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
@@ -1,3 +1,8 @@
+type RfiRequestAccessConfiguration {
+  configuration: RequestAccessConfiguration
+  isUserCanAction: Boolean!
+}
+
 type CaseRfi implements BasicObject & StixObject & StixCoreObject & StixDomainObject & Container & Case {
   id: ID! # internal_id
   standard_id: String!
@@ -167,7 +172,7 @@ type CaseRfi implements BasicObject & StixObject & StixCoreObject & StixDomainOb
   severity: String
   priority: String
   x_opencti_request_access: String
-  requestAccessConfiguration: RequestAccessConfiguration
+  requestAccessConfiguration: RfiRequestAccessConfiguration
   x_opencti_workflow_id: String
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
@@ -403,7 +403,7 @@ export const addRequestAccess = async (context: AuthContext, user: AuthUser, inp
   return requestForInformation.id;
 };
 
-export const checkRequestAction = async (context: AuthContext, user: AuthUser, id: string) => {
+export const checkRequestAction = async (context: AuthContext, user: AuthUser, id: string, status: ActionStatus) => {
   // region Check validity
   await checkRequestAccessEnabled(context, user);
   const rfi = await findRFIById(context, user, id);
@@ -415,7 +415,7 @@ export const checkRequestAction = async (context: AuthContext, user: AuthUser, i
   if (!action.entities || !action.members) {
     throw UnsupportedError('This RFI is not compatible');
   }
-  const x_opencti_workflow_id = await getRFIStatusForAction(context, user, ActionStatus.APPROVED);
+  const x_opencti_workflow_id = await getRFIStatusForAction(context, user, status);
   if (isEmptyField((x_opencti_workflow_id))) {
     throw UnsupportedError('This RFI is not correctly configured');
   }
@@ -426,7 +426,7 @@ export const checkRequestAction = async (context: AuthContext, user: AuthUser, i
 export const approveRequestAccess = async (context: AuthContext, user: AuthUser, id: string) => {
   logApp.debug('[OPENCTI-MODULE][Request Access] Approving request access:', { id });
   // region Check validity
-  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id);
+  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id, ActionStatus.APPROVED);
   // endregion
   // region Check if the target instance can be manipulated
   const targetInstanceToShare = (action.entities ?? [])[0];
@@ -476,7 +476,7 @@ export const approveRequestAccess = async (context: AuthContext, user: AuthUser,
 export const declineRequestAccess = async (context: AuthContext, user: AuthUser, id: string) => {
   logApp.debug(`[OPENCTI-MODULE][Request Access] Reject for RFI ${id}`);
   // region Check validity
-  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id);
+  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id, ActionStatus.DECLINED);
   // endregion
   // region Moving RFI to rejected
   const allActionStatuses = await getRFIStatusMap(context, user);

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
@@ -12,7 +12,15 @@ import {
   StatusScope
 } from '../../generated/graphql';
 import { addCaseRfi, findById as findRFIById } from '../case/case-rfi/case-rfi-domain';
-import { MEMBER_ACCESS_RIGHT_ADMIN, MEMBER_ACCESS_RIGHT_EDIT, SYSTEM_USER } from '../../utils/access';
+import {
+  getUserAccessRight,
+  isUserCanAccessStoreElement,
+  isUserHasCapability,
+  KNOWLEDGE_ORGANIZATION_RESTRICT,
+  MEMBER_ACCESS_RIGHT_ADMIN,
+  MEMBER_ACCESS_RIGHT_EDIT,
+  SYSTEM_USER
+} from '../../utils/access';
 import { internalLoadById, listAllEntities } from '../../database/middleware-loader';
 import { ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS } from '../../schema/internalObject';
 import { BUS_TOPICS, logApp } from '../../config/conf';
@@ -23,7 +31,7 @@ import { findById as findOrganizationById } from '../organization/organization-d
 import { elLoadById } from '../../database/engine';
 import type { BasicGroupEntity, BasicStoreBase, BasicStoreCommon, BasicWorkflowStatus } from '../../types/store';
 import { extractEntityRepresentativeName } from '../../database/entity-representative';
-import { ENTITY_TYPE_CONTAINER_CASE_RFI } from '../case/case-rfi/case-rfi-types';
+import { type BasicStoreEntityCaseRfi, ENTITY_TYPE_CONTAINER_CASE_RFI } from '../case/case-rfi/case-rfi-types';
 import { FunctionalError, UnsupportedError, ValidationError } from '../../config/errors';
 import { getEntitiesListFromCache, getEntityFromCache } from '../../database/cache';
 import type { BasicStoreSettings } from '../../types/settings';
@@ -198,67 +206,81 @@ export const computeAuthorizedMembersForRequestAccess = async (context: AuthCont
   return authorizedMembers;
 };
 
+export const isUserCanActionRequestAccess = async (context: AuthContext, user: AuthUser, rfi: BasicStoreEntityCaseRfi) => {
+  // User need to have edit capability on the RFI
+  const userAccessRight = getUserAccessRight(user, rfi);
+  const isRfiRestricted = userAccessRight === MEMBER_ACCESS_RIGHT_ADMIN || userAccessRight === MEMBER_ACCESS_RIGHT_EDIT;
+  const isRfiAccessible = await isUserCanAccessStoreElement(context, user, rfi);
+  const isCanEdit = isRfiAccessible && isRfiRestricted;
+  // User need to have sharing capability to start the action
+  const isCanManageSharing = isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT); // Imply KNUPDATE
+  return isCanEdit && isCanManageSharing;
+};
+
 export const getRequestAccessConfiguration = async (
   context: AuthContext,
   user: AuthUser,
-  entitySetting: BasicStoreEntityEntitySetting | undefined
+  entitySetting: BasicStoreEntityEntitySetting
 ) => {
-  let rfiEntitySettings = entitySetting;
-  if (entitySetting) {
-    rfiEntitySettings = await getRfiEntitySettings(context, user);
-  }
-  logApp.debug('[OPENCTI-MODULE][Request Access] getRequestAccessConfiguration - entitySetting:', { rfiEntitySettings });
+  logApp.debug('[OPENCTI-MODULE][Request Access] getRequestAccessConfiguration - entitySetting:', { entitySettings: entitySetting });
   let declinedStatus;
   let approvedStatus;
   const allAdmins = [];
-  if (rfiEntitySettings) {
-    logApp.debug('[OPENCTI-MODULE][Request Access] rfiEntitySettings ok', {
-      approvedId: rfiEntitySettings.request_access_workflow?.approved_workflow_id,
-      declinedId: rfiEntitySettings.request_access_workflow?.declined_workflow_id,
-      approval_admin: rfiEntitySettings.request_access_workflow?.approval_admin,
-    });
+  logApp.debug('[OPENCTI-MODULE][Request Access] entitySetting ok', {
+    approvedId: entitySetting.request_access_workflow?.approved_workflow_id,
+    declinedId: entitySetting.request_access_workflow?.declined_workflow_id,
+    approval_admin: entitySetting.request_access_workflow?.approval_admin,
+  });
+  const declinedId = entitySetting.request_access_workflow?.declined_workflow_id;
+  if (declinedId) {
+    logApp.debug('[OPENCTI-MODULE][Request Access] findStatusById:', { statusId: declinedId });
+    declinedStatus = await findStatusById(context, user, declinedId);
+  }
+  if (entitySetting.request_access_workflow?.approved_workflow_id) {
+    logApp.debug('[OPENCTI-MODULE][Request Access] findStatusById:', { statusId: entitySetting.request_access_workflow?.approved_workflow_id });
+    approvedStatus = await findStatusById(context, user, entitySetting.request_access_workflow?.approved_workflow_id);
+  }
+  if (entitySetting.request_access_workflow?.approval_admin) {
+    logApp.debug('[OPENCTI-MODULE][Request Access] approval_admin before looking for members:', { approval_admin: entitySetting.request_access_workflow?.approval_admin });
 
-    const declinedId = rfiEntitySettings.request_access_workflow?.declined_workflow_id;
-    if (declinedId) {
-      logApp.debug('[OPENCTI-MODULE][Request Access] findStatusById:', { statusId: declinedId });
-      declinedStatus = await findStatusById(context, user, declinedId);
-    }
+    const approvalAdminIds = entitySetting.request_access_workflow?.approval_admin;
 
-    if (rfiEntitySettings.request_access_workflow?.approved_workflow_id) {
-      logApp.debug('[OPENCTI-MODULE][Request Access] findStatusById:', { statusId: rfiEntitySettings.request_access_workflow?.approved_workflow_id });
-      approvedStatus = await findStatusById(context, user, rfiEntitySettings.request_access_workflow?.approved_workflow_id);
-    }
-
-    if (rfiEntitySettings.request_access_workflow?.approval_admin) {
-      logApp.debug('[OPENCTI-MODULE][Request Access] approval_admin before looking for members:', { approval_admin: rfiEntitySettings.request_access_workflow?.approval_admin });
-
-      const approvalAdminIds = rfiEntitySettings.request_access_workflow?.approval_admin;
-
-      if (approvalAdminIds.length > 0) {
-        for (let i = 0; i < approvalAdminIds.length; i += 1) {
-          const group: BasicGroupEntity = await findGroupById(context, user, approvalAdminIds[0]) as unknown as BasicGroupEntity;
-          logApp.debug('[OPENCTI-MODULE][Request Access] approval_admin members:', { group });
-          // group previously selected can be deleted at some point.
-          if (group) {
-            allAdmins.push({
-              id: group.id,
-              name: group.name
-            });
-          }
+    if (approvalAdminIds.length > 0) {
+      for (let i = 0; i < approvalAdminIds.length; i += 1) {
+        const group: BasicGroupEntity = await findGroupById(context, user, approvalAdminIds[0]) as unknown as BasicGroupEntity;
+        logApp.debug('[OPENCTI-MODULE][Request Access] approval_admin members:', { group });
+        // group previously selected can be deleted at some point.
+        if (group) {
+          allAdmins.push({
+            id: group.id,
+            name: group.name
+          });
         }
       }
     }
-
-    const requestAccessConfigResult: RequestAccessConfiguration = {
-      declined_status: declinedStatus,
-      approved_status: approvedStatus,
-      approval_admin: allAdmins,
-      id: REQUEST_ACCESS_CONFIGURATION_ID,
-    };
-    logApp.debug('[OPENCTI-MODULE][Request Access] getRequestAccessConfiguration result:', requestAccessConfigResult);
-    return requestAccessConfigResult;
   }
-  return null;
+  const requestAccessConfigResult: RequestAccessConfiguration = {
+    declined_status: declinedStatus,
+    approved_status: approvedStatus,
+    approval_admin: allAdmins,
+    id: REQUEST_ACCESS_CONFIGURATION_ID,
+  };
+  logApp.debug('[OPENCTI-MODULE][Request Access] getRequestAccessConfiguration result:', requestAccessConfigResult);
+  return requestAccessConfigResult;
+};
+
+export const getRfiAccessConfiguration = async (
+  context: AuthContext,
+  user: AuthUser,
+  rfi: BasicStoreEntityCaseRfi
+) => {
+  const rfiEntitySettings = await getRfiEntitySettings(context, user);
+  const requestAccessConfiguration = await getRequestAccessConfiguration(context, user, rfiEntitySettings);
+  const isUserCanAction = await isUserCanActionRequestAccess(context, user, rfi);
+  return {
+    configuration: requestAccessConfiguration,
+    isUserCanAction
+  };
 };
 
 export const configureRequestAccess = async (context: AuthContext, user: AuthUser, input: RequestAccessConfigureInput) => {

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
@@ -35,7 +35,7 @@ import { getDraftContext } from '../../utils/draftContext';
 import { notify } from '../../database/redis';
 import { publishUserAction } from '../../listener/UserActionListener';
 import { verifyRequestAccessEnabled } from './requestAccessUtils';
-import { isEmptyField } from '../../database/utils';
+import { isEmptyField, isNotEmptyField } from '../../database/utils';
 
 export const REQUEST_SHARE_ACCESS_INFO_TYPE = 'Request sharing';
 
@@ -402,6 +402,10 @@ export const approveRequestAccess = async (context: AuthContext, user: AuthUser,
   const instanceToShare = await internalLoadById(context, user, targetInstanceToShare);
   if (isEmptyField(instanceToShare)) {
     throw UnsupportedError('You cant share the requested element (restrictions or markings)');
+  }
+  // If user have access but restrictions is applied, element will not be shared by organization
+  if (isNotEmptyField((instanceToShare.restricted_members))) {
+    throw UnsupportedError('Element is not sharable at the moment (restricted)');
   }
   await addOrganizationRestriction(context, user, targetInstanceToShare, action.members[0]);
   // endregion

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
@@ -44,6 +44,7 @@ import { notify } from '../../database/redis';
 import { publishUserAction } from '../../listener/UserActionListener';
 import { verifyRequestAccessEnabled } from './requestAccessUtils';
 import { isEmptyField, isNotEmptyField } from '../../database/utils';
+import { RELATION_OBJECT_MARKING } from '../../schema/stixRefRelationship';
 
 export const REQUEST_SHARE_ACCESS_INFO_TYPE = 'Request sharing';
 
@@ -393,6 +394,7 @@ export const addRequestAccess = async (context: AuthContext, user: AuthUser, inp
     information_types: [REQUEST_SHARE_ACCESS_INFO_TYPE],
     x_opencti_request_access: `${JSON.stringify(action)}`,
     authorized_members,
+    objectMarking: elementData[RELATION_OBJECT_MARKING] ?? [],
     x_opencti_workflow_id: firstStatus.id,
     revoked: false
   };

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccess-domain.ts
@@ -403,7 +403,7 @@ export const addRequestAccess = async (context: AuthContext, user: AuthUser, inp
   return requestForInformation.id;
 };
 
-export const checkRequestAction = async (context: AuthContext, user: AuthUser, id: string, status: ActionStatus) => {
+export const checkRequestActionAndGetWorkflow = async (context: AuthContext, user: AuthUser, id: string, status: ActionStatus) => {
   // region Check validity
   await checkRequestAccessEnabled(context, user);
   const rfi = await findRFIById(context, user, id);
@@ -426,7 +426,7 @@ export const checkRequestAction = async (context: AuthContext, user: AuthUser, i
 export const approveRequestAccess = async (context: AuthContext, user: AuthUser, id: string) => {
   logApp.debug('[OPENCTI-MODULE][Request Access] Approving request access:', { id });
   // region Check validity
-  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id, ActionStatus.APPROVED);
+  const { action, x_opencti_workflow_id } = await checkRequestActionAndGetWorkflow(context, user, id, ActionStatus.APPROVED);
   // endregion
   // region Check if the target instance can be manipulated
   const targetInstanceToShare = (action.entities ?? [])[0];
@@ -476,7 +476,7 @@ export const approveRequestAccess = async (context: AuthContext, user: AuthUser,
 export const declineRequestAccess = async (context: AuthContext, user: AuthUser, id: string) => {
   logApp.debug(`[OPENCTI-MODULE][Request Access] Reject for RFI ${id}`);
   // region Check validity
-  const { action, x_opencti_workflow_id } = await checkRequestAction(context, user, id, ActionStatus.DECLINED);
+  const { action, x_opencti_workflow_id } = await checkRequestActionAndGetWorkflow(context, user, id, ActionStatus.DECLINED);
   // endregion
   // region Moving RFI to rejected
   const allActionStatuses = await getRFIStatusMap(context, user);

--- a/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccessUtils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/requestAccess/requestAccessUtils.ts
@@ -1,4 +1,4 @@
-import { isFeatureEnabled } from '../../config/conf';
+import { isFeatureEnabled, logApp } from '../../config/conf';
 import type { BasicStoreSettings } from '../../types/settings';
 import type { BasicStoreEntityEntitySetting } from '../entitySetting/entitySetting-types';
 
@@ -28,16 +28,18 @@ export const verifyRequestAccessEnabled = (settings: BasicStoreSettings, rfiEnti
   }
 
   // 4. At least one auth member admin should be configured.
-  const isRequestAccesApprovalAdminConfigured: boolean = rfiEntitySettings?.request_access_workflow?.approval_admin !== undefined
+  const isRequestAccessApprovalAdminConfigured: boolean = rfiEntitySettings?.request_access_workflow?.approval_admin !== undefined
     && rfiEntitySettings?.request_access_workflow?.approval_admin.length >= 1;
-  if (!isRequestAccesApprovalAdminConfigured) {
+  if (!isRequestAccessApprovalAdminConfigured) {
     message.push('At least one approval administrator must be configured in entity settings.');
   }
 
   const isEnabled: boolean = isEEConfigured
     && isPlatformOrgSetup
     && areRequestAccessStatusConfigured
-    && isRequestAccesApprovalAdminConfigured;
+    && isRequestAccessApprovalAdminConfigured;
+
+  logApp.debug('Request access enabled result:', { enabled: isEnabled, message: message.join(' ') });
 
   return {
     enabled: isEnabled,

--- a/opencti-platform/opencti-graphql/src/resolvers/subType.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/subType.js
@@ -1,5 +1,5 @@
 import { findAll, findById as findSubTypeById, findById } from '../domain/subType';
-import { batchGlobalStatusesByType, batchRequestAccessStatusesByType, createStatus, getTypeStatuses, statusDelete, statusEditField } from '../domain/status';
+import { batchGlobalStatusesByType, batchRequestAccessStatusesByType, createStatus, isGlobalWorkflowEnabled, statusDelete, statusEditField } from '../domain/status';
 import { batchEntitySettingsByType } from '../modules/entitySetting/entitySetting-domain';
 import { batchLoader } from '../database/middleware';
 
@@ -13,10 +13,7 @@ const subTypeResolvers = {
     subTypes: (_, args, context) => findAll(context, context.user, args),
   },
   SubType: {
-    workflowEnabled: async (current, _, context) => {
-      const statusesEdges = await getTypeStatuses(context, context.user, current.label);
-      return statusesEdges.edges.length > 0;
-    },
+    workflowEnabled: (current, _, context) => isGlobalWorkflowEnabled(context, context.user, current.id),
     statuses: (current, _, context) => statusesGlobalByTypeLoader.load(current.id, context, context.user),
     statusesRequestAccess: (current, _, context) => statusesRequestAccessByTypeLoader.load(current.id, context, context.user),
     settings: (current, _, context) => entitySettingsByTypeLoader.load(current.id, context, context.user), // Simpler before moving workflow

--- a/opencti-platform/opencti-graphql/src/types/store.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/store.d.ts
@@ -118,6 +118,7 @@ interface BasicStoreBase extends BasicStoreIdentifier {
   draft_change?: DraftChange;
   // representative
   representative: Representative
+  restricted_members?: Array<AuthorizedMember>;
 }
 
 interface StoreMarkingDefinition extends BasicStoreEntity {
@@ -184,7 +185,6 @@ interface BasicStoreCommon extends BasicStoreBase {
   [RELATION_OBJECT_ASSIGNEE]?: Array<string>;
   [RELATION_OBJECT_PARTICIPANT]?: Array<string>;
   [RELATION_EXTERNAL_REFERENCE]?: Array<string>;
-  restricted_members?: Array<AuthorizedMember>;
 }
 
 interface StoreCommon {

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -528,19 +528,6 @@ export const isMarkingAllowed = (element: BasicStoreCommon, userAuthorizedMarkin
   return true;
 };
 
-export const canRequestAccess = async (context: AuthContext, user: AuthUser, elements: Array<BasicStoreCommon>) => {
-  const settings = await getEntityFromCache<BasicStoreSettings>(context, user, ENTITY_TYPE_SETTINGS);
-  const hasPlatformOrg = !!settings.platform_organization;
-  const elementsThatRequiresAccess: Array<BasicStoreCommon> = [];
-  for (let i = 0; i < elements.length; i += 1) {
-    if (!isOrganizationAllowed(context, elements[i], user, hasPlatformOrg)) {
-      elementsThatRequiresAccess.push(elements[i]);
-    }
-    // TODO before removing ORGA_SHARING_REQUEST_FF: When it's ready check Authorized members
-  }
-  return elementsThatRequiresAccess;
-};
-
 export const checkUserFilterStoreElements = (
   context: AuthContext,
   user: AuthUser,

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/requestAccess-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/requestAccess-domain-test.ts
@@ -40,7 +40,7 @@ describe('Request access domain  - initialized status', async () => {
     expect(approvedStatusId?.length, 'The status id must be a string not empty').toBeGreaterThan(1);
     if (approvedStatusId) {
       const statusInRfi = await findStatusById(testContext, ADMIN_USER, approvedStatusId);
-      const statusData = await findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
+      const statusData = findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
       expect(statusData.name).toBe('APPROVED');
     }
 
@@ -49,7 +49,7 @@ describe('Request access domain  - initialized status', async () => {
     expect(declinedStatusId?.length, 'The status id must be a string not empty').toBeGreaterThan(1);
     if (declinedStatusId) {
       const statusInRfi = await findStatusById(testContext, ADMIN_USER, declinedStatusId);
-      const statusData = await findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
+      const statusData = findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
       expect(statusData.name).toBe('DECLINED');
     }
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/requestAccess-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/requestAccess-domain-test.ts
@@ -40,7 +40,7 @@ describe('Request access domain  - initialized status', async () => {
     expect(approvedStatusId?.length, 'The status id must be a string not empty').toBeGreaterThan(1);
     if (approvedStatusId) {
       const statusInRfi = await findStatusById(testContext, ADMIN_USER, approvedStatusId);
-      const statusData = findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
+      const statusData = await findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
       expect(statusData.name).toBe('APPROVED');
     }
 
@@ -49,7 +49,7 @@ describe('Request access domain  - initialized status', async () => {
     expect(declinedStatusId?.length, 'The status id must be a string not empty').toBeGreaterThan(1);
     if (declinedStatusId) {
       const statusInRfi = await findStatusById(testContext, ADMIN_USER, declinedStatusId);
-      const statusData = findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
+      const statusData = await findTemplateById(testContext, ADMIN_USER, statusInRfi.template_id);
       expect(statusData.name).toBe('DECLINED');
     }
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/requestAccess-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/requestAccess-test.ts
@@ -461,7 +461,6 @@ describe('Add Request Access to an entity and create an RFI.', async () => {
     });
 
     expect(requestAccessData).not.toBeNull();
-    console.log('requestAccessData:', requestAccessData);
     caseRfiIdForApproval = requestAccessData?.data?.requestAccessAdd;
     expect(caseRfiIdForApproval).not.toBeNull();
   });
@@ -562,7 +561,6 @@ describe('Add Request Access to an entity and create an RFI.', async () => {
   });
 
   it('should reject the created Case RFI first time be ok', async () => {
-    // FIXME use a user and not admin !
     const queryResult = await queryAsUserWithSuccess(USER_EDITOR.client, {
       query: DECLINE_RFI_QUERY,
       variables: { id: caseRfiIdForReject },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* On entity settings configuration, the "workflow enabled" should be true only if there is global status configured.
* Organization choice in request access popup come from RootQuery "me" (instead of new query with filter) to avoid capacity issues on organization request => new component MyOrganizationField.tsx
* Verify element marking before proposing the request access button

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* relates to #9657 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
