### PR TITLE
Worker Thread Pool Size config variables should be integers

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -581,12 +581,14 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             "OPENCTI_EXECUTION_POOL_SIZE",
             ["opencti", "execution_pool_size"],
             config,
+            True,
             default=5,
         )
         self.listen_pool_size = get_config_variable(
             "WORKER_LISTEN_POOL_SIZE",
             ["worker", "listen_pool_size"],
             config,
+            True,
             default=5,
         )
         # Load worker config


### PR DESCRIPTION
### Proposed changes

Ensure Worker Thread Pool environment variables are set to integers

### Related issues
* https://github.com/OpenCTI-Platform/opencti/issues/10481


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments
