### PR TITLE
[frontend] open automatically first filter added (#9092)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -33,7 +33,7 @@ export interface FilterIconButtonProps {
 interface FilterIconButtonIfFiltersProps extends FilterIconButtonProps {
   filters: FilterGroup,
   hasRenderedRef: boolean;
-  setHasRenderedRef: () => void;
+  setHasRenderedRef: (value: boolean) => void;
 }
 const FilterIconButtonWithRepresentativesQuery: FunctionComponent<FilterIconButtonIfFiltersProps> = ({
   filters,
@@ -94,15 +94,16 @@ const FilterIconButtonWithRepresentativesQuery: FunctionComponent<FilterIconButt
   );
 };
 
-const EmptyFilter: FunctionComponent<{ setHasRenderedRef: () => void }> = ({ setHasRenderedRef }) => {
+interface EmptyFilterProps {
+  setHasRenderedRef: (value: boolean) => void
+}
+
+const EmptyFilter: FunctionComponent<EmptyFilterProps> = ({ setHasRenderedRef }) => {
   useEffect(() => {
-    setHasRenderedRef();
+    setHasRenderedRef(true);
   }, []);
   return null;
 };
-
-// availableEntityTypes
-// availableRelationshipTypes
 
 const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
   availableFilterKeys,
@@ -125,8 +126,8 @@ const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
   hasSavedFilters,
 }) => {
   const hasRenderedRef = useRef(false);
-  const setHasRenderedRef = () => {
-    hasRenderedRef.current = true;
+  const setHasRenderedRef = (value: boolean) => {
+    hasRenderedRef.current = value;
   };
   const displayedFilters = filters
     ? {

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -119,7 +119,7 @@ interface FilterIconButtonContainerProps {
   chipColor?: ChipOwnProps['color'];
   helpers?: handleFilterHelpers;
   hasRenderedRef: boolean;
-  setHasRenderedRef: () => void;
+  setHasRenderedRef: (value: boolean) => void;
   availableRelationFilterTypes?: Record<string, string[]>;
   entityTypes?: string[];
   filtersRestrictions?: FiltersRestrictions;
@@ -184,14 +184,13 @@ FilterIconButtonContainerProps
       const newFilterAdded = hasRenderedRef
         && itemRefToPopover.current
         && oldItemRefToPopover.current !== itemRefToPopover.current;
-      const firstFilterAdded = !hasRenderedRef && itemRefToPopover.current && oldItemRefToPopover.current === null;
-      if (newFilterAdded || firstFilterAdded) {
+      if (newFilterAdded) {
         setFilterChipsParams({
           filterId: helpers?.getLatestAddFilterId(),
           anchorEl: itemRefToPopover.current as unknown as HTMLElement,
         });
       } else {
-        setHasRenderedRef();
+        setHasRenderedRef(true);
       }
       oldItemRefToPopover.current = itemRefToPopover.current;
     }, [displayedFilters]);

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -181,7 +181,11 @@ FilterIconButtonContainerProps
     // activate popover feature on chip only when "helper" is defined, not the best way to handle but
     // it means that the new filter feature is activated. Will be removed in the next version when we generalize the feature on every filter.
     useEffect(() => {
-      if (hasRenderedRef && itemRefToPopover.current && oldItemRefToPopover.current !== itemRefToPopover.current) {
+      const newFilterAdded = hasRenderedRef
+        && itemRefToPopover.current
+        && oldItemRefToPopover.current !== itemRefToPopover.current;
+      const firstFilterAdded = !hasRenderedRef && itemRefToPopover.current && oldItemRefToPopover.current === null;
+      if (newFilterAdded || firstFilterAdded) {
         setFilterChipsParams({
           filterId: helpers?.getLatestAddFilterId(),
           anchorEl: itemRefToPopover.current as unknown as HTMLElement,

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -46,12 +46,8 @@ export const DataTableDisplayFilters = ({
     },
   } = useDataTableContext();
 
-  if (!isFilterGroupNotEmpty(filters)) {
-    return null;
-  }
-
   return (
-    <div id="filter-container" style={{ minHeight: 10, display: 'flex', alignItems: 'center' }}>
+    <div id="filter-container" style={{ display: 'flex', alignItems: 'center' }}>
       <FilterIconButton
         helpers={helpers}
         availableFilterKeys={availableFilterKeys}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FunctionComponent, ReactElement } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import { BiotechOutlined } from '@mui/icons-material';
@@ -9,12 +9,28 @@ import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import { useFormatter } from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
+import { Filter, FilterGroup } from '../../../../utils/filters/filtersHelpers-types';
+import { FilterSearchContext } from '../../../../utils/filters/filtersUtils';
 
-const DialogFilters = ({
+interface DialogFiltersProps {
+  handleOpenFilters: (event: React.SyntheticEvent) => void;
+  disabled?: boolean;
+  open: boolean;
+  filters?: FilterGroup;
+  handleCloseFilters: () => void;
+  defaultHandleRemoveFilter: (key: string, id?: string) => void;
+  handleSwitchGlobalMode?: () => void;
+  handleSwitchLocalMode?: (filter: Filter) => void;
+  handleSearch: () => void;
+  filterElement: ReactElement;
+  searchContext?: FilterSearchContext;
+  availableEntityTypes?: string[];
+  availableRelationshipTypes?: string[];
+}
+
+const DialogFilters: FunctionComponent<DialogFiltersProps> = ({
   handleOpenFilters,
   disabled,
-  size,
-  fontSize,
   open,
   filters,
   handleCloseFilters,
@@ -34,9 +50,9 @@ const DialogFilters = ({
         <IconButton
           onClick={handleOpenFilters}
           disabled={disabled}
-          size={size || 'medium'}
+          size={'medium'}
         >
-          <BiotechOutlined fontSize={fontSize || 'medium'} />
+          <BiotechOutlined fontSize={'medium'} />
         </IconButton>
       </Tooltip>
       <Dialog

--- a/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
@@ -14,8 +14,6 @@ interface FiltersProps {
   variant?: string;
   isDatatable?: boolean;
   disabled?: boolean;
-  size?: number;
-  fontSize?: number;
   availableFilterKeys: string[];
   availableEntityTypes?: string[];
   availableRelationshipTypes?: string[];
@@ -35,8 +33,6 @@ const Filters: FunctionComponent<FiltersProps> = ({
   variant,
   isDatatable,
   disabled,
-  size,
-  fontSize,
   availableFilterKeys,
   availableEntityTypes,
   availableRelationshipTypes,
@@ -113,8 +109,6 @@ const Filters: FunctionComponent<FiltersProps> = ({
       <DialogFilters
         handleOpenFilters={handleOpenFilters}
         disabled={disabled}
-        size={size}
-        fontSize={fontSize}
         open={isOpen}
         filters={filters}
         handleCloseFilters={handleCloseFilters}
@@ -148,8 +142,6 @@ const Filters: FunctionComponent<FiltersProps> = ({
         />
       ) : (
         <ListFiltersWithoutLocalStorage
-          size={size}
-          fontSize={fontSize}
           handleOpenFilters={handleOpenFilters}
           handleCloseFilters={handleCloseFilters}
           open={isOpen}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -26,8 +26,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 type ListFiltersProps = {
-  size?: number;
-  fontSize?: number;
   handleOpenFilters: (event: SyntheticEvent) => void;
   handleCloseFilters: (event: SyntheticEvent) => void;
   isOpen: boolean;

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.jsx
@@ -22,8 +22,6 @@ const useStyles = makeStyles(() => ({
 }));
 
 const ListFiltersWithoutLocalStorage = ({
-  size,
-  fontSize,
   handleOpenFilters,
   handleCloseFilters,
   open,
@@ -34,15 +32,15 @@ const ListFiltersWithoutLocalStorage = ({
 }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
-  let icon = <FilterListOutlined fontSize={fontSize || 'medium'} />;
+  let icon = <FilterListOutlined fontSize={'medium'} />;
   let tooltip = t_i18n('Filters');
   let color = 'primary';
   if (type === 'from') {
-    icon = <RayStartArrow fontSize={fontSize || 'medium'} />;
+    icon = <RayStartArrow fontSize={'medium'} />;
     tooltip = t_i18n('Dynamic source filters');
     color = 'warning';
   } else if (type === 'to') {
-    icon = <RayEndArrow fontSize={fontSize || 'medium'} />;
+    icon = <RayEndArrow fontSize={'medium'} />;
     tooltip = t_i18n('Dynamic target filters');
     color = 'success';
   }
@@ -67,7 +65,7 @@ const ListFiltersWithoutLocalStorage = ({
             color={color}
             onClick={handleOpenFilters}
             style={{ float: 'left', marginTop: -2 }}
-            size={size || 'large'}
+            size={'large'}
           >
             {icon}
           </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -558,6 +558,10 @@ const PlaybookAddComponentsContent = ({
         name: selectedComponent.name,
         ...defaultConfig,
       };
+    const entityTypes = componentId === 'PLAYBOOK_INTERNAL_DATA_CRON'
+      ? ['Stix-Core-Object', 'stix-core-relationship']
+      : ['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering'];
+    const searchContext = { entityTypes };
     return (
       <div className={classes.config}>
         <Formik
@@ -620,15 +624,15 @@ const PlaybookAddComponentsContent = ({
                           <Filters
                             helpers={helpers}
                             availableFilterKeys={componentId === 'PLAYBOOK_INTERNAL_DATA_CRON' ? availableQueryFilterKeys : stixFilters}
-                            searchContext={{ entityTypes: componentId === 'PLAYBOOK_INTERNAL_DATA_CRON' ? ['Stix-Core-Object', 'stix-core-relationship'] : ['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering'] }}
+                            searchContext={searchContext}
                           />
                         </Box>
                         <div className="clearfix" />
                         <FilterIconButton
                           filters={filters}
                           helpers={helpers}
-                          entityTypes={componentId === 'PLAYBOOK_INTERNAL_DATA_CRON' ? ['Stix-Core-Object', 'stix-core-relationship'] : ['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering']}
-                          searchContext={{ entityTypes: componentId === 'PLAYBOOK_INTERNAL_DATA_CRON' ? ['Stix-Core-Object', 'stix-core-relationship'] : ['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering'] }}
+                          entityTypes={entityTypes}
+                          searchContext={searchContext}
                           styleNumber={2}
                           redirection
                         />

--- a/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionCreation.tsx
@@ -264,7 +264,8 @@ const RetentionCreation = ({ paginationOptions }: { paginationOptions: Retention
                 </Box>
                 <FilterIconButton
                   filters={filters}
-                  helpers={helpers}styleNumber={2}
+                  helpers={helpers}
+                  styleNumber={2}
                   redirection
                   searchContext={{ entityTypes: ['Stix-Core-Object', 'stix-core-relationship'] }}
                 />

--- a/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionEdition.jsx
@@ -229,6 +229,7 @@ const RetentionEditionContainer = (props) => {
                 <FilterIconButton
                   filters={filters}
                   helpers={helpers}
+                  styleNumber={2}
                   redirection
                   searchContext={{ entityTypes: ['Stix-Core-Object', 'stix-core-relationship'] }}
                 />

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
@@ -98,63 +98,53 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
       </Box>
 
       <Box sx={{ paddingTop: 1 }}>
-        {isFilterGroupNotEmpty(filtersDynamicFrom) && (
-          <>
-            <div style={{ marginTop: 8, color: 'orange' }}>
-              {t_i18n('Pre-query to get data to be used as source entity of the relationship (limited to 5000)')}
-            </div>
-            <FilterIconButton
-              filters={filtersDynamicFrom}
-              helpers={helpersDynamicFrom}
-              chipColor={'warning'}
-              entityTypes={['Stix-Core-Object']}
-              searchContext={searchContext}
-              availableEntityTypes={[
-                'Stix-Domain-Object',
-                'Stix-Cyber-Observable',
-              ]}
-              fintelTemplatesContext={context === 'fintelTemplate'}
-            />
-          </>
-        )}
+        {isFilterGroupNotEmpty(filtersDynamicFrom) && (<div style={{ marginTop: 8, color: 'orange' }}>
+          {t_i18n('Pre-query to get data to be used as source entity of the relationship (limited to 5000)')}
+        </div>)}
+        <FilterIconButton
+          filters={filtersDynamicFrom}
+          helpers={helpersDynamicFrom}
+          chipColor={'warning'}
+          entityTypes={['Stix-Core-Object']}
+          searchContext={searchContext}
+          availableEntityTypes={[
+            'Stix-Domain-Object',
+            'Stix-Cyber-Observable',
+          ]}
+          fintelTemplatesContext={context === 'fintelTemplate'}
+        />
 
-        {isFilterGroupNotEmpty(filtersDynamicTo) && (
-          <>
-            <div style={{ marginTop: 8, color: '#03A847' }}>
-              {t_i18n('Pre-query to get data to be used as target entity of the relationship (limited to 5000)')}
-            </div>
-            <FilterIconButton
-              filters={filtersDynamicTo}
-              helpers={helpersDynamicTo}
-              chipColor={'success'}
-              entityTypes={['Stix-Core-Object']}
-              searchContext={searchContext}
-              availableEntityTypes={[
-                'Stix-Domain-Object',
-                'Stix-Cyber-Observable',
-              ]}
-              fintelTemplatesContext={context === 'fintelTemplate'}
-            />
-          </>
-        )}
+        {isFilterGroupNotEmpty(filtersDynamicTo)
+          && (<div style={{ marginTop: 8, color: '#03A847' }}>
+            {t_i18n('Pre-query to get data to be used as target entity of the relationship (limited to 5000)')}
+          </div>)
+        }
+        <FilterIconButton
+          filters={filtersDynamicTo}
+          helpers={helpersDynamicTo}
+          chipColor={'success'}
+          entityTypes={['Stix-Core-Object']}
+          searchContext={searchContext}
+          availableEntityTypes={[
+            'Stix-Domain-Object',
+            'Stix-Cyber-Observable',
+          ]}
+          fintelTemplatesContext={context === 'fintelTemplate'}
+        />
 
-        {isFilterGroupNotEmpty(filters) && (
-          <>
-            {perspective === 'relationships' && (
-              <div style={{ marginTop: 8 }}>
-                {t_i18n('Result: the relationships with source respecting the source pre-query, target respecting the target pre-query, and matching:')}
-              </div>
-            )}
-            <FilterIconButton
-              filters={filters}
-              helpers={helpers}
-              searchContext={searchContext}
-              availableEntityTypes={availableEntityTypes}
-              entityTypes={searchContext.entityTypes}
-              fintelTemplatesContext={context === 'fintelTemplate'}
-            />
-          </>
-        ) }
+        {isFilterGroupNotEmpty(filters) && perspective === 'relationships' && (
+          <div style={{ marginTop: 8 }}>
+            {t_i18n('Result: the relationships with source respecting the source pre-query, target respecting the target pre-query, and matching:')}
+          </div>
+        )}
+        <FilterIconButton
+          filters={filters}
+          helpers={helpers}
+          searchContext={searchContext}
+          availableEntityTypes={availableEntityTypes}
+          entityTypes={searchContext.entityTypes}
+          fintelTemplatesContext={context === 'fintelTemplate'}
+        />
       </Box>
     </>
   );

--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -34,7 +34,7 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
   await expect(incidentPage.getPage()).toBeVisible();
 
   // Filter on label
-  await filter.addFilter('Label', 'background-task', true);
+  await filter.addFilter('Label', 'background-task');
   await expect(dataTable.getNumberElements(2)).toBeVisible();
 
   // Select all
@@ -91,13 +91,13 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
   await expect(entitiesPage.getPage()).toBeVisible();
 
   // Filter by the new label
-  await filter.addFilter('Label', 'background-task-filter-add-label', true);
+  await filter.addFilter('Label', 'background-task-filter-add-label');
   await expect(dataTable.getNumberElements(3)).toBeVisible(); // 2 by this test + 1 in stix imported data
 
   // Clear filter on label
   await filter.removeLastFilter();
 
-  await filter.addFilter('Label', 'background-task-search-add-label', true);
+  await filter.addFilter('Label', 'background-task-search-add-label');
   if (!await dataTable.getNumberElements(2).isVisible({ timeout: 500 })) {
     // Try to reload page in case it's a flake.
     await entitiesPage.goto();

--- a/opencti-platform/opencti-front/tests_e2e/model/DashboardWidgets.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/DashboardWidgets.pageModel.ts
@@ -81,7 +81,7 @@ export default class DashboardWidgetsPageModel {
     await this.selectWidget('List');
     await this.selectPerspective('Entities');
     await this.fillLabel('Malwares');
-    await this.filters.addFilter('Entity type', 'Malware', false);
+    await this.filters.addFilter('Entity type', 'Malware');
     await this.filters.addFilter('Label', 'e2e');
     await this.validateFilters();
     await this.titleField.fill('List of malwares');
@@ -93,7 +93,7 @@ export default class DashboardWidgetsPageModel {
     await this.selectWidget('Timeline');
     await this.selectPerspective('Entities');
     await this.fillLabel('Malware');
-    await this.filters.addFilter('Entity type', 'Malware', false);
+    await this.filters.addFilter('Entity type', 'Malware');
     await this.filters.addFilter('Label', 'e2e');
     await this.validateFilters();
     await this.titleField.fill('Timeline of malwares');
@@ -104,7 +104,7 @@ export default class DashboardWidgetsPageModel {
     await this.openWidgetModal();
     await this.selectWidget('Number');
     await this.selectPerspective('Entities');
-    await this.filters.addFilter('Entity type', 'Entity', false);
+    await this.filters.addFilter('Entity type', 'Entity');
     await this.filters.addFilter('Label', 'e2e');
     await this.validateFilters();
     await this.titleField.fill('Number of entities');

--- a/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
@@ -3,12 +3,9 @@ import { Page, expect } from '@playwright/test';
 export default class FiltersPageModel {
   constructor(private page: Page) {}
 
-  async addFilter(filterKey: string, filterLabel: string, autoOpen = true) {
+  async addFilter(filterKey: string, filterLabel: string) {
     await this.page.getByLabel('Add filter').click();
     await this.page.getByRole('option', { name: filterKey }).click();
-    if (!autoOpen) {
-      await this.page.getByRole('button', { name: `${filterKey} =` }).click();
-    }
     await this.page.getByRole('combobox', { name: filterKey }).click();
     await this.page.getByLabel(filterLabel, { exact: true }).getByRole('checkbox').check();
     return this.page.mouse.click(10, 10);


### PR DESCRIPTION

### Proposed changes
When we add a first filter in an elements list, the filter popup should opens automatically

![image](https://github.com/user-attachments/assets/ba2aa811-1d18-43e9-9f9f-c35cf6842151)



### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9092