### PR TITLE
[backend/frontend] align MIME type detection in import workflow with backend behavior

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7909,6 +7909,7 @@ type Query {
   importFiles(first: Int, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
   pendingFiles(first: Int, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
   filesMetrics: FilesMetrics
+  guessMimeType(fileId: String!): String
   askAiActivity(busId: String, language: String, forceRefresh: Boolean): AiActivity
   indexedFiles(first: Int, after: ID, search: String): IndexedFileConnection
   indexedFilesCount(search: String): Int

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -12787,6 +12787,7 @@ type Query {
     filters: FilterGroup
   ): FileConnection @auth(for: [KNOWLEDGE_KNASKIMPORT])
   filesMetrics: FilesMetrics @auth(for: [SETTINGS_FILEINDEXING])
+  guessMimeType(fileId: String!): String @auth(for: [KNOWLEDGE_KNASKIMPORT])
   askAiActivity(busId: String, language: String, forceRefresh: Boolean): AiActivity @auth(for: [KNOWLEDGE])
 
   ######## INDEXED FILES

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19774,6 +19774,7 @@ export type Query = {
   groupingsNumber?: Maybe<Number>;
   groupingsTimeSeries?: Maybe<Array<Maybe<TimeSeries>>>;
   groups?: Maybe<GroupConnection>;
+  guessMimeType?: Maybe<Scalars['String']['output']>;
   identities?: Maybe<IdentityConnection>;
   identity?: Maybe<Identity>;
   importFiles?: Maybe<FileConnection>;
@@ -20753,6 +20754,11 @@ export type QueryGroupsArgs = {
   orderBy?: InputMaybe<GroupsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
   search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGuessMimeTypeArgs = {
+  fileId: Scalars['String']['input'];
 };
 
 
@@ -39425,6 +39431,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   groupingsNumber?: Resolver<Maybe<ResolversTypes['Number']>, ParentType, ContextType, Partial<QueryGroupingsNumberArgs>>;
   groupingsTimeSeries?: Resolver<Maybe<Array<Maybe<ResolversTypes['TimeSeries']>>>, ParentType, ContextType, RequireFields<QueryGroupingsTimeSeriesArgs, 'endDate' | 'field' | 'interval' | 'operation' | 'startDate'>>;
   groups?: Resolver<Maybe<ResolversTypes['GroupConnection']>, ParentType, ContextType, Partial<QueryGroupsArgs>>;
+  guessMimeType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QueryGuessMimeTypeArgs, 'fileId'>>;
   identities?: Resolver<Maybe<ResolversTypes['IdentityConnection']>, ParentType, ContextType, Partial<QueryIdentitiesArgs>>;
   identity?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType, RequireFields<QueryIdentityArgs, 'id'>>;
   importFiles?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<QueryImportFilesArgs>>;

--- a/opencti-platform/opencti-graphql/src/resolvers/file.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/file.js
@@ -1,4 +1,4 @@
-import { loadFile } from '../database/file-storage';
+import { guessMimeType, loadFile } from '../database/file-storage';
 import { batchFileMarkingDefinitions, batchFileWorks, deleteImport, filesMetrics, uploadAndAskJobImport, uploadImport, uploadPending } from '../domain/file';
 import { batchLoader } from '../database/middleware';
 import { batchCreator } from '../domain/user';
@@ -24,6 +24,7 @@ const fileResolvers = {
       return paginatedForPathWithEnrichment(context, context.user, 'import/pending', undefined, opts);
     },
     filesMetrics: (_, args, context) => filesMetrics(context, context.user),
+    guessMimeType: (_, { fileId }) => guessMimeType(fileId),
   },
   File: {
     objectMarking: (rel, _, context) => markingDefinitionsLoader.load(rel, context, context.user),

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/file-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/file-test.ts
@@ -1,0 +1,32 @@
+import { expect, it, describe } from 'vitest';
+import gql from 'graphql-tag';
+import { queryAsAdmin } from '../../utils/testQuery';
+
+describe('File resolver standard behavior', () => {
+  // TODO: this test suite should address all queries and mutations from src/resolvers/file.js
+
+  it('should guess mimetypes correctly', async () => {
+    const GUESS_MIMETYPE_QUERY = gql`
+      query guessMimeType {
+        file1: guessMimeType(fileId: "pdf_report")
+        file2: guessMimeType(fileId: "path/1/file.yar")
+        file3: guessMimeType(fileId: "path/to/iamajsonfile.json")
+        file4: guessMimeType(fileId: "path/to/iamapdf.pdf")
+        file5: guessMimeType(fileId: "path/to/i Have space and 💖.txt")
+        file6: guessMimeType(fileId: "unknown")
+        file7: guessMimeType(fileId: "export/Malware/b4bebef0-7f1b-4212-b09d-f376adb3181a/(ExportFileStix)_Malware-Paradise Ransomware_all.json")
+      }
+    `;
+    const queryResult = await queryAsAdmin({
+      query: GUESS_MIMETYPE_QUERY,
+    });
+
+    expect(queryResult.data?.file1).toBe('application/pdf');
+    expect(queryResult.data?.file2).toBe('text/yara+plain');
+    expect(queryResult.data?.file3).toBe('application/json');
+    expect(queryResult.data?.file4).toBe('application/pdf');
+    expect(queryResult.data?.file5).toBe('text/plain');
+    expect(queryResult.data?.file6).toBe('application/octet-stream');
+    expect(queryResult.data?.file7).toBe('application/json');
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add new query in file module to `guessMimeType` of a filename, using same mechanics as when a file is uploaded and imported automatically. This uses the platform config, for instance remapping mime type oif `.yar` file to `test/plain+yara`
* call this API when selecting a file in the import wizard, to accurately detect the right connector(s) to suggest

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9760 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

