### PR TITLE
[frontend] removing an indicator score from the UI should not be possible (#8021)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -106,7 +106,7 @@ const IndicatorEditionOverviewComponent = ({
       }),
     x_mitre_platforms: Yup.array().nullable(),
     x_opencti_score: Yup.number()
-      .nullable()
+      .required(t_i18n('This field is required'))
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
     description: Yup.string().nullable(),
@@ -180,15 +180,20 @@ const IndicatorEditionOverviewComponent = ({
       if (name === 'x_opencti_workflow_id') {
         finalValue = value.value;
       }
-      editor.fieldPatch({
-        variables: {
-          id: indicator.id,
-          input: {
-            key: name,
-            value: finalValue ?? '',
-          },
-        },
-      });
+      indicatorValidator
+        .validateAt(name, { [name]: value })
+        .then(() => {
+          editor.fieldPatch({
+            variables: {
+              id: indicator.id,
+              input: {
+                key: name,
+                value: finalValue ?? '',
+              },
+            },
+          });
+        })
+        .catch(() => false);
     }
   };
 


### PR DESCRIPTION
### Proposed changes
It should not be possible to remove an indicator score from the UI (ie indicator edition panel)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8021