### PR TITLE
[frontend] every user should be able to manage its own notifications (#10290)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -16,7 +16,7 @@ import { getParentTypes } from '../schema/schemaUtils';
 import { ENTITY_TYPE_VOCABULARY } from '../modules/vocabulary/vocabulary-types';
 import { ENTITY_TYPE_DELETE_OPERATION } from '../modules/deleteOperation/deleteOperation-types';
 import { BackgroundTaskScope, Capabilities, FilterMode } from '../generated/graphql';
-import { extractFilterGroupValues, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
+import { extractFilterGroupValues, findFiltersFromKey, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import { getDraftContext } from '../utils/draftContext';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
@@ -46,7 +46,7 @@ export const checkActionValidity = async (context, user, input, scope, taskType)
   const filters = isFilterGroupNotEmpty(baseFilterObject)
     ? (baseFilterObject?.filters ?? [])
     : [];
-  const entityTypeFilters = filters.filter((f) => f.key.includes('entity_type'));
+  const entityTypeFilters = findFiltersFromKey(filters, 'entity_type');
   const entityTypeFiltersValues = entityTypeFilters.map((f) => f.values).flat();
   if (scope === BackgroundTaskScope.Settings) { // 01. Background task of scope Settings
     const isAuthorized = isUserHasCapability(user, SETTINGS_SETLABELS);
@@ -97,7 +97,7 @@ export const checkActionValidity = async (context, user, input, scope, taskType)
       if (!isNotifications) {
         throw ForbiddenAccess('The targeted ids are not notifications.');
       }
-      const userFilters = filters.filter((f) => f.key === 'user_id');
+      const userFilters = findFiltersFromKey(filters, 'user_id');
       const isUserData = userFilters.length > 0
         && userFilters[0].values.length === 1
         && userFilters[0].values[0] === user.id;

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -20,6 +20,7 @@ import { extractFilterGroupValues, findFiltersFromKey, isFilterGroupNotEmpty } f
 import { getDraftContext } from '../utils/draftContext';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
+import { TYPE_FILTER, USER_ID_FILTER } from '../utils/filtering/filtering-constants';
 
 export const TASK_TYPE_QUERY = 'QUERY';
 export const TASK_TYPE_RULE = 'RULE';
@@ -46,7 +47,7 @@ export const checkActionValidity = async (context, user, input, scope, taskType)
   const filters = isFilterGroupNotEmpty(baseFilterObject)
     ? (baseFilterObject?.filters ?? [])
     : [];
-  const entityTypeFilters = findFiltersFromKey(filters, 'entity_type');
+  const entityTypeFilters = findFiltersFromKey(filters, TYPE_FILTER);
   const entityTypeFiltersValues = entityTypeFilters.map((f) => f.values).flat();
   if (scope === BackgroundTaskScope.Settings) { // 01. Background task of scope Settings
     const isAuthorized = isUserHasCapability(user, SETTINGS_SETLABELS);
@@ -97,7 +98,7 @@ export const checkActionValidity = async (context, user, input, scope, taskType)
       if (!isNotifications) {
         throw ForbiddenAccess('The targeted ids are not notifications.');
       }
-      const userFilters = findFiltersFromKey(filters, 'user_id');
+      const userFilters = findFiltersFromKey(filters, USER_ID_FILTER);
       const isUserData = userFilters.length > 0
         && userFilters[0].values.length === 1
         && userFilters[0].values[0] === user.id;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -6,6 +6,7 @@ import { ENTITY_TYPE_VOCABULARY } from '../../../src/modules/vocabulary/vocabula
 import { ENTITY_TYPE_WORKSPACE } from '../../../src/modules/workspace/workspace-types';
 import { ENTITY_TYPE_NOTIFICATION } from '../../../src/modules/notification/notification-types';
 import { TYPE_FILTER, USER_ID_FILTER } from '../../../src/utils/filtering/filtering-constants';
+import { BackgroundTaskScope } from '../../../src/generated/graphql';
 
 const filterEntityType = (entityType: string) => {
   return JSON.stringify({
@@ -55,7 +56,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   ]);
 
   describe('Scope SETTINGS', () => {
-    const scope = 'SETTINGS';
+    const scope = BackgroundTaskScope.Settings;
 
     it('should throw an error if the user has no capa SETTINGS_SETLABELS', async () => {
       const user = userParticipate;
@@ -70,7 +71,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope KNOWLEDGE', () => {
-    const scope = 'KNOWLEDGE';
+    const scope = BackgroundTaskScope.Knowledge;
 
     it('should throw an error if the user has no capa KNOWLEDGE_UPDATE', async () => {
       const user = userParticipate;
@@ -124,7 +125,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope USER', () => {
-    const scope = 'USER';
+    const scope = BackgroundTaskScope.User;
 
     it('should throw an error if task QUERY and filter is not Notifications', async () => {
       const user = userUpdate;
@@ -147,6 +148,20 @@ describe('Background task validity check (checkActionValidity)', () => {
       };
       await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
+      }).rejects.toThrowError('You are not allowed to do this.');
+      const input2 = {
+        actions: [{ type: ACTION_TYPE_ADD }],
+        filters: JSON.stringify({
+          mode: 'and',
+          filters: [
+            { key: TYPE_FILTER, values: [ENTITY_TYPE_NOTIFICATION] },
+            { key: USER_ID_FILTER, values: ['fake_user_id'] },
+          ],
+          filterGroups: []
+        }),
+      };
+      await expect(async () => {
+        await checkActionValidity(testContext, user, input2, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
@@ -177,7 +192,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope IMPORT', () => {
-    const scope = 'IMPORT';
+    const scope = BackgroundTaskScope.Import;
 
     it('should throw an error if the user has no capa KNOWLEDGE_KNASKIMPORT', async () => {
       const user = userParticipate;
@@ -203,7 +218,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope DASHBOARD', () => {
-    const scope = 'DASHBOARD';
+    const scope = BackgroundTaskScope.Dashboard;
 
     it('should throw an error if the user has no capa EXPLORE_EXUPDATE_EXDELETE', async () => {
       const user = userParticipate;
@@ -257,7 +272,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope INVESTIGATION', () => {
-    const scope = 'INVESTIGATION';
+    const scope = BackgroundTaskScope.Investigation;
 
     it('should throw an error if the user has no capa KNOWLEDGE_KNGETEXPORT_KNASKEXPORT', async () => {
       const user = userParticipate;
@@ -311,7 +326,7 @@ describe('Background task validity check (checkActionValidity)', () => {
   });
 
   describe('Scope PUBLIC_DASHBOARD', () => {
-    const scope = 'PUBLIC_DASHBOARD';
+    const scope = BackgroundTaskScope.PublicDashboard;
 
     it('should throw an error if the user has no capa EXPLORE_EXUPDATE_PUBLISH', async () => {
       const user = userParticipate;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -5,13 +5,14 @@ import { ACTION_TYPE_ADD } from '../../../src/domain/backgroundTask';
 import { ENTITY_TYPE_VOCABULARY } from '../../../src/modules/vocabulary/vocabulary-types';
 import { ENTITY_TYPE_WORKSPACE } from '../../../src/modules/workspace/workspace-types';
 import { ENTITY_TYPE_NOTIFICATION } from '../../../src/modules/notification/notification-types';
+import { TYPE_FILTER, USER_ID_FILTER } from '../../../src/utils/filtering/filtering-constants';
 
 const filterEntityType = (entityType: string) => {
   return JSON.stringify({
     mode: 'and',
     filters: [
       {
-        key: ['entity_type'],
+        key: [TYPE_FILTER],
         values: [entityType],
         operator: 'eq',
         mode: 'or'
@@ -26,7 +27,7 @@ const filterWorkspaceType = (type: 'dashboard' | 'investigation') => {
     mode: 'and',
     filters: [
       {
-        key: ['entity_type'],
+        key: [TYPE_FILTER],
         values: [ENTITY_TYPE_WORKSPACE],
         operator: 'eq',
         mode: 'or'
@@ -56,13 +57,13 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope SETTINGS', () => {
     const scope = 'SETTINGS';
 
-    it('should throw an error if the user has no capa SETTINGS_SETLABELS', () => {
+    it('should throw an error if the user has no capa SETTINGS_SETLABELS', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
@@ -71,48 +72,48 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope KNOWLEDGE', () => {
     const scope = 'KNOWLEDGE';
 
-    it('should throw an error if the user has no capa KNOWLEDGE_UPDATE', () => {
+    it('should throw an error if the user has no capa KNOWLEDGE_UPDATE', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if deletion actions and no capa KNOWLEDGE_DELETE', () => {
+    it('should throw an error if deletion actions and no capa KNOWLEDGE_DELETE', async () => {
       const user = userUpdate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if task QUERY and targeting vocabularies', () => {
+    it('should throw an error if task QUERY and targeting vocabularies', async () => {
       const user = userUpdate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }],
         filters: filterEntityType(ENTITY_TYPE_VOCABULARY)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not knowledge.');
     });
 
-    it('should throw an error if task QUERY and targets are not knowledge', () => {
+    it('should throw an error if task QUERY and targets are not knowledge', async () => {
       const user = userUpdate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }],
         filters: filterEntityType(ENTITY_TYPE_WORKSPACE)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not knowledge.');
     });
@@ -125,28 +126,45 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope USER', () => {
     const scope = 'USER';
 
-    it('should throw an error if task QUERY and filter is not Notifications', () => {
+    it('should throw an error if task QUERY and filter is not Notifications', async () => {
       const user = userUpdate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }],
         filters: filterEntityType(ENTITY_TYPE_WORKSPACE)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not notifications.');
     });
 
-    it('should throw an error if task QUERY and user has no capa SETTINGS_SET_ACCESSES and not own data', () => {
+    it('should throw an error if task QUERY and user has no capa SETTINGS_SET_ACCESSES and not own data', async () => {
       const user = userUpdate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }],
         filters: filterEntityType(ENTITY_TYPE_NOTIFICATION)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
+    });
+
+    it('should NOT throw an error if task QUERY and filter is Notification of the user', async () => {
+      const user = userUpdate;
+      const type = TASK_TYPE_QUERY;
+      const input = {
+        actions: [{ type: ACTION_TYPE_DELETE }],
+        filters: JSON.stringify({
+          mode: 'and',
+          filters: [
+            { key: TYPE_FILTER, values: [ENTITY_TYPE_NOTIFICATION] },
+            { key: USER_ID_FILTER, values: [user.id] },
+          ],
+          filterGroups: []
+        }),
+      };
+      await checkActionValidity(testContext, user, input, scope, type);
     });
 
     it.skip('should throw an error if task LIST and targets are not Notifications', () => {
@@ -161,24 +179,24 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope IMPORT', () => {
     const scope = 'IMPORT';
 
-    it('should throw an error if the user has no capa KNOWLEDGE_KNASKIMPORT', () => {
+    it('should throw an error if the user has no capa KNOWLEDGE_KNASKIMPORT', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if some actions are not deletions', () => {
+    it('should throw an error if some actions are not deletions', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }, { type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('Background tasks of scope Import can only be deletions.');
     });
@@ -187,48 +205,48 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope DASHBOARD', () => {
     const scope = 'DASHBOARD';
 
-    it('should throw an error if the user has no capa EXPLORE_EXUPDATE_EXDELETE', () => {
+    it('should throw an error if the user has no capa EXPLORE_EXUPDATE_EXDELETE', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if some actions are not deletions', () => {
+    it('should throw an error if some actions are not deletions', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }, { type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('Background tasks of scope dashboard can only be deletions.');
     });
 
-    it('should throw an error if task QUERY and filter is not Workspace', () => {
+    it('should throw an error if task QUERY and filter is not Workspace', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }],
         filters: filterEntityType(ENTITY_TYPE_NOTIFICATION)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not dashboard.');
     });
 
-    it('should throw an error if task QUERY and filter type is not dashboard', () => {
+    it('should throw an error if task QUERY and filter type is not dashboard', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }],
         filters: filterWorkspaceType('investigation')
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not dashboard.');
     });
@@ -241,48 +259,48 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope INVESTIGATION', () => {
     const scope = 'INVESTIGATION';
 
-    it('should throw an error if the user has no capa KNOWLEDGE_KNGETEXPORT_KNASKEXPORT', () => {
+    it('should throw an error if the user has no capa KNOWLEDGE_KNGETEXPORT_KNASKEXPORT', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if some actions are not deletions', () => {
+    it('should throw an error if some actions are not deletions', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }, { type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('Background tasks of scope investigation can only be deletions.');
     });
 
-    it('should throw an error if task QUERY and filter is not Workspace', () => {
+    it('should throw an error if task QUERY and filter is not Workspace', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }],
         filters: filterEntityType(ENTITY_TYPE_NOTIFICATION)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not investigations.');
     });
 
-    it('should throw an error if task QUERY and filter type is not investigation', () => {
+    it('should throw an error if task QUERY and filter type is not investigation', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }],
         filters: filterWorkspaceType('dashboard')
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not investigations.');
     });
@@ -295,36 +313,36 @@ describe('Background task validity check (checkActionValidity)', () => {
   describe('Scope PUBLIC_DASHBOARD', () => {
     const scope = 'PUBLIC_DASHBOARD';
 
-    it('should throw an error if the user has no capa EXPLORE_EXUPDATE_PUBLISH', () => {
+    it('should throw an error if the user has no capa EXPLORE_EXUPDATE_PUBLISH', async () => {
       const user = userParticipate;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('You are not allowed to do this.');
     });
 
-    it('should throw an error if some actions are not deletions', () => {
+    it('should throw an error if some actions are not deletions', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }, { type: ACTION_TYPE_ADD }]
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('Background tasks of scope Public dashboard can only be deletions.');
     });
 
-    it('should throw an error if task QUERY and filter is not PublicDashboard', () => {
+    it('should throw an error if task QUERY and filter is not PublicDashboard', async () => {
       const user = userEditor;
       const type = TASK_TYPE_QUERY;
       const input = {
         actions: [{ type: ACTION_TYPE_DELETE }],
         filters: filterEntityType(ENTITY_TYPE_NOTIFICATION)
       };
-      expect(async () => {
+      await expect(async () => {
         await checkActionValidity(testContext, user, input, scope, type);
       }).rejects.toThrowError('The targeted ids are not public dashboards.');
     });


### PR DESCRIPTION
### Proposed changes
A user should be able to manage its own notifiations (ie mark them as read / delete them), even if he only has the read only capability

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10290