### PR TITLE
[frontend] Observable types displayed with technical name in Decay rules (#9902)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/ObservableTypesField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObservableTypesField.tsx
@@ -57,6 +57,7 @@ const ObservableTypesField: FunctionComponent<ObservableTypesFieldProps> = ({
       }}
       required={required}
       options={allObservableTypes}
+      getOptionLabel={(option: string) => t_i18n(`entity_${option}`)}
       onChange={typeof onChange === 'function' ? onChange : null}
       isOptionEqualToValue={(option: string, value: string) => option === value}
       style={style}

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
@@ -169,7 +169,11 @@ const DecayRuleComponent = ({ queryRef }: DecayRuleComponentProps) => {
                     </Box>
                   </Typography>
                   <FieldOrEmpty source={decayRule.decay_observable_types}>
-                    <span>{decayRule.decay_observable_types?.join(', ')}</span>
+                    <span>
+                      {decayRule.decay_observable_types
+                        ?.map((option) => t_i18n(`entity_${option}`))
+                        .join(', ')}
+                    </span>
                   </FieldOrEmpty>
                 </Grid>
                 <Grid item xs={12}>


### PR DESCRIPTION
### Proposed changes

* Translate the functional type of the list and chips on the creation form

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9902
