### PR TITLE
[frontend/backend] add bulk search in activity logs (#9403)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -84,59 +84,6 @@ const searchStixCoreObjectsLinesQuery = graphql`
   }
 `;
 
-export const searchStixCoreObjectsLinesSearchQuery = graphql`
-  query SearchStixCoreObjectsLinesSearchQuery(
-    $types: [String]
-    $filters: FilterGroup
-    $search: String
-  ) {
-    stixCoreObjects(types: $types, search: $search, filters: $filters) {
-      edges {
-        node {
-          id
-          entity_type
-          created_at
-          updated_at
-          draftVersion {
-            draft_id
-            draft_operation
-          }
-          ... on StixObject {
-            representative {
-              main
-              secondary
-            }
-          }
-          createdBy {
-            ... on Identity {
-              name
-            }
-          }
-          objectMarking {
-            id
-            definition_type
-            definition
-            x_opencti_order
-            x_opencti_color
-          }
-          objectLabel {
-            id
-            value
-            color
-          }
-          creators {
-            id
-            name
-          }
-          containersNumber {
-            total
-          }
-        }
-      }
-    }
-  }
-`;
-
 export const searchStixCoreObjectsLinesFragment = graphql`
   fragment SearchStixCoreObjectsLines_data on Query
   @argumentDefinitions(

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -7981,6 +7981,7 @@ type Query {
   stixCoreObjects(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   stixCoreObjectsRestricted(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   globalSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
+  bulkSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection
   stixCoreObjectsTimeSeries(authorId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, types: [String], filters: FilterGroup, search: String): [TimeSeries]
   stixCoreObjectsMultiTimeSeries(startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, timeSeriesParameters: [StixCoreObjectsTimeSeriesParameters]): [MultiTimeSeries]

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -13019,6 +13019,15 @@ type Query {
     orderMode: OrderingMode
     filters: FilterGroup
   ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
+  bulkSearch(
+    first: Int
+    after: ID
+    search: String
+    types: [String]
+    orderBy: StixCoreObjectsOrdering
+    orderMode: OrderingMode
+    filters: FilterGroup
+  ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection @auth(for: [KNOWLEDGE_KNGETEXPORT])
   stixCoreObjectsTimeSeries(
     authorId: String

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -123,7 +123,17 @@ export const findAll = async (context, user, args) => {
       event_type: 'command',
       event_scope: 'search',
       event_access: 'extended',
+      message: 'asks for `advanced search`',
       context_data: contextData,
+    });
+  } else if (args.bulkSearch) {
+    await publishUserAction({
+      user,
+      event_type: 'command',
+      event_scope: 'search',
+      event_access: 'extended',
+      message: 'asks for `bulk search`',
+      context_data: { input: args },
     });
   }
   return listEntitiesPaginated(context, user, types, args);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19683,6 +19683,7 @@ export type Query = {
   backgroundTask?: Maybe<BackgroundTask>;
   backgroundTasks?: Maybe<BackgroundTaskConnection>;
   bookmarks?: Maybe<StixDomainObjectConnection>;
+  bulkSearch?: Maybe<StixCoreObjectConnection>;
   campaign?: Maybe<Campaign>;
   campaigns?: Maybe<CampaignConnection>;
   campaignsTimeSeries?: Maybe<Array<Maybe<TimeSeries>>>;
@@ -20134,6 +20135,17 @@ export type QueryBookmarksArgs = {
   after?: InputMaybe<Scalars['ID']['input']>;
   filters?: InputMaybe<FilterGroup>;
   first?: InputMaybe<Scalars['Int']['input']>;
+  types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryBulkSearchArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<StixCoreObjectsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
   types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
@@ -39341,6 +39353,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   backgroundTask?: Resolver<Maybe<ResolversTypes['BackgroundTask']>, ParentType, ContextType, RequireFields<QueryBackgroundTaskArgs, 'id'>>;
   backgroundTasks?: Resolver<Maybe<ResolversTypes['BackgroundTaskConnection']>, ParentType, ContextType, Partial<QueryBackgroundTasksArgs>>;
   bookmarks?: Resolver<Maybe<ResolversTypes['StixDomainObjectConnection']>, ParentType, ContextType, Partial<QueryBookmarksArgs>>;
+  bulkSearch?: Resolver<Maybe<ResolversTypes['StixCoreObjectConnection']>, ParentType, ContextType, Partial<QueryBulkSearchArgs>>;
   campaign?: Resolver<Maybe<ResolversTypes['Campaign']>, ParentType, ContextType, Partial<QueryCampaignArgs>>;
   campaigns?: Resolver<Maybe<ResolversTypes['CampaignConnection']>, ParentType, ContextType, Partial<QueryCampaignsArgs>>;
   campaignsTimeSeries?: Resolver<Maybe<Array<Maybe<ResolversTypes['TimeSeries']>>>, ParentType, ContextType, RequireFields<QueryCampaignsTimeSeriesArgs, 'endDate' | 'field' | 'interval' | 'operation' | 'startDate'>>;

--- a/opencti-platform/opencti-graphql/src/listener/UserActionListener.ts
+++ b/opencti-platform/opencti-graphql/src/listener/UserActionListener.ts
@@ -21,6 +21,7 @@ export interface UserSearchActionContextData {
 export interface UserSearchAction extends BasicUserAction {
   event_type: 'command'
   event_scope: 'search'
+  message: string
   context_data: UserSearchActionContextData
 }
 

--- a/opencti-platform/opencti-graphql/src/manager/activityListener.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityListener.ts
@@ -202,8 +202,7 @@ const initActivityManager = () => {
       }
       if (action.event_type === 'command') {
         if (action.event_scope === 'search') {
-          const message = 'asks for `advanced search`';
-          await activityLogger(action, message);
+          await activityLogger(action, action.message);
         }
         if (action.event_scope === 'export') {
           const { format, entity_name } = action.context_data;

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
@@ -64,6 +64,7 @@ const stixCoreObjectResolvers = {
     stixCoreObject: (_, { id }, context) => findById(context, context.user, id),
     stixCoreObjectRaw: (_, { id }, context) => stixLoadByIdStringify(context, context.user, id),
     globalSearch: (_, args, context) => findAll(context, context.user, { ...args, globalSearch: true }),
+    bulkSearch: (_, args, context) => findAll(context, context.user, { ...args, bulkSearch: true }),
     stixCoreObjects: (_, args, context) => findAll(context, context.user, args),
     stixCoreObjectsRestricted: (_, args, context) => findAllAuthMemberRestricted(context, context.user, args),
     stixCoreObjectsTimeSeries: (_, args, context) => {


### PR DESCRIPTION
### Proposed changes
In the extended case (ie the user has an activity trigger on it or is in the activty configuration), there should be an activity log for bulk searches (for the moment, log only for advanced searches)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9403