### PR TITLE
[backend] fix the base time set in decayRule test

### DIFF
--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
@@ -385,7 +385,7 @@ describe('Decay chart data generation', () => {
   });
 
   it('should compute live score serie correctly', () => {
-    // YYYY-MM-DDTHH:mm:ss.sssZ
+    // YYYY-MM-DDTHH:mm:ss.sss
     const startDate = new Date('2023-12-15T00:00:00.000');
 
     const computedScoreList: number[] = computeScoreList(100);

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
@@ -386,7 +386,7 @@ describe('Decay chart data generation', () => {
 
   it('should compute live score serie correctly', () => {
     // YYYY-MM-DDTHH:mm:ss.sssZ
-    const startDate = new Date('2023-12-15T00:00:00.000Z');
+    const startDate = new Date('2023-12-15T00:00:00.000');
 
     const computedScoreList: number[] = computeScoreList(100);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change the base time

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10257 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Reproducible Steps

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
To test this PR, you need to:
* change your time zone: setting for the test should be in a timezone that is UTC offset to the negative. Like - UTC-5
* run the test with 'yarn test decayRule'
*  Results: check that all tests are passed
