### PR TITLE
[backend] fix clean up of denormalized rel if multiple rel of same type exists (#7208)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3731,7 +3731,7 @@ export const elRemoveRelationConnection = async (context, user, elementsImpact) 
           let source = `if(ctx._source[params.rel_key] != null){
               for (int i=params.cleanupIds.length-1; i>=0; i--) {
                 def cleanupIndex = ctx._source[params.rel_key].indexOf(params.cleanupIds[i]);
-                if(cleanupIndex !== 1){
+                if(cleanupIndex !== -1){
                   ctx._source[params.rel_key].remove(cleanupIndex);
                 }
             }

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3728,17 +3728,19 @@ export const elRemoveRelationConnection = async (context, user, elementsImpact) 
           const [relationType, relationIndex, side, sideType] = typeAndIndex.split('|');
           const refField = isStixRefRelationship(relationType) && isInferredIndex(relationIndex) ? ID_INFERRED : ID_INTERNAL;
           const rel_key = buildRefRelationKey(relationType, refField);
-          let source = `Map foundIds = new HashMap();
+          let source = `if(ctx._source[params.rel_key] != null){
+            Map foundIds = new HashMap();
             for (int i=params.cleanupIds.length-1; i>=0; i--) {
               boolean currentFound = false;
               for (int j=ctx._source[params.rel_key].length-1; j>=0; j--) {
-                if (!currentFound && foundIds[j] != false && ctx._source[params.rel_key][i] == params.cleanupIds[i]) {
+                if (!currentFound && foundIds[j] != false && ctx._source[params.rel_key][j] == params.cleanupIds[i]) {
                   currentFound = true;
                   foundIds[j] = true;
                   ctx._source[params.rel_key].remove(j);
                 }
               }
             }
+          }
           `;
           // Only impact the updated at on the from side of the ref relationship
           const fromSide = side === 'from';

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3728,18 +3728,29 @@ export const elRemoveRelationConnection = async (context, user, elementsImpact) 
           const [relationType, relationIndex, side, sideType] = typeAndIndex.split('|');
           const refField = isStixRefRelationship(relationType) && isInferredIndex(relationIndex) ? ID_INFERRED : ID_INTERNAL;
           const rel_key = buildRefRelationKey(relationType, refField);
-          let source = `if (ctx._source['${rel_key}'] != null) ctx._source['${rel_key}'] = ctx._source['${rel_key}'].stream().filter(id -> !params.cleanupIds.contains(id)).collect(Collectors.toList())`;
+          let source = `Map foundIds = new HashMap();
+            for (int i=params.cleanupIds.length-1; i>=0; i--) {
+              boolean currentFound = false;
+              for (int j=ctx._source[params.rel_key].length-1; j>=0; j--) {
+                if (!currentFound && foundIds[j] != false && ctx._source[params.rel_key][i] == params.cleanupIds[i]) {
+                  currentFound = true;
+                  foundIds[j] = true;
+                  ctx._source[params.rel_key].remove(j);
+                }
+              }
+            }
+          `;
           // Only impact the updated at on the from side of the ref relationship
           const fromSide = side === 'from';
           if (fromSide && isStixRefRelationship(relationType)) {
             if (isUpdatedAtObject(sideType)) {
-              source += '; ctx._source[\'updated_at\'] = params.updated_at';
+              source += 'ctx._source[\'updated_at\'] = params.updated_at;';
             }
             if (isModifiedObject(sideType)) {
-              source += '; ctx._source[\'modified\'] = params.updated_at';
+              source += 'ctx._source[\'modified\'] = params.updated_at;';
             }
           }
-          const script = { source, params: { cleanupIds, updated_at: now() } };
+          const script = { source, params: { rel_key, cleanupIds, updated_at: now() } };
           updates.push([
             { update: { _index: fromIndex, _id: elId, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
             { script },
@@ -3776,7 +3787,7 @@ export const computeDeleteElementsImpacts = async (cleanupRelations, toBeRemoved
         elementsImpact[relation.fromId] = { [cleanKey]: [relation.toId] };
       } else {
         const current = elementsImpact[relation.fromId];
-        if (current[cleanKey] && !current[cleanKey].includes(relation.toId)) {
+        if (current[cleanKey]) {
           elementsImpact[relation.fromId][cleanKey].push(relation.toId);
         } else {
           elementsImpact[relation.fromId][cleanKey] = [relation.toId];
@@ -3791,7 +3802,7 @@ export const computeDeleteElementsImpacts = async (cleanupRelations, toBeRemoved
         elementsImpact[relation.toId] = { [cleanKey]: [relation.fromId] };
       } else {
         const current = elementsImpact[relation.toId];
-        if (current[cleanKey] && !current[cleanKey].includes(relation.fromId)) {
+        if (current[cleanKey]) {
           elementsImpact[relation.toId][cleanKey].push(relation.fromId);
         } else {
           elementsImpact[relation.toId][cleanKey] = [relation.fromId];

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3729,18 +3729,13 @@ export const elRemoveRelationConnection = async (context, user, elementsImpact) 
           const refField = isStixRefRelationship(relationType) && isInferredIndex(relationIndex) ? ID_INFERRED : ID_INTERNAL;
           const rel_key = buildRefRelationKey(relationType, refField);
           let source = `if(ctx._source[params.rel_key] != null){
-            Map foundIds = new HashMap();
-            for (int i=params.cleanupIds.length-1; i>=0; i--) {
-              boolean currentFound = false;
-              for (int j=ctx._source[params.rel_key].length-1; j>=0; j--) {
-                if (!currentFound && foundIds[j] != false && ctx._source[params.rel_key][j] == params.cleanupIds[i]) {
-                  currentFound = true;
-                  foundIds[j] = true;
-                  ctx._source[params.rel_key].remove(j);
+              for (int i=params.cleanupIds.length-1; i>=0; i--) {
+                def cleanupIndex = ctx._source[params.rel_key].indexOf(params.cleanupIds[i]);
+                if(cleanupIndex !== 1){
+                  ctx._source[params.rel_key].remove(cleanupIndex);
                 }
-              }
             }
-          }
+          }  
           `;
           // Only impact the updated at on the from side of the ref relationship
           const fromSide = side === 'from';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* keep 'duplicates' in computeDeleteElementsImpacts. If a 'duplicate' id is found, it is there for a good reason: it needs to be taken into account, because it means that there are 2 relations of the same type and same target
* change script in elRemoveRelationConnection to only remove first occurence of cleanUpIds

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7208 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
