### PR TITLE
[frontend] Detect changes in CK Editor when in Source mode (#8694)

### DIFF
--- a/opencti-platform/opencti-front/src/components/CKEditor.tsx
+++ b/opencti-platform/opencti-front/src/components/CKEditor.tsx
@@ -221,6 +221,22 @@ const CKEditor = (props: CKEditorProps<ClassicEditor>) => {
       editor={ClassicEditor}
       config={config}
       {...props}
+      onReady={(editor) => { // to detect changes in source editing mode
+        props.onReady?.(editor); // call parent-provided onReady if defined
+        if (editor.plugins.has('SourceEditing')) {
+          const sourceEditingPlugin = editor.plugins.get('SourceEditing');
+          sourceEditingPlugin.on('change:isSourceEditingMode', (evt, _, isSourceEditingMode) => {
+            if (isSourceEditingMode) {
+              const textarea = document.querySelector('.ck-source-editing-area textarea') as HTMLTextAreaElement;
+              if (textarea) {
+                textarea.addEventListener('input', () => {
+                  props.onChange?.(evt, editor); // trigger manually onChange
+                });
+              }
+            }
+          });
+        }
+      }}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -538,8 +538,8 @@ class StixCoreObjectContentComponent extends Component {
                 >
                   <CKEditor
                     data={currentContent ?? ''}
-                    onChange={() => {
-                      this.setState({ changed: true });
+                    onChange={(_, editor) => {
+                      this.setState({ currentContent: editor.getData(), changed: true });
                     }}
                     onBlur={(_, editor) => {
                       this.onHtmlFieldChange(editor.getData());


### PR DESCRIPTION
### Proposed changes
In the Content tab of a Container, in the text area to edit an html file, detect changes when in Source mode to be able to save the changes in Source mode.

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8694