### PR TITLE
[frontend] do not use particles for links (#10586)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -178,9 +178,6 @@ const Graph = ({
               linkCanvasObjectMode={() => 'after'}
               linkCanvasObject={(link, ctx) => (shouldDisplayLinks ? linkLabelPaint(link, ctx) : null)}
               linkLineDash={(link) => (link.isNestedInferred ? [2, 1] : null)}
-              linkDirectionalParticles={(link) => (link.inferred ? 20 : 0)}
-              linkDirectionalParticleWidth={2}
-              linkDirectionalParticleSpeed={() => 0.002}
               linkColor={linkColorPaint}
               nodePointerAreaPaint={nodePointerAreaPaint} // What's for?
               nodeCanvasObject={(node, ctx) => nodePaint(node, ctx, {

--- a/opencti-platform/opencti-front/src/components/graph/SimpleGraph2D.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/SimpleGraph2D.tsx
@@ -8,11 +8,13 @@ import { GraphRef2D } from './GraphContext';
 interface SimpleGraph2DProps extends ForceGraphProps<GraphNode, GraphLink> {
   parentRef: MutableRefObject<HTMLDivElement | null>
   onReady?: (graphRef: GraphRef2D) => void
+  showParticules?: boolean
 }
 
 const SimpleGraph2D = ({
   parentRef,
   onReady,
+  showParticules = false,
   ...graphProps
 }: SimpleGraph2DProps) => {
   const initialized = useRef(false);
@@ -47,9 +49,9 @@ const SimpleGraph2D = ({
       linkCanvasObjectMode={() => 'after'}
       linkCanvasObject={(link, ctx) => linkLabelPaint(link, ctx)}
       linkLineDash={(link) => (link.isNestedInferred ? [2, 1] : null)}
-      linkDirectionalParticles={(link) => (link.inferred ? 20 : 0)}
-      linkDirectionalParticleWidth={2}
-      linkDirectionalParticleSpeed={() => 0.002}
+      linkDirectionalParticles={(link) => (link.inferred && showParticules ? 20 : 0)}
+      linkDirectionalParticleWidth={showParticules ? 2 : undefined}
+      linkDirectionalParticleSpeed={showParticules ? 0.002 : undefined}
       linkColor={linkColorPaint}
       nodePointerAreaPaint={nodePointerAreaPaint} // What's for?
       nodeCanvasObject={(node, ctx) => nodePaint(node, ctx)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
@@ -101,6 +101,7 @@ const StixCoreRelationshipInference = ({ stixRelationship, inference }) => {
       />
       <div ref={parentRef} style={{ height: 430 }}>
         <SimpleGraph2D
+          showParticules
           onReady={(graphRef) => {
             graphRef.d3Force('link').distance(80);
             graphRef.zoomToFit(200, 140);


### PR DESCRIPTION
### Proposed changes

* Remove the usage of particles in graphs, except for graph explaining inferred relation

### Related issues

* #10586 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
