### PR TITLE
[frontend] Graphs: display loading long enough to avoid blink effect (#10584)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -86,13 +86,17 @@ const Graph = ({
 
   useGraphFilter();
 
+  const isLoadingData = (loadingCurrent ?? 0) < (loadingTotal ?? 0);
+
   useEffect(() => {
     // A short timeout to be sure graph is ready.
     setTimeout(() => {
-      if (zoom) setZoom(zoom);
-      else zoomToFit();
-    }, 100);
-  }, [mode3D]);
+      if (!isLoadingData) {
+        if (zoom) setZoom(zoom);
+        else zoomToFit();
+      }
+    }, 200);
+  }, [mode3D, isLoadingData]);
 
   const shouldDisplayLinks = graphData?.links.length ?? 0 < 200;
   const selectedEntities = [...selectedLinks, ...selectedNodes];
@@ -123,8 +127,6 @@ const Graph = ({
     toggleNode(node, e);
   };
 
-  const isLoadingData = (loadingCurrent ?? 0) < (loadingTotal ?? 0);
-
   return (
     <RectangleSelection
       graphId={graphId}
@@ -132,7 +134,7 @@ const Graph = ({
       onSelection={selectFromFreeRectangle}
     >
       <div style={{ position: 'relative' }} id={graphId}>
-        {isLoadingData && <GraphLoadingAlert />}
+        <GraphLoadingAlert />
         {selectedEntities.length > 0 && <EntitiesDetailsRightsBar />}
         {mode3D ? (
           <ForceGraph3D<GraphNode, GraphLink>


### PR DESCRIPTION
### Proposed changes

* Do not display loading if only one page
* If multiple pages to load, display loading at least 1.5s to avoid blink effect

### Related issues

* #10584 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality