### PR TITLE
[frontend] Dont display previous result while AskAI content is loading (#10665)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/TextFieldAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/TextFieldAskAI.tsx
@@ -115,7 +115,7 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
   const handleOpenAskAI = () => setDisplayAskAI(true);
   const handleCloseAskAI = () => {
     setContent('');
-    setDisplayAskAI(false)
+    setDisplayAskAI(false);
   };
 
   const [commitMutationFixSpelling] = useApiMutation<TextFieldAskAIFixSpellingMutation>(textFieldAskAIFixSpellingMutation);

--- a/opencti-platform/opencti-front/src/private/components/common/form/TextFieldAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/TextFieldAskAI.tsx
@@ -88,6 +88,7 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
   const { t_i18n } = useFormatter();
   const isEnterpriseEdition = useEnterpriseEdition();
   const { enabled, configured } = useAI();
+
   const [content, setContent] = useState('');
   const [disableResponse, setDisableResponse] = useState(false);
   const [openToneOptions, setOpenToneOptions] = useState(false);
@@ -96,6 +97,7 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
   const [menuOpen, setMenuOpen] = useState<{ open: boolean; anchorEl: HTMLButtonElement | null; }>({ open: false, anchorEl: null });
   const [busId, setBusId] = useState<string | null>(null);
   const [displayAskAI, setDisplayAskAI] = useState(false);
+
   const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (isEnterpriseEdition) {
       event.preventDefault();
@@ -111,13 +113,18 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
   };
   const handleCloseToneOptions = () => setOpenToneOptions(false);
   const handleOpenAskAI = () => setDisplayAskAI(true);
-  const handleCloseAskAI = () => setDisplayAskAI(false);
+  const handleCloseAskAI = () => {
+    setContent('');
+    setDisplayAskAI(false)
+  };
+
   const [commitMutationFixSpelling] = useApiMutation<TextFieldAskAIFixSpellingMutation>(textFieldAskAIFixSpellingMutation);
   const [commitMutationMakeShorter] = useApiMutation<TextFieldAskAIMakeShorterMutation>(textFieldAskAIMakeShorterMutation);
   const [commitMutationMakeLonger] = useApiMutation<TextFieldAskAIMakeLongerMutation>(textFieldAskAIMakeLongerMutation);
   const [commitMutationChangeTone] = useApiMutation<TextFieldAskAIChangeToneMutation>(textFieldAskAIChangeToneMutation);
   const [commitMutationSummarize] = useApiMutation<TextFieldAskAISummarizeMutation>(textFieldAskAISummarizeMutation);
   const [commitMutationExplain] = useApiMutation<TextFieldAskAIExplainMutation>(textFieldAskAIExplainMutation);
+
   const handleAskAi = (action: string, canBeAccepted = true) => {
     setDisableResponse(true);
     handleCloseMenu();
@@ -232,6 +239,7 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
         // do nothing
     }
   };
+
   const renderButton = () => {
     return (
       <>
@@ -329,6 +337,7 @@ const TextFieldAskAI: FunctionComponent<TextFieldAskAiProps> = ({
       </>
     );
   };
+
   if (variant === 'markdown') {
     return (
       <div style={style || { position: 'absolute', top: 17, right: 0, paddingTop: 4 }}>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
@@ -89,6 +89,7 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
   const navigate = useNavigate();
   const isKnowledgeUploader = useGranted([KNOWLEDGE_KNUPLOAD]);
   const defaultLanguageName = getDefaultAiLanguage();
+
   const [language, setLanguage] = useState(defaultLanguageName);
   const [content, setContent] = useState('');
   const [acceptedResult, setAcceptedResult] = useState<string | null>(null);
@@ -102,12 +103,18 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
   const [disableResponse, setDisableResponse] = useState(false);
   const [busId, setBusId] = useState<string | null>(null);
   const [displayAskAI, setDisplayAskAI] = useState(false);
+
   const action = 'container-report' as 'container-report' | 'summarize-files' | 'convert-files';
   const handleOpenAskAI = () => setDisplayAskAI(true);
-  const handleCloseAskAI = () => setDisplayAskAI(false);
+  const handleCloseAskAI = () => {
+    setContent('');
+    setDisplayAskAI(false);
+  }
+
   const [commitMutationUpdateContent] = useApiMutation<StixCoreObjectMappableContentFieldPatchMutation>(stixCoreObjectMappableContentFieldPatchMutation);
   const [commitMutationCreateFile] = useApiMutation<StixCoreObjectContentFilesUploadStixCoreObjectMutation>(stixCoreObjectContentFilesUploadStixCoreObjectMutation);
   const [commitMutationContainerReport] = useApiMutation<StixCoreObjectAskAIContainerReportMutation>(stixCoreObjectAskAIContainerReportMutation);
+
   const handleAskAiContent = () => {
     handleCloseOptions();
     setDisableResponse(true);
@@ -133,6 +140,7 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
       },
     });
   };
+
   const handleAskAi = () => {
     // check paragraphs value is correct
     if (action === 'container-report' || action === 'summarize-files') {
@@ -147,10 +155,12 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
       handleAskAiContent();
     }
   };
+
   const handleCancelDestination = () => {
     setAcceptedResult(null);
     setDisplayAskAI(true);
   };
+
   const submitAcceptedResult = () => {
     setIsSubmitting(true);
     if (destination === 'content') {
@@ -205,6 +215,7 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
       });
     }
   };
+
   return (
     <>
       <Dialog

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
@@ -109,7 +109,7 @@ const StixCoreObjectAskAI: FunctionComponent<StixCoreObjectAskAiProps> = ({
   const handleCloseAskAI = () => {
     setContent('');
     setDisplayAskAI(false);
-  }
+  };
 
   const [commitMutationUpdateContent] = useApiMutation<StixCoreObjectMappableContentFieldPatchMutation>(stixCoreObjectMappableContentFieldPatchMutation);
   const [commitMutationCreateFile] = useApiMutation<StixCoreObjectContentFilesUploadStixCoreObjectMutation>(stixCoreObjectContentFilesUploadStixCoreObjectMutation);

--- a/opencti-platform/opencti-front/src/utils/ai/ResponseDialog.tsx
+++ b/opencti-platform/opencti-front/src/utils/ai/ResponseDialog.tsx
@@ -148,8 +148,6 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
                 id="response-dialog-editor"
                 data={content}
                 onChange={(_, editor) => {
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore
                   setContent(editor.getData());
                 }}
                 disabled={isDisabled}


### PR DESCRIPTION
### Proposed changes
While Ask AI content is loading, display nothing in the text area (instead of displaying the eventual previous Ask AI result content)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10665