### PR TITLE
[backend] Add authorized members on notifications 

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
@@ -324,7 +324,7 @@ export const notificationEditRead = async (context: AuthContext, user: AuthUser,
   return notify(BUS_TOPICS[ENTITY_TYPE_NOTIFICATION].EDIT_TOPIC, element, user);
 };
 export const addNotification = async (context: AuthContext, user: AuthUser, notification: NotificationAddInput) => {
-  const members = [{ id: user.id, access_right: MEMBER_ACCESS_RIGHT_ADMIN }];
+  const members = [{ id: notification.user_id, access_right: MEMBER_ACCESS_RIGHT_ADMIN }];
   const notificationWithAuthorized = {
     ...notification,
     restricted_members: members,

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-domain.ts
@@ -293,7 +293,8 @@ export const notificationGet = (context: AuthContext, user: AuthUser, narrativeI
   return storeLoadById(context, user, narrativeId, ENTITY_TYPE_NOTIFICATION) as unknown as BasicStoreEntityNotification;
 };
 export const notificationsFind = (context: AuthContext, user: AuthUser, opts: QueryNotificationsArgs) => {
-  return listEntitiesPaginated<BasicStoreEntityNotification>(context, user, [ENTITY_TYPE_NOTIFICATION], opts);
+  const queryArgs = { ...opts, includeAuthorities: true };
+  return listEntitiesPaginated<BasicStoreEntityNotification>(context, user, [ENTITY_TYPE_NOTIFICATION], queryArgs);
 };
 export const myNotificationsFind = (context: AuthContext, user: AuthUser, opts: QueryNotificationsArgs) => {
   const queryFilters = addFilter(opts.filters, 'user_id', user.id);
@@ -323,7 +324,13 @@ export const notificationEditRead = async (context: AuthContext, user: AuthUser,
   return notify(BUS_TOPICS[ENTITY_TYPE_NOTIFICATION].EDIT_TOPIC, element, user);
 };
 export const addNotification = async (context: AuthContext, user: AuthUser, notification: NotificationAddInput) => {
-  const created = await createEntity(context, user, notification, ENTITY_TYPE_NOTIFICATION);
+  const members = [{ id: user.id, access_right: MEMBER_ACCESS_RIGHT_ADMIN }];
+  const notificationWithAuthorized = {
+    ...notification,
+    restricted_members: members,
+    authorized_authorities: [SETTINGS_SET_ACCESSES, VIRTUAL_ORGANIZATION_ADMIN] // Add extra capabilities
+  };
+  const created = await createEntity(context, user, notificationWithAuthorized, ENTITY_TYPE_NOTIFICATION);
   const unreadNotificationsCount = await myUnreadNotificationsCount(context, user, created.user_id);
   await notify(BUS_TOPICS[NOTIFICATION_NUMBER].EDIT_TOPIC, { count: unreadNotificationsCount, user_id: created.user_id }, user);
   return notify(BUS_TOPICS[ENTITY_TYPE_NOTIFICATION].ADDED_TOPIC, created, user);

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
@@ -74,6 +74,7 @@ export interface NotificationAddInput {
     events: Array<NotificationContentEvent>
   }>
   trigger_id?: string
+  user_id: string
 }
 
 // region Database types

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -118,6 +118,8 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
       upsert: false,
       isFilterable: false
     },
+    authorizedMembers,
+    authorizedAuthorities,
   ],
   relations: [],
   representative: (stix: StixNotification) => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-delete-cleanup-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-delete-cleanup-test.ts
@@ -44,7 +44,9 @@ const createNotificationForUser = async (context: AuthContext, user: AuthUser) =
     notification_content: [{
       title: '',
       events: []
-    }] };
+    }],
+    user_id: user.id,
+  };
   return addNotification(context, user, notificationInput);
 };
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/notifications-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/notifications-test.ts
@@ -1,0 +1,164 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { ADMIN_USER, getUserIdByEmail, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { addNotification } from '../../../src/modules/notification/notification-domain';
+import type { AuthUser } from '../../../src/types/user';
+import { adminQueryWithSuccess, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
+
+const READ_NOTIFICATION_QUERY = gql`
+  query notification($id: String!) {
+    notification(id: $id) {
+      id
+      name
+    }
+  }
+`;
+const DELETE_NOTIFICATION_QUERY = gql`
+  mutation NotificationDelete($id: ID!) {
+    notificationDelete(id: $id)
+  }
+`;
+const MARK_READ_NOTIFICATION_QUERY = gql`
+  mutation NotificationMarkRead($id: ID!, $read: Boolean!) {
+    notificationMarkRead(id: $id, read: $read) {
+      is_read
+    }
+  }
+`;
+
+describe('Notifications resolver restriction behavior', () => {
+  let adminNotificationId: string;
+  let userNotificationId: string;
+  beforeAll(async () => {
+    // Admin creates 1 notification
+    const adminNotificationInput = {
+      is_read: false,
+      name: 'Admin notification',
+      notification_type: 'live',
+      notification_content: [
+        {
+          title: 'report same org intersec',
+          events: [
+            {
+              operation: 'update',
+              message: '[report] report same org intersec - `admin` replaces `description updated` in `Description`',
+              instance_id: 'report--b07ba95d-8a26-59c9-91a0-54a0829eae09'
+            }
+          ]
+        }
+      ],
+      user_id: ADMIN_USER.id
+    };
+
+    const adminNotification = await addNotification(testContext, ADMIN_USER, adminNotificationInput);
+    adminNotificationId = adminNotification.id;
+
+    // User creates 1 notification
+    const userID = await getUserIdByEmail(USER_EDITOR.email);
+    const userNotificationInput = {
+      is_read: false,
+      name: 'User notification',
+      notification_type: 'live',
+      notification_content: [
+        {
+          title: 'report same org intersec',
+          events: [
+            {
+              operation: 'update',
+              message: '[report] report same org intersec - `admin` replaces `description updated` in `Description`',
+              instance_id: 'report--b07ba95d-8a26-59c9-91a0-54a0829eae09'
+            }
+          ]
+        }
+      ],
+      user_id: userID
+    };
+    const userNotification = await addNotification(testContext, USER_EDITOR as unknown as AuthUser, userNotificationInput);
+    userNotificationId = userNotification.id;
+  });
+
+  it('Admin user should get its own notification', async () => {
+    const notification = await adminQueryWithSuccess({
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    expect(notification.id).toEqual(adminNotificationId);
+  });
+  it.todo('Admin user should get user notification', async () => {
+    const notification = await adminQueryWithSuccess({
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    expect(notification.id).toEqual(userNotificationId);
+  });
+  it.todo('User should get its own notification', async () => {
+    const notification = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    expect(notification.id).toEqual(userNotificationId);
+  });
+  it.todo('User should not get Admin notification', async () => {
+    const notification = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    expect(notification.id).toBeNull();
+  });
+  it.todo('User should not update Admin notification', async () => {
+    const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: MARK_READ_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    expect(result).toBeNull();
+  });
+  it.todo('User should not delete Admin notification', async () => {
+    const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: DELETE_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    expect(result).toBeNull();
+  });
+  it.todo('Admin should delete User notification', async () => {
+    await adminQueryWithSuccess({
+      query: DELETE_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    const notification = await adminQueryWithSuccess({
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    expect(notification.id).toBeNull();
+  });
+  it.todo('Admin should delete its own notification', async () => {
+    await adminQueryWithSuccess({
+      query: DELETE_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    const notification = await adminQueryWithSuccess({
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    expect(notification.id).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/notifications-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/notifications-test.ts
@@ -1,9 +1,8 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, getUserIdByEmail, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { addNotification } from '../../../src/modules/notification/notification-domain';
-import type { AuthUser } from '../../../src/types/user';
-import { adminQueryWithSuccess, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
+import { adminQueryWithSuccess, queryAsUserIsExpectedError, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
 
 const READ_NOTIFICATION_QUERY = gql`
   query notification($id: String!) {
@@ -54,7 +53,7 @@ describe('Notifications resolver restriction behavior', () => {
     adminNotificationId = adminNotification.id;
 
     // User creates 1 notification
-    const userID = await getUserIdByEmail(USER_EDITOR.email);
+    const user = await getAuthUser(USER_EDITOR.id);
     const userNotificationInput = {
       is_read: false,
       name: 'User notification',
@@ -71,94 +70,94 @@ describe('Notifications resolver restriction behavior', () => {
           ]
         }
       ],
-      user_id: userID
+      user_id: user.id
     };
-    const userNotification = await addNotification(testContext, USER_EDITOR as unknown as AuthUser, userNotificationInput);
+    const userNotification = await addNotification(testContext, user, userNotificationInput);
     userNotificationId = userNotification.id;
   });
 
   it('Admin user should get its own notification', async () => {
-    const notification = await adminQueryWithSuccess({
+    const result = await adminQueryWithSuccess({
       query: READ_NOTIFICATION_QUERY,
       variables: {
         id: adminNotificationId
       }
     });
-    expect(notification.id).toEqual(adminNotificationId);
+    expect(result.data.notification.id).toEqual(adminNotificationId);
   });
-  it.todo('Admin user should get user notification', async () => {
-    const notification = await adminQueryWithSuccess({
+  it('Admin user should get user notification', async () => {
+    const result = await adminQueryWithSuccess({
       query: READ_NOTIFICATION_QUERY,
       variables: {
         id: userNotificationId
       }
     });
-    expect(notification.id).toEqual(userNotificationId);
+    expect(result.data.notification.id).toEqual(userNotificationId);
   });
-  it.todo('User should get its own notification', async () => {
-    const notification = await queryAsUserWithSuccess(USER_EDITOR.client, {
-      query: READ_NOTIFICATION_QUERY,
-      variables: {
-        id: userNotificationId
-      }
-    });
-    expect(notification.id).toEqual(userNotificationId);
-  });
-  it.todo('User should not get Admin notification', async () => {
-    const notification = await queryAsUserWithSuccess(USER_EDITOR.client, {
-      query: READ_NOTIFICATION_QUERY,
-      variables: {
-        id: adminNotificationId
-      }
-    });
-    expect(notification.id).toBeNull();
-  });
-  it.todo('User should not update Admin notification', async () => {
+  it('User should get its own notification', async () => {
     const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: userNotificationId
+      }
+    });
+    expect(result.data.notification.id).toEqual(userNotificationId);
+  });
+  it('User should not get Admin notification', async () => {
+    const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+      query: READ_NOTIFICATION_QUERY,
+      variables: {
+        id: adminNotificationId
+      }
+    });
+    expect(result.data.notification).toBeNull();
+  });
+  it('User should not update Admin notification', async () => {
+    await queryAsUserIsExpectedError(USER_EDITOR.client, {
       query: MARK_READ_NOTIFICATION_QUERY,
       variables: {
-        id: adminNotificationId
-      }
-    });
-    expect(result).toBeNull();
+        id: adminNotificationId,
+        read: true,
+      },
+    }, 'Cant find element to update', 'FUNCTIONAL_ERROR');
   });
-  it.todo('User should not delete Admin notification', async () => {
-    const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+  it('User should not delete Admin notification', async () => {
+    await queryAsUserIsExpectedError(USER_EDITOR.client, {
       query: DELETE_NOTIFICATION_QUERY,
       variables: {
-        id: adminNotificationId
-      }
-    });
-    expect(result).toBeNull();
+        id: adminNotificationId,
+        read: true,
+      },
+    }, 'Already deleted elements', 'ALREADY_DELETED_ERROR');
   });
-  it.todo('Admin should delete User notification', async () => {
+  it('Admin should delete User notification', async () => {
     await adminQueryWithSuccess({
       query: DELETE_NOTIFICATION_QUERY,
       variables: {
         id: userNotificationId
       }
     });
-    const notification = await adminQueryWithSuccess({
+    const result = await adminQueryWithSuccess({
       query: READ_NOTIFICATION_QUERY,
       variables: {
         id: userNotificationId
       }
     });
-    expect(notification.id).toBeNull();
+    expect(result.data.notification).toBeNull();
   });
-  it.todo('Admin should delete its own notification', async () => {
+  it('Admin should delete its own notification', async () => {
     await adminQueryWithSuccess({
       query: DELETE_NOTIFICATION_QUERY,
       variables: {
         id: adminNotificationId
       }
     });
-    const notification = await adminQueryWithSuccess({
+    const result = await adminQueryWithSuccess({
       query: READ_NOTIFICATION_QUERY,
       variables: {
         id: userNotificationId
       }
     });
-    expect(notification.id).toBeNull();
+    expect(result.data.notification).toBeNull();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -15,6 +15,7 @@ import { generateStandardId, MARKING_TLP_AMBER, MARKING_TLP_AMBER_STRICT, MARKIN
 import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE, ENTITY_TYPE_USER } from '../../src/schema/internalObject';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../src/modules/organization/organization-types';
 import type { ConfidenceLevel } from '../../src/generated/graphql';
+import { findById } from '../../src/domain/user';
 // endregion
 
 export const SYNC_RAW_START_REMOTE_URI = conf.get('app:sync_raw_start_remote_uri');
@@ -628,6 +629,13 @@ export const getUserIdByEmail = async (email: string) => {
     return null;
   }
   return data.users.edges[0].node.id;
+};
+export const getAuthUser = async (id: string) => {
+  const user = await findById(testContext, ADMIN_USER, id);
+  return {
+    ...user,
+    origin: { referer: 'test', user_id: user.internal_id },
+  } as AuthUser;
 };
 
 // endregion


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add authorized members on notifications
* add resolver test for notifications

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
