### PR TITLE
[frontend] Fix exporting image by skipping fonts (#10680)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Image.js
+++ b/opencti-platform/opencti-front/src/utils/Image.js
@@ -24,6 +24,7 @@ export const exportImage = (
       .toBlob(container, {
         useCORS: true,
         allowTaint: true,
+        skipFonts: true,
         pixelRatio,
         backgroundColor,
         style: { margin: 0 },


### PR DESCRIPTION
### Proposed changes

* Skip fonts in lib `html-to-image`

### Related issues

* #10680 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality