### PR TITLE
[CI] copy opencti-platform without nodes_modules for start services (#10684)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,6 +59,9 @@ steps:
       - yarn check-ts
       - yarn lint
       - if [ $(wget --server-response "http://opencti-raw-start:4100/health?health_access_key=cihealthkey" -O opencti-raw-start-health 2>&1 | grep -c "200 OK") != 1 ]; then echo "ERROR opencti-raw-start has not start correctly"; exit 1; fi
+      - if [ $(wget --server-response "http://opencti-live-start:4200/health?health_access_key=cihealthkey" -O opencti-live-start-health 2>&1 | grep -c "200 OK") != 1 ]; then echo "ERROR opencti-live-start has not start correctly"; exit 1; fi
+      - if [ $(wget --server-response "http://opencti-direct-start:4300/health?health_access_key=cihealthkey" -O opencti-direct-start 2>&1 | grep -c "200 OK") != 1 ]; then echo "ERROR opencti-direct-start has not start correctly"; exit 1; fi
+      - if [ $(wget --server-response "http://opencti-restore-start:4400/health?health_access_key=cihealthkey" -O opencti-restore-start 2>&1 | grep -c "200 OK") != 1 ]; then echo "ERROR opencti-restore-start has not start correctly"; exit 1; fi
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
       - dependencies-checkout
@@ -262,6 +265,7 @@ services:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
       APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
+      APP__HEALTH_ACCESS_KEY: cihealthkey
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: live-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -296,6 +300,7 @@ services:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
       APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
+      APP__HEALTH_ACCESS_KEY: cihealthkey
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: direct-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -308,7 +313,7 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
     commands:
       - sleep 10
-      - cp -a /tmp/platform-reference/* /tmp/direct-start-platform/
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/direct-start-platform/
       - apk add build-base git libffi-dev cargo
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
@@ -352,6 +357,7 @@ services:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
       APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
+      APP__HEALTH_ACCESS_KEY: cihealthkey
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: restore-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -365,7 +371,7 @@ services:
     commands:
       - sleep 10
       - apk add build-base git libffi-dev cargo
-      - cp -a /tmp/platform-reference/* /tmp/restore-start-platform/
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/restore-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,11 +13,12 @@ steps:
       - chmod 777 scripts/*
       - ./scripts/clone-dependencies.sh "${DRONE_SOURCE_BRANCH}" "${DRONE_TARGET_BRANCH}" "$(pwd)" "${DRONE_PULL_REQUEST}"
       - ls -lart
+      # copy opencti-platform without nodes_modules
+      - cp -R opencti-platform /tmp/platform-reference
       - cd "$DRONE_WORKSPACE/client-python"
       - echo "[INFO] using client-python on branch $(git branch --show-current)"
       - git log -n 1
-      - # copy opencti-platform without nodes_modules
-      - cp -R opencti-platform /tmp/platform-reference
+
 
   - name: api-tests
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,12 +9,12 @@ steps:
       GITHUB_TOKEN:
           from_secret: github_token
     commands:
+      # copy opencti-platform without nodes_modules
+      - cp -R opencti-platform platform-reference
       - apk add git github-cli
       - chmod 777 scripts/*
       - ./scripts/clone-dependencies.sh "${DRONE_SOURCE_BRANCH}" "${DRONE_TARGET_BRANCH}" "$(pwd)" "${DRONE_PULL_REQUEST}"
       - ls -lart
-      # copy opencti-platform without nodes_modules
-      - cp -R opencti-platform /tmp/platform-reference
       - cd "$DRONE_WORKSPACE/client-python"
       - echo "[INFO] using client-python on branch $(git branch --show-current)"
       - git log -n 1
@@ -58,6 +58,7 @@ steps:
       - yarn build
       - yarn check-ts
       - yarn lint
+      - if [ $(wget --server-response "http://opencti-raw-start:4100/health?health_access_key=cihealthkey" -O opencti-raw-start-health 2>&1 | grep -c "200 OK") != 1 ]; then echo "ERROR opencti-raw-start has not start correctly"; exit 1; fi
       - NODE_OPTIONS=--max_old_space_size=8192 yarn test
     depends_on:
       - dependencies-checkout
@@ -224,6 +225,7 @@ services:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
       APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
+      APP__HEALTH_ACCESS_KEY: cihealthkey
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: raw-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -238,7 +240,7 @@ services:
       - sleep 10
       - ls -lart
       - apk add build-base git libffi-dev cargo
-      - cp -a /tmp/platform-reference/* /tmp/raw-start-platform/
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/raw-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -246,6 +248,7 @@ services:
       - yarn install
       - yarn install:python
       - NODE_OPTIONS=--max_old_space_size=8192 yarn start
+
   - name: opencti-live-start
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
     volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -279,7 +279,7 @@ services:
     commands:
       - sleep 10
       - apk add build-base git libffi-dev cargo
-      - cp -a /tmp/platform-reference/* /tmp/live-start-platform/
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/live-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -393,6 +393,7 @@ services:
         from_secret: ee_license
       APP__ADMIN__TOKEN: bfa014e0-e02e-4aa6-a42b-603b19dcf159
       APP__APP_LOG__EXTENDED_ERROR_MESSAGE: true
+      APP__HEALTH_ACCESS_KEY: cihealthkey
       REDIS__HOSTNAME: redis
       REDIS__NAMESPACE: e2e-start
       ELASTICSEARCH__URL: http://elastic:9200
@@ -406,7 +407,7 @@ services:
       PUBLISHER_MANAGER__ENABLED: false
     commands:
       - apk add build-base git libffi-dev cargo
-      - cp -a /tmp/platform-reference/* /tmp/e2e-start-platform/
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/e2e-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]

--- a/.drone.yml
+++ b/.drone.yml
@@ -313,8 +313,8 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
     commands:
       - sleep 10
-      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/direct-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/direct-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,8 @@ steps:
       - cd "$DRONE_WORKSPACE/client-python"
       - echo "[INFO] using client-python on branch $(git branch --show-current)"
       - git log -n 1
+      - # copy opencti-platform without nodes_modules
+      - cp -R opencti-platform /tmp/platform-reference
 
   - name: api-tests
     image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
@@ -234,8 +236,8 @@ services:
     commands:
       - sleep 10
       - ls -lart
-      - cp -a opencti-platform/* /tmp/raw-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cp -a /tmp/platform-reference/* /tmp/raw-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -268,8 +270,8 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
     commands:
       - sleep 10
-      - cp -a opencti-platform/* /tmp/live-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cp -a /tmp/platform-reference/* /tmp/live-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -302,7 +304,7 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
     commands:
       - sleep 10
-      - cp -a opencti-platform/* /tmp/direct-start-platform/
+      - cp -a /tmp/platform-reference/* /tmp/direct-start-platform/
       - apk add build-base git libffi-dev cargo
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
@@ -322,8 +324,8 @@ services:
       WORKER_LOG_LEVEL: info
     commands:
       - sleep 10
-      - cp -a opencti-worker /tmp/direct-start-worker
       - apk add build-base git libffi-dev cargo
+      - cp -a opencti-worker /tmp/direct-start-worker
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -358,8 +360,8 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
     commands:
       - sleep 10
-      - cp -a opencti-platform/* /tmp/restore-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cp -a /tmp/platform-reference/* /tmp/restore-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]
@@ -393,8 +395,8 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
       PUBLISHER_MANAGER__ENABLED: false
     commands:
-      - cp -a opencti-platform/* /tmp/e2e-start-platform/
       - apk add build-base git libffi-dev cargo
+      - cp -a /tmp/platform-reference/* /tmp/e2e-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
       - pip install -r requirements.txt
       - pip install -e .[dev,doc]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add health check configuration to start service
* fail fast api-test when one of start service has not started correctly
* change the way opencti-platform is cp for start service to avoid "can't cp" errors.

![image](https://github.com/user-attachments/assets/1f1f3efd-9336-4707-a5aa-71aacf7c785d)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #10684 
* closes in a way #7246

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
