### PR TITLE
[frontend] Display all filters inline with a single tooltip(#9806)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -271,7 +271,7 @@ FilterIconButtonContainerProps
     }
   }
   const allFilterKeys = displayedFilters.map((filter) => filter.key);
-  const allRegardingOf = allFilterKeys.every((key) => key === 'regardingOf');
+  const allRegardingOfFilterKeys = allFilterKeys.every((key) => key === 'regardingOf');
   const buildKeyLabel = (filterOperator: string, filterLabel: string, values: string[]) => {
     const isOperatorDisplayed = filterOperatorsWithIcon.includes(filterOperator);
     return (
@@ -327,7 +327,7 @@ FilterIconButtonContainerProps
   return (
     <Tooltip
       title={
-        allRegardingOf
+        allRegardingOfFilterKeys
           ? undefined
           : tooltipContent
     }

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -270,158 +270,168 @@ FilterIconButtonContainerProps
       };
     }
   }
+  const allFilterKeys = displayedFilters.map((filter) => filter.key);
+  const allRegardingOf = allFilterKeys.every((key) => key === 'regardingOf');
+  const buildKeyLabel = (filterOperator: string, filterLabel: string, values: string[]) => {
+    const isOperatorDisplayed = filterOperatorsWithIcon.includes(filterOperator);
+    return (
+      <>
+        {truncate(filterLabel, 20)}
+        {isOperatorDisplayed ? (
+          <Box component="span" sx={{ padding: '0 4px', fontWeight: 'normal' }}>
+            {convertOperatorToIcon(filterOperator)}
+          </Box>
+        ) : (
+          <>
+            <Box component="span" sx={{ padding: '0 4px', fontWeight: 'normal' }}>
+              {t_i18n(filterOperator)}
+            </Box>
+            {values.length > 0 && ':'}
+          </>
+        )}
+      </>
+    );
+  };
 
-  return (
-    <Box sx={boxStyle}>
+  const tooltipContent = (
+    <Box>
       {displayedFilters.map((currentFilter, index) => {
         const filterKey = currentFilter.key;
         const filterLabel = t_i18n(useFilterDefinition(filterKey, entityTypes)?.label ?? filterKey);
         const filterOperator = currentFilter.operator ?? 'eq';
-        const filterValues = currentFilter.values;
-        const isOperatorDisplayed = filterOperatorsWithIcon.includes(filterOperator ?? 'eq');
-        const keyLabel = (
-          <>
-            {truncate(filterLabel, 20)}
-            {!isOperatorDisplayed && (
-              <Box
-                component={'span'}
-                sx={{ padding: '0 4px', fontWeight: 'normal' }}
-              >
-                {t_i18n(filterOperator)}
-              </Box>
-            )}
-            {isOperatorDisplayed
-              ? convertOperatorToIcon(filterOperator ?? 'eq')
-              : currentFilter.values.length > 0 && ':'}
-          </>
-        );
+        const keyLabel = buildKeyLabel(filterOperator, filterLabel, currentFilter.values);
         const isNotLastFilter = index < displayedFilters.length - 1;
 
-        const chipVariant = currentFilter.values.length === 0 && !['nil', 'not_nil'].includes(filterOperator ?? 'eq')
-          ? 'outlined'
-          : 'filled';
-        // darken the bg color when filled (quickfix for 'warning' and 'success' chipColor unreadable with regardingOf filter)
-        const chipSx = (chipColor === 'warning' || chipColor === 'success') && chipVariant === 'filled'
-          ? { bgcolor: `${chipColor}.dark` }
-          : undefined;
-        const authorizeFilterRemoving = !(filtersRestrictions?.preventRemoveFor?.includes(filterKey))
-          && isFilterEditable(filtersRestrictions, filterKey, filterValues);
         return (
-          <Fragment key={currentFilter.id ?? `filter-${index}`}>
-            <Tooltip
-              title={
-                filterKey === 'regardingOf'
-                  ? undefined
-                  : <FilterValues
-                      label={keyLabel}
-                      tooltip={true}
-                      currentFilter={currentFilter}
-                      handleSwitchLocalMode={handleSwitchLocalMode}
-                      filtersRepresentativesMap={filtersRepresentativesMap}
-                      redirection={redirection}
-                      entityTypes={entityTypes}
-                      filtersRestrictions={filtersRestrictions}
-                    />
-              }
-            >
-              <Box
-                sx={{
-                  padding: styleNumber === 3 ? '0 4px' : '0',
-                  display: 'flex',
-                }}
-              >
-                <Chip
-                  color={chipColor}
-                  ref={
-                    helpers?.getLatestAddFilterId() === currentFilter.id
-                      ? itemRefToPopover
-                      : null
-                  }
-                  classes={{ root: classFilter, label: classes.chipLabel }}
-                  variant={chipVariant}
-                  sx={{ ...chipSx, borderRadius: 1 }}
-                  label={
-                    <FilterValues
-                      label={keyLabel}
-                      tooltip={false}
-                      currentFilter={currentFilter}
-                      handleSwitchLocalMode={helpers?.handleSwitchLocalMode ?? handleSwitchLocalMode}
-                      filtersRepresentativesMap={filtersRepresentativesMap}
-                      redirection={redirection}
-                      onClickLabel={(event) => handleChipClick(event, currentFilter?.id)}
-                      isReadWriteFilter={isReadWriteFilter}
-                      chipColor={chipColor}
-                      entityTypes={entityTypes}
-                      filtersRestrictions={filtersRestrictions}
-                    />
-                  }
-                  disabled={
-                    disabledPossible ? displayedFilters.length === 1 : undefined
-                  }
-                  onDelete={
-                    (isReadWriteFilter && authorizeFilterRemoving)
-                      ? () => manageRemoveFilter(
-                        currentFilter.id,
-                        filterKey,
-                        filterOperator,
-                      )
-                      : undefined
-                  }
-                />
-              </Box>
-            </Tooltip>
+          <Box key={currentFilter.id ?? `tooltip-${index}`}>
+            <FilterValues
+              label={keyLabel}
+              tooltip={true}
+              currentFilter={currentFilter}
+              handleSwitchLocalMode={handleSwitchLocalMode}
+              filtersRepresentativesMap={filtersRepresentativesMap}
+              redirection={redirection}
+              entityTypes={entityTypes}
+              filtersRestrictions={filtersRestrictions}
+            />
+
             {isNotLastFilter && (
-              <Box
-                sx={{
-                  padding: styleNumber === 3 ? '0 4px' : '0',
-                  display: 'flex',
-                }}
-              >
+            <div>{t_i18n(globalMode.toUpperCase())}   </div>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+
+  return (
+    <Tooltip
+      title={
+        allRegardingOf
+          ? undefined
+          : tooltipContent
+    }
+      arrow
+      placement="bottom-start"
+    >
+      <Box sx={boxStyle}>
+        {displayedFilters.map((currentFilter, index) => {
+          const filterKey = currentFilter.key;
+          const filterOperator = currentFilter.operator ?? 'eq';
+          const filterValues = currentFilter.values;
+          const isNotLastFilter = index < displayedFilters.length - 1;
+
+          const chipVariant = currentFilter.values.length === 0 && !['nil', 'not_nil'].includes(filterOperator)
+            ? 'outlined'
+            : 'filled';
+
+          const chipSx = (chipColor === 'warning' || chipColor === 'success') && chipVariant === 'filled'
+            ? { bgcolor: `${chipColor}.dark` }
+            : undefined;
+          const filterLabel = t_i18n(useFilterDefinition(filterKey, entityTypes)?.label ?? filterKey);
+
+          const keyLabel = buildKeyLabel(filterOperator, filterLabel, currentFilter.values);
+          const authorizeFilterRemoving = !(filtersRestrictions?.preventRemoveFor?.includes(filterKey))
+            && isFilterEditable(filtersRestrictions, filterKey, filterValues);
+          return (
+            <Fragment key={currentFilter.id ?? `filter-${index}`}>
+              <Chip
+                color={chipColor}
+                ref={
+                  helpers?.getLatestAddFilterId() === currentFilter.id
+                    ? itemRefToPopover
+                    : null
+                }
+                classes={{ root: classFilter, label: classes.chipLabel }}
+                variant={chipVariant}
+                sx={{ ...chipSx, borderRadius: 1 }}
+                label={
+                  <FilterValues
+                    label={keyLabel}
+                    tooltip={false}
+                    currentFilter={currentFilter}
+                    handleSwitchLocalMode={helpers?.handleSwitchLocalMode ?? handleSwitchLocalMode}
+                    filtersRepresentativesMap={filtersRepresentativesMap}
+                    redirection={redirection}
+                    onClickLabel={(event) => handleChipClick(event, currentFilter?.id)}
+                    isReadWriteFilter={isReadWriteFilter}
+                    chipColor={chipColor}
+                    entityTypes={entityTypes}
+                    filtersRestrictions={filtersRestrictions}
+                  />
+                }
+                disabled={disabledPossible ? displayedFilters.length === 1 : undefined}
+                onDelete={
+                  (isReadWriteFilter && authorizeFilterRemoving)
+                    ? () => manageRemoveFilter(
+                      currentFilter.id,
+                      filterKey,
+                      filterOperator,
+                    )
+                    : undefined
+                }
+              />
+              {isNotLastFilter && (
                 <FilterIconButtonGlobalMode
                   classOperator={classOperator}
                   globalMode={globalMode}
-                  handleSwitchGlobalMode={() => {
-                    if (helpers?.handleSwitchGlobalMode) {
-                      helpers.handleSwitchGlobalMode();
-                    } else if (handleSwitchGlobalMode) {
-                      handleSwitchGlobalMode();
-                    }
-                  }}
+                  handleSwitchGlobalMode={
+                    helpers?.handleSwitchGlobalMode ?? handleSwitchGlobalMode
+                  }
                 />
-              </Box>
-            )}
-          </Fragment>
-        );
-      })}
-      {filterChipsParams.anchorEl && (
-        <>
-          <FilterChipPopover
-            filters={filters.filters}
-            params={filterChipsParams}
-            handleClose={handleClose}
-            open={open}
-            helpers={helpers}
+              )}
+            </Fragment>
+          );
+        })}
+        {filterChipsParams.anchorEl && (
+          <>
+            <FilterChipPopover
+              filters={filters.filters}
+              params={filterChipsParams}
+              handleClose={handleClose}
+              open={open}
+              helpers={helpers}
+              filtersRepresentativesMap={filtersRepresentativesMap}
+              availableRelationFilterTypes={availableRelationFilterTypes}
+              entityTypes={entityTypes}
+              searchContext={searchContext}
+              availableEntityTypes={availableEntityTypes}
+              availableRelationshipTypes={availableRelationshipTypes}
+              fintelTemplatesContext={fintelTemplatesContext}
+            />
+          </>
+        )}
+        {filters.filterGroups && filters.filterGroups.length > 0 && ( // if there are filterGroups, we display a warning box // TODO display correctly filterGroups
+          <DisplayFilterGroup
             filtersRepresentativesMap={filtersRepresentativesMap}
-            availableRelationFilterTypes={availableRelationFilterTypes}
-            entityTypes={entityTypes}
-            searchContext={searchContext}
-            availableEntityTypes={availableEntityTypes}
-            availableRelationshipTypes={availableRelationshipTypes}
-            fintelTemplatesContext={fintelTemplatesContext}
+            filterObj={filters}
+            filterMode={filters.mode}
+            classFilter={classFilter}
+            classChipLabel={classes.chipLabel}
           />
-        </>
-      )}
-      {filters.filterGroups
-        && filters.filterGroups.length > 0 && ( // if there are filterGroups, we display a warning box // TODO display correctly filterGroups
-        <DisplayFilterGroup
-          filtersRepresentativesMap={filtersRepresentativesMap}
-          filterObj={filters}
-          filterMode={filters.mode}
-          classFilter={classFilter}
-          classChipLabel={classes.chipLabel}
-        />
-      )}
-    </Box>
+        )}
+      </Box>
+    </Tooltip>
   );
 };
 

--- a/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/filters.pageModel.ts
@@ -12,6 +12,6 @@ export default class FiltersPageModel {
   }
   async removeLastFilter() {
     await expect(this.page.getByTestId('CancelIcon').last()).toBeVisible();
-    await this.page.getByTestId('CancelIcon').last().click({ force: true});
+    await this.page.getByTestId('CancelIcon').last().click({ force: true });
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* one tooltip
* refacto filterIconButtonContainer

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*  #9806 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
