### PR TITLE
[backend/frontend] Add score to Organizations (#9811)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3091,7 +3091,6 @@
   "The value must be greater than or equal to 0": "The value must be greater than or equal to 0",
   "The value must be greater than or equal to 1": "The value must be greater than or equal to 1",
   "The value must be less than or equal to 100": "The value must be less than or equal to 100",
-  "The value must contain digits only": "The value must contain digits only",
   "The value must not be empty": "The value must not be empty",
   "The value must not be empty.": "The value must not be empty.",
   "The value should be between 0 and 100": "The value should be between 0 and 100",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3091,6 +3091,7 @@
   "The value must be greater than or equal to 0": "The value must be greater than or equal to 0",
   "The value must be greater than or equal to 1": "The value must be greater than or equal to 1",
   "The value must be less than or equal to 100": "The value must be less than or equal to 100",
+  "The value must contain digits only": "The value must contain digits only",
   "The value must not be empty": "The value must not be empty",
   "The value must not be empty.": "The value must not be empty.",
   "The value should be between 0 and 100": "The value should be between 0 and 100",

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -59,7 +59,7 @@ interface OrganizationAddInput {
   confidence: number | null
   x_opencti_reliability: string | undefined
   x_opencti_organization_type: string | undefined
-  x_opencti_score: number | null
+  x_opencti_score: string | null
   createdBy: FieldOption | null
   objectMarking: FieldOption[]
   objectLabel: FieldOption[]
@@ -147,7 +147,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
         description: values.description,
         x_opencti_reliability: values.x_opencti_reliability,
         x_opencti_organization_type: values.x_opencti_organization_type,
-        x_opencti_score: parseInt(String(values.x_opencti_score), 10),
+        x_opencti_score: values.x_opencti_score ? parseInt(values.x_opencti_score, 10) : null,
         createdBy: values.createdBy?.value,
         confidence: parseInt(String(values.confidence), 10),
         objectMarking: values.objectMarking.map((v) => v.value),

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -105,8 +105,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
     x_opencti_score: Yup.number()
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
-      .max(100, t_i18n('The value must be less than or equal to 100'))
-      .test('Digits only', t_i18n('The value must contain digits only'), (val) => /^\d+$/.test(String(val))),
+      .max(100, t_i18n('The value must be less than or equal to 100')),
   };
   const organizationValidator = useSchemaCreationValidation(ORGANIZATION_TYPE, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -59,7 +59,7 @@ interface OrganizationAddInput {
   confidence: number | null
   x_opencti_reliability: string | undefined
   x_opencti_organization_type: string | undefined
-  x_opencti_score: number
+  x_opencti_score: number | null
   createdBy: FieldOption | null
   objectMarking: FieldOption[]
   objectLabel: FieldOption[]
@@ -105,7 +105,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
     x_opencti_score: Yup.number()
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
-      .max(100, t_i18n('The value must be less than or equal to 100')),
+      .max(100, t_i18n('The value must be less than or equal to 100'))
+      .test('Digits only', t_i18n('The value must contain digits only'), (val) => /^\d+$/.test(String(val))),
   };
   const organizationValidator = useSchemaCreationValidation(ORGANIZATION_TYPE, basicShape);
 
@@ -185,7 +186,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       objectLabel: [],
       externalReferences: [],
       file: null,
-      x_opencti_score: 50,
+      x_opencti_score: null,
     },
   );
 
@@ -231,14 +232,6 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
         </ProgressBar>
         <Form>
           <Field
-            component={TextField}
-            variant="standard"
-            name="x_opencti_score"
-            label={t_i18n('Score')}
-            fullWidth={true}
-            type="number"
-          />
-          <Field
             component={BulkTextField}
             variant="standard"
             name="name"
@@ -275,6 +268,15 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
+          />
+          <Field
+            component={TextField}
+            variant="standard"
+            name="x_opencti_score"
+            label={t_i18n('Score')}
+            fullWidth={true}
+            type="number"
+            style={fieldSpacingContainerStyle}
           />
           <CreatedByField
             name="createdBy"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -31,6 +31,7 @@ import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextM
 import ProgressBar from '../../../../components/ProgressBar';
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
+import TextField from '../../../../components/TextField';
 
 const organizationMutation = graphql`
   mutation OrganizationCreationMutation($input: OrganizationAddInput!) {
@@ -58,6 +59,7 @@ interface OrganizationAddInput {
   confidence: number | null
   x_opencti_reliability: string | undefined
   x_opencti_organization_type: string | undefined
+  x_opencti_score: number
   createdBy: FieldOption | null
   objectMarking: FieldOption[]
   objectLabel: FieldOption[]
@@ -100,6 +102,10 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       .nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
+    x_opencti_score: Yup.number()
+      .nullable()
+      .min(0, t_i18n('The value must be greater than or equal to 0'))
+      .max(100, t_i18n('The value must be less than or equal to 100')),
   };
   const organizationValidator = useSchemaCreationValidation(ORGANIZATION_TYPE, basicShape);
 
@@ -141,6 +147,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
         description: values.description,
         x_opencti_reliability: values.x_opencti_reliability,
         x_opencti_organization_type: values.x_opencti_organization_type,
+        x_opencti_score: parseInt(String(values.x_opencti_score), 10),
         createdBy: values.createdBy?.value,
         confidence: parseInt(String(values.confidence), 10),
         objectMarking: values.objectMarking.map((v) => v.value),
@@ -178,6 +185,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       objectLabel: [],
       externalReferences: [],
       file: null,
+      x_opencti_score: 50,
     },
   );
 
@@ -222,6 +230,14 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
           <BulkResult variablesToString={(v) => v.input.name} />
         </ProgressBar>
         <Form>
+          <Field
+            component={TextField}
+            variant="standard"
+            name="x_opencti_score"
+            label={t_i18n('Score')}
+            fullWidth={true}
+            type="number"
+          />
           <Field
             component={BulkTextField}
             variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -12,6 +12,7 @@ import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import type { Theme } from '../../../../components/Theme';
+import ItemScore from '../../../../components/ItemScore';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -66,6 +67,14 @@ const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsCompone
               source={organization.description}
               limit={400}
             />
+            <Typography
+              variant="h3"
+              gutterBottom={true}
+              style={{ marginTop: 20 }}
+            >
+              {t_i18n('Score')}
+            </Typography>
+            <ItemScore score={organization.x_opencti_score} />
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
@@ -103,6 +112,7 @@ const OrganizationDetails = createFragmentContainer(
             id
             description
             contact_information
+            x_opencti_score
             x_opencti_reliability
             x_opencti_organization_type
             objectLabel {

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -116,7 +116,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
     x_opencti_score: Yup.number()
-      .nullable(),
+      .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
   };

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -116,7 +116,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
     x_opencti_score: Yup.number()
-      .nullable()
+      .nullable(),
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
   };

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -115,6 +115,10 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    x_opencti_score: Yup.number()
+      .required(t_i18n('This field is required'))
+      .min(0, t_i18n('The value must be greater than or equal to 0'))
+      .max(100, t_i18n('The value must be less than or equal to 100')),
   };
   const organizationValidator = useSchemaEditionValidation('Organization', basicShape);
 
@@ -181,6 +185,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     x_opencti_organization_type: organization.x_opencti_organization_type,
     x_opencti_reliability: organization.x_opencti_reliability,
     x_opencti_workflow_id: convertStatus(t_i18n, organization) as FieldOption,
+    x_opencti_score: organization.x_opencti_score,
     createdBy: convertCreatedBy(organization) as FieldOption,
     objectMarking: convertMarkings(organization),
     references: [],
@@ -277,6 +282,23 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             variant="edit"
             containerStyle={fieldSpacingContainerStyle}
           />
+          <Field
+            component={TextField}
+            variant="standard"
+            name="x_opencti_score"
+            label={t_i18n('Score')}
+            type="number"
+            fullWidth={true}
+            style={{ marginTop: 20 }}
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            helperText={
+              <SubscriptionFocus
+                context={context}
+                fieldName="x_opencti_score"
+              />
+            }
+          />
           {organization.workflowEnabled && (
             <StatusField
               name="x_opencti_workflow_id"
@@ -342,6 +364,7 @@ export default createFragmentContainer(OrganizationEditionOverviewComponent, {
         contact_information
         x_opencti_organization_type
         x_opencti_reliability
+        x_opencti_score
         createdBy {
           ... on Identity {
             id

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -116,9 +116,10 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
     x_opencti_score: Yup.number()
-      .required(t_i18n('This field is required'))
+      .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
-      .max(100, t_i18n('The value must be less than or equal to 100')),
+      .max(100, t_i18n('The value must be less than or equal to 100'))
+      .test('Digits only', t_i18n('The value must contain digits only'), (val) => /^\d+$/.test(String(val))),
   };
   const organizationValidator = useSchemaEditionValidation('Organization', basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -118,8 +118,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
     x_opencti_score: Yup.number()
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
-      .max(100, t_i18n('The value must be less than or equal to 100'))
-      .test('Digits only', t_i18n('The value must contain digits only'), (val) => /^\d+$/.test(String(val))),
+      .max(100, t_i18n('The value must be less than or equal to 100')),
   };
   const organizationValidator = useSchemaEditionValidation('Organization', basicShape);
 

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -12043,6 +12043,7 @@ type Organization implements BasicObject & StixObject & StixCoreObject & StixDom
   x_opencti_aliases: [String]
   x_opencti_reliability: String
   x_opencti_organization_type: String
+  x_opencti_score: Int
   sectors: SectorConnection
   members(first: Int, after: ID, orderBy: UsersOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): UserConnection
   authorized_authorities: [String]
@@ -12072,6 +12073,7 @@ enum OrganizationsOrdering {
   updated_at
   x_opencti_organization_type
   x_opencti_workflow_id
+  x_opencti_score
   _score
 }
 
@@ -12098,6 +12100,7 @@ input OrganizationAddInput {
   lang: String
   x_opencti_organization_type: String
   x_opencti_reliability: String
+  x_opencti_score: Int
   createdBy: String
   objectMarking: [String]
   objectLabel: [String]

--- a/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
@@ -386,8 +386,9 @@ export const convertIdentityToStix = (instance: StoreEntityIdentity, type: strin
         firstname: instance.x_opencti_firstname,
         lastname: instance.x_opencti_lastname,
         organization_type: instance.x_opencti_organization_type,
-        reliability: instance.x_opencti_reliability
-      })
+        reliability: instance.x_opencti_reliability,
+        score: instance.x_opencti_score,
+      }),
     }
   };
 };

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -14,7 +14,7 @@ import {
 import { listAllToEntitiesThroughRelations, listEntities, listEntitiesThroughRelationsPaginated, storeLoadById, storeLoadByIds } from '../database/middleware-loader';
 import { elCount, elFindByIds } from '../database/engine';
 import { workToExportFile } from './work';
-import { FunctionalError, UnsupportedError } from '../config/errors';
+import { FunctionalError, UnsupportedError, ValidationError } from '../config/errors';
 import { isEmptyField, isNotEmptyField, READ_INDEX_INFERRED_ENTITIES, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import {
   ENTITY_TYPE_CONTAINER_NOTE,
@@ -201,6 +201,13 @@ export const stixDomainObjectEditField = async (context, user, stixObjectId, inp
   const stixDomainObject = await storeLoadById(context, user, stixObjectId, ABSTRACT_STIX_DOMAIN_OBJECT);
   if (!stixDomainObject) {
     throw FunctionalError('Cannot edit the field, Stix-Domain-Object cannot be found.');
+  }
+  const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
+  if (scoreEditInput) {
+    const newScore = scoreEditInput.value[0];
+    if (newScore === null || newScore === undefined || (newScore && (newScore < 0 || newScore > 100))) {
+      throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
+    }
   }
   // Validate specific relations, created by and markings
   const markingsInput = input.find((inputData) => inputData.key === INPUT_MARKINGS);

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -205,7 +205,7 @@ export const stixDomainObjectEditField = async (context, user, stixObjectId, inp
   const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
   if (scoreEditInput) {
     const newScore = scoreEditInput.value[0];
-    if (newScore === null || newScore === undefined || (newScore && (newScore < 0 || newScore > 100))) {
+    if (newScore !== null && newScore !== undefined && (newScore && (newScore < 0 || newScore > 100))) {
       throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
     }
   }

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -18057,6 +18057,7 @@ export type Organization = BasicObject & Identity & StixCoreObject & StixDomainO
   x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
   x_opencti_organization_type?: Maybe<Scalars['String']['output']>;
   x_opencti_reliability?: Maybe<Scalars['String']['output']>;
+  x_opencti_score?: Maybe<Scalars['Int']['output']>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
 };
 
@@ -18231,6 +18232,7 @@ export type OrganizationAddInput = {
   x_opencti_aliases?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   x_opencti_organization_type?: InputMaybe<Scalars['String']['input']>;
   x_opencti_reliability?: InputMaybe<Scalars['String']['input']>;
+  x_opencti_score?: InputMaybe<Scalars['Int']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
   x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -18258,6 +18260,7 @@ export enum OrganizationsOrdering {
   Name = 'name',
   UpdatedAt = 'updated_at',
   XOpenctiOrganizationType = 'x_opencti_organization_type',
+  XOpenctiScore = 'x_opencti_score',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
@@ -38790,6 +38793,7 @@ export type OrganizationResolvers<ContextType = any, ParentType extends Resolver
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_organization_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_opencti_reliability?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  x_opencti_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
@@ -34,9 +34,9 @@ export const findAll = (context: AuthContext, user: AuthUser, args: EntityOption
 };
 
 export const addOrganization = async (context: AuthContext, user: AuthUser, organization: OrganizationAddInput) => {
-  if (organization.x_opencti_score === null
-    || organization.x_opencti_score === undefined
-    || (organization.x_opencti_score && (organization.x_opencti_score < 0 || organization.x_opencti_score > 100))) {
+  if (organization.x_opencti_score !== null
+    && organization.x_opencti_score !== undefined
+    && (organization.x_opencti_score && (organization.x_opencti_score < 0 || organization.x_opencti_score > 100))) {
     throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
   }
   const organizationWithClass = { identity_class: ENTITY_TYPE_IDENTITY_ORGANIZATION.toLowerCase(), ...organization };

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization-domain.ts
@@ -19,7 +19,7 @@ import { ENTITY_TYPE_USER } from '../../schema/internalObject';
 import { type BasicStoreEntityOrganization, ENTITY_TYPE_IDENTITY_ORGANIZATION } from './organization-types';
 import type { AuthContext, AuthUser } from '../../types/user';
 import type { BasicObject, OrganizationAddInput, ResolversTypes } from '../../generated/graphql';
-import { AlreadyDeletedError, FunctionalError } from '../../config/errors';
+import { AlreadyDeletedError, FunctionalError, ValidationError } from '../../config/errors';
 import { isUserHasCapability, SETTINGS_SET_ACCESSES } from '../../utils/access';
 import { publishUserAction } from '../../listener/UserActionListener';
 import type { BasicStoreCommon, BasicStoreEntity } from '../../types/store';
@@ -34,6 +34,11 @@ export const findAll = (context: AuthContext, user: AuthUser, args: EntityOption
 };
 
 export const addOrganization = async (context: AuthContext, user: AuthUser, organization: OrganizationAddInput) => {
+  if (organization.x_opencti_score === null
+    || organization.x_opencti_score === undefined
+    || (organization.x_opencti_score && (organization.x_opencti_score < 0 || organization.x_opencti_score > 100))) {
+    throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
+  }
   const organizationWithClass = { identity_class: ENTITY_TYPE_IDENTITY_ORGANIZATION.toLowerCase(), ...organization };
   const created = await createEntity(context, user, organizationWithClass, ENTITY_TYPE_IDENTITY_ORGANIZATION);
   return notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC, created, user);

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
@@ -106,6 +106,7 @@ type Organization implements BasicObject & StixObject & StixCoreObject & StixDom
   x_opencti_reliability: String
   # Organization
   x_opencti_organization_type: String
+  x_opencti_score: Int
   sectors: SectorConnection
   members(
     first: Int
@@ -159,6 +160,7 @@ enum OrganizationsOrdering {
   updated_at
   x_opencti_organization_type
   x_opencti_workflow_id
+  x_opencti_score
   _score
 }
 
@@ -200,6 +202,7 @@ input OrganizationAddInput {
   lang: String
   x_opencti_organization_type: String
   x_opencti_reliability: String
+  x_opencti_score: Int @constraint(min: 0, max: 100)
   createdBy: String
   objectMarking: [String]
   objectLabel: [String]

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization.ts
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization.ts
@@ -43,6 +43,7 @@ const ORGANIZATION_DEFINITION: ModuleDefinition<StoreEntityOrganization, StixOrg
     xOpenctiReliability,
     { name: 'default_dashboard', label: 'Default dashboard', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'x_opencti_organization_type', label: 'Organization type', type: 'string', format: 'vocabulary', vocabularyCategory: 'organization_type_ov', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'x_opencti_score', label: 'Score', type: 'numeric', precision: 'integer', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'default_hidden_types', label: 'Default hidden types', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'authorized_authorities', label: 'Authorized authorities', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'grantable_groups', label: 'Grantable groups', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -597,6 +597,7 @@ const attributePathMapping: any = {
   x_opencti_score: {
     [ENTITY_TYPE_INDICATOR]: `/extensions/${STIX_EXT_OCTI}/score`,
     [ABSTRACT_STIX_CYBER_OBSERVABLE]: `/extensions/${STIX_EXT_OCTI_SCO}/score`,
+    [ENTITY_TYPE_IDENTITY_ORGANIZATION]: `/extensions/${STIX_EXT_OCTI}/score`,
   },
   x_opencti_detection: {
     [ENTITY_TYPE_INDICATOR]: `/extensions/${STIX_EXT_OCTI}/detection`,

--- a/opencti-platform/opencti-graphql/src/types/stix-2-1-sdo.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/stix-2-1-sdo.d.ts
@@ -52,6 +52,7 @@ export interface StixIdentityExtension extends StixOpenctiExtension {
   lastname: string;
   organization_type: string;
   reliability: string;
+  score: number;
 }
 // name, description, roles, identity_class, sectors, contact_information
 export interface StixIdentity extends StixDomainObject {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
@@ -39,6 +39,7 @@ const READ_QUERY = gql`
       standard_id
       name
       description
+      x_opencti_score
       sectors {
         edges {
           node {
@@ -57,6 +58,15 @@ const READ_QUERY = gql`
         }
       }
       toStix
+    }
+  }
+`;
+
+const UPDATE_QUERY = gql`
+  mutation OrganizationEdit($id: ID!, $input: [EditInput]!) {
+    organizationFieldPatch(id: $id, input: $input) {
+      id
+      name
     }
   }
 `;
@@ -86,6 +96,7 @@ describe('Organization resolver standard behavior', () => {
         name: 'Organization',
         stix_id: organizationStixId,
         description: 'Organization description',
+        x_opencti_score: 50,
       },
     };
     const organization = await queryAsAdmin({
@@ -95,6 +106,7 @@ describe('Organization resolver standard behavior', () => {
     expect(organization).not.toBeNull();
     expect(organization.data.organizationAdd).not.toBeNull();
     expect(organization.data.organizationAdd.name).toEqual('Organization');
+    expect(organization.data.organizationAdd.x_opencti_score).toEqual(50);
     organizationInternalId = organization.data.organizationAdd.id;
   });
   it('should organization loaded by internal id', async () => {
@@ -142,19 +154,18 @@ describe('Organization resolver standard behavior', () => {
     expect(queryResult.data.organizations.edges.length).toEqual(9);
   });
   it('should update organization', async () => {
-    const UPDATE_QUERY = gql`
-      mutation OrganizationEdit($id: ID!, $input: [EditInput]!) {
-        organizationFieldPatch(id: $id, input: $input) {
-          id
-          name
-        }
-      }
-    `;
     const queryResult = await queryAsAdmin({
       query: UPDATE_QUERY,
       variables: { id: organizationInternalId, input: { key: 'name', value: ['Organization - test'] } },
     });
     expect(queryResult.data.organizationFieldPatch.name).toEqual('Organization - test');
+  });
+  it('should update score', async () => {
+    const queryResult = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: { id: organizationInternalId, input: { key: 'x_opencti_score', value: 10 } },
+    });
+    expect(queryResult.data.organizationFieldPatch.x_opencti_score).toEqual(10);
   });
   it('should context patch organization', async () => {
     const CONTEXT_PATCH_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/organization-test.js
@@ -67,6 +67,7 @@ const UPDATE_QUERY = gql`
     organizationFieldPatch(id: $id, input: $input) {
       id
       name
+      x_opencti_score
     }
   }
 `;
@@ -87,6 +88,7 @@ describe('Organization resolver standard behavior', () => {
           id
           name
           description
+          x_opencti_score
         }
       }
     `;

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -62,7 +62,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['marking-definition'].length).toBe(2);
       expect(updateEventsByTypes['campaign'].length).toBe(7);
       expect(updateEventsByTypes['relationship'].length).toBe(8);
-      expect(updateEventsByTypes['identity'].length).toBe(23);
+      expect(updateEventsByTypes['identity'].length).toBe(24);
       expect(updateEventsByTypes['malware'].length).toBe(19);
       expect(updateEventsByTypes['intrusion-set'].length).toBe(4);
       expect(updateEventsByTypes['data-component'].length).toBe(4);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -86,7 +86,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(198);
+      expect(updateEvents.length).toBe(199);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1203;
+export const RAW_EVENTS_SIZE = 1204;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add score attribute for Organization
*  Add score to graphQL schema
*  Add score in STIX extensions
* Add resolver test
* Add score in creation/update UI form
* Add score in Organization details screen

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/9811
* Client python PR: https://github.com/OpenCTI-Platform/client-python/pull/884

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
