### PR TITLE
[backend] refresh cache for Resolved filters at playbook/stream/trigger update (#10593)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -4,7 +4,7 @@ import { addCacheForEntity, refreshCacheForEntity, removeCacheForEntity, writeCa
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENTITY_TYPE_RESOLVED_FILTERS } from '../schema/stixDomainObject';
 import { ENTITY_TYPE_ENTITY_SETTING } from '../modules/entitySetting/entitySetting-types';
-import { FilterMode, OrderingMode, type StreamCollection } from '../generated/graphql';
+import { FilterMode, OrderingMode } from '../generated/graphql';
 import { extractFilterGroupValuesToResolveForCache } from '../utils/filtering/filtering-resolution';
 import { type BasicStoreEntityTrigger, ENTITY_TYPE_TRIGGER } from '../modules/notification/notification-types';
 import { stixLoadByIds } from '../database/middleware';
@@ -76,12 +76,12 @@ const extractResolvedFiltersFromInstance = (instance: BasicStoreCommon) => {
   const filteringIds = []; // will contain the ids that are in the instance filters values
   if (instance.entity_type === ENTITY_TYPE_STREAM_COLLECTION) {
     const streamFilterIds = extractFilterGroupValuesToResolveForCache(
-      JSON.parse((instance as StreamCollection).filters ?? initialFilterGroup)
+      JSON.parse((instance as BasicStreamEntity).filters ?? initialFilterGroup)
     );
     filteringIds.push(...streamFilterIds);
   } else if (instance.entity_type === ENTITY_TYPE_TRIGGER) {
     const triggerFilterIds = extractFilterGroupValuesToResolveForCache(
-      JSON.parse((instance as BasicStoreEntityTrigger).filters ?? initialFilterGroup)
+      JSON.parse((instance as BasicTriggerEntity).filters ?? initialFilterGroup)
     );
     filteringIds.push(...triggerFilterIds);
   } else if (instance.entity_type === ENTITY_TYPE_CONNECTOR) {
@@ -99,7 +99,7 @@ const extractResolvedFiltersFromInstance = (instance: BasicStoreCommon) => {
       .flat();
     filteringIds.push(...playbookFilterIds);
   } else {
-    throw FunctionalError(`Resolved filters are only saved in cache for streams, triggers, connectors and playbooks, not for ${instance.entity_type}`);
+    throw FunctionalError('Resolved filters are only saved in cache for streams, triggers, connectors and playbooks, not for this entity type', { entity_type: instance.entity_type });
   }
   return filteringIds;
 };

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -8,12 +8,7 @@ import { FilterMode, OrderingMode } from '../generated/graphql';
 import { extractFilterGroupValuesToResolveForCache } from '../utils/filtering/filtering-resolution';
 import { type BasicStoreEntityTrigger, ENTITY_TYPE_TRIGGER } from '../modules/notification/notification-types';
 import { stixLoadByIds } from '../database/middleware';
-import {
-  type EntityOptions,
-  internalFindByIds,
-  listAllEntities,
-  listAllRelations
-} from '../database/middleware-loader';
+import { type EntityOptions, internalFindByIds, listAllEntities, listAllRelations } from '../database/middleware-loader';
 import { pubSubSubscription } from '../database/redis';
 import { connectors as findConnectors } from '../database/repository';
 import { buildCompleteUsers, resolveUserById } from '../domain/user';
@@ -51,11 +46,7 @@ import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
 import { ENTITY_TYPE_DECAY_RULE } from '../modules/decayRule/decayRule-types';
 import { fromBase64, isNotEmptyField } from '../database/utils';
 import { findAllPlaybooks } from '../modules/playbook/playbook-domain';
-import {
-  type BasicStoreEntityPublicDashboard,
-  ENTITY_TYPE_PUBLIC_DASHBOARD,
-  type PublicDashboardCached
-} from '../modules/publicDashboard/publicDashboard-types';
+import { type BasicStoreEntityPublicDashboard, ENTITY_TYPE_PUBLIC_DASHBOARD, type PublicDashboardCached } from '../modules/publicDashboard/publicDashboard-types';
 import { getAllowedMarkings } from '../modules/publicDashboard/publicDashboard-domain';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { getEnterpriseEditionInfoFromPem } from '../modules/settings/licensing';
@@ -117,6 +108,12 @@ const platformResolvedFilters = (context: AuthContext) => {
   };
   const refreshFilter = async (values: Map<string, StixObject>, instance: BasicStoreCommon) => {
     const filteringIds = [];
+    // Stream filters
+    // TODO
+    // Trigger filters
+    // TODO
+    // Connectors filters (for enrichment connectors)
+    // TODO
     // Playbook filters
     if (instance.entity_type === ENTITY_TYPE_PLAYBOOK) {
       const playbookFilterIds = ((JSON.parse(instance.playbook_definition)) as ComponentDefinition)


### PR DESCRIPTION
### Proposed changes
Fix the cache update for Resolved filters
To fix the issue: after updating a playbook / stream / trigger / connector filters, if the filters contained ids, the playbook / stream / trigger / connector doesn't work anymore (doesn't detect changes concerning the added ids).

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10593