### PR TITLE
[frontend]  Sorting should not trigger full reload (#10252)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -9,7 +9,7 @@ import DataTableFilters, { DataTableDisplayFilters } from './DataTableFilters';
 import SearchInput from '../SearchInput';
 import { DataTableProps } from './dataTableTypes';
 import useAuth from '../../utils/hooks/useAuth';
-import { useDataTable, useLineData } from './dataTableHooks';
+import { useLineData } from './dataTableHooks';
 import DataTableComponent from './components/DataTableComponent';
 import { UsePreloadedPaginationFragment } from '../../utils/hooks/usePreloadedPaginationFragment';
 import { FilterIconButtonProps } from '../FilterIconButton';

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -247,7 +247,6 @@ const DataTable = (props: OCTIDataTableProps) => {
         availableFilterKeys={availableFilterKeys}
         dataQueryArgs={{ ...dataQueryArgs }}
         useLineData={useLineData(lineFragment)}
-        useDataTable={useDataTable}
         settingsMessagesBannerHeight={settingsMessagesBannerHeight}
         filtersComponent={(
           <DataTableInternalFilters

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -29,7 +29,7 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps) => {
   return (
     <DataTableComponent
       {...props}
-      useDataTable={() => ({ data })}
+      data={data}
       useLineData={(line) => line}
       dataQueryArgs={(line: never) => line}
       resolvePath={(a) => a}

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -39,14 +39,11 @@ const DataTableBody = ({
   } = useDataTableContext();
 
   const {
-    data: paginatedData,
+    data: queryData,
     isLoading,
     loadMore,
     hasMore,
-  } = useDataTable(dataQueryArgs);
-
-  // data is from datatableWithoutFragment
-  const queryData = data ?? paginatedData;
+  } = data ? { data } : useDataTable(dataQueryArgs); // data is from datatableWithoutFragment
 
   const resolvedData = useMemo(() => {
     if (!queryData) {

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -10,7 +10,6 @@ import { useDataTable } from '../dataTableHooks';
 
 const DataTableBody = ({
   settingsMessagesBannerHeight = 0,
-  data,
   hasFilterComponent,
   dataTableToolBarComponent,
   pageStart,
@@ -36,6 +35,7 @@ const DataTableBody = ({
     useDataTablePaginationLocalStorage: {
       viewStorage: { filters },
     },
+    data,
   } = useDataTableContext();
 
   const {

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -10,6 +10,7 @@ import { useDataTable } from '../dataTableHooks';
 
 const DataTableBody = ({
   settingsMessagesBannerHeight = 0,
+  data,
   hasFilterComponent,
   dataTableToolBarComponent,
   pageStart,
@@ -38,11 +39,14 @@ const DataTableBody = ({
   } = useDataTableContext();
 
   const {
-    data: queryData,
+    data: paginatedData,
     isLoading,
     loadMore,
     hasMore,
   } = useDataTable(dataQueryArgs);
+
+  // data is from datatableWithoutFragment
+  const queryData = data ?? paginatedData;
 
   const resolvedData = useMemo(() => {
     if (!queryData) {

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -6,6 +6,7 @@ import DataTableLine, { DataTableLinesDummy } from './DataTableLine';
 import { useDataTableContext } from './DataTableContext';
 import { ICON_COLUMN_SIZE, SELECT_COLUMN_SIZE } from './DataTableHeader';
 import callbackResizeObserver from '../../../utils/resizeObservers';
+import { useDataTable } from '../dataTableHooks';
 
 const DataTableBody = ({
   settingsMessagesBannerHeight = 0,
@@ -26,12 +27,7 @@ const DataTableBody = ({
     endsWithAction,
     actions,
     columns,
-    useDataTable: {
-      data: queryData,
-      isLoading,
-      loadMore,
-      hasMore,
-    },
+    dataQueryArgs,
     useDataTableToggle: {
       selectedElements,
       onToggleEntity,
@@ -40,6 +36,13 @@ const DataTableBody = ({
       viewStorage: { filters },
     },
   } = useDataTableContext();
+
+  const {
+    data: queryData,
+    isLoading,
+    loadMore,
+    hasMore,
+  } = useDataTable(dataQueryArgs);
 
   const resolvedData = useMemo(() => {
     if (!queryData) {

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -26,7 +26,6 @@ type DataTableComponentProps = Pick<DataTableProps,
 | 'variant'
 | 'actions'
 | 'icon'
-| 'data'
 | 'availableFilterKeys'
 | 'initialValues'
 | 'disableNavigation'
@@ -42,6 +41,7 @@ type DataTableComponentProps = Pick<DataTableProps,
 | 'useComputeLink'
 | 'selectOnLineClick'
 | 'onLineClick'
+| 'data'
 | 'disableLineSelection'>;
 
 const DataTableComponent = ({

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -34,7 +34,6 @@ type DataTableComponentProps = Pick<DataTableProps,
 | 'resolvePath'
 | 'redirectionModeEnabled'
 | 'useLineData'
-| 'useDataTable'
 | 'rootRef'
 | 'createButton'
 | 'disableToolBar'
@@ -53,7 +52,6 @@ const DataTableComponent = ({
   dataQueryArgs,
   redirectionModeEnabled = false,
   useLineData,
-  useDataTable,
   useComputeLink,
   settingsMessagesBannerHeight,
   filtersComponent,
@@ -176,7 +174,7 @@ const DataTableComponent = ({
         resolvePath,
         redirectionModeEnabled,
         useLineData,
-        useDataTable: useDataTable(dataQueryArgs),
+        dataQueryArgs,
         useDataCellHelpers: useDataCellHelpers(helpers, variant),
         useDataTableToggle: useDataTableToggle(storageKey),
         useComputeLink: useComputeLink ?? defaultComputeLink,

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -26,6 +26,7 @@ type DataTableComponentProps = Pick<DataTableProps,
 | 'variant'
 | 'actions'
 | 'icon'
+| 'data'
 | 'availableFilterKeys'
 | 'initialValues'
 | 'disableNavigation'
@@ -50,6 +51,7 @@ const DataTableComponent = ({
   initialValues,
   availableFilterKeys,
   dataQueryArgs,
+  data,
   redirectionModeEnabled = false,
   useLineData,
   useComputeLink,
@@ -175,6 +177,7 @@ const DataTableComponent = ({
         redirectionModeEnabled,
         useLineData,
         dataQueryArgs,
+        data,
         useDataCellHelpers: useDataCellHelpers(helpers, variant),
         useDataTableToggle: useDataTableToggle(storageKey),
         useComputeLink: useComputeLink ?? defaultComputeLink,

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -3,6 +3,8 @@ import type { Dispatch, MutableRefObject, ReactNode, SetStateAction } from 'reac
 import React from 'react';
 import { GraphQLTaggedNode } from 'react-relay';
 import { PopoverProps } from '@mui/material/Popover/Popover';
+import { UsePreloadedPaginationFragment } from 'src/utils/hooks/usePreloadedPaginationFragment';
+import { OperationType } from 'relay-runtime';
 import type { LocalStorage } from '../../utils/hooks/useLocalStorageModel';
 import { NumberOfElements, PaginationLocalStorage, UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 import { FilterGroup } from '../../utils/filters/filtersHelpers-types';
@@ -46,7 +48,7 @@ export interface DataTableContextProps {
   resolvePath: (data: any) => any
   redirectionModeEnabled?: boolean
   useLineData: DataTableProps['useLineData']
-  useDataTable: ReturnType<DataTableProps['useDataTable']>
+  dataQueryArgs: UsePreloadedPaginationFragment<OperationType>,
   useDataCellHelpers: DataTableProps['useDataCellHelpers']
   useDataTableToggle: ReturnType<DataTableProps['useDataTableToggle']>
   useComputeLink: (entity: any) => string | undefined

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -49,6 +49,7 @@ export interface DataTableContextProps {
   redirectionModeEnabled?: boolean
   useLineData: DataTableProps['useLineData']
   dataQueryArgs: UsePreloadedPaginationFragment<OperationType>,
+  data: unknown,
   useDataCellHelpers: DataTableProps['useDataCellHelpers']
   useDataTableToggle: ReturnType<DataTableProps['useDataTableToggle']>
   useComputeLink: (entity: any) => string | undefined
@@ -88,6 +89,7 @@ export interface DataTableProps {
   handleCopy?: () => void
   lineFragment?: GraphQLTaggedNode
   dataQueryArgs: any
+  data?: unknown
   availableFilterKeys?: string[] | undefined;
   redirectionModeEnabled?: boolean
   additionalFilters?: FilterGroup


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* useDatatable removed from props and called on datatable body
* data from datatableWithoutFragment passed on props

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10252 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
