### PR TITLE
[backend] refresh cache only if it has been initialized (#10593)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -74,18 +74,16 @@ const handleCacheForEntity = async (instance: BasicStoreCommon | BasicStoreCommo
   const types = R.uniq(instances.map((i) => [i.entity_type, ...(STORE_ENTITIES_LINKS[i.entity_type] ?? [])]).flat());
   for (let index = 0; index < types.length; index += 1) {
     const type = types[index];
-    if (cache[type]) {
+    if (cache[type] && cache[type].values) {
       if (cache[type][fn]) {
-        if (cache[type].values) { // modify cache only if it has been initialized
-          logApp.debug(`${fn} reset cache for entity`, { type });
-          cache[type].values = await cache[type][fn](cache[type].values, instance);
-        }
+        logApp.debug(`${fn} reset cache for entity`, { type });
+        cache[type].values = await cache[type][fn](cache[type].values, instance);
       } else {
         logApp.debug('Simple reset cache for entity', { type });
         cache[type].values = undefined;
       }
     } else {
-      // This entity type is not part of the caching system
+      // This entity type is not part of the caching system or it has not been initialized yet
     }
   }
 };

--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -76,7 +76,7 @@ const handleCacheForEntity = async (instance: BasicStoreCommon | BasicStoreCommo
     const type = types[index];
     if (cache[type]) {
       if (cache[type][fn]) {
-        if (cache[type][fn].values) { // modify cache only if it has been initialized
+        if (cache[type].values) { // modify cache only if it has been initialized
           logApp.debug(`${fn} reset cache for entity`, { type });
           cache[type].values = await cache[type][fn](cache[type].values, instance);
         }

--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -76,8 +76,10 @@ const handleCacheForEntity = async (instance: BasicStoreCommon | BasicStoreCommo
     const type = types[index];
     if (cache[type]) {
       if (cache[type][fn]) {
-        logApp.debug(`${fn} reset cache for entity`, { type });
-        cache[type].values = await cache[type][fn](cache[type].values, instance);
+        if (cache[type][fn].values) { // modify cache only if it has been initialized
+          logApp.debug(`${fn} reset cache for entity`, { type });
+          cache[type].values = await cache[type][fn](cache[type].values, instance);
+        }
       } else {
         logApp.debug('Simple reset cache for entity', { type });
         cache[type].values = undefined;


### PR DESCRIPTION
### Proposed changes
refresh cache only if it has been initialized
to avoid resolved filters and users cache update whereas cache values for these entity types are null