### PR TITLE
[frontend] Add support for dynamic configurable required fields to Entities

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -60,7 +60,7 @@ interface EventAddInput {
   event_types: string[];
   start_time: Date | null;
   stop_time: Date | null;
-  createdBy: FieldOption | null;
+  createdBy: FieldOption | undefined;
   objectMarking: FieldOption[];
   objectLabel: FieldOption[];
   externalReferences: { value: string }[];
@@ -71,8 +71,8 @@ interface EventFormProps {
   updater: (store: RecordSourceSelectorProxy, key: string) => void;
   onReset?: () => void;
   onCompleted?: () => void;
-  defaultCreatedBy?: { value: string; label: string };
-  defaultMarkingDefinitions?: { value: string; label: string }[];
+  defaultCreatedBy?: FieldOption;
+  defaultMarkingDefinitions?: FieldOption[];
   inputValue?: string;
   bulkModalOpen?: boolean;
   onBulkModalClose: () => void;
@@ -178,7 +178,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
     start_time: null,
     confidence: null,
     stop_time: null,
-    createdBy: defaultCreatedBy ?? null,
+    createdBy: defaultCreatedBy ?? undefined, // undefined for Require Fields Flagging, if Configured Mandatory Field
     objectMarking: defaultMarkingDefinitions ?? [],
     objectLabel: [],
     externalReferences: [],

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -18,7 +18,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { EventCreationMutation, EventCreationMutation$variables } from './__generated__/EventCreationMutation.graphql';
 import { EventsLinesPaginationQuery$variables } from './__generated__/EventsLinesPaginationQuery.graphql';
@@ -91,8 +91,9 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(EVENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),
@@ -103,8 +104,8 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .min(Yup.ref('start_time'), 'The end date can\'t be before start date')
       .nullable(),
-  };
-  const eventValidator = useSchemaCreationValidation(EVENT_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const eventValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<EventCreationMutation>(
     eventMutation,
@@ -186,6 +187,8 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
     <Formik<EventAddInput>
       initialValues={initialValues}
       validationSchema={eventValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -222,6 +225,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Event']}
             />
@@ -229,6 +233,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               label={t_i18n('Event types')}
               type="event-type-ov"
               name="event_types"
+              required={(mandatoryAttributes.includes('event_types'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple
               onChange={setFieldValue}
@@ -237,6 +242,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows={4}
@@ -247,6 +253,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               name="start_time"
               textFieldProps={{
                 label: t_i18n('Start date'),
+                required: (mandatoryAttributes.includes('start_time')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -257,6 +264,7 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
               name="stop_time"
               textFieldProps={{
                 label: t_i18n('End date'),
+                required: (mandatoryAttributes.includes('stop_time')),
                 variant: 'standard',
                 fullWidth: true,
                 style: { ...fieldSpacingContainerStyle },
@@ -268,22 +276,26 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -104,6 +104,8 @@ export const EventCreationForm: FunctionComponent<EventFormProps> = ({
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)'))
       .min(Yup.ref('start_time'), 'The end date can\'t be before start date')
       .nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const eventValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -18,7 +18,7 @@ import { buildDate, parse } from '../../../../utils/Time';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import EventDeletion from './EventDeletion';
@@ -75,11 +75,14 @@ const eventMutationRelationDelete = graphql`
   }
 `;
 
+const EVENT_TYPE = 'Event';
+
 const EventEditionOverviewComponent = (props) => {
   const { event, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(EVENT_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     event_types: Yup.array().nullable(),
@@ -90,8 +93,8 @@ const EventEditionOverviewComponent = (props) => {
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const eventValidator = useSchemaEditionValidation('Event', basicShape);
+  }, mandatoryAttributes);
+  const eventValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: eventMutationFieldPatch,
@@ -173,6 +176,8 @@ const EventEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={eventValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -190,6 +195,7 @@ const EventEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -201,6 +207,7 @@ const EventEditionOverviewComponent = (props) => {
             label={t_i18n('Event types')}
             type="event-type-ov"
             name="event_types"
+            required={(mandatoryAttributes.includes('event_types'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             onChange={(name, value) => setFieldValue(name, value)}
@@ -213,6 +220,7 @@ const EventEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -230,6 +238,7 @@ const EventEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             textFieldProps={{
               label: t_i18n('Start date'),
+              required: (mandatoryAttributes.includes('start_time')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -245,6 +254,7 @@ const EventEditionOverviewComponent = (props) => {
             onSubmit={handleSubmitField}
             textFieldProps={{
               label: t_i18n('End date'),
+              required: (mandatoryAttributes.includes('stop_time')),
               variant: 'standard',
               fullWidth: true,
               style: { marginTop: 20 },
@@ -276,6 +286,7 @@ const EventEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -285,6 +296,7 @@ const EventEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -93,6 +93,7 @@ const EventEditionOverviewComponent = (props) => {
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const eventValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -93,6 +93,7 @@ const EventEditionOverviewComponent = (props) => {
       .nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const eventValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -56,7 +56,7 @@ interface IndividualAddInput {
   description: string
   confidence: number | null
   x_opencti_reliability: string | undefined
-  createdBy: FieldOption | null
+  createdBy: FieldOption | undefined
   objectMarking: FieldOption[]
   objectLabel: FieldOption[]
   externalReferences: { value: string }[]
@@ -67,8 +67,8 @@ interface IndividualFormProps {
   updater: (store: RecordSourceSelectorProxy, key: string) => void
   onReset?: () => void;
   onCompleted?: () => void;
-  defaultCreatedBy?: { value: string, label: string }
-  defaultMarkingDefinitions?: { value: string, label: string }[]
+  defaultCreatedBy?: FieldOption;
+  defaultMarkingDefinitions?: FieldOption[];
   inputValue?: string;
   bulkModalOpen?: boolean;
   onBulkModalClose: () => void;
@@ -168,7 +168,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
       description: '',
       x_opencti_reliability: undefined,
       confidence: null,
-      createdBy: defaultCreatedBy ?? null,
+      createdBy: defaultCreatedBy ?? undefined, // undefined for Require Fields Flagging, if Configured Mandatory Field
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
       externalReferences: [],

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -95,6 +95,8 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const individualValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { IndividualCreationMutation, IndividualCreationMutation$variables } from './__generated__/IndividualCreationMutation.graphql';
@@ -87,17 +87,16 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
-  };
-  const individualValidator = useSchemaCreationValidation(INDIVIDUAL_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const individualValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<IndividualCreationMutation>(
     individualMutation,
@@ -179,6 +178,8 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
     <Formik<IndividualAddInput>
       initialValues={initialValues}
       validationSchema={individualValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -222,6 +223,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['User']}
             />
@@ -229,6 +231,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -242,28 +245,33 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
               label={t_i18n('Reliability')}
               type="reliability_ov"
               name="x_opencti_reliability"
+              required={(mandatoryAttributes.includes('x_opencti_reliability'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple={false}
               onChange={setFieldValue}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -97,6 +97,7 @@ const IndividualEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const individualValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -97,6 +97,7 @@ const IndividualEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const individualValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -15,7 +15,7 @@ import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -83,19 +83,22 @@ const individualMutationRelationDelete = graphql`
   }
 `;
 
+const INDIVIDUAL_TYPE = 'Individual';
+
 const IndividualEditionOverviewComponent = (props) => {
   const { individual, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(INDIVIDUAL_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const individualValidator = useSchemaEditionValidation('Individual', basicShape);
+  }, mandatoryAttributes);
+  const individualValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: individualMutationFieldPatch,
@@ -175,6 +178,8 @@ const IndividualEditionOverviewComponent = (props) => {
     <Formik enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={individualValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -193,6 +198,7 @@ const IndividualEditionOverviewComponent = (props) => {
             name="name"
             disabled={external}
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -204,6 +210,7 @@ const IndividualEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -227,6 +234,7 @@ const IndividualEditionOverviewComponent = (props) => {
             variant="standard"
             name="contact_information"
             label={t_i18n('Contact information')}
+            required={(mandatoryAttributes.includes('contact_information'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -241,6 +249,7 @@ const IndividualEditionOverviewComponent = (props) => {
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -264,6 +273,7 @@ const IndividualEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -273,6 +283,7 @@ const IndividualEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -104,6 +104,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const organizationValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -58,8 +58,8 @@ interface OrganizationAddInput {
   confidence: number | null
   x_opencti_reliability: string | undefined
   x_opencti_organization_type: string | undefined
-  x_opencti_score: string | null
-  createdBy: FieldOption | null
+  x_opencti_score: string | undefined
+  createdBy: FieldOption | undefined
   objectMarking: FieldOption[]
   objectLabel: FieldOption[]
   externalReferences: { value: string }[]
@@ -70,8 +70,8 @@ interface OrganizationFormProps {
   updater: (store: RecordSourceSelectorProxy, key: string) => void
   onReset?: () => void;
   onCompleted?: () => void;
-  defaultCreatedBy?: { value: string, label: string }
-  defaultMarkingDefinitions?: { value: string, label: string }[]
+  defaultCreatedBy?: FieldOption;
+  defaultMarkingDefinitions?: FieldOption[];
   inputValue?: string;
   bulkModalOpen?: boolean;
   onBulkModalClose: () => void;
@@ -147,7 +147,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
         description: values.description,
         x_opencti_reliability: values.x_opencti_reliability,
         x_opencti_organization_type: values.x_opencti_organization_type,
-        x_opencti_score: values.x_opencti_score ? parseInt(values.x_opencti_score, 10) : null,
+        x_opencti_score: values.x_opencti_score ? parseInt(values.x_opencti_score, 10) : undefined,
         createdBy: values.createdBy?.value,
         confidence: parseInt(String(values.confidence), 10),
         objectMarking: values.objectMarking.map((v) => v.value),
@@ -179,13 +179,13 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       description: '',
       x_opencti_reliability: undefined,
       x_opencti_organization_type: undefined,
-      createdBy: defaultCreatedBy ?? null,
+      createdBy: defaultCreatedBy ?? undefined, // undefined for Require Fields Flagging, if Configured Mandatory Field
       confidence: null,
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
       externalReferences: [],
       file: null,
-      x_opencti_score: null,
+      x_opencti_score: undefined,
     },
   );
 
@@ -278,6 +278,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             component={TextField}
             variant="standard"
             name="x_opencti_score"
+            required={(mandatoryAttributes.includes('x_opencti_score'))}
             label={t_i18n('Score')}
             fullWidth={true}
             type="number"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { OrganizationCreationMutation, OrganizationCreationMutation$variables } from './__generated__/OrganizationCreationMutation.graphql';
 import { OrganizationsLinesPaginationQuery$variables } from './__generated__/OrganizationsLinesPaginationQuery.graphql';
@@ -90,10 +90,9 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ORGANIZATION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),
@@ -105,8 +104,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
-  };
-  const organizationValidator = useSchemaCreationValidation(ORGANIZATION_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const organizationValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<OrganizationCreationMutation>(
     organizationMutation,
@@ -191,6 +190,8 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
   return <Formik<OrganizationAddInput>
     initialValues={initialValues}
     validationSchema={organizationValidator}
+    validateOnChange={false}
+    validateOnBlur={false}
     onSubmit={onSubmit}
     onReset={onReset}
          >
@@ -234,6 +235,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             detectDuplicate={['Organization']}
           />
@@ -241,6 +243,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -255,6 +258,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             label={t_i18n('Organization type')}
             type="organization_type_ov"
             name="x_opencti_organization_type"
+            required={(mandatoryAttributes.includes('x_opencti_organization_type'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
@@ -263,6 +267,7 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             containerStyle={fieldSpacingContainerStyle}
             multiple={false}
             onChange={setFieldValue}
@@ -278,22 +283,26 @@ export const OrganizationCreationForm: FunctionComponent<OrganizationFormProps> 
           />
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ObjectLabelField
             name="objectLabel"
+            required={(mandatoryAttributes.includes('objectLabel'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.objectLabel}
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
           />
           <ExternalReferencesField
             name="externalReferences"
+            required={(mandatoryAttributes.includes('externalReferences'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -17,7 +17,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import StatusField from '../../common/form/StatusField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
@@ -79,6 +79,8 @@ const organizationMutationRelationDelete = graphql`
   }
 `;
 
+const ORGANIZATION_TYPE = 'Organization';
+
 type OrganizationGenericData = OrganizationEditionOverview_organization$data & GenericData;
 
 interface OrganizationEditionOverviewComponentProps {
@@ -103,8 +105,9 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
   handleClose,
 }) => {
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(ORGANIZATION_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
@@ -116,8 +119,8 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
-  };
-  const organizationValidator = useSchemaEditionValidation('Organization', basicShape);
+  }, mandatoryAttributes);
+  const organizationValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: organizationMutationFieldPatch,
@@ -194,6 +197,8 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={organizationValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -211,6 +216,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -222,6 +228,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -259,6 +266,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             label={t_i18n('Organization type')}
             type="organization_type_ov"
             name="x_opencti_organization_type"
+            required={(mandatoryAttributes.includes('x_opencti_organization_type'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -271,6 +279,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -311,6 +320,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -320,6 +330,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -294,6 +294,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
             component={TextField}
             variant="standard"
             name="x_opencti_score"
+            required={(mandatoryAttributes.includes('x_opencti_score'))}
             label={t_i18n('Score')}
             type="number"
             fullWidth={true}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -119,6 +119,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
+    createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const organizationValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -119,6 +119,7 @@ const OrganizationEditionOverviewComponent: FunctionComponent<OrganizationEditio
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const organizationValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -15,7 +15,7 @@ import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import { SectorCreationMutation, SectorCreationMutation$variables } from './__generated__/SectorCreationMutation.graphql';
 import { SectorsLinesPaginationQuery$variables } from './__generated__/SectorsLinesPaginationQuery.graphql';
@@ -106,15 +106,13 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
-    description: Yup.string()
-      .nullable(),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SECTOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
+    description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
-  };
-  const sectorValidator = useSchemaCreationValidation(SECTOR_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const sectorValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<SectorCreationMutation>(
     sectorMutation,
@@ -197,6 +195,8 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
     <Formik<SectorAddInput>
       initialValues={initialValues}
       validationSchema={sectorValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -240,6 +240,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['Sector']}
             />
@@ -247,6 +248,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -258,22 +260,26 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -111,6 +111,8 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
     name: Yup.string().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const sectorValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -75,7 +75,7 @@ interface SectorAddInput {
   name: string;
   description: string;
   confidence: number | null;
-  createdBy: FieldOption | null;
+  createdBy: FieldOption | undefined;
   objectMarking: FieldOption[];
   objectLabel: FieldOption[];
   externalReferences: { value: string }[];
@@ -86,8 +86,8 @@ interface SectorFormProps {
   updater: (store: RecordSourceSelectorProxy, key: string) => void;
   onReset?: () => void;
   onCompleted?: () => void;
-  defaultCreatedBy?: { value: string; label: string };
-  defaultMarkingDefinitions?: { value: string; label: string }[];
+  defaultCreatedBy?: FieldOption;
+  defaultMarkingDefinitions?: FieldOption[];
   inputValue?: string;
   bulkModalOpen?: boolean;
   onBulkModalClose: () => void;
@@ -185,7 +185,7 @@ export const SectorCreationForm: FunctionComponent<SectorFormProps> = ({
       name: inputValue ?? '',
       description: '',
       confidence: null,
-      createdBy: defaultCreatedBy ?? null,
+      createdBy: defaultCreatedBy ?? undefined, // undefined for Require Fields Flagging, if Configured Mandatory Field
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
       externalReferences: [],

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -14,7 +14,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -79,17 +79,20 @@ const sectorMutationRelationDelete = graphql`
   }
 `;
 
+const SECTOR_TYPE = 'Sector';
+
 const SectorEditionOverviewComponent = (props) => {
   const { sector, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SECTOR_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const sectorValidator = useSchemaEditionValidation('Sector', basicShape);
+  }, mandatoryAttributes);
+  const sectorValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: sectorMutationFieldPatch,
@@ -170,6 +173,8 @@ const SectorEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={sectorValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -187,6 +192,7 @@ const SectorEditionOverviewComponent = (props) => {
             variant="standard"
             name="name"
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -198,6 +204,7 @@ const SectorEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -231,6 +238,7 @@ const SectorEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -240,6 +248,7 @@ const SectorEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -91,6 +91,7 @@ const SectorEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const sectorValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -91,6 +91,7 @@ const SectorEditionOverviewComponent = (props) => {
     confidence: Yup.number().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const sectorValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -56,7 +56,7 @@ interface SystemAddInput {
   description: string;
   confidence: number | null;
   x_opencti_reliability: string | undefined;
-  createdBy: FieldOption | null;
+  createdBy: FieldOption | undefined;
   objectMarking: FieldOption[];
   objectLabel: FieldOption[];
   externalReferences: { value: string }[];
@@ -170,7 +170,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
       description: '',
       confidence: null,
       x_opencti_reliability: undefined,
-      createdBy: defaultCreatedBy ?? null,
+      createdBy: defaultCreatedBy ?? undefined, // undefined for Require Fields Flagging, if Configured Mandatory Field
       objectMarking: defaultMarkingDefinitions ?? [],
       objectLabel: [],
       externalReferences: [],

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -14,7 +14,7 @@ import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
-import { useSchemaCreationValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { SystemCreationMutation, SystemCreationMutation$variables } from './__generated__/SystemCreationMutation.graphql';
@@ -87,17 +87,15 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
   const { t_i18n } = useFormatter();
   const [progressBarOpen, setProgressBarOpen] = useState(false);
 
-  const basicShape = {
-    name: Yup.string()
-      .min(2)
-      .required(t_i18n('This field is required')),
-    description: Yup.string()
-      .nullable(),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SYSTEM_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().min(2),
+    description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
-  };
-  const systemValidator = useSchemaCreationValidation(SYSTEM_TYPE, basicShape);
+  }, mandatoryAttributes);
+  const systemValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 
   const [commit] = useApiMutation<SystemCreationMutation>(
     systemMutation,
@@ -182,6 +180,8 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
     <Formik<SystemAddInput>
       initialValues={initialValues}
       validationSchema={systemValidator}
+      validateOnChange={false}
+      validateOnBlur={false}
       onSubmit={onSubmit}
       onReset={onReset}
     >
@@ -225,6 +225,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               variant="standard"
               name="name"
               label={t_i18n('Name')}
+              required={(mandatoryAttributes.includes('name'))}
               fullWidth={true}
               detectDuplicate={['User']}
             />
@@ -232,6 +233,7 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               component={MarkdownField}
               name="description"
               label={t_i18n('Description')}
+              required={(mandatoryAttributes.includes('description'))}
               fullWidth={true}
               multiline={true}
               rows="4"
@@ -245,28 +247,33 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
               label={t_i18n('Reliability')}
               type="reliability_ov"
               name="x_opencti_reliability"
+              required={(mandatoryAttributes.includes('x_opencti_reliability'))}
               containerStyle={fieldSpacingContainerStyle}
               multiple={false}
               onChange={setFieldValue}
             />
             <CreatedByField
               name="createdBy"
+              required={(mandatoryAttributes.includes('createdBy'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ObjectLabelField
               name="objectLabel"
+              required={(mandatoryAttributes.includes('objectLabel'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.objectLabel}
             />
             <ObjectMarkingField
               name="objectMarking"
+              required={(mandatoryAttributes.includes('objectMarking'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
             />
             <ExternalReferencesField
               name="externalReferences"
+              required={(mandatoryAttributes.includes('externalReferences'))}
               style={fieldSpacingContainerStyle}
               setFieldValue={setFieldValue}
               values={values.externalReferences}

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -94,6 +94,8 @@ export const SystemCreationForm: FunctionComponent<SystemFormProps> = ({
     confidence: Yup.number().nullable(),
     x_opencti_reliability: Yup.string()
       .nullable(),
+    createdBy: Yup.object().nullable(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const systemValidator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -94,6 +94,7 @@ const SystemEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const systemValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -94,6 +94,7 @@ const SystemEditionOverviewComponent = (props) => {
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
+    createdBy: Yup.object().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
   const systemValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -15,7 +15,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import StatusField from '../../common/form/StatusField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
-import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
+import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
@@ -80,19 +80,22 @@ const systemMutationRelationDelete = graphql`
   }
 `;
 
+const SYSTEM_TYPE = 'System';
+
 const SystemEditionOverviewComponent = (props) => {
   const { system, enableReferences, context, handleClose } = props;
   const { t_i18n } = useFormatter();
-  const basicShape = {
-    name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
+  const { mandatoryAttributes } = useIsMandatoryAttribute(SYSTEM_TYPE);
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     confidence: Yup.number().nullable(),
     contact_information: Yup.string().nullable(),
     x_opencti_reliability: Yup.string().nullable(),
     references: Yup.array(),
     x_opencti_workflow_id: Yup.object(),
-  };
-  const systemValidator = useSchemaEditionValidation('System', basicShape);
+  }, mandatoryAttributes);
+  const systemValidator = useDynamicSchemaEditionValidation(mandatoryAttributes, basicShape);
 
   const queries = {
     fieldPatch: systemMutationFieldPatch,
@@ -173,6 +176,8 @@ const SystemEditionOverviewComponent = (props) => {
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={systemValidator}
+      validateOnChange={true}
+      validateOnBlur={true}
       onSubmit={onSubmit}
     >
       {({
@@ -191,6 +196,7 @@ const SystemEditionOverviewComponent = (props) => {
             name="name"
             disabled={external}
             label={t_i18n('Name')}
+            required={(mandatoryAttributes.includes('name'))}
             fullWidth={true}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -202,6 +208,7 @@ const SystemEditionOverviewComponent = (props) => {
             component={MarkdownField}
             name="description"
             label={t_i18n('Description')}
+            required={(mandatoryAttributes.includes('description'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -225,6 +232,7 @@ const SystemEditionOverviewComponent = (props) => {
             variant="standard"
             name="contact_information"
             label={t_i18n('Contact information')}
+            required={(mandatoryAttributes.includes('contact_information'))}
             fullWidth={true}
             multiline={true}
             rows="4"
@@ -239,6 +247,7 @@ const SystemEditionOverviewComponent = (props) => {
             label={t_i18n('Reliability')}
             type="reliability_ov"
             name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
             onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
@@ -262,6 +271,7 @@ const SystemEditionOverviewComponent = (props) => {
           )}
           <CreatedByField
             name="createdBy"
+            required={(mandatoryAttributes.includes('createdBy'))}
             style={fieldSpacingContainerStyle}
             setFieldValue={setFieldValue}
             helpertext={
@@ -271,6 +281,7 @@ const SystemEditionOverviewComponent = (props) => {
           />
           <ObjectMarkingField
             name="objectMarking"
+            required={(mandatoryAttributes.includes('objectMarking'))}
             style={fieldSpacingContainerStyle}
             helpertext={
               <SubscriptionFocus context={context} fieldname="objectMarking" />


### PR DESCRIPTION
This is a PR that was originally submitted under - https://github.com/OpenCTI-Platform/opencti/pull/8965. The original was auto-closed when release/6.6.0 branch was recently closed and the new release/current approach was adopted.

This submission has been rebased to release/current and reopened.