### PR TITLE
[frontend] Improve graph initial zoom + unfix behavior (#10741)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -47,6 +47,7 @@ const Graph = ({
     zoomToFit,
     applyForces,
     setIsExpandOpen,
+    initForces,
   } = useGraphInteractions();
 
   const {
@@ -93,11 +94,16 @@ const Graph = ({
     // A short timeout to be sure graph is ready.
     setTimeout(() => {
       if (!isLoadingData) {
-        if (zoom) setZoom(zoom);
-        else zoomToFit();
+        initForces();
         if (withForces) applyForces();
+
+        // Another short timeout to wait forces to be applied
+        setTimeout(() => {
+          if (zoom) setZoom(zoom);
+          else zoomToFit();
+        }, 1000);
       }
-    }, 200);
+    }, 100);
   }, [mode3D, isLoadingData]);
 
   const shouldDisplayLinks = graphData?.links.length ?? 0 < 200;
@@ -193,6 +199,7 @@ const Graph = ({
               graphData={graphData}
               dagMode={modeTree ?? undefined}
               dagLevelDistance={50}
+              nodeRelSize={4}
               cooldownTicks={(!withForces || isLoadingData) ? 0 : 100}
               enablePanInteraction={!selectFree && !selectFreeRectangle}
               linkDirectionalArrowLength={3}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Configure power of graph forces (from values of old graphs)
* Wait more on init before zoom (to wait animations)
* Change behavior of click "unfix nodes" to make a complete layout reset (as before)

### Related issues

* #10741 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality