### PR TITLE
[backend] fix entities without internal_id (#10172)

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1742823297614-fix-missing-internal-ids.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1742823297614-fix-missing-internal-ids.js
@@ -1,0 +1,26 @@
+import { logApp } from '../config/conf';
+import { elUpdateByQueryForMigration } from '../database/engine';
+import { READ_DATA_INDICES } from '../database/utils';
+
+const message = '[MIGRATION] add internal_id for entities that have not this field';
+
+export const up = async (next) => {
+  logApp.info(`${message} > started`);
+  const updateQuery = {
+    script: {
+      source: 'ctx._source.internal_id = ctx._id; ',
+    },
+    query: {
+      bool: {
+        must_not: [{ exists: { field: 'internal_id' } }],
+      },
+    },
+  };
+  await elUpdateByQueryForMigration(
+    message,
+    READ_DATA_INDICES,
+    updateQuery
+  );
+  logApp.info(`${message} > done`);
+  next();
+};


### PR DESCRIPTION
### Proposed changes
Add internal_id for entities having no internal_id
(Removing an entity internal_id is not possible anymore after a former fix: https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10172