### PR TITLE
[frontend] Bug fix for the overflowing User Session area

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -609,7 +609,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
                 </Security>
                 <div className="clearfix" />
                 <FieldOrEmpty source={orderedSessions}>
-                  <List style={{ marginTop: -2 }}>
+                  <List style={{ marginTop: -2, width: '100%', maxHeight: 400, overflowY: 'auto' }}>
                     {orderedSessions
                       && orderedSessions.map((session: Session) => (
                         <ListItem

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -670,7 +670,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         </Grid>
         <Triggers recipientId={user.id} filterKey="authorized_members.id" />
         <Grid item xs={6} style={{ marginTop: 10 }}>
-          <Typography variant="h4" gutterBottom={true} style={{ paddingBottom: '22px' }}>
+          <Typography variant="h4" gutterBottom={true} style={{ paddingBottom: '21px' }}>
             {t_i18n('Operations')}
           </Typography>
           <Paper

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -670,7 +670,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         </Grid>
         <Triggers recipientId={user.id} filterKey="authorized_members.id" />
         <Grid item xs={6} style={{ marginTop: 10 }}>
-          <Typography variant="h4" gutterBottom={true}>
+          <Typography variant="h4" gutterBottom={true} style={{ paddingBottom: '22px' }}>
             {t_i18n('Operations')}
           </Typography>
           <Paper


### PR DESCRIPTION
Ticket: [1085](https://jira.324cate.com/browse/TIM-1085)

Decompose - https://github.com/OpenCTI-Platform/opencti/pull/10763
Part #1 - modify https://github.com/OpenCTI-Platform/opencti/pull/10763 to just contain the bug fix/scroll are for the User Session Widget area.
 
The capability is currently managed in master-TIM and needs to be merged into Open Source Github version.