### PR TITLE
[frontend] fix redirection to Entities created by a user (#10697)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -165,8 +165,6 @@ const Search = () => {
   useEffect(() => {
     if (paramsFilters) {
       storageHelpers.handleSetFilters(deserializeFilterGroupForFrontend(paramsFilters) ?? emptyFilterGroup);
-    } else {
-      storageHelpers.handleClearAllFilters();
     }
   }, [paramsFilters]);
 


### PR DESCRIPTION
### Proposed changes
When clicking on 'View all entities created by a user' in a user history (in user overview) : should redirect to the Advanced search with the filter 'creators = the_user'

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10697