### PR TITLE
[frontend] When only one export connector is available for the desired format, it should be directly selected (#10700)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -189,6 +189,15 @@ const StixCoreObjectFileExportForm = ({
         }, [values.format]);
 
         useEffect(() => {
+          if (values.format) {
+            const validConnectors = connectors.filter((c) => c.connectorScope?.includes(values.format));
+            if (validConnectors.length === 1 && !values.connector) {
+              setFieldValue('connector', validConnectors[0]);
+            }
+          }
+        }, [values.format, connectors, values.connector, setFieldValue]);
+
+        useEffect(() => {
           const connector = values.connector?.value;
           if (connector !== BUILT_IN_HTML_TO_PDF.value) setFieldValue('fileToExport', null);
           if (connector !== BUILT_IN_FROM_TEMPLATE.value) setFieldValue('template', null);


### PR DESCRIPTION
### Proposed changes

* pre-select connector if only one matches selected format

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/10700