### PR TITLE
[frontend] Removing popover should not show cascade delete in investigations (#10793)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -62,6 +62,7 @@ const GraphToolbarRemoveConfirm = ({
   const [commitDeleteObjectKnowledgeGraph] = useKnowledgeGraphDeleteObject();
 
   const {
+    context,
     graphData,
     graphState: {
       selectedLinks,
@@ -240,7 +241,7 @@ const GraphToolbarRemoveConfirm = ({
           <Typography variant="body1">
             {t_i18n('Do you want to remove these elements?')}
           </Typography>
-          <Alert
+          {context !== 'investigation' && (<Alert
             severity="warning"
             variant="outlined"
             style={{ marginTop: 20 }}
@@ -257,7 +258,7 @@ const GraphToolbarRemoveConfirm = ({
                 )}
               />
             </FormGroup>
-          </Alert>
+          </Alert>)}
 
           {totalToDelete > 0 && (
             <div

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -241,24 +241,26 @@ const GraphToolbarRemoveConfirm = ({
           <Typography variant="body1">
             {t_i18n('Do you want to remove these elements?')}
           </Typography>
-          {context !== 'investigation' && (<Alert
-            severity="warning"
-            variant="outlined"
-            style={{ marginTop: 20 }}
-          >
-            <AlertTitle>{t_i18n('Cascade delete')}</AlertTitle>
-            <FormGroup>
-              <FormControlLabel
-                label={t_i18n('Delete the element if no other containers contain it')}
-                control={(
-                  <Checkbox
-                    checked={andDelete}
-                    onChange={() => setAndDelete((d) => !d)}
-                  />
+          {context !== 'investigation' && (
+            <Alert
+              severity="warning"
+              variant="outlined"
+              style={{ marginTop: 20 }}
+            >
+              <AlertTitle>{t_i18n('Cascade delete')}</AlertTitle>
+              <FormGroup>
+                <FormControlLabel
+                  label={t_i18n('Delete the element if no other containers contain it')}
+                  control={(
+                    <Checkbox
+                      checked={andDelete}
+                      onChange={() => setAndDelete((d) => !d)}
+                    />
                 )}
-              />
-            </FormGroup>
-          </Alert>)}
+                />
+              </FormGroup>
+            </Alert>)
+          }
 
           {totalToDelete > 0 && (
             <div


### PR DESCRIPTION
### Proposed changes
When removing an entity from an investigation graph, the 'cascade delete' part should not be displayed

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10793