### PR TITLE
[frontend] Make deletion calls in knowledge graphs sequential (#10784)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -127,6 +127,8 @@ const GraphToolbarRemoveConfirm = ({
     setTotalToDelete(allSelection.length + associatedLinks.length);
 
     // Remove selected nodes and links
+    // /!\ We are voluntary using await in loop to call API
+    // sequentially to avoid lock issues when deleting.
     for (const el of allSelection) {
       const { id } = el;
       const isNode = isGraphNode(el);
@@ -165,6 +167,8 @@ const GraphToolbarRemoveConfirm = ({
     }
 
     // Remove links associated to removed nodes
+    // /!\ We are voluntary using await in loop to call API
+    // sequentially to avoid lock issues when deleting.
     for (const { id } of associatedLinks) {
       // eslint-disable-next-line no-await-in-loop
       await promiseOnDeleteRelation(

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -187,6 +187,7 @@ const GraphToolbarRemoveConfirm = ({
     removeLinks(linksToRemove);
     setTotalToDelete(0);
     setCurrentDeleted(0);
+    setAndDelete(false);
   };
 
   const remove = (referencesValues?: ReferenceFormData) => {

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -69,6 +69,13 @@ const GraphToolbarRemoveConfirm = ({
     },
   } = useGraphContext();
 
+  const close = () => {
+    setTotalToDelete(0);
+    setCurrentDeleted(0);
+    setAndDelete(false);
+    onClose();
+  };
+
   const {
     clearSelection,
     removeLinks,
@@ -180,14 +187,10 @@ const GraphToolbarRemoveConfirm = ({
       setCurrentDeleted((old) => old + 1);
     }
 
-    clearSelection();
-    onClose();
-
     removeNodes(nodesToRemove);
     removeLinks(linksToRemove);
-    setTotalToDelete(0);
-    setCurrentDeleted(0);
-    setAndDelete(false);
+    clearSelection();
+    close();
   };
 
   const remove = (referencesValues?: ReferenceFormData) => {
@@ -207,7 +210,7 @@ const GraphToolbarRemoveConfirm = ({
         },
       );
       clearSelection();
-      onClose();
+      close();
     }
   };
 
@@ -231,7 +234,7 @@ const GraphToolbarRemoveConfirm = ({
         keepMounted
         slotProps={{ paper: { elevation: 1 } }}
         slots={{ transition: Transition }}
-        onClose={onClose}
+        onClose={close}
       >
         <DialogContent>
           <Typography variant="body1">
@@ -277,7 +280,7 @@ const GraphToolbarRemoveConfirm = ({
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose} disabled={totalToDelete > 0}>
+          <Button onClick={close} disabled={totalToDelete > 0}>
             {t_i18n('Cancel')}
           </Button>
           <Button color="secondary" onClick={confirm} disabled={totalToDelete > 0}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Call delete mutation sequentially
* Remove all elements in the graph at the end
* Add a progress bar

### Related issues

* #10784 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

