### PR TITLE
[backend] fix cron playbook node filter saving (#9646)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -125,7 +125,7 @@ const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = (input: PlaybookAdd
   if (config.filters) {
     const filterGroup = JSON.parse(config.filters) as FilterGroup;
     if (input.component_id === PLAYBOOK_INTERNAL_DATA_CRON.id) {
-      stringifiedFilters = JSON.stringify(checkAndConvertFilters(filterGroup, userId));
+      stringifiedFilters = JSON.stringify(checkAndConvertFilters(filterGroup, userId, { noFiltersConvert: true }));
     } else { // our stix matching is currently limited, we need to validate the input filters
       validateFilterGroupForStixMatch(filterGroup);
       stringifiedFilters = config.filters;

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -349,17 +349,21 @@ export const checkFiltersValidity = (filterGroup: FilterGroup, noFiltersChecking
  * - check that the key is available with respect to the schema, throws an Error if not
  * - convert relation refs key if any
  */
-export const checkAndConvertFilters = (inputFilterGroup: FilterGroup | null | undefined, userId: string, opts: { noFiltersChecking?: boolean } = {}) => {
+export const checkAndConvertFilters = (
+  inputFilterGroup: FilterGroup | null | undefined,
+  userId: string,
+  opts: { noFiltersChecking?: boolean, noFiltersConvert?: boolean } = {}
+) => {
   if (!inputFilterGroup) {
     return undefined;
   }
   // 01. check filters validity
-  const { noFiltersChecking = false } = opts;
+  const { noFiltersChecking = false, noFiltersConvert = false } = opts;
   checkFiltersValidity(inputFilterGroup, noFiltersChecking);
   // 02. replace dynamic @me value
   const filterGroup = replaceMeValuesInFilters(inputFilterGroup, userId);
   // 03. convert relation refs
-  if (!noFiltersChecking && isFilterGroupNotEmpty(inputFilterGroup)) {
+  if (!noFiltersChecking && !noFiltersConvert && isFilterGroupNotEmpty(inputFilterGroup)) {
     return convertRelationRefsFilterKeys(filterGroup);
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* instead of converting filter when saving cron playbook node, convert it in playbook manager when node is run instead
* keep @me conversion during cron playbook node save: we can't resolve @me dynamically in playbook manager because we no longer know what to resolve @me to

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9646
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
