### PR TITLE
[frontend] Display the all users in Creators trigger filter of Connector (#9023)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.jsx
@@ -30,7 +30,7 @@ import DangerZoneBlock from '../../common/danger_zone/DangerZoneBlock';
 import Filters from '../../common/lists/Filters';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { useFormatter } from '../../../../components/i18n';
-import { getConnectorAvailableFilterKeys, getConnectorFilterEntityTypes, getConnectorOnlyContextualStatus, getConnectorTriggerStatus } from '../../../../utils/Connector';
+import { useGetConnectorAvailableFilterKeys, useGetConnectorFilterEntityTypes, getConnectorOnlyContextualStatus, getConnectorTriggerStatus } from '../../../../utils/Connector';
 import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty, serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 import { FIVE_SECONDS } from '../../../../utils/Time';
@@ -119,8 +119,8 @@ const ConnectorComponent = ({ connector, relay }) => {
   // connector trigger filters
   const connectorFilters = deserializeFilterGroupForFrontend(connector.connector_trigger_filters);
   const connectorFiltersEnabled = connector.connector_type === 'INTERNAL_ENRICHMENT';
-  const connectorFiltersScope = getConnectorFilterEntityTypes(connector);
-  const connectorAvailableFilterKeys = getConnectorAvailableFilterKeys(connector);
+  const connectorFiltersScope = useGetConnectorFilterEntityTypes(connector);
+  const connectorAvailableFilterKeys = useGetConnectorAvailableFilterKeys(connector);
   const [filters, helpers] = useFiltersState(connectorFilters);
 
   const [displayResetState, setDisplayResetState] = useState(false);
@@ -247,6 +247,7 @@ const ConnectorComponent = ({ connector, relay }) => {
       filterGroups: [],
     },
   };
+  const filtersSearchContext = { entityTypes: connectorFiltersScope, connectorsScope: true };
 
   const theme = useTheme();
   const userHasSettingsCapability = useGranted([SETTINGS_SETACCESSES]);
@@ -413,7 +414,7 @@ const ConnectorComponent = ({ connector, relay }) => {
                     <Filters
                       availableFilterKeys={connectorAvailableFilterKeys}
                       helpers={helpers}
-                      searchContext={{ entityTypes: connectorFiltersScope }}
+                      searchContext={filtersSearchContext}
                     />
                   </Box>
                   {filters && (
@@ -422,7 +423,7 @@ const ConnectorComponent = ({ connector, relay }) => {
                         filters={filters}
                         helpers={helpers}
                         styleNumber={2}
-                        searchContext={{ entityTypes: connectorFiltersScope }}
+                        searchContext={filtersSearchContext}
                         entityTypes={connectorFiltersScope}
                       />
                     </Box>

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -18,6 +18,7 @@ export type { FilterGroup as GqlFilterGroup } from './__generated__/useSearchEnt
 export interface FilterSearchContext {
   entityTypes: string[]
   elementId?: string[]
+  connectorsScope?: boolean
 }
 
 export type FiltersRestrictions = {

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -612,7 +612,6 @@ const useSearchEntities = ({
         case 'creator_id':
         case 'contextCreator':
           if (searchContext.connectorsScope && canDisplayAllUsers) {
-            console.log('fetch creators');
             // fetch all the users
             fetchQuery(usersLinesSearchQuery, {
               first: 10,

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -27,6 +27,8 @@ import { KillChainPhasesSearchQuery$data } from '@components/settings/__generate
 import { triggersQueriesSearchQuery } from '@components/profile/triggers/TriggersQueries';
 import { TriggersQueriesSearchQuery$data } from '@components/profile/triggers/__generated__/TriggersQueriesSearchQuery.graphql';
 import { OptionValue } from '@components/common/lists/FilterAutocomplete';
+import { usersLinesSearchQuery } from '@components/settings/users/UsersLines';
+import { UsersLinesSearchQuery$data } from '@components/settings/users/__generated__/UsersLinesSearchQuery.graphql';
 import useAuth, { FilterDefinition } from '../hooks/useAuth';
 import { useSearchEntitiesStixCoreObjectsSearchQuery$data } from './__generated__/useSearchEntitiesStixCoreObjectsSearchQuery.graphql';
 import { useFormatter } from '../../components/i18n';
@@ -35,9 +37,10 @@ import { fetchQuery } from '../../relay/environment';
 import { useSearchEntitiesSchemaSCOSearchQuery$data } from './__generated__/useSearchEntitiesSchemaSCOSearchQuery.graphql';
 import type { Theme } from '../../components/Theme';
 import useAttributes, { containerTypes } from '../hooks/useAttributes';
-import { contextFilters, entityTypesFilters, ME_FILTER_VALUE } from './filtersUtils';
+import { contextFilters, entityTypesFilters, FilterSearchContext, ME_FILTER_VALUE } from './filtersUtils';
 import { useSearchEntitiesDashboardsQuery$data } from './__generated__/useSearchEntitiesDashboardsQuery.graphql';
 import { convertMarking } from '../edition';
+import useGranted, { SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../hooks/useGranted';
 
 const filtersStixCoreObjectsSearchQuery = graphql`
   query useSearchEntitiesStixCoreObjectsSearchQuery(
@@ -250,7 +253,7 @@ const useSearchEntities = ({
 }: {
   availableEntityTypes?: string[];
   availableRelationshipTypes?: string[];
-  searchContext: { entityTypes: string[]; elementId?: string[] };
+  searchContext: FilterSearchContext;
   searchScope: Record<string, string[]>;
   setInputValues: (
     value: { key: string; values: string[]; operator?: string }[],
@@ -261,6 +264,7 @@ const useSearchEntities = ({
   const { schema, me } = useAuth();
   const { stixCoreObjectTypes } = useAttributes();
   const theme = useTheme() as Theme;
+  const canDisplayAllUsers = useGranted([SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN]);
   const filterKeysMap = new Map();
   (searchContext.entityTypes).forEach((entityType) => {
     const currentMap = schema.filterKeysSchema.get(entityType);
@@ -607,6 +611,20 @@ const useSearchEntities = ({
         // region user usage (with caching)
         case 'creator_id':
         case 'contextCreator':
+          if (searchContext.connectorsScope && canDisplayAllUsers) {
+            console.log('fetch creators');
+            // fetch all the users
+            fetchQuery(usersLinesSearchQuery, {
+              first: 10,
+              orderBy: 'name',
+              orderMode: 'asc',
+            })
+              .toPromise()
+              .then((response) => {
+                const data = response as UsersLinesSearchQuery$data;
+                buildCachedOptionsFromGenericFetchResponse(filterKey, 'User', data?.users);
+              });
+          }
           if (!cacheEntities[filterKey]) {
             // fetch only the identities listed as creator of at least 1 thing + myself
             fetchQuery(identitySearchCreatorsSearchQuery, {

--- a/opencti-platform/opencti-front/src/utils/hooks/useSchema.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useSchema.ts
@@ -37,7 +37,11 @@ const useSchema = () => {
     ];
   }, [schema]);
 
+  const availableAndAbstractEntityTypes = availableEntityTypes.map((e) => e.id)
+    .concat(['Stix-Domain-Object', 'Stix-Core-Object', 'Stix-Cyber-Observable']);
+
   return {
+    allEntityTypes: availableAndAbstractEntityTypes,
     availableEntityTypes,
     isRelationship,
     schema,


### PR DESCRIPTION
### Proposed changes
If in Connector overview, in the connector trigger filter, for the 'Creators' filter key : display all the users (and not only the ones that are creators of some entites in the platform) if the current user has the right to see them. 

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/9023