### PR TITLE
[backend] Fix bulk indexing fail error when creating data sharing (#10812)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3083,8 +3083,8 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   // authorized_members renaming
   if (input.authorized_members?.length > 0) {
     input.restricted_members = input.authorized_members;
-    delete input.authorized_members;
   }
+  delete input.authorized_members; // always remove authorized_members input, even if empty
   // endregion
   // validate authorized members access (when creating a new entity with authorized members)
   if (input.restricted_members?.length > 0) {


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* error was [{"reason":"[1:353] mapping set to strict, dynamic introduction of [authorized_members] within [_doc] is not allowed","type":"strict_dynamic_mapping_exception"}] due to renaming of authorized_members, we were sending an empty array which was not removed.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10812

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
