### PR TITLE
[backend] log user self-updates in activity stream (#10821)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -719,7 +719,7 @@ export const userEditField = async (context, user, userId, rawInputs) => {
     user,
     event_type: 'mutation',
     event_scope: 'update',
-    event_access: personalUpdate ? 'extended' : 'administration',
+    event_access: 'administration',
     message: `updates \`${inputs.map((i) => i.key).join(', ')}\` for ${personalUpdate ? '`themselves`' : `user \`${actionEmail}\``}`,
     context_data: { id: userId, entity_type: ENTITY_TYPE_USER, input }
   });


### PR DESCRIPTION
### Proposed changes

* Display updating made to a user by itself in the activity log.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/10821