### PR TITLE
[frontend/backend] handle update resulting in a standard_id change in draft (#10817)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
@@ -265,7 +265,11 @@ const DraftEntities : FunctionComponent<DraftEntitiesProps> = ({
   }
 
   const getRedirectionLink = (stixObject: DraftEntities_node$data) => {
-    return isReadOnly ? `/dashboard/id/${stixObject.standard_id}` : computeLink(stixObject);
+    if (isReadOnly) {
+      const isUpdatedEntity = stixObject.draftVersion?.draft_operation === 'update' || stixObject.draftVersion?.draft_operation === 'update_linked';
+      return isUpdatedEntity ? `/dashboard/id/${stixObject.id}` : `/dashboard/id/${stixObject.standard_id}`;
+    }
+    return computeLink(stixObject);
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
@@ -277,7 +277,11 @@ const DraftRelationships : FunctionComponent<DraftRelationshipsProps> = ({ isRea
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getRedirectionLink = (stixRelationship: any) => {
-    return isReadOnly ? `/dashboard/id/${stixRelationship.standard_id}` : computeLink(stixRelationship);
+    if (isReadOnly) {
+      const isUpdatedEntity = stixRelationship.draftVersion?.draft_operation === 'update' || stixRelationship.draftVersion?.draft_operation === 'update_linked';
+      return isUpdatedEntity ? `/dashboard/id/${stixRelationship.id}` : `/dashboard/id/${stixRelationship.standard_id}`;
+    }
+    return computeLink(stixRelationship);
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
@@ -377,7 +377,11 @@ const DraftSightings : FunctionComponent<DraftSightingsProps> = ({ isReadOnly })
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getRedirectionLink = (stixSighting: any) => {
-    return isReadOnly ? `/dashboard/id/${stixSighting.standard_id}` : computeLink(stixSighting);
+    if (isReadOnly) {
+      const isUpdatedEntity = stixSighting.draftVersion?.draft_operation === 'update' || stixSighting.draftVersion?.draft_operation === 'update_linked';
+      return isUpdatedEntity ? `/dashboard/id/${stixSighting.id}` : `/dashboard/id/${stixSighting.standard_id}`;
+    }
+    return computeLink(stixSighting);
   };
 
   return (

--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -103,7 +103,8 @@ export const buildUpdateFieldPatch = (rawUpdatePatch) => {
     for (let i = 0; i < updatePatchKeys.length; i += 1) {
       const currentKey = updatePatchKeys[i];
       const currentValues = parsedUpdatePatch[currentKey];
-      if (currentValues) {
+      // Ignore standard id in patch: standard id update will be handled by the platform if needed when applying the patch
+      if (currentKey !== 'standard_id' && currentValues) {
         if (currentValues.replaced_value && currentValues.replaced_value.length > 0) {
           const replaceInput = { key: currentKey, value: currentValues.replaced_value, operation: EditOperation.Replace };
           resultFieldPatch.push(replaceInput);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* change validated draft link to entities: link to internal_id of entity for updated entities instead of standard_id
* remove standard_id from update patch: let ingestion handle standard_id change during patch if needed

related client PR https://github.com/OpenCTI-Platform/client-python/pull/888

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10817 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
