### PR TITLE
[backend] notif buffering implementation (#8685)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -302,7 +302,9 @@
   "publisher_manager": {
     "enabled": true,
     "lock_key": "publisher_manager_lock",
-    "interval": 10000
+    "interval": 10000,
+    "enable_buffering": false,
+    "buffering_minutes": 3
   },
   "sync_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -304,7 +304,7 @@
     "lock_key": "publisher_manager_lock",
     "interval": 10000,
     "enable_buffering": false,
-    "buffering_seconds": 60000
+    "buffering_seconds": 60
   },
   "sync_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -304,7 +304,7 @@
     "lock_key": "publisher_manager_lock",
     "interval": 10000,
     "enable_buffering": false,
-    "buffering_minutes": 3
+    "buffering_seconds": 60000
   },
   "sync_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -303,7 +303,7 @@
     "enabled": true,
     "lock_key": "publisher_manager_lock",
     "interval": 10000,
-    "enable_buffering": false,
+    "enable_buffering": true,
     "buffering_seconds": 60
   },
   "sync_manager": {

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -8,7 +8,7 @@
     "build:types": "graphql-codegen --config graphql-codegen.yml",
     "build:schema": "yarn build:types && node builder/schema/schema.js && node build/script-generate-schema.js",
     "build:prod": "yarn build:types && yarn check-ts && node builder/prod/prod.js",
-    "build:dev": "node builder/dev/dev.js",
+    "build:dev": "yarn build:schema && node builder/dev/dev.js",
     "build:antlr": "java -jar ./builder/antlr/antlr-4.13.0-complete.jar -Dlanguage=JavaScript ./src/stixpattern/STIXPattern.g4 -o ./src/stixpattern/",
     "migrate:add": "migrate create --template-file src/utils/migration-template.js --migrations-dir=./src/migrations",
     "clean:relations": "yarn build:prod && node build/script-clean-relations.js",

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -44,7 +44,7 @@ import { findById } from '../domain/user';
 const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
 const PUBLISHER_ENABLE_BUFFERING = conf.get('publisher_manager:enable_buffering');
-const PUBLISHER_BUFFERING_MINUTES = conf.get('publisher_manager:buffering_minutes');
+const PUBLISHER_BUFFERING_SECONDS = conf.get('publisher_manager:buffering_seconds');
 const STREAM_SCHEDULE_TIME = 10000;
 
 export const internalProcessNotification = async (
@@ -303,7 +303,7 @@ const handleEntityNotificationBuffer = async () => {
     const key = bufferKeys[i];
     const value = liveNotificationBufferPerEntity[key];
     if (value) {
-      const isBufferingTimeElapsed = (dateNow - value.timestamp) > PUBLISHER_BUFFERING_MINUTES * 60000;
+      const isBufferingTimeElapsed = (dateNow - value.timestamp) > PUBLISHER_BUFFERING_SECONDS * 1000;
       // If buffer is older than configured buffering time length, it needs to be sent
       if (isBufferingTimeElapsed) {
         const bufferEvents = value.events.map((e) => e.data);

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -273,10 +273,10 @@ const processBufferedEvents = async (
       if (impactedData.length > 0) {
         const currentUser = impactedData[0].user;
         const dataToSend = impactedData.map((d) => d.data);
-        const triggersInDataToSend = [...new Set(dataToSend.map((d) => triggerMap.get(d.notification_id)?.name).filter((t) => t))];
+        const triggersInDataToSend = [...new Set(dataToSend.map((d) => triggerMap.get(d.notification_id)).filter((t) => t))];
         // If multiple triggers generated notification data, we need to create a "buffer" trigger containing the names of all triggers
         if (triggersInDataToSend.length > 1) {
-          const bufferTriggersName = triggersInDataToSend.join(';');
+          const bufferTriggersName = triggersInDataToSend.map((t) => t?.name).join(';');
           const bufferTrigger = { name: bufferTriggersName, trigger_type: 'buffer' } as BasicStoreEntityTrigger;
           // There is no await in purpose, the goal is to send notification and continue without waiting result.
           internalProcessNotification(context, settings, triggerMap, currentUser, allNotifiersMap.get(notifier) ?? {} as BasicStoreEntityNotifier, dataToSend, bufferTrigger).catch((reason) => logApp.error('[OPENCTI-MODULE] Publisher manager unknown error.', { cause: reason }));

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -276,8 +276,8 @@ const processBufferedEvents = async (
         const currentUser = impactedData[0].user;
         const dataToSend = impactedData.map((d) => d.data);
         const triggersInDataToSend = [...new Set(dataToSend.map((d) => triggerMap.get(d.notification_id)).filter((t) => t))];
-        // If multiple triggers generated notification data, we need to create a "buffer" trigger containing the names of all triggers
-        if (triggersInDataToSend.length > 1) {
+        // If triggers can't be found, no need to send the data
+        if (triggersInDataToSend.length >= 1) {
           // There is no await in purpose, the goal is to send notification and continue without waiting result.
           internalProcessNotification(
             context,

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -266,7 +266,7 @@ const processLiveBufferNotificationEvents = async (
       if (impactedData.length > 0) {
         const currentUser = impactedData[0].user;
         const dataToSend = impactedData.map((d) => d.data);
-        const bufferTriggersName = dataToSend.map((d) => notificationMap.get(d.notification_id)).filter((t) => t).join(';');
+        const bufferTriggersName = [...new Set(dataToSend.map((d) => notificationMap.get(d.notification_id)?.name).filter((t) => t))].join(';');
         const bufferNotification = { name: bufferTriggersName, trigger_type: 'buffer' } as BasicStoreEntityTrigger;
         // There is no await in purpose, the goal is to send notification and continue without waiting result.
         internalProcessNotification(context, settings, notificationMap, currentUser, notifierMap.get(notifier) ?? {} as BasicStoreEntityNotifier, dataToSend, bufferNotification).catch((reason) => logApp.error('[OPENCTI-MODULE] Publisher manager unknown error.', { cause: reason }));

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification-types.ts
@@ -73,7 +73,7 @@ export interface NotificationAddInput {
     title: string,
     events: Array<NotificationContentEvent>
   }>
-  trigger_id?: string
+  trigger_id?: string | string[]
   user_id: string
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notification/notification.ts
@@ -73,7 +73,7 @@ const NOTIFICATION_DEFINITION: ModuleDefinition<StoreEntityNotification, StixNot
   },
   attributes: [
     { name: 'name', label: 'Trigger name', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'trigger_id', label: 'Trigger', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_TRIGGER], mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'trigger_id', label: 'Trigger', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_TRIGGER], mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: true },
     { name: 'notification_type', label: 'Notification type', type: 'string', format: 'enum', values: TRIGGER_TYPE_VALUES, mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     {
       name: 'notification_content',

--- a/opencti-platform/opencti-graphql/src/modules/notifier/notifier-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/notifier/notifier-domain.ts
@@ -189,6 +189,6 @@ export const testNotifier = async (context: AuthContext, user: AuthUser, notifie
     user_id: user.id,
     user_email: user.user_email,
     notifiers: [],
-  }, notifier, MOCK_NOTIFICATIONS[notifier.notifier_test_id], { created: (new Date()).toISOString() } as unknown as BasicStoreEntityTrigger);
+  }, notifier, MOCK_NOTIFICATIONS[notifier.notifier_test_id], [{ created: (new Date()).toISOString() }] as unknown as BasicStoreEntityTrigger[]);
   return result?.error;
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* buffer live notifications per targeted entities in publisher manager.
When PUBLISHER_ENABLE_BUFFERING is enabled, notifcation events are stored in memory of publisher manager instead of being sent immediately. 
When the buffer time is older than the time configured in PUBLISHER_BUFFERING_MINUTES, we send the content of the buffer for an entity.
  

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8685 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
Possible things to discuss/improve:
* we currently handle the buffers in the same loop as the stream handling (in `notificationHandler` of the publisherManager). We might want to create a separate cron scheduler, the same way it is done in other managers (notificationManager for exemple)
* we might need to handle event loop locking in  `handleEntityNotificationBuffer` method
