### PR TITLE
[frontend] DataTable: compute table width before calling loading lines (#10759)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -15,16 +15,12 @@ const DataTableBody = ({
   pageStart,
   pageSize,
   hideHeaders = false,
-  tableRef,
 }: DataTableBodyProps) => {
   const {
     rootRef,
     variant,
     resolvePath,
-    tableWidthState: [tableWidth, setTableWidth],
-    startsWithAction,
-    startsWithIcon,
-    endsWithAction,
+    tableWidthState: [tableWidth],
     actions,
     columns,
     dataQueryArgs,
@@ -57,25 +53,6 @@ const DataTableBody = ({
       loadMore?.(pageSize);
     }
   }, [resolvedData]);
-
-  // Keep table width up to date.
-  useLayoutEffect(() => {
-    let observer: ResizeObserver;
-    if (tableRef.current) {
-      const resize = (el: Element) => {
-        let offset = 10;
-        if (startsWithAction) offset += SELECT_COLUMN_SIZE;
-        if (startsWithIcon) offset += ICON_COLUMN_SIZE;
-        if (endsWithAction) offset += SELECT_COLUMN_SIZE;
-        if ((el.clientWidth - offset) !== tableWidth) {
-          setTableWidth(el.clientWidth - offset);
-        }
-      };
-      resize(tableRef.current);
-      observer = callbackResizeObserver(tableRef.current, resize);
-    }
-    return () => { observer?.disconnect(); };
-  }, [tableRef.current, tableWidth, endsWithAction, startsWithAction, startsWithIcon]);
 
   const onToggleShiftEntity: DataTableLineProps['onToggleShiftEntity'] = (currentIndex, currentEntity, event) => {
     if (selectedElements && !R.isEmpty(selectedElements)) {

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -158,7 +158,6 @@ export interface DataTableBodyProps {
   pageSize: number
   pageStart: number
   hideHeaders: DataTableProps['hideHeaders']
-  tableRef: MutableRefObject<HTMLDivElement | null>
 }
 
 export interface DataTableDisplayFiltersProps {


### PR DESCRIPTION
### Proposed changes

* Compute width of datatable before displaying dummy lines. Before the width was computed inside the component Body which is called only after the data are loaded

### Related issues

* #10759 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality