### PR TITLE
[frontend] [CSV Mapper] Two "Author" field on the Note representation (#10551)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributesForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributesForm.tsx
@@ -76,7 +76,7 @@ CsvMapperRepresentationAttributesFormProps
   )?.attributes ?? [];
 
   const mutableSchemaAttributes: SchemaAttribute[] = entitySchemaAttributes.map((schema) => {
-    if (schema.name === 'hashes') {
+    if (schema.name === 'hashes' || schema.name === 'authors') {
       return (schema.mappings ?? []).map((mapping) => ({
         ...mapping,
         defaultValues: null,


### PR DESCRIPTION
### Proposed changes

* Remove the field "authors" from the mapping of a csv mapper as it's not used in the platform (see conversation in issue)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10551