### PR TITLE
[backend] keep raw observable value format when converting observableValues in stix (#10883)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-converter.ts
@@ -29,7 +29,7 @@ const convertIndicatorToStix = (instance: StoreEntityIndicator): StixIndicator =
         detection: instance.x_opencti_detection,
         score: instance.x_opencti_score,
         main_observable_type: instance.x_opencti_main_observable_type,
-        observable_values: getObservableValuesFromPattern(instance.pattern),
+        observable_values: getObservableValuesFromPattern(instance.pattern, true),
       }),
       [STIX_EXT_MITRE]: buildMITREExtensions(instance)
     }

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -212,8 +212,11 @@ export const promoteIndicatorToObservables = async (context: AuthContext, user: 
   return createObservablesFromIndicator(context, user, input, indicator);
 };
 
-export const getObservableValuesFromPattern = (pattern: string) => {
+export const getObservableValuesFromPattern = (pattern: string, rawFormat = false) => {
   const observableValues = extractObservablesFromIndicatorPattern(pattern);
+  if (rawFormat) {
+    return observableValues;
+  }
   return observableValues.map((o) => (o.hashes ? { ...o, hashes: stixHashesToInput(o) } : o));
 };
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we had different formats for hashes when converting in stix between hashed observables and indicator hashed observable values. We now convert hashes to the same format for both
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10883 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
