### PR TITLE
[frontend] Patch to correct duplicate persona chips

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetailsChips.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetailsChips.tsx
@@ -33,6 +33,9 @@ const typeMappings: Record<SupportedTypes, MappingFields> = {
   },
 };
 
+interface SeenPersonaID<T> {
+  [Key:string]: T;
+}
 interface ThreatActorIndividualDetailsChipsProps {
   data: ThreatActorIndividualDetails_ThreatActorIndividual$data,
   relType: SupportedTypes,
@@ -47,10 +50,14 @@ ThreatActorIndividualDetailsChipsProps
   const { title, field, path, AddComponent } = typeMappings[relType];
 
   const getRelationshipsOfType = (rel_type: SupportedTypes) => {
+    const seen_persona_id_dict: SeenPersonaID<number> = {};
     const relations = [];
     for (const { node } of data.stixCoreRelationships?.edges ?? []) {
       const { relationship_type } = node ?? {};
-      if (relationship_type === rel_type) relations.push(node);
+      if (relationship_type === rel_type && node.to?.id !== undefined && !(node.to.id in seen_persona_id_dict)) {
+        relations.push(node);
+        seen_persona_id_dict[node.to.id] = 1;
+      }
     }
     return relations;
   };

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetailsChips.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetailsChips.tsx
@@ -33,9 +33,6 @@ const typeMappings: Record<SupportedTypes, MappingFields> = {
   },
 };
 
-interface SeenPersonaID<T> {
-  [Key:string]: T;
-}
 interface ThreatActorIndividualDetailsChipsProps {
   data: ThreatActorIndividualDetails_ThreatActorIndividual$data,
   relType: SupportedTypes,
@@ -50,13 +47,13 @@ ThreatActorIndividualDetailsChipsProps
   const { title, field, path, AddComponent } = typeMappings[relType];
 
   const getRelationshipsOfType = (rel_type: SupportedTypes) => {
-    const seen_persona_id_dict: SeenPersonaID<number> = {};
+    const seen_persona_id_set = new Set<string>();
     const relations = [];
     for (const { node } of data.stixCoreRelationships?.edges ?? []) {
       const { relationship_type } = node ?? {};
-      if (relationship_type === rel_type && node.to?.id !== undefined && !(node.to.id in seen_persona_id_dict)) {
+      if (relationship_type === rel_type && node.to?.id !== undefined && !(seen_persona_id_set.has(node.to.id))) {
         relations.push(node);
-        seen_persona_id_dict[node.to.id] = 1;
+        seen_persona_id_set.add(node.to.id);
       }
     }
     return relations;


### PR DESCRIPTION
See Issue - https://github.com/OpenCTI-Platform/opencti/issues/10897

### Proposed changes

* Deduplicates erroneous push for seen persona chips on a Threat Actor, resulting in duplicate chips displayed

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10897

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

N/A
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
