### PR TITLE
[CI] add a log file for sync-raw test on jfrog output

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -142,6 +142,7 @@ steps:
       - jf rt bdi $JFROG_BUILD_NAME --max-days=30 --url=$JFROG_URL --access-token=$JFROG_TOKEN
     depends_on:
       - frontend-e2e-tests
+      - api-tests
 
   - name: frontend-verify-translation
     image: node:22.14.0

--- a/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/00-Raw/sync-raw-test.js
@@ -5,6 +5,7 @@ import { execChildPython } from '../../../src/python/pythonBridge';
 import { checkPostSyncContent, checkPreSyncContent, INDICATOR_NUMBERS, LABEL_NUMBERS, MALWARE_NUMBERS, VOCABULARY_NUMBERS } from '../sync-utils';
 import { elAggregationCount } from '../../../src/database/engine';
 import { READ_DATA_INDICES } from '../../../src/database/utils';
+import { writeTestDataToFile } from '../../utils/testOutput';
 
 const LIST_QUERY = gql`
   query vocabularies(
@@ -49,6 +50,7 @@ describe('Database sync raw', () => {
       const execution = await execChildPython(testContext, ADMIN_USER, PYTHON_PATH, 'local_synchronizer.py', syncOpts);
       expect(execution).not.toBeNull();
       expect(execution.status).toEqual('success');
+      writeTestDataToFile(JSON.stringify(execution.messages), 'sync-test-all-event.json');
       // to uncomment for debug if counters are failing
       // expect(execution.messages.length, `Execution messages ${JSON.stringify(execution.messages)}`).toEqual(0);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
We already have log for raw test and live test, the test log file for sync-raw test is missing.

In the way to debug https://github.com/OpenCTI-Platform/opencti/pull/10714 test issues.

### Proposed changes

* Add the log file of all sync raw test even in the test output that is archived on JFrog.
* Wait until api-tests step is ended before gathering build artefact.

### Related issues


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
