### PR TITLE
[backend] One prefix missing on cyberark configuration

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/credentials.ts
+++ b/opencti-platform/opencti-graphql/src/config/credentials.ts
@@ -15,7 +15,7 @@ export const enrichWithRemoteCredentials = async (prefix: string, baseConfigurat
       const object = conf.get(`${prefix}:credentials_provider:${provider}:object`);
       // https options
       let certs: Certificates | undefined;
-      const rejectUnauthorized = conf.get('elasticsearch:credentials_provider:https_cert:reject_unauthorized') || false;
+      const rejectUnauthorized = conf.get(`${prefix}:credentials_provider:https_cert:reject_unauthorized`) || false;
       if (conf.get(`${prefix}:credentials_provider:https_cert:crt`)) {
         certs = {
           cert: conf.get(`${prefix}:credentials_provider:https_cert:crt`),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* one prefix replacement was missing, so for other configuration than elasticsearch (redis for example) this is a bug.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
