### PR TITLE
[frontend] Scrollable User Activity History Tab (#11427)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemHistory.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemHistory.tsx
@@ -1,0 +1,35 @@
+import { Tooltip } from '@mui/material';
+import React, { FunctionComponent } from 'react';
+import MarkdownDisplay from './MarkdownDisplay';
+
+interface ItemHistoryProps {
+  username: string,
+  message: string,
+}
+
+const ItemHistory: FunctionComponent<ItemHistoryProps> = ({
+  username,
+  message,
+}) => {
+  return (
+    <Tooltip
+      title={(
+        <MarkdownDisplay
+          content={`\`${username}\` ${message}`}
+          remarkGfmPlugin
+          commonmark
+        />
+      )}
+    >
+      <div style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+        <MarkdownDisplay
+          content={`\`${username}\` ${message}`}
+          remarkGfmPlugin
+          commonmark
+        />
+      </div>
+    </Tooltip>
+  );
+};
+
+export default ItemHistory;

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -28,6 +28,7 @@ import ItemOperations from '../ItemOperations';
 import ItemDueDate from '../ItemDueDate';
 import { APP_BASE_PATH } from '../../relay/environment';
 import FieldOrEmpty from '../FieldOrEmpty';
+import ItemHistory from '../ItemHistory';
 
 const chipStyle = {
   fontSize: '12px',
@@ -1305,6 +1306,22 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     percentWidth: 10,
     isSortable: true,
     render: ({ x_opencti_score }) => <ItemScore score={x_opencti_score} />,
+  },
+  timestamp: {
+    id: 'timestamp',
+    label: 'Timestamp',
+    percentWidth: 50,
+    isSortable: true,
+    render: ({ timestamp }, { nsdt }) => defaultRender(nsdt(timestamp)),
+  },
+  event_scope: {
+    id: 'event_scope',
+    label: 'Activity',
+    percentWidth: 50,
+    isSortable: false,
+    render: ({ user, context_data }) => (
+      <ItemHistory username={user.name} message={context_data.message} />
+    ),
   },
 };
 

--- a/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import makeStyles from '@mui/styles/makeStyles';
+import useHelper from '../../../../utils/hooks/useHelper';
 import AccessesMenu from '../AccessesMenu';
 import Security from '../../../../utils/Security';
 import { VIRTUAL_ORGANIZATION_ADMIN, SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
@@ -18,7 +19,6 @@ import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import UserEdition from './UserEdition';
 import UserHistoryTab from './UserHistoryTab';
-import useHelper from 'src/utils/hooks/useHelper';
 
 const userEditionQuery = graphql`
   query RootUserEditionQuery($id: String!) {
@@ -149,7 +149,7 @@ const RootUserComponent = ({ queryRef, userId, refetch }) => {
                 to={`/dashboard/settings/accesses/users/${data.id}/history`}
                 value={`/dashboard/settings/accesses/users/${data.id}/history`}
                 label={t_i18n('History')}
-              />}
+                                   />}
             </Tabs>
           </Box>
           <Routes>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/Root.jsx
@@ -17,6 +17,8 @@ import UserAnalytics from './UserAnalytics';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import UserEdition from './UserEdition';
+import UserHistoryTab from './UserHistoryTab';
+import useHelper from 'src/utils/hooks/useHelper';
 
 const userEditionQuery = graphql`
   query RootUserEditionQuery($id: String!) {
@@ -81,6 +83,7 @@ const userQuery = graphql`
           organizationsOrderMode: $organizationsOrderMode
         )
       ...UserAnalytics_user
+      ...UserHistoryTab_user
     }
   }
 `;
@@ -102,6 +105,8 @@ const RootUserComponent = ({ queryRef, userId, refetch }) => {
     userEditionQuery,
     { id: userId },
   );
+  const { isFeatureEnable } = useHelper();
+  const isUserHistoryTab = isFeatureEnable('USER_HISTORY_TAB');
   return (
     <Security needs={[SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN]}>
       {data ? (
@@ -139,6 +144,12 @@ const RootUserComponent = ({ queryRef, userId, refetch }) => {
                 value={`/dashboard/settings/accesses/users/${data.id}/analytics`}
                 label={t_i18n('Analytics')}
               />
+              {isUserHistoryTab && <Tab
+                component={Link}
+                to={`/dashboard/settings/accesses/users/${data.id}/history`}
+                value={`/dashboard/settings/accesses/users/${data.id}/history`}
+                label={t_i18n('History')}
+              />}
             </Tabs>
           </Box>
           <Routes>
@@ -152,6 +163,12 @@ const RootUserComponent = ({ queryRef, userId, refetch }) => {
               path="/analytics"
               element={ (
                 <UserAnalytics data={data} refetch={refetch} />
+              )}
+            />
+            <Route
+              path="/history"
+              element={(
+                <UserHistoryTab data={data} refetch={refetch} />
               )}
             />
           </Routes>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
@@ -70,11 +70,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const userHistoryLineFragment = graphql`
+export const userHistoryLineFragment = graphql`
   fragment UserHistoryLine_node on Log {
     id
     event_type
     event_scope
+    event_status
     timestamp
     user {
       name

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLines.tsx
@@ -37,7 +37,7 @@ export const userHistoryLinesQuery = graphql`
     @arguments( types: $types, search: $search, orderBy: $orderBy, orderMode: $orderMode, filters: $filters, cursor: $cursor)}
 `;
 
-const userHistoryLinesFragment = graphql`
+export const userHistoryLinesFragment = graphql`
     fragment UserHistoryLines_data on Query
     @argumentDefinitions(
       types: { type: "[String!]" }
@@ -62,6 +62,11 @@ const userHistoryLinesFragment = graphql`
             id
             ...UserHistoryLine_node
           }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+          globalCount
         }
       }
     }

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryTab.tsx
@@ -1,0 +1,352 @@
+import React, { FunctionComponent, useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import { Avatar, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Tooltip } from '@mui/material';
+import { DeleteOutlined, StorageOutlined } from '@mui/icons-material';
+import { Link } from 'react-router-dom';
+import { LinkVariantPlus, LinkVariantRemove, Merge, VectorRadius } from 'mdi-material-ui';
+import { v4 as uuid } from 'uuid';
+import { deepOrange, green, indigo, lightGreen, orange, pink, red, teal, yellow } from '@mui/material/colors';
+import { useTheme } from '@mui/styles';
+import { UserHistoryTab_user$key } from './__generated__/UserHistoryTab_user.graphql';
+import DataTable from '../../../../components/dataGrid/DataTable';
+import { emptyFilterGroup, GqlFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { userHistoryLineFragment } from './UserHistoryLine';
+import { userHistoryLinesFragment, userHistoryLinesQuery } from './UserHistoryLines';
+import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
+import { UserHistoryLinesQuery, UserHistoryLinesQuery$variables } from './__generated__/UserHistoryLinesQuery.graphql';
+import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
+import { UsePreloadedPaginationFragment } from '../../../../utils/hooks/usePreloadedPaginationFragment';
+import { UserHistoryLines_data$data } from './__generated__/UserHistoryLines_data.graphql';
+import useGranted, { KNOWLEDGE, SETTINGS_SECURITYACTIVITY } from '../../../../utils/hooks/useGranted';
+import { DataTableProps } from '../../../../components/dataGrid/dataTableTypes';
+import { useFormatter } from '../../../../components/i18n';
+import ItemIcon from '../../../../components/ItemIcon';
+import type { Theme } from '../../../../components/Theme';
+import { UserHistoryLine_node$data } from './__generated__/UserHistoryLine_node.graphql';
+import MarkdownDisplay from '../../../../components/MarkdownDisplay';
+
+const LOCAL_STORAGE_KEY = 'audits';
+
+const userFragment = graphql`
+  fragment UserHistoryTab_user on User {
+    id
+  }
+`;
+
+interface UserHistoryTabProps {
+  data: UserHistoryTab_user$key;
+}
+
+const UserHistoryTab: FunctionComponent<UserHistoryTabProps> = ({
+  data: userData,
+}) => {
+  const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
+  const user = useFragment(userFragment, userData);
+  const [message, setMessage] = useState<string>('-');
+  const [open, setOpen] = useState<boolean>(false);
+  const handleOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+    setMessage('-');
+  };
+  const dataColumns: DataTableProps['dataColumns'] = {
+    event_scope: {},
+    timestamp: {},
+  };
+  const initialValues = {
+    searchTerm: '',
+    sortBy: 'timestamp',
+    orderAsc: true,
+    openExports: false,
+    filters: emptyFilterGroup,
+  };
+  const { helpers, paginationOptions } = usePaginationLocalStorage<UserHistoryLinesQuery$variables>(
+    LOCAL_STORAGE_KEY,
+    initialValues,
+  );
+  const isGrantedToAudit = useGranted([SETTINGS_SECURITYACTIVITY]);
+  const isGrantedToKnowledge = useGranted([KNOWLEDGE]);
+  let historyTypes = ['History'];
+  if (isGrantedToAudit && !isGrantedToKnowledge) {
+    historyTypes = ['Activity'];
+  } else if (isGrantedToAudit && isGrantedToKnowledge) {
+    historyTypes = ['History', 'Activity'];
+  }
+  const queryPaginationOptions = {
+    ...paginationOptions,
+    types: historyTypes,
+    filters: {
+      mode: 'or',
+      filterGroups: [],
+      filters: [
+        { key: ['user_id'], values: [user.id], operator: 'wildcard', mode: 'or' },
+        { key: ['context_data.id'], values: [user.id], operator: 'wildcard', mode: 'or' },
+      ],
+    } as GqlFilterGroup,
+    first: 25,
+  } as unknown as UserHistoryLinesQuery$variables;
+  const queryRef = useQueryLoading<UserHistoryLinesQuery>(
+    userHistoryLinesQuery,
+    queryPaginationOptions,
+  );
+  const preloadedPaginationProps = {
+    linesQuery: userHistoryLinesQuery,
+    linesFragment: userHistoryLinesFragment,
+    queryRef,
+    nodePath: ['audits', 'pageInfo', 'globalCount'],
+    setNumberOfElements: helpers.handleSetNumberOfElements,
+  } as UsePreloadedPaginationFragment<UserHistoryLinesQuery>;
+
+  // Entities and relationships redirection filters
+  const technicalCreatorFilters = JSON.stringify({
+    mode: 'and',
+    filterGroups: [],
+    filters: [
+      {
+        key: 'creator_id',
+        values: [
+          user.id,
+        ],
+        operator: 'eq',
+        mode: 'or',
+        id: uuid(), // because filters in the URL
+      },
+    ],
+  });
+
+  const renderIcon = (eventScope: string | null | undefined, eventMessage: string | undefined, commit: string | null | undefined) => {
+    setMessage(eventMessage ?? '-');
+    if (eventScope === 'create') {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${pink[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <ItemIcon type={eventScope} color="inherit" size="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'merge') {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${teal[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <Merge fontSize="small" />
+        </Avatar>
+      );
+    }
+    if (
+      eventScope === 'update'
+      && (eventMessage?.includes('replaces') || eventMessage?.includes('updates'))
+    ) {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${green[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <ItemIcon type={eventScope} color="inherit" size="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'update' && eventMessage?.includes('changes')) {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${green[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <ItemIcon type={eventScope} color="inherit" size="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'update' && eventMessage?.includes('adds')) {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${indigo[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <LinkVariantPlus fontSize="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'update' && eventMessage?.includes('removes')) {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${deepOrange[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+          onClick={() => commit && handleOpen()}
+        >
+          <LinkVariantRemove fontSize="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'delete') {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${red[500]}`,
+            color: theme.palette.text?.primary,
+          }}
+        >
+          <DeleteOutlined fontSize="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'read') {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${lightGreen[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+        >
+          <ItemIcon type={eventScope} color="inherit" size="small" />
+        </Avatar>
+      );
+    }
+    if (eventScope === 'download') {
+      return (
+        <Avatar
+          sx={{
+            width: 25,
+            height: 25,
+            backgroundColor: 'transparent',
+            border: `1px solid ${orange[500]}`,
+            color: theme.palette.text?.primary,
+            cursor: commit ? 'pointer' : 'auto',
+          }}
+        >
+          <ItemIcon type={eventScope} color="inherit" size="small" />
+        </Avatar>
+      );
+    }
+    return (
+      <Avatar
+        sx={{
+          width: 25,
+          height: 25,
+          backgroundColor: 'transparent',
+          border: `1px solid ${yellow[500]}`,
+          color: theme.palette.text?.primary,
+        }}
+        onClick={() => commit && handleOpen()}
+      >
+        <ItemIcon type={eventScope} color="inherit" size="small" />
+      </Avatar>
+    );
+  };
+
+  return (
+    <>
+      {queryRef && (
+        <DataTable
+          dataColumns={dataColumns}
+          resolvePath={(data: UserHistoryLines_data$data) => data.audits?.edges?.map((n) => n?.node)}
+          storageKey={LOCAL_STORAGE_KEY}
+          initialValues={initialValues}
+          lineFragment={userHistoryLineFragment}
+          preloadedPaginationProps={preloadedPaginationProps}
+          disableNavigation
+          disableLineSelection
+          disableSelectAll
+          icon={(data: UserHistoryLine_node$data) => renderIcon(data.event_scope, data.context_data?.message, data.context_data?.commit)}
+          additionalHeaderButtons={[
+            (<Tooltip title={t_i18n('View all entities created by user')} key="entities">
+              <IconButton
+                component={Link}
+                to={`/dashboard/search/knowledge/?filters=${encodeURIComponent(technicalCreatorFilters)}`}
+                size="large"
+                color="primary"
+              >
+                <StorageOutlined fontSize="small" />
+              </IconButton>
+            </Tooltip>),
+            (<Tooltip title={t_i18n('View all relationships created by user')} key="relations">
+              <IconButton
+                component={Link}
+                to={`/dashboard/data/relationships/?filters=${encodeURIComponent(technicalCreatorFilters)}`}
+                size="large"
+                color="primary"
+              >
+                <VectorRadius fontSize="small" />
+              </IconButton>
+            </Tooltip>),
+          ]}
+        />
+      )}
+      <Dialog
+        open={open}
+        slotProps={{ paper: { elevation: 1 } }}
+        onClose={handleClose}
+        fullWidth={true}
+      >
+        <DialogTitle>{t_i18n('Commit message')}</DialogTitle>
+        <DialogContent>
+          <MarkdownDisplay
+            content={message}
+            remarkGfmPlugin={true}
+            commonmark={true}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button color="primary" onClick={handleClose}>
+            {t_i18n('Close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default UserHistoryTab;


### PR DESCRIPTION
### Proposed changes

* Add a new History tab to the user page
* A dataTable of the history lines that are found on the user overview
* Submission based on mockups provided
* Feature flag controlled by USER_HISTORY_TAB

### Related issues

* closes #11427
* [Initial Submission](https://github.com/OpenCTI-Platform/opencti/pull/10763)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


### Further comments
