### PR TITLE
[frontend] Relationship start/stop time name uniformization (#8766)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/RelationshipDetails.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/RelationshipDetails.tsx
@@ -356,13 +356,17 @@ RelationshipDetailsComponentProps
     return (
       <>
         <Typography variant="h3" gutterBottom={true} className={classes.label}>
-          {t_i18n('First seen')}
+          {stixRelationship.entity_type !== 'stix-sighting-relationship'
+            ? t_i18n('Start time')
+            : t_i18n('First seen')}
         </Typography>
         {stixRelationship.entity_type !== 'stix-sighting-relationship'
           ? fldt(stixRelationship.start_time)
           : fldt(stixRelationship.first_seen)}
         <Typography variant="h3" gutterBottom={true} className={classes.label}>
-          {t_i18n('Last seen')}
+          {stixRelationship.entity_type !== 'stix-sighting-relationship'
+            ? t_i18n('Stop time')
+            : t_i18n('Last seen')}
         </Typography>
         {stixRelationship.entity_type !== 'stix-sighting-relationship'
           ? fldt(stixRelationship.stop_time)

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.jsx
@@ -488,9 +488,9 @@ class StixCoreRelationshipCreation extends Component {
                   >
                     {t(`relationship_${relation.node.relationship_type}`)}
                     <br />
-                    {t('First obs.')} {fsd(relation.node.start_time)}
+                    {t('Start time')} {fsd(relation.node.start_time)}
                     <br />
-                    {t('Last obs.')} {fsd(relation.node.stop_time)}
+                    {t('Stop time')} {fsd(relation.node.stop_time)}
                   </div>
                 </Tooltip>
               </div>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
@@ -264,8 +264,8 @@ class StixCyberObservableEntities extends Component {
                     {this.SortHeader('name', 'Name', false)}
                     {this.SortHeader('createdBy', 'Author', false)}
                     {this.SortHeader('creator', 'Creator', false)}
-                    {this.SortHeader('start_time', 'First obs.', true)}
-                    {this.SortHeader('stop_time', 'Last obs.', true)}
+                    {this.SortHeader('start_time', 'Start time', true)}
+                    {this.SortHeader('stop_time', 'Stop time', true)}
                     {this.SortHeader('confidence', 'Confidence level', true)}
                   </div>
                 }


### PR DESCRIPTION
### Proposed changes
The start/stop time of relationships should be named as 'Start time' and 'Stop time' everywhere

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8766