### PR TITLE
[frontend] align filter popover on chip instead of label (#10723)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -205,7 +205,7 @@ FilterIconButtonContainerProps
     if (helpers) {
       setFilterChipsParams({
         filterId,
-        anchorEl: event.currentTarget,
+        anchorEl: event.currentTarget.parentElement ?? event.currentTarget,
       });
     }
   };


### PR DESCRIPTION
### Proposed changes

* Align filter popover on chip component

### Related issues

* close #10723 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

the bug appears because the popover is aligned on the currentTarget, and here the currentTarget is the chip label, so the popover is aligned on the text and get the chip padding left