### PR TITLE
[frontend/backend] History message for new version of a file upload (#10598)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -216,7 +216,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
           </Avatar>
         );
       }
-      if (eventScope === 'update' && (eventMesage.includes('adds') || eventMesage.includes('new version'))) {
+      if (eventScope === 'update' && (eventMesage.includes('adds'))) {
         return (
           <Avatar
             sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -216,7 +216,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
           </Avatar>
         );
       }
-      if (eventScope === 'update' && (eventMesage.includes('adds'))) {
+      if (eventScope === 'update') {
         return (
           <Avatar
             sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -111,7 +111,6 @@ class StixCoreObjectHistoryLineComponent extends Component {
   }
 
   renderIcon(eventScope, isRelation, eventMesage, commit) {
-    console.log('eventScope', eventScope);
     const { theme } = this.props;
     if (isRelation) {
       if (eventScope === 'create') {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -111,6 +111,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
   }
 
   renderIcon(eventScope, isRelation, eventMesage, commit) {
+    console.log('eventScope', eventScope);
     const { theme } = this.props;
     if (isRelation) {
       if (eventScope === 'create') {
@@ -216,7 +217,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
           </Avatar>
         );
       }
-      if (eventScope === 'update' && eventMesage.includes('adds')) {
+      if (eventScope === 'update' && (eventMesage.includes('adds') || eventMesage.includes('new version'))) {
         return (
           <Avatar
             sx={{

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -798,13 +798,13 @@ export const stixCoreObjectImportPush = async (context, user, id, file, args = {
       const newExternalRefs = [...(previous[INPUT_EXTERNAL_REFS] ?? []), addedExternalRef];
       const instance = { ...previous, x_opencti_files: resolvedFiles, [INPUT_EXTERNAL_REFS]: newExternalRefs };
       const message = is_upsert
-        ? `uploads a new version of \`${up.name}\` in \`files\` and \`external_references\``
+        ? `adds a new version of \`${up.name}\` in \`files\` and \`external_references\``
         : `adds \`${up.name}\` in \`files\` and \`external_references\``;
       await storeUpdateEvent(context, user, previous, instance, message);
     } else {
       const instance = { ...previous, x_opencti_files: resolvedFiles };
       const message = is_upsert
-        ? `uploads a new version of \`${up.name}\` in \`files\``
+        ? `adds a new version of \`${up.name}\` in \`files\``
         : `adds \`${up.name}\` in \`files\``;
       await storeUpdateEvent(context, user, previous, instance, message);
     }

--- a/opencti-platform/opencti-graphql/src/listener/UserActionListener.ts
+++ b/opencti-platform/opencti-graphql/src/listener/UserActionListener.ts
@@ -176,7 +176,7 @@ export const publishUserAction = async (userAction: UserAction) => {
   return Promise.all(actionPromises);
 };
 
-export const completeContextDataForEntity = <T extends BasicStoreCommon, C extends ElementContextData>(inputContextData: C, data: T) => {
+export const completeContextDataForEntity = <T extends BasicStoreCommon | null, C extends ElementContextData>(inputContextData: C, data: T) => {
   const contextData = { ...inputContextData };
   if (data) {
     if (data.creator_id) {
@@ -201,10 +201,16 @@ export const completeContextDataForEntity = <T extends BasicStoreCommon, C exten
   return contextData;
 };
 
-export const buildContextDataForFile = (entity: BasicStoreObject, path: string, filename: string, file_markings: string[] = [], input: unknown = {}) => {
+export const buildContextDataForFile = (
+  entity: BasicStoreObject | null,
+  path: string,
+  filename: string,
+  file_markings: string[] = [],
+  input: unknown = {},
+) => {
   const baseData: UserFileActionContextData = {
     path,
-    id: entity?.internal_id,
+    id: entity?.internal_id ?? '',
     entity_name: entity ? extractEntityRepresentativeName(entity) : 'global',
     entity_type: entity?.entity_type ?? 'global',
     file_name: filename,

--- a/opencti-platform/opencti-graphql/src/manager/activityListener.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityListener.ts
@@ -185,8 +185,11 @@ const initActivityManager = () => {
           await activityLogger(action, message);
         }
         if (action.event_scope === 'create') {
-          const { file_name, entity_name, entity_type, path } = action.context_data;
-          let message = `adds \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`;
+          const { file_name, entity_name, entity_type, path, input } = action.context_data;
+          // @ts-expect-error input type unknown
+          let message = input?.is_upsert
+            ? `uploads a new version of \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`
+            : `adds \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`;
           if (path.includes('import/pending')) {
             message = `creates Analyst Workbench \`${file_name}\` for \`${entity_name}\` (${entity_type})`;
           }

--- a/opencti-platform/opencti-graphql/src/manager/activityListener.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityListener.ts
@@ -188,7 +188,7 @@ const initActivityManager = () => {
           const { file_name, entity_name, entity_type, path, input } = action.context_data;
           // @ts-expect-error input type unknown
           let message = input?.is_upsert
-            ? `uploads a new version of \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`
+            ? `adds a new version of \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`
             : `adds \`${file_name}\` in \`files\` for \`${entity_name}\` (${entity_type})`;
           if (path.includes('import/pending')) {
             message = `creates Analyst Workbench \`${file_name}\` for \`${entity_name}\` (${entity_type})`;


### PR DESCRIPTION
### Proposed changes
Different history message when uploading a file in an entity : 
- When uploading a file in an entity: 'add file_name in files'
- When uploading a file that already exist in an entity (file upsert): 'adds a new version of file_name in files'

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10598