### PR TITLE
[backend] add correct user_inside_platform_organization in taskManager context (#11043)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
+++ b/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
@@ -1,4 +1,4 @@
-import { executionContext, isBypassUser, SYSTEM_USER } from '../utils/access';
+import { executionContext, isUserInPlatformOrganization, SYSTEM_USER } from '../utils/access';
 import { getEntityFromCache } from '../database/cache';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { authenticateUserFromRequest, userWithOrigin } from '../domain/user';
@@ -28,13 +28,7 @@ export const createAuthenticatedContext = async (req, res, contextName) => {
       if (executeContext.user_with_session) {
         executeContext.user_otp_validated = req.session?.user.otp_validated ?? false;
       }
-      if (isBypassUser(executeContext.user)) {
-        executeContext.user_inside_platform_organization = true;
-      } else {
-        const userOrganizationIds = (user.organizations ?? []).map((organization) => organization.internal_id);
-        executeContext.user_inside_platform_organization = settings.platform_organization
-          ? userOrganizationIds.includes(settings.platform_organization) : true;
-      }
+      executeContext.user_inside_platform_organization = isUserInPlatformOrganization(user, settings);
     }
   } catch (error) {
     logApp.error('Fail to authenticate the user in graphql context hook', { cause: error });

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -48,7 +48,7 @@ import {
   INPUT_OBJECTS,
   RULE_PREFIX
 } from '../schema/general';
-import { BYPASS, executionContext, getUserAccessRight, isBypassUser, MEMBER_ACCESS_RIGHT_ADMIN, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
+import { BYPASS, executionContext, getUserAccessRight, isUserInPlatformOrganization, MEMBER_ACCESS_RIGHT_ADMIN, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
 import { buildInternalEvent, rulesApplyHandler, rulesCleanHandler } from './ruleManager';
 import { buildEntityFilters, internalFindByIds, listAllRelations } from '../database/middleware-loader';
 import { getActivatedRules, getRule } from '../domain/rules';
@@ -651,13 +651,7 @@ export const taskHandler = async () => {
     logApp.debug(`[OPENCTI-MODULE][TASK-MANAGER] Executing job using userId:${rawUser.id}, for task ${task.internal_id}`);
     const draftID = task.draft_context ?? '';
     const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
-    let user_inside_platform_organization = false;
-    if (isBypassUser(user)) {
-      user_inside_platform_organization = true;
-    } else {
-      const userOrganizationIds = (user.organizations ?? []).map((organization) => organization.internal_id);
-      user_inside_platform_organization = settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
-    }
+    const user_inside_platform_organization = isUserInPlatformOrganization(user, settings);
     const fullContext = { ...context, draft_context: draftID, user_inside_platform_organization };
     let jobToExecute;
     if (isQueryTask) {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -48,7 +48,7 @@ import {
   INPUT_OBJECTS,
   RULE_PREFIX
 } from '../schema/general';
-import { BYPASS, executionContext, getUserAccessRight, MEMBER_ACCESS_RIGHT_ADMIN, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
+import { BYPASS, executionContext, getUserAccessRight, isBypassUser, MEMBER_ACCESS_RIGHT_ADMIN, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
 import { buildInternalEvent, rulesApplyHandler, rulesCleanHandler } from './ruleManager';
 import { buildEntityFilters, internalFindByIds, listAllRelations } from '../database/middleware-loader';
 import { getActivatedRules, getRule } from '../domain/rules';
@@ -80,7 +80,7 @@ import { processDeleteOperation, restoreDelete } from '../modules/deleteOperatio
 import { addOrganizationRestriction, removeOrganizationRestriction } from '../domain/stix';
 import { stixDomainObjectAddRelation } from '../domain/stixDomainObject';
 import { BackgroundTaskScope } from '../generated/graphql';
-import { ENTITY_TYPE_INTERNAL_FILE } from '../schema/internalObject';
+import { ENTITY_TYPE_INTERNAL_FILE, ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { deleteFile } from '../database/file-storage';
 import { checkUserIsAdminOnDashboard } from '../modules/publicDashboard/publicDashboard-utils';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
@@ -90,6 +90,7 @@ import { deleteDraftWorkspace } from '../modules/draftWorkspace/draftWorkspace-d
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { elRemoveElementFromDraft } from '../database/draft-engine';
 import { stixObjectOrRelationshipAddRefRelations, stixObjectOrRelationshipDeleteRefRelation } from '../domain/stixObjectOrStixRelationship';
+import { getEntityFromCache } from '../database/cache';
 
 // Task manager responsible to execute long manual tasks
 // Each API will start is task manager.
@@ -642,14 +643,22 @@ export const taskHandler = async () => {
       return;
     }
     // endregion
-    const draftID = task.draft_context ?? '';
-    const fullContext = { ...context, draft_context: draftID };
     const startPatch = { last_execution_date: now() };
     await updateTask(context, task.id, startPatch);
     // Fetch the user responsible for the task
     const rawUser = await resolveUserByIdFromCache(context, task.initiator_id);
     const user = { ...rawUser, origin: { user_id: rawUser.id, referer: 'background_task' } };
     logApp.debug(`[OPENCTI-MODULE][TASK-MANAGER] Executing job using userId:${rawUser.id}, for task ${task.internal_id}`);
+    const draftID = task.draft_context ?? '';
+    const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+    let user_inside_platform_organization = false;
+    if (isBypassUser(user)) {
+      user_inside_platform_organization = true;
+    } else {
+      const userOrganizationIds = (user.organizations ?? []).map((organization) => organization.internal_id);
+      user_inside_platform_organization = settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
+    }
+    const fullContext = { ...context, draft_context: draftID, user_inside_platform_organization };
     let jobToExecute;
     if (isQueryTask) {
       jobToExecute = await computeQueryTaskElements(fullContext, user, task);

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -704,3 +704,11 @@ export const validateMarking = async (context: AuthContext, user: AuthUser, mark
     throw FunctionalError('User trying to create the data has missing markings', { id: markingId, user_markings: userMarkingIds });
   }
 };
+
+export const isUserInPlatformOrganization = (user: AuthUser, settings: BasicStoreSettings) => {
+  if (isBypassUser(user)) {
+    return true;
+  }
+  const userOrganizationIds = (user.organizations ?? []).map((organization) => organization.internal_id);
+  return settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* user_inside_platform_organization was always set to false in taskManager. It is now computed from the task initiator user
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11043 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
