### PR TITLE
[frontend] remove loader in importFile

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
@@ -5,10 +5,8 @@ import { ImportFilesContextQuery } from '@components/common/files/import_files/_
 import { ImportFilesContextGuessMimeTypeQuery$data } from '@components/common/files/import_files/__generated__/ImportFilesContextGuessMimeTypeQuery.graphql';
 import useGranted from '../../../../../utils/hooks/useGranted';
 import useQueryLoading from '../../../../../utils/hooks/useQueryLoading';
-import Loader, { LoaderVariant } from '../../../../../components/Loader';
 import useDraftContext from '../../../../../utils/hooks/useDraftContext';
 import { fetchQuery } from '../../../../../relay/environment';
-import { FiligranLoader } from 'filigran-icon';
 
 export const importFilesQuery = graphql`
   query ImportFilesContextQuery($id: String!) {

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
@@ -8,6 +8,7 @@ import useQueryLoading from '../../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../../components/Loader';
 import useDraftContext from '../../../../../utils/hooks/useDraftContext';
 import { fetchQuery } from '../../../../../relay/environment';
+import { FiligranLoader } from 'filigran-icon';
 
 export const importFilesQuery = graphql`
   query ImportFilesContextQuery($id: String!) {
@@ -205,7 +206,7 @@ export const ImportFilesProvider = ({ children, initialValue }: {
   }, []);
 
   return queryRef && (
-    <React.Suspense fallback={<Loader variant={LoaderVariant.container}/>}>
+    <React.Suspense>
       <ImportFilesContext.Provider
         value={{
           canSelectImportMode,


### PR DESCRIPTION
### Proposed changes

* delete the loader in importFile to avoid breaking the UI when displaying the loader
* issue metionned in notion (only in release/current)
* Linked to https://github.com/OpenCTI-Platform/opencti/pull/11019 into master

### Before
The home page during the first loading
![image](https://github.com/user-attachments/assets/176bf239-75c4-42e3-8169-13e7ef625780)
