### PR TITLE
[frontend] Lines layout is broken in observable / knowledge section (#10797)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipPopover.jsx
@@ -123,6 +123,7 @@ class StixNestedRefRelationshipPopover extends Component {
           aria-haspopup="true"
           disabled={disabled}
           size="large"
+          color="primary"
         >
           <MoreVertOutlined />
         </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -119,6 +119,7 @@ class StixCyberObservableEntitiesLinesComponent extends Component {
               <ListItem
                 key={node.id}
                 divider={true}
+                disablePadding
                 secondaryAction={node.is_inferred ? (
                   <Tooltip
                     title={

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
@@ -86,6 +86,7 @@ class StixCyberObservableNestedEntitiesLinesComponent extends Component {
                 <ListItem
                   key={stixCoreObject.id}
                   divider={true}
+                  disablePadding
                   secondaryAction={
                     <StixNestedRefRelationshipPopover
                       stixNestedRefRelationshipId={stixNestedRefRelationship.id}


### PR DESCRIPTION
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10797
