### PR TITLE
[frontend] Typo in the word WORKFLOW under customization/report (#11046)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3502,7 +3502,6 @@
   "WITH": "MIT",
   "with the value": "mit dem Wert",
   "Within": "Unter",
-  "Worflow": "Arbeitsablauf",
   "Work end time": "Endzeit der Arbeit",
   "Work start time": "Startzeit der Arbeit",
   "Workbench": "Werkbank",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3502,7 +3502,6 @@
   "WITH": "WITH",
   "with the value": "with the value",
   "Within": "Within",
-  "Worflow": "Worflow",
   "Work end time": "Work end time",
   "Work start time": "Work start time",
   "Workbench": "Workbench",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3502,7 +3502,6 @@
   "WITH": "CON",
   "with the value": "con el valor",
   "Within": "En",
-  "Worflow": "Flujo de trabajo",
   "Work end time": "Hora de fin de la ejecución",
   "Work start time": "Hora de inicio de la ejecución",
   "Workbench": "Banco de trabajo",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3502,7 +3502,6 @@
   "WITH": "AVEC",
   "with the value": "avec la valeur",
   "Within": "Dans l'intervalle",
-  "Worflow": "Flux de travail",
   "Work end time": "Fin de l'éxécution",
   "Work start time": "Début de l'exécution",
   "Workbench": "Espace de travail",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3502,7 +3502,6 @@
   "WITH": "WITH",
   "with the value": "値",
   "Within": "内",
-  "Worflow": "ワーフロー",
   "Work end time": "作業終了時刻",
   "Work start time": "作業開始時刻",
   "Workbench": "ワークベンチ",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3502,7 +3502,6 @@
   "WITH": "WITH",
   "with the value": "값과 함께",
   "Within": "내",
-  "Worflow": "Worflow",
   "Work end time": "작업 종료 시간",
   "Work start time": "작업 시작 시간",
   "Workbench": "워크벤치",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3502,7 +3502,6 @@
   "WITH": "有",
   "with the value": "与值",
   "Within": "内",
-  "Worflow": "工作流程",
   "Work end time": "工作结束时间",
   "Work start time": "工作开始时间",
   "Workbench": "工作台",

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
@@ -132,7 +132,7 @@ const SubTypeComponent: React.FC<SubTypeProps> = ({ queryRef }) => {
 
         <Grid item xs={12}>
           <Typography variant="h4" gutterBottom={true}>
-            {t_i18n('Worflow')}
+            {t_i18n('Workflow')}
           </Typography>
           <Paper
             style={paperStyle}


### PR DESCRIPTION
### Proposed changes

* Fix typo and translation


### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/11046
