### PR TITLE
[Backend/Frontend] Add CSV Feed export functionality

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -11771,6 +11771,7 @@ type IngestionCsv implements InternalObject & BasicObject {
   current_state_date: DateTime
   last_execution_date: DateTime
   markings: [String!]
+  toConfigurationExport: String!
 }
 
 enum IngestionCsvOrdering {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -11229,6 +11229,7 @@ export type IngestionCsv = BasicObject & InternalObject & {
   parent_types: Array<Maybe<Scalars['String']['output']>>;
   scheduling_period?: Maybe<Scalars['String']['output']>;
   standard_id: Scalars['String']['output'];
+  toConfigurationExport: Scalars['String']['output'];
   updated_at?: Maybe<Scalars['DateTime']['output']>;
   uri: Scalars['String']['output'];
   user?: Maybe<Creator>;
@@ -37431,6 +37432,7 @@ export type IngestionCsvResolvers<ContextType = any, ParentType extends Resolver
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   scheduling_period?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  toConfigurationExport?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updated_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['Creator']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
@@ -5,6 +5,7 @@ import {
   addIngestionCsv,
   csvFeedAddInputFromImport,
   csvFeedGetCsvMapper,
+  csvFeedMapperExport,
   deleteIngestionCsv,
   findAllPaginated,
   findById,
@@ -24,6 +25,7 @@ const ingestionCsvResolvers: Resolvers = {
   IngestionCsv: {
     user: (ingestionCsv, _, context) => creatorLoader.load(ingestionCsv.user_id, context, context.user),
     csvMapper: (ingestionCsv, _, context) => csvFeedGetCsvMapper(context, ingestionCsv),
+    toConfigurationExport: (ingestionCsv, _, context) => csvFeedMapperExport(context, context.user, ingestionCsv)
   },
   Mutation: {
     ingestionCsvTester: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -21,6 +21,7 @@ type IngestionCsv implements InternalObject & BasicObject {
     current_state_date: DateTime
     last_execution_date: DateTime
     markings: [String!]
+    toConfigurationExport: String!
 }
 
 enum IngestionCsvOrdering {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvFeed-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/csvFeed-test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
 import { editorQuery, queryAsAdmin, USER_PARTICIPATE } from '../../utils/testQuery';
-import { createUploadFromTestDataFile, queryAsAdminWithSuccess, queryAsUser } from '../../utils/testQueryHelper';
+import { queryAsAdminWithSuccess, queryAsUser } from '../../utils/testQueryHelper';
 import { logApp } from '../../../src/config/conf';
 
 describe('CSV Feed resolver standard behavior', () => {
@@ -177,32 +177,5 @@ describe('CSV Feed resolver standard behavior', () => {
       variables: { id: internalFeedId }
     });
     logApp.info('deleteFeedResponse:', deleteFeedResponse);
-  });
-
-  const TEST_MUTATION = gql`
-    query CsvFeedAddInputFromImport($file: Upload!) {
-      csvFeedAddInputFromImport(file: $file){
-        authentication_type
-        name
-        csvMapper {
-          name
-        }
-      }
-    }
-  `;
-
-  it('should test a json file against import', async () => {
-    const upload = await createUploadFromTestDataFile('csvFeed/test-csv-feed.json', 'test-csv-feed.json', 'application/json');
-
-    const queryResult = await queryAsAdmin({
-      query: TEST_MUTATION,
-      variables: {
-        file: upload,
-      },
-    });
-    expect(queryResult.data?.csvFeedAddInputFromImport).toBeDefined();
-    expect(queryResult.data?.csvFeedAddInputFromImport.csvMapper).toBeDefined();
-    expect(queryResult.data?.csvFeedAddInputFromImport.csvMapper.name).toBe('Inline CSV Feed');
-    expect(queryResult.data?.csvFeedAddInputFromImport.name).toBe('Test name');
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the possibility to export CSV Feed configuration in json. It will be always inline


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Related #10350 
