### PR TITLE
[backend/frontend] Forgot password improvements (#9605)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/Login.tsx
+++ b/opencti-platform/opencti-front/src/public/components/Login.tsx
@@ -129,6 +129,7 @@ const Login: FunctionComponent<LoginProps> = ({ type, settings }) => {
   const { dimension } = useDimensions();
   const isEnterpriseEdition = settings.platform_enterprise_edition.license_validated;
   const [resetPassword, setResetPassword] = useState(false);
+  const [email, setEmail] = useState('');
 
   const renderExternalAuthButton = (provider?: string | null) => {
     switch (provider) {
@@ -283,17 +284,17 @@ const Login: FunctionComponent<LoginProps> = ({ type, settings }) => {
       )}
       {isAuthForm && !isConsentMessage && !resetPassword && (
         <Paper variant="outlined" classes={{ root: classes.login }}>
-          <LoginForm onClickForgotPassword={() => setResetPassword(true)} />
+          <LoginForm onClickForgotPassword={() => setResetPassword(true)} email={email} setEmail={setEmail} />
         </Paper>
       )}
       {isAuthForm && isConsentMessage && checked && !resetPassword && (
         <Paper variant="outlined" classes={{ root: classes.login }}>
-          <LoginForm onClickForgotPassword={() => setResetPassword(true)} />
+          <LoginForm onClickForgotPassword={() => setResetPassword(true)} email={email} setEmail={setEmail} />
         </Paper>
       )}
       {resetPassword && (
         <Paper variant="outlined" classes={{ root: classes.login }}>
-          <ResetPassword onCancel={() => setResetPassword(false)} />
+          <ResetPassword onCancel={() => setResetPassword(false)} email={email} setEmail={setEmail} />
         </Paper>
       )}
       {isAuthButtons && !isConsentMessage && renderExternalAuth(authSSOs)}

--- a/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
@@ -69,7 +69,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword, e
   };
 
   const initialValues = {
-    email: email,
+    email,
     password: '',
   };
 

--- a/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
@@ -35,10 +35,12 @@ interface RelayResponseError extends Error {
 
 interface LoginFormProps {
   onClickForgotPassword: () => void;
+  email: string;
+  setEmail: (value: string) => void;
 }
 
 const FLASH_COOKIE = 'opencti_flash';
-const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword }) => {
+const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword, email, setEmail }) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const [cookies, , removeCookie] = useCookies([FLASH_COOKIE]);
@@ -67,7 +69,7 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword })
   };
 
   const initialValues = {
-    email: '',
+    email: email,
     password: '',
   };
 
@@ -87,6 +89,9 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword })
               name="email"
               label={t_i18n('Login')}
               fullWidth={true}
+              onBlur={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                setEmail(e.currentTarget.value);
+              }}
             />
             <Field
               component={TextField}

--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -211,8 +211,7 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
       {step === Step.ASK_RESET && (
         <Formik
           initialValues={{ email }}
-          initialTouched={{ email: !R.isEmpty(flashError) }}
-          initialErrors={{ email: !R.isEmpty(flashError) ? t_i18n(flashError) : '' }}
+          validateOnMount={true}
           validationSchema={resetValidation(t_i18n)}
           onSubmit={onSubmitAskOtp}
         >

--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -210,7 +210,7 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
     <>
       {step === Step.ASK_RESET && (
         <Formik
-          initialValues={{ email: email }}
+          initialValues={{ email }}
           initialTouched={{ email: !R.isEmpty(flashError) }}
           initialErrors={{ email: !R.isEmpty(flashError) ? t_i18n(flashError) : '' }}
           validationSchema={resetValidation(t_i18n)}

--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -19,6 +19,8 @@ import { ResetPasswordChangePasswordMutation } from './__generated__/ResetPasswo
 
 interface ResetProps {
   onCancel: () => void;
+  email: string;
+  setEmail: (value: string) => void;
 }
 
 export const AskSendOtpMutation = graphql`
@@ -79,12 +81,11 @@ enum Step {
 }
 const FLASH_COOKIE = 'opencti_flash';
 
-const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel }) => {
+const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmail }) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const [step, setStep] = useState(Step.ASK_RESET);
   const [cookies, , removeCookie] = useCookies([FLASH_COOKIE]);
-  const [email, setEmail] = useState('');
   const [transactionId, setTransactionId] = useState('');
   const [otp, setOtp] = useState('');
   const [otpError, setOtpError] = useState(false);
@@ -209,7 +210,7 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel }) => {
     <>
       {step === Step.ASK_RESET && (
         <Formik
-          initialValues={{ email: '' }}
+          initialValues={{ email: email }}
           initialTouched={{ email: !R.isEmpty(flashError) }}
           initialErrors={{ email: !R.isEmpty(flashError) ? t_i18n(flashError) : '' }}
           validationSchema={resetValidation(t_i18n)}
@@ -222,6 +223,9 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel }) => {
                 name="email"
                 label={t_i18n('Email address')}
                 fullWidth={true}
+                onBlur={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  setEmail(e.currentTarget.value);
+                }}
               />
               <Button
                 type="submit"

--- a/opencti-platform/opencti-graphql/src/manager/activityListener.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityListener.ts
@@ -30,7 +30,7 @@ import { REDACTED_INFORMATION } from '../database/utils';
 const INTERNAL_READ_ENTITIES = [ENTITY_TYPE_WORKSPACE];
 const LOGS_SENSITIVE_FIELDS = conf.get('app:app_logs:logs_redacted_inputs') ?? [];
 const UNSUPPORTED_INTPUT_PROPS = ['_id', 'sort', 'i_attributes', 'i_relation']; // add 'objectOrganization' ?
-export const EVENT_SCOPE_VALUES = ['create', 'update', 'delete', 'read', 'search', 'enrich', 'download', 'import', 'export', 'login', 'logout', 'unauthorized', 'disseminate'];
+export const EVENT_SCOPE_VALUES = ['create', 'update', 'delete', 'read', 'search', 'enrich', 'download', 'import', 'export', 'login', 'logout', 'unauthorized', 'disseminate', 'forgot'];
 export const EVENT_TYPE_VALUES = ['authentication', 'read', 'mutation', 'file', 'command'];
 export const EVENT_ACCESS_VALUES = ['extended', 'administration'];
 export const EVENT_STATUS_VALUES = ['error', 'success'];

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -173,7 +173,7 @@ export const changePassword = async (context: AuthContext, input: ChangePassword
   }
   try {
     const authUser = await findById(context, ADMIN_USER, userId);
-    await userEditField(context, authUser, authUser.id, [
+    await userEditField(context, SYSTEM_USER, authUser.id, [
       { key: 'password', value: [input.newPassword] }
     ]);
     await killUserSessions(authUser.id);

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -59,14 +59,17 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
     const hashedOtp = bcrypt.hashSync(resetOtp);
     await redisSetForgotPasswordOtp(transactionId, { hashedOtp, email, mfa_activated: mfa_activated ?? false, mfa_validated: false, userId: id });
     // Create and send the email
-    const body = `Hi ${name},</br></br>`
-        + 'A request has been made to reset your OpenCTI password.</br></br>'
-        + 'Enter the following password recovery code:</br></br>'
-        + `<b>${resetOtp}</b>`;
+    const body = `<p>Hi ${name},</p>`
+      + '<p>We have received a request to reset the password for your account associated with this email address. To proceed with resetting your password, please use the verification code provided below:</p>'
+      + `<p><b>${resetOtp}</b></p>`
+      + '<p>Please enter this code on the password reset page to create a new password for your account.</p>'
+      + '<p>If you did not request this password reset, it is possible that someone else is trying to access your account. Do not forward or give this code to anyone.</p>'
+      + '<p>For any assistance or if you have concerns, do not hesitate to contact the system administrator.</p>'
+      + '<p>Sincerely,</p>';
     const sendMailArgs: SendMailArgs = {
       from: settings.platform_email,
       to: user_email,
-      subject: `${resetOtp} is your recovery code of your OpenCTI account`,
+      subject: 'Your OpenCTI account - Password recovery code',
       html: ejs.render(OCTI_EMAIL_TEMPLATE, { settings, body }),
     };
     await sendMail(sendMailArgs);
@@ -169,15 +172,14 @@ export const changePassword = async (context: AuthContext, input: ChangePassword
     ]);
     await killUserSessions(authUser.id);
     await redisDelForgotPassword(input.transactionId, email);
-    const body = `Hi ${authUser.name},</br></br>`
-      + 'We wanted to let you know that your account password was successfully changed.</br></br>'
-      + 'If you initiated this change, no further action is required. However, if you did not authorize this change, please reset your password immediately and contact the system administrator so that we may investigate and take appropriate measures to secure your account.</br></br>'
-      + 'Sincerely,</br></br>'
-      + 'Filigran</br></br>';
+    const body = `<p>Hi ${authUser.name},</p>`
+      + '<p>We wanted to let you know that your account password was successfully changed.</p>'
+      + '<p>If you initiated this change, no further action is required. However, if you did not request this change, please reset your password immediately and contact the system administrator.</p>'
+      + '<p>Sincerely,</p>';
     const sendMailArgs: SendMailArgs = {
       from: settings.platform_email,
       to: email,
-      subject: 'The password of your OpenCTI account has been changed',
+      subject: 'Your OpenCTI account - Password updated',
       html: ejs.render(OCTI_EMAIL_TEMPLATE, { settings, body }),
     };
     await sendMail(sendMailArgs);

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -60,7 +60,7 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
   // Delete the previous OTP if it exists based on the pointer
   if (previousKey.id) await redisDelForgotPassword(previousKey.id, email);
 
-  // Generate and store the new OTP; create a new pointer using the new UUID
+  // Store the new OTP; create a new key using the new UUID
   await redisSetForgotPasswordOtp(transactionId, { hashedOtp, email, mfa_activated: mfa_activated ?? false, mfa_validated: false, userId: id });
 
   // Send email

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -80,7 +80,7 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
       event_scope: 'forgot',
       event_access: 'administration',
       context_data: undefined,
-      message: `send an OTP to ${user_email}`,
+      message: `sends password reset code to ${user_email}`,
     });
   } catch (e) {
     // Prevent wrong email address, but return transactionId too if it fails
@@ -107,9 +107,9 @@ export const verifyOtp = async (input: VerifyOtpInput) => {
       event_scope: 'forgot',
       event_access: 'administration',
       context_data: undefined,
-      message: `OTP checked is expired or not found for ${input.transactionId}`,
+      message: `Password reset code is expired or not found for ${input.transactionId}`,
     });
-    throw UnsupportedError('OTP expired or not found. Please request a new one.');
+    throw UnsupportedError('Password reset code expired or not found. Please request a new one.');
   }
   const isMatch = bcrypt.compareSync(input.otp, hashedOtp);
   if (!isMatch) {
@@ -119,9 +119,9 @@ export const verifyOtp = async (input: VerifyOtpInput) => {
       event_scope: 'forgot',
       event_access: 'administration',
       context_data: undefined,
-      message: `OTP checked is invalid for ${email}`,
+      message: `Password reset code is invalid for ${email}`,
     });
-    throw UnsupportedError('Invalid OTP. Please check the code and try again.');
+    throw UnsupportedError('Invalid password reset code. Please check the code and try again.');
   }
   await publishUserAction({
     user: SYSTEM_USER,
@@ -129,7 +129,7 @@ export const verifyOtp = async (input: VerifyOtpInput) => {
     event_scope: 'forgot',
     event_access: 'administration',
     context_data: undefined,
-    message: `OTP checked is valid for ${email}`,
+    message: `Password reset code is valid for ${email}`,
   });
   return { mfa_activated };
 };
@@ -161,9 +161,9 @@ export const changePassword = async (context: AuthContext, input: ChangePassword
       event_scope: 'forgot',
       event_access: 'administration',
       context_data: undefined,
-      message: `OTP checked is invalid for ${email}`,
+      message: `Password reset code is invalid for ${email}`,
     });
-    throw UnsupportedError('Invalid OTP. Please check the code and try again.');
+    throw UnsupportedError('Invalid password reset code. Please check the code and try again.');
   }
   try {
     const authUser = await findById(context, ADMIN_USER, userId);

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/auth-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/auth-test.ts
@@ -10,13 +10,6 @@ describe('getLocalProviderUser', () => {
     expect(user.user_email).toEqual('anais@opencti.io');
     expect(user.name).toEqual('anais@opencti.io');
   });
-  it('Should throw an error if no user founded', async () => {
-    expect(async () => getLocalProviderUser('noResul@opencti.io')).rejects.toThrow('User not found');
-  });
-  it('Should throw an error if user is external', async () => {
-    // admin is external
-    expect(async () => getLocalProviderUser('admin@opencti.io')).rejects.toThrow('External user');
-  });
 });
 
 describe('generateOtp', () => {


### PR DESCRIPTION
### Proposed changes

* Update emails content
* Update audit logs content
* Keep the email adress writed between the login form and the reset form
* Update error management
* Add 'forgot' scope into filters in activity page
* Remove some tests linked to error management

### Related issues

* #9605 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

* Currently, the audit log doesn't work for the password update from the forgot password process. (It works from the profile page)