### PR TITLE
[frontend] Improve close import file dialog (#10616)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -24,6 +24,8 @@ import {
   ImportFilesDialogEntityMutation,
   ImportFilesDialogEntityMutation$variables,
 } from '@components/common/files/import_files/__generated__/ImportFilesDialogEntityMutation.graphql';
+import { Close } from '@mui/icons-material';
+import IconButton from '@mui/material/IconButton';
 import { useFormatter } from '../../../../../components/i18n';
 import Transition from '../../../../../components/Transition';
 import { handleErrorInForm, MESSAGING$ } from '../../../../../relay/environment';
@@ -431,6 +433,7 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
       slots={{ transition: Transition }}
       fullWidth
       maxWidth={false}
+      onClose={handleClose}
       slotProps={{
         paper: {
           elevation: 1,
@@ -440,8 +443,16 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
         },
       }}
     >
-      <DialogTitle>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Typography variant="h5">{t_i18n('Import files')}</Typography>
+        <IconButton
+          aria-label="Close"
+          onClick={handleClose}
+          size="large"
+          color="primary"
+        >
+          <Close fontSize="small" color="primary"/>
+        </IconButton>
       </DialogTitle>
       <DialogContent sx={{ paddingInline: 20, marginBlock: 10 }}>
         {!uploadStatus ? (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Close button to close import files dialog
* Handle escape key and click out of the dialog

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes https://github.com/OpenCTI-Platform/opencti/issues/10616

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
