### PR TITLE
[backend] Add a condition on stix delete to use marking deletion (#11112)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/markingDefinition.js
+++ b/opencti-platform/opencti-graphql/src/domain/markingDefinition.js
@@ -110,6 +110,10 @@ export const addAllowedMarkingDefinition = async (context, user, markingDefiniti
 };
 
 export const markingDefinitionDelete = async (context, user, markingDefinitionId) => {
+  return markingDefinitionDeleteAndUpdateGroups(context, user, markingDefinitionId, {});
+};
+
+export const markingDefinitionDeleteAndUpdateGroups = async (context, user, markingDefinitionId, opts) => {
   // remove the marking from the groups max shareable markings config if needed
   const groupsWithMarkingInShareableMarkings = await listAllEntities(context, SYSTEM_USER, [ENTITY_TYPE_GROUP], {
     filters: {
@@ -129,7 +133,7 @@ export const markingDefinitionDelete = async (context, user, markingDefinitionId
     await Promise.all(editShareableMarkingsPromises);
   }
   // delete the marking
-  const element = await deleteElementById(context, user, markingDefinitionId, ENTITY_TYPE_MARKING_DEFINITION);
+  const element = await deleteElementById(context, user, markingDefinitionId, ENTITY_TYPE_MARKING_DEFINITION, opts);
   // users of group impacted must be refreshed
   await notifyMembersOfNewMarking(context, user, element);
   return markingDefinitionId;

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/marking-definition-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/marking-definition-test.js
@@ -4,8 +4,8 @@ import { addAllowedMarkingDefinition, markingDefinitionDelete } from '../../../s
 import { cleanMarkings, handleMarkingOperations } from '../../../src/utils/markingDefinition-utils';
 import { SYSTEM_USER } from '../../../src/utils/access';
 import { UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE, UPDATE_OPERATION_REPLACE } from '../../../src/database/utils';
-import { resetCacheForEntity } from "../../../src/database/cache";
-import { ENTITY_TYPE_MARKING_DEFINITION } from "../../../src/schema/stixMetaObject";
+import { resetCacheForEntity } from '../../../src/database/cache';
+import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 
 const markings = [
   {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When a stix delete is on marking, use deletion path that propagates all marking changes required.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #11112 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
