### PR TITLE
[frontend] fix headings options in ckeditor (#10661)

### DIFF
--- a/opencti-platform/opencti-front/src/components/CKEditor.tsx
+++ b/opencti-platform/opencti-front/src/components/CKEditor.tsx
@@ -204,6 +204,14 @@ const CKEDITOR_DEFAULT_CONFIG: EditorConfig = {
       'mergeTableCells',
     ],
   },
+  heading: {
+    options: [
+      { class: 'ck-heading_paragraph', model: 'paragraph', title: 'Paragraph' },
+      { class: 'ck-heading_heading1', model: 'heading1', view: 'h1', title: 'Heading 1' },
+      { class: 'ck-heading_heading2', model: 'heading2', view: 'h2', title: 'Heading 2' },
+      { class: 'ck-heading_heading3', model: 'heading3', view: 'h3', title: 'Heading 3' },
+    ],
+  },
 };
 
 type CKEditorProps<T extends Editor> = Omit<ReactCKEditor<T>['props'], 'editor' | 'config'>;


### PR DESCRIPTION
### Proposed changes

Fix the headings option in ckeditor so we are aligning on the most rationale behavior: heading 1 > h1, heading 2 > h2, heading 3 > h3.


### Related issues
* closes #10661 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Note that there are 2 separate issues here:

* apparently, CKEditor default config is faulty ; it inverses heading 2 and 3.
* it is by default normal to start heading 1 at h2 ; CKEditor keeps h1 for the title. See [here](https://ckeditor.com/docs/ckeditor5/latest/features/headings.html#heading-levels)