### PR TITLE
[backend] Language entity type should not be exposed in UI (#10698)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/subType.ts
+++ b/opencti-platform/opencti-graphql/src/domain/subType.ts
@@ -11,13 +11,17 @@ import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../schema/stixCyberObservable
 import { telemetry } from '../config/tracing';
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
+import { ENTITY_TYPE_LANGUAGE } from '../modules/language/language-types';
+
+const NOT_EXPOSED_TYPES = [ENTITY_TYPE_LANGUAGE];
 
 // -- ENTITY TYPES --
 
 export const queryDefaultSubTypes = async (context: AuthContext, user: AuthUser, search : string | null = null) => {
   const queryDefaultSubTypesFn = async () => {
     const sortByLabel = R.sortBy(R.toLower);
-    const types = schemaTypesDefinition.get(ABSTRACT_STIX_DOMAIN_OBJECT).filter((n) => n.includes(search ?? ''));
+    const types = schemaTypesDefinition.get(ABSTRACT_STIX_DOMAIN_OBJECT)
+      .filter((n) => n.includes(search ?? '') && !NOT_EXPOSED_TYPES.includes(n));
     const finalResult = R.pipe(
       sortByLabel,
       R.map((n) => ({ node: { id: n, label: n } })),
@@ -48,14 +52,15 @@ const querySubTypes = async (context: AuthContext, user: AuthUser, { type = null
   if (type === null) {
     return queryDefaultSubTypes(context, user, search);
   }
-  const sortByLabel = R.sortBy(R.toLower);
 
   let types;
   if (type === ABSTRACT_STIX_NESTED_REF_RELATIONSHIP) {
     types = schemaRelationsRefDefinition.getDatables();
   } else {
-    types = schemaTypesDefinition.get(type).filter((n) => n.includes(search ?? ''));
+    types = schemaTypesDefinition.get(type)
+      .filter((n) => n.includes(search ?? '') && !NOT_EXPOSED_TYPES.includes(n));
   }
+  const sortByLabel = R.sortBy(R.toLower);
   const finalResult = R.pipe(
     sortByLabel,
     R.map((n) => ({ node: { id: n, label: n } })),

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -599,7 +599,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Tracking-Number')).toBe(1);
     expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
     expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
-    expect(data.edges.length).toEqual(544);
+    expect(data.edges.length).toEqual(543);
   });
   it('should entity paginate with field exist filter', async () => {
     const filters = {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -49,7 +49,7 @@ const elWhiteUser = async () => {
 };
 
 const VOCABULARY_COUNT = 347;
-const ENTITY_SETTINGS_COUNT = 42;
+export const ENTITY_SETTINGS_COUNT = 42;
 
 describe('Elasticsearch configuration test', () => {
   it('should configuration correct', async () => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -49,6 +49,7 @@ const elWhiteUser = async () => {
 };
 
 const VOCABULARY_COUNT = 347;
+const ENTITY_SETTINGS_COUNT = 42;
 
 describe('Elasticsearch configuration test', () => {
   it('should configuration correct', async () => {
@@ -414,7 +415,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
     expect(entityTypeMap.get('Credential')).toBe(1);
     expect(entityTypeMap.get('DecayRule')).toBe(4);
-    expect(entityTypeMap.get('EntitySetting')).toBe(44);
+    expect(entityTypeMap.get('EntitySetting')).toBe(ENTITY_SETTINGS_COUNT);
     expect(entityTypeMap.get('External-Reference')).toBe(7);
     expect(entityTypeMap.get('StixFile')).toBe(1);
     expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
@@ -563,7 +564,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Course-Of-Action')).toBe(1);
     expect(entityTypeMap.get('Credential')).toBe(1);
     expect(entityTypeMap.get('DecayRule')).toBe(4);
-    expect(entityTypeMap.get('EntitySetting')).toBe(44);
+    expect(entityTypeMap.get('EntitySetting')).toBe(ENTITY_SETTINGS_COUNT);
     expect(entityTypeMap.get('External-Reference')).toBe(7);
     expect(entityTypeMap.get('StixFile')).toBe(1);
     expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
@@ -696,7 +697,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Capability')).toBe(42);
     expect(entityTypeMap.get('Credential')).toBe(1);
     expect(entityTypeMap.get('DecayRule')).toBe(4);
-    expect(entityTypeMap.get('EntitySetting')).toBe(44);
+    expect(entityTypeMap.get('EntitySetting')).toBe(ENTITY_SETTINGS_COUNT);
     expect(entityTypeMap.get('StixFile')).toBe(1);
     expect(entityTypeMap.get('Group')).toBe(TESTING_GROUPS.length + 3);
     expect(entityTypeMap.get('ManagerConfiguration')).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/entitySetting-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/entitySetting-test.js
@@ -6,6 +6,7 @@ import { executionContext, SYSTEM_USER } from '../../../src/utils/access';
 import { ENTITY_TYPE_CONTAINER_NOTE } from '../../../src/schema/stixDomainObject';
 import { schemaAttributesDefinition } from '../../../src/schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../../src/schema/schema-relationsRef';
+import { ENTITY_SETTINGS_COUNT } from '../01-database/elasticSearch-test';
 
 const LIST_QUERY = gql`
   query entitySettings {
@@ -63,7 +64,7 @@ describe('EntitySetting resolver standard behavior', () => {
     const context = executionContext('test');
     await initCreateEntitySettings(context, SYSTEM_USER);
     const queryResult = await queryAsAdmin({ query: LIST_QUERY });
-    expect(queryResult.data.entitySettings.edges.length).toEqual(44);
+    expect(queryResult.data.entitySettings.edges.length).toEqual(ENTITY_SETTINGS_COUNT);
 
     const entitySettingNote = queryResult.data.entitySettings.edges.filter((entitySetting) => entitySetting.node.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
     expect(entitySettingNote.platform_entity_files_ref).toBeFalsy();


### PR DESCRIPTION
### Proposed changes
Language entity type should not be exposed in the UI
- in the entity type filter values list
- in Customization > Entity types

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10698