### PR TITLE
[backend/frontend] validate Indicator & Observable score value (#10975)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "Der Wert muss eine Zahl sein",
   "The value must be a string": "Der Wert muss eine Zeichenkette sein",
   "The value must be an email address": "Der Wert muss eine E-Mail Adresse sein",
+  "The value must be an integer": "Der Wert muss eine ganze Zahl sein",
   "The value must be an URL": "Der Wert muss eine URL sein",
   "The value must be between min and max value": "Der Wert muss zwischen dem Minimal- und Maximalwert liegen",
   "The value must be greater than or equal to 0": "Der Wert muss größer als oder gleich 0 sein",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "The value must be a number",
   "The value must be a string": "The value must be a string",
   "The value must be an email address": "The value must be an email address",
+  "The value must be an integer": "The value must be an integer",
   "The value must be an URL": "The value must be an URL",
   "The value must be between min and max value": "The value must be between min and max value",
   "The value must be greater than or equal to 0": "The value must be greater than or equal to 0",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "El valor debe ser un número",
   "The value must be a string": "El valor debe ser una cadena.",
   "The value must be an email address": "El valor debe ser una dirección de correo electrónico",
+  "The value must be an integer": "El valor debe ser un número entero",
   "The value must be an URL": "El valor debe ser una dirección URL",
   "The value must be between min and max value": "El valor debe estar entre el valor mínimo y máximo",
   "The value must be greater than or equal to 0": "El valor debe ser mayor o igual a 0",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "La valeur doit être un nombre",
   "The value must be a string": "La valeur doit être une chaîne",
   "The value must be an email address": "La valeur doit être une adresse email",
+  "The value must be an integer": "La valeur doit être un nombre entier",
   "The value must be an URL": "La valeur doit être une URL",
   "The value must be between min and max value": "La valeur doit être comprise entre la valeur min et max",
   "The value must be greater than or equal to 0": "La valeur doit être supérieure ou égale à 0",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "数値を入力してください",
   "The value must be a string": "値は文字列である必要があります",
   "The value must be an email address": "メールアドレスを入力してください",
+  "The value must be an integer": "値は整数でなければならない。",
   "The value must be an URL": "URLを入力してください",
   "The value must be between min and max value": "値は最小値と最大値の間でなければなりません",
   "The value must be greater than or equal to 0": "値は 0 以上である必要があります",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "값은 숫자여야 합니다",
   "The value must be a string": "값은 문자열이어야 합니다",
   "The value must be an email address": "값은 이메일 주소여야 합니다",
+  "The value must be an integer": "값은 정수여야 합니다",
   "The value must be an URL": "값은 URL이어야 합니다",
   "The value must be between min and max value": "값은 최소 값과 최대 값 사이여야 합니다",
   "The value must be greater than or equal to 0": "값은 0 이상이어야 합니다",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3084,6 +3084,7 @@
   "The value must be a number": "该值必须是一个数字",
   "The value must be a string": "该值必须是字符串",
   "The value must be an email address": "该值必须是一个邮件地址",
+  "The value must be an integer": "数值必须是整数",
   "The value must be an URL": "该值必须是一个URL",
   "The value must be between min and max value": "该值必须介于最小值和最大值之间",
   "The value must be greater than or equal to 0": "该值必须大于或等于 0",

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -142,7 +142,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
         return !valid_from || !value || value > valid_from;
       }),
     x_mitre_platforms: Yup.array().nullable(),
-    x_opencti_score: Yup.number()
+    x_opencti_score: Yup.number().integer(t_i18n('The value must be an integer'))
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.jsx
@@ -105,7 +105,7 @@ const IndicatorEditionOverviewComponent = ({
         return !valid_from || !value || value > valid_from;
       }),
     x_mitre_platforms: Yup.array().nullable(),
-    x_opencti_score: Yup.number()
+    x_opencti_score: Yup.number().integer(t_i18n('The value must be an integer'))
       .required(t_i18n('This field is required'))
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -602,7 +602,7 @@ const StixCyberObservableCreation = ({
             }
 
             const stixCyberObservableValidation = () => Yup.object().shape({
-              x_opencti_score: Yup.number()
+              x_opencti_score: Yup.number().integer(t_i18n('The value must be an integer'))
                 .nullable()
                 .min(0, t_i18n('The value must be greater than or equal to 0'))
                 .max(100, t_i18n('The value must be less than or equal to 100')),

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -240,7 +240,7 @@ const StixCyberObservableEditionOverviewComponent = ({
   };
 
   const stixCyberObservableValidation = Yup.object().shape({
-    x_opencti_score: Yup.number()
+    x_opencti_score: Yup.number().integer(t_i18n('The value must be an integer'))
       .nullable()
       .min(0, t_i18n('The value must be greater than or equal to 0'))
       .max(100, t_i18n('The value must be less than or equal to 100')),

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -29,7 +29,7 @@ import { ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT, buildRefRe
 import { RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE, } from '../schema/stixRefRelationship';
 import { askEntityExport, askListExport, exportTransformFilters } from './stix';
 import { RELATION_BASED_ON } from '../schema/stixCoreRelationship';
-import { now, utcDate } from '../utils/format';
+import { checkScore, now, utcDate } from '../utils/format';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../modules/grouping/grouping-types';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
@@ -201,6 +201,13 @@ export const stixDomainObjectEditField = async (context, user, stixObjectId, inp
   const stixDomainObject = await storeLoadById(context, user, stixObjectId, ABSTRACT_STIX_DOMAIN_OBJECT);
   if (!stixDomainObject) {
     throw FunctionalError('Cannot edit the field, Stix-Domain-Object cannot be found.');
+  }
+  const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
+  if (scoreEditInput) {
+    const newScore = scoreEditInput.value[0];
+    if (newScore !== null && newScore !== undefined && newScore) {
+      checkScore(newScore);
+    }
   }
   // Validate specific relations, created by and markings
   const markingsInput = input.find((inputData) => inputData.key === INPUT_MARKINGS);

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -51,7 +51,7 @@ import {
 } from '../decayRule/decayRule-domain';
 import { isModuleActivated } from '../../domain/settings';
 import { stixDomainObjectEditField } from '../../domain/stixDomainObject';
-import { prepareDate, utcDate } from '../../utils/format';
+import { checkScore, prepareDate, utcDate } from '../../utils/format';
 import { checkObservableValue, isCacheEmpty } from '../../database/exclusionListCache';
 import { stixHashesToInput } from '../../schema/fieldDataAdapter';
 
@@ -264,9 +264,7 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   const { formattedPattern } = await validateIndicatorPattern(context, user, indicator.pattern_type, indicator.pattern);
 
   const indicatorBaseScore = indicator.x_opencti_score ?? 50;
-  if (indicatorBaseScore < 0 || indicatorBaseScore > 100) {
-    throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
-  }
+  checkScore(indicatorBaseScore);
 
   const isDecayActivated = await isModuleActivated('INDICATOR_DECAY_MANAGER');
   // find default decay rule (even if decay is not activated, it is used to compute default validFrom and validUntil)
@@ -358,9 +356,7 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   const scoreEditInput = input.find((e) => e.key === 'x_opencti_score');
   if (scoreEditInput) {
     const newScore = scoreEditInput.value[0];
-    if (newScore < 0 || newScore > 100) {
-      throw ValidationError('The score should be between 0 and 100', 'x_opencti_score');
-    }
+    checkScore(newScore);
     if (indicator.decay_applied_rule && !scoreEditInput.value.includes(indicator.decay_base_score)) {
       const updateDate = utcDate();
       finalInput.push({ key: 'decay_base_score', value: [newScore] });

--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -20,6 +20,7 @@ import {
   ENTITY_WINDOWS_REGISTRY_KEY,
   ENTITY_WINDOWS_REGISTRY_VALUE_TYPE
 } from '../schema/stixCyberObservable';
+import { ValidationError } from '../config/errors';
 
 const DEFAULT_TRUNCATE_LIMIT = 64;
 
@@ -188,6 +189,15 @@ export const observableValue = (stixCyberObservable) => {
     default:
       return stixCyberObservable.value || stixCyberObservable.name || 'Unknown';
   }
+};
+
+export const checkScore = (newScore) => {
+  if (newScore) {
+    if (newScore < 0 || newScore > 100 || !Number.isInteger(newScore)) {
+      throw ValidationError('The score should be an integer between 0 and 100', 'x_opencti_score');
+    }
+  }
+  return true;
 };
 
 // Be careful to align this script with the previous function

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/format-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/format-utils-test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { checkScore } from '../../../src/utils/format';
+
+describe('checkScoreValue tests', () => {
+  it('should throw validationError for score > 100', () => {
+    expect(() => checkScore(110))
+      .toThrowError('The score should be an integer between 0 and 100');
+  });
+  it('should throw validationError for score < 0', () => {
+    expect(() => checkScore(-3))
+      .toThrowError('The score should be an integer between 0 and 100');
+  });
+  it('should throw validationError for non integer score', () => {
+    expect(() => checkScore(0.5))
+      .toThrowError('The score should be an integer between 0 and 100');
+  });
+  it('should return true if score is undefined', () => {
+    const check = checkScore(undefined);
+    expect(check).toEqual(true);
+  });
+  it('should return true if score is an integer between 0 and 100', () => {
+    const check = checkScore(40);
+    expect(check).toEqual(true);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/indicator-test.ts
@@ -134,7 +134,7 @@ describe('Indicator resolver standard behavior', () => {
       query: CREATE_QUERY,
       variables: INDICATOR_TO_CREATE,
     });
-    expect(indicator.errors?.[0]?.message).toEqual('The score should be between 0 and 100');
+    expect(indicator.errors?.[0]?.message).toEqual('The score should be an integer between 0 and 100');
   });
   it('should indicator created', async () => {
     // Create the indicator
@@ -253,13 +253,13 @@ describe('Indicator resolver standard behavior', () => {
       variables: { id: firstIndicatorInternalId, input: { key: 'x_opencti_score', value: ['142'] } },
     });
     expect(queryResulAbove100.errors).toBeDefined();
-    expect(queryResulAbove100.errors[0].message).toBe('The score should be between 0 and 100');
+    expect(queryResulAbove100.errors[0].message).toBe('The score should be an integer between 0 and 100');
     const queryResultBelow0 = await adminQuery({
       query: UPDATE_QUERY,
       variables: { id: firstIndicatorInternalId, input: { key: 'x_opencti_score', value: ['-42'] } },
     });
     expect(queryResultBelow0.errors).toBeDefined();
-    expect(queryResultBelow0.errors[0].message).toBe('The score should be between 0 and 100');
+    expect(queryResultBelow0.errors[0].message).toBe('The score should be an integer between 0 and 100');
   });
   it('should not update indicator with incorrectly formatted pattern', async () => {
     const queryResult = await adminQuery({

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -86,7 +86,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);
       expect(updateEventsByTypes['vocabulary'].length).toBe(3);
       expect(updateEventsByTypes['vulnerability'].length).toBe(3);
-      expect(updateEvents.length).toBe(199);
+      expect(updateEvents.length).toBe(198);
       for (let updateIndex = 0; updateIndex < updateEvents.length; updateIndex += 1) {
         const event = updateEvents[updateIndex];
         const { data: insideData, origin, type } = event;

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -80,7 +80,7 @@ describe('Raw streams tests', () => {
       expect(updateEventsByTypes['note'].length).toBe(3);
       expect(updateEventsByTypes['opinion'].length).toBe(6);
       expect(updateEventsByTypes['report'].length).toBe(19);
-      expect(updateEventsByTypes['ipv4-addr'].length).toBe(5);
+      expect(updateEventsByTypes['ipv4-addr'].length).toBe(4);
       expect(updateEventsByTypes['tool'].length).toBe(9);
       expect(updateEventsByTypes['sighting'].length).toBe(4);
       expect(updateEventsByTypes['threat-actor'].length).toBe(17);

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -23,7 +23,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1212;
+export const RAW_EVENTS_SIZE = 1211;
 export const SYNC_LIVE_EVENTS_SIZE = 613;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- add check for integer in UI creation and edition form for Observables/Indicators/
- avoid score edition with non integer value through API or Observables/Indicators/
- refactor stixCyberObservableEditField to iterate on input if several updates


### Related issues
- closes: https://github.com/OpenCTI-Platform/opencti/issues/10975

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
