### PR TITLE
[frontend] Fix spacing in import files dialog free textarea and stepper  (#10795)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -459,7 +459,7 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
           <>
             <ImportFilesStepper/>
             {/* Remove stepper height (25px) */}
-            <Box sx={{ paddingBlock: 10, height: 'calc(100% - 25px)' }}>
+            <Box sx={{ paddingBlock: 5, height: 'calc(100% - 25px)' }}>
               {activeStep === 0 && (<ImportFilesToggleMode/>)}
               {activeStep === 1 && (<ImportFilesUploader connectorsForImport={connectorsForImport}/>)}
               {activeStep === 2 && (

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
@@ -61,6 +61,9 @@ const ImportFilesFreeText = ({ onSumbit, onClose }: { onSumbit: (file: File) => 
               variant="standard"
               InputProps={{ sx: { background: theme.palette.background.paper } }}
               InputLabelProps={{ shrink: true }}
+              slotProps={{
+                htmlInput: { style: { padding: 8 } },
+              }}
             />
             <Box sx={{ display: 'flex', marginLeft: 'auto' }}>
               <Button

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesToggleMode.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesToggleMode.tsx
@@ -36,7 +36,7 @@ const ImportFilesToggleMode = () => {
         gap: 4,
         justifyContent: 'center',
         alignItems: 'center',
-        minHeight: '50vh',
+        minHeight: '60vh',
         flexWrap: 'wrap',
       }}
     >


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix spacing in import files dialog free textarea and stepper  

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes https://github.com/OpenCTI-Platform/opencti/issues/10795

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
