### PR TITLE
[frontend/backend] EO 14168 implemented via Feature Flag USG_EO_14168_COMPLIANT

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "Die Einstellungen wurden aktualisiert",
   "Severity": "Schweregrad",
   "severity": "Schweregrad",
+  "Sex": "Geschlecht",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "SHA-1-Werte können nur A-F und 0-9 enthalten, 40 Zeichen",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "SHA-256-Werte können nur A-F und 0-9 enthalten, 64 Zeichen",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "SHA-512-Werte können nur A-F und 0-9 enthalten, 128 Zeichen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "Settings have been updated",
   "Severity": "Severity",
   "severity": "Severity",
+  "Sex": "Sex",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "SHA-1 values can only include A-F and 0-9, 40 characters",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "SHA-256 values can only include A-F and 0-9, 64 characters",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "SHA-512 values can only include A-F and 0-9, 128 characters",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "La configuración ha sido actualizada",
   "Severity": "Severidad",
   "severity": "Gravedad",
+  "Sex": "Sexo",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "Los valores SHA-1 sólo pueden incluir A-F y 0-9, 40 caracteres",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "Los valores SHA-256 sólo pueden incluir A-F y 0-9, 64 caracteres",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "Los valores SHA-512 sólo pueden incluir A-F y 0-9, 128 caracteres",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "Les paramètres ont été mis à jour",
   "Severity": "Sévérité",
   "severity": "Sévérité",
+  "Sex": "Sexe",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "Les valeurs SHA-1 ne peuvent inclure que A-F et 0-9, 40 caractères",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "Les valeurs SHA-256 ne peuvent comprendre que A-F et 0-9, 64 caractères",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "Les valeurs SHA-512 ne peuvent inclure que A-F et 0-9, 128 caractères",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2912,6 +2912,7 @@
   "Settings have been updated": "Le impostazioni sono state aggiornate",
   "Severity": "Severità",
   "severity": "severità",
+  "Sex": "Sesso",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "Valori SHA-1 possono includere solo A-F e 0-9, 40 caratteri",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "Valori SHA-256 possono includere solo A-F e 0-9, 64 caratteri",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "Valori SHA-512 possono includere solo A-F e 0-9, 128 caratteri",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "設定を変更しました",
   "Severity": "重大度",
   "severity": "重大度",
+  "Sex": "性別",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "SHA-1値はA-Fと0-9、40文字のみを含むことができます。",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "SHA-256値にはA-Fと0-9、64文字のみを含めることができます。",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "SHA-512値には、A-Fと0-9、128文字のみを含めることができます。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "설정이 업데이트되었습니다",
   "Severity": "심각도",
   "severity": "심각도",
+  "Sex": "성별",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "SHA-1 값은 A-F 및 0-9, 40자만 포함할 수 있습니다",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "SHA-256 값은 A-F 및 0-9, 64자만 포함할 수 있습니다",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "SHA-512 값은 A-F 및 0-9, 128자만 포함할 수 있습니다",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2927,6 +2927,7 @@
   "Settings have been updated": "设置已更新",
   "Severity": "严重程度",
   "severity": "严重性",
+  "Sex": "性别",
   "SHA-1 values can only include A-F and 0-9, 40 characters": "SHA-1值只能包含A-F和0-9，40个字符",
   "SHA-256 values can only include A-F and 0-9, 64 characters": "SHA-256 值只能包含 A-F 和 0-9，64 个字符",
   "SHA-512 values can only include A-F and 0-9, 128 characters": "SHA-512 值只能包含 A-F 和 0-9，128 个字符",

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -45,6 +45,7 @@ import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextM
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 interface ErrorBadgeProps extends BadgeProps {
   errors?: FormikErrors<ThreatActorIndividualAddInput>;
@@ -320,6 +321,7 @@ ThreatActorIndividualFormProps
     weight: [],
   });
 
+  const { isFeatureEnable } = useHelper();
   return (
     <Formik<ThreatActorIndividualAddInput>
       initialValues={initialValues}
@@ -594,7 +596,7 @@ ThreatActorIndividualFormProps
                 />
                 <OpenVocabField
                   name="gender"
-                  label={t_i18n('Gender')}
+                  label={isFeatureEnable('USG_EO_14168_COMPLIANT') ? t_i18n('Sex') : t_i18n('Gender')}
                   required={(mandatoryAttributes.includes('gender'))}
                   type="gender_ov"
                   variant="edit"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDemographics.tsx
@@ -10,6 +10,7 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import CardLabel from '../../../../components/CardLabel';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -64,6 +65,8 @@ const ThreatActorIndividualDemographics = ({
       }
     }
   }
+
+  const { isFeatureEnable } = useHelper();
   return (
     <>
       <Typography variant="h4" gutterBottom={true}>
@@ -182,7 +185,7 @@ const ThreatActorIndividualDemographics = ({
           </Grid>
           <Grid item xs={4}>
             <CardLabel >
-              {t_i18n('Gender')}
+              {isFeatureEnable('USG_EO_14168_COMPLIANT') ? t_i18n('Sex') : t_i18n('Gender')}
             </CardLabel>
             <FieldOrEmpty source={threatActorIndividual.gender}>
               <ItemOpenVocab

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
@@ -24,6 +24,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 const threatActorIndividualEditionDemographicsFocus = graphql`
   mutation ThreatActorIndividualEditionDemographicsFocusMutation(
@@ -178,6 +179,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
     },
   };
 
+  const { isFeatureEnable } = useHelper();
   return (
     <div>
       <Formik
@@ -248,7 +250,7 @@ const ThreatActorIndividualEditionDemographicsComponent = ({
               />
               <OpenVocabField
                 name="gender"
-                label={t_i18n('Gender')}
+                label={isFeatureEnable('USG_EO_14168_COMPLIANT') ? t_i18n('Sex') : t_i18n('Gender')}
                 required={(mandatoryAttributes.includes('gender'))}
                 type="gender_ov"
                 variant="edit"

--- a/opencti-platform/opencti-front/src/utils/tests/FilterUtilsConstants.ts
+++ b/opencti-platform/opencti-front/src/utils/tests/FilterUtilsConstants.ts
@@ -2264,7 +2264,7 @@ filterKeysSchema.set('Stix-Core-Object', new Map([
     'gender',
     {
       filterKey: 'gender',
-      label: 'Gender',
+      label: 'Gender/Sex',
       type: 'vocabulary',
       multiple: false,
       subEntityTypes: [

--- a/opencti-platform/opencti-graphql/src/migrations/_DISABLED-eo14168-vocabularies.js
+++ b/opencti-platform/opencti-graphql/src/migrations/_DISABLED-eo14168-vocabularies.js
@@ -1,0 +1,109 @@
+/*
+ * Filename: _DISABLED-eo14168-vocabularies.js
+ *
+ * This migration is disabled by default. System Owners only need to run the migration if you are implementing the
+ * application of the USG_EO_14168_COMPLIANT feature flag. This feature flag applies platform compliance to the
+ * US Government Executive Order 14168 which mandates that US Government Agencies use "sex" instead of "gender"
+ * within deployed applications/forms/policies/etc. It additionally specifies vocabularies that can be used
+ * to define "sex".
+ *
+ * To enable the feature flag, add USG_EO_14168_COMPLIANT to the opencti-graphql/conf/default.json
+ * (or whichever config you use to launch your platform)
+ * Example:
+ * app: {
+ * ....... some config file options ......
+ *        "enabled_dev_features": [
+ *              "USG_EO_14168_COMPLIANT"
+ *          ],
+ * ....... more config file options ......
+ * }
+ *
+ * You will then need to rename this migration file by replacing _DISABLED with the current milliseconds from epoch.
+ *
+ * Example: _DISABLED-eo14168-vocabularies.js --> 1749044611722-eo14168-vocabularies.js
+ *  Where the 1749044611722 in standard GMT time translates to: Wednesday, June 4, 2025 1:43:31.722 PM
+ *
+ * To get the current milliseconds from epoch for use in the rename here are various methods:
+ *    - Date command rounded to nearest millisecond: date +%s000
+ *    - Python command: python3 -c 'import time; print(int(time.time() * 1000))'
+ *    - Node command: node -e 'console.log(Date.now())'
+ *
+ * After you have done the above two steps (enabled the feature flag and renamed the file to a current epoch), you will
+ * have to redeploy/build using the code repo you have made these changes within. At launch the OpenCTI instance it
+ * will process the changes to the vocabularies stored within Elastic. Specifically, it will deleted the default
+ * options of 'nonbinary' and 'other'. It will add a new option of 'unknown'.
+ *
+ * Records stored with the previous selection of 'nonbinary' or 'other' will move to 'null'.
+ * They are not migrated to the new 'other' selection, by default, however the migration could support this, if added.
+ * Lastly, the "Gender" UI field will now reflect 'Sex' as the field name on forms and in
+ * change history actions.
+ */
+
+import { logMigration } from '../config/conf';
+import { elRawSearch } from '../database/engine';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { addVocabulary, deleteVocabulary } from '../modules/vocabulary/vocabulary-domain';
+import { READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
+
+const newVocabularies = {
+  gender_ov: [
+    // { key: 'male' }, // Gender and Sex Option  - USG EO 14168 Compliant - remains/existing
+    // { key: 'female' }, // Gender and Sex Option  - USG EO 14168 Compliant - remains/existing
+    { key: 'unknown' }, // Sex option - USG EO 14168 Compliant - to be added by migration
+    // { key: 'nonbinary' }, // Gender option - NOT USG EO 14168 Compliant - to be removed by migration
+    // { key: 'other' }, // Gender option - NOT USG EO 14168 Compliant - to be removed by migration
+  ],
+};
+
+const deleteVocabularies = [
+  'nonbinary', // Gender option - NOT USG EO 14168 Compliant - to be removed by migration
+  'other', // Gender option - NOT USG EO 14168 Compliant - to be removed by migration
+];
+
+const message = '[MIGRATION] EO 14168 Migration';
+export const up = async (next) => {
+  logMigration.info(`${message} > started`);
+  // Create new vocabularies
+  const context = executionContext('migration');
+  const vocabularyKeys = Object.keys(newVocabularies);
+  for (let i = 0; i < vocabularyKeys.length; i += 1) {
+    const key = vocabularyKeys[i];
+    const elements = newVocabularies[key];
+    for (let elementIndex = 0; elementIndex < elements.length; elementIndex += 1) {
+      const element = elements[elementIndex];
+      const data = { name: element.key, description: '', category: key, builtIn: false };
+      await addVocabulary(context, SYSTEM_USER, data);
+    }
+  }
+
+  const query = {
+    index: READ_INDEX_STIX_META_OBJECTS,
+    body: {
+      query: {
+        term: {
+          'category.keyword': {
+            value: 'gender_ov',
+          }
+        }
+      },
+      size: 10
+    },
+  };
+  const genderOVData = await elRawSearch(context, SYSTEM_USER, '', query);
+  const genderOVHits = genderOVData.hits?.hits;
+  logMigration.info(`${message} > finding vocabs to delete`);
+  for (let index = 0; index < genderOVHits?.length; index += 1) {
+    const currentEntityOV = genderOVHits[index];
+    const currentEntityOVId = currentEntityOV._source.internal_id;
+    const currentEntityOVName = currentEntityOV._source.name;
+    if (deleteVocabularies.includes(currentEntityOVName)) {
+      await deleteVocabulary(context, SYSTEM_USER, currentEntityOVId);
+    }
+  }
+  logMigration.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.ts
+++ b/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.ts
@@ -50,6 +50,7 @@ import { ENTITY_TYPE_EVENT } from '../event/event-types';
 import { ENTITY_HASHED_OBSERVABLE_STIX_FILE, ENTITY_PERSONA } from '../../schema/stixCyberObservable';
 import { ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA } from '../administrativeArea/administrativeArea-types';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
+import { isFeatureEnabled } from '../../config/conf';
 
 interface Measures {
   measure: number | null
@@ -112,7 +113,7 @@ const THREAT_ACTOR_INDIVIDUAL_DEFINITION: ModuleDefinition<StoreEntityThreatActo
     { name: 'secondary_motivations', label: 'Secondary motivation', type: 'string', format: 'vocabulary', vocabularyCategory: 'attack_motivation_ov', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
     { name: 'personal_motivations', label: 'Personal motivations', type: 'string', format: 'vocabulary', vocabularyCategory: 'attack_motivation_ov', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: true },
     { name: 'date_of_birth', label: 'Date of birth', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'gender', label: 'Gender', type: 'string', format: 'vocabulary', vocabularyCategory: 'gender_ov', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'gender', label: (isFeatureEnabled('USG_EO_14168_COMPLIANT') ? 'Sex' : 'Gender'), type: 'string', format: 'vocabulary', vocabularyCategory: 'gender_ov', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'job_title', label: 'Job title', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'marital_status', label: 'Marital status', type: 'string', format: 'vocabulary', vocabularyCategory: 'marital_status_ov', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'eye_color', label: 'Eye color', type: 'string', format: 'vocabulary', vocabularyCategory: 'eye_color_ov', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary-utils.ts
@@ -1161,10 +1161,11 @@ export const openVocabularies: Record<VocabularyCategory, Array<{ key: string, d
     { key: 'unknown', description: 'There is not enough information available to determine the type of tool' },
   ],
   gender_ov: [
-    { key: 'male' },
-    { key: 'female' },
-    { key: 'nonbinary' },
-    { key: 'other' },
+    { key: 'male' }, // Gender and Sex Option  - USG EO 14168 Compliant
+    { key: 'female' }, // Gender and Sex Option  - USG EO 14168 Compliant
+    { key: 'nonbinary' }, // Gender Option
+    { key: 'other' }, // Gender Option
+    { key: 'unknown' }, // Sex option - USG EO 14168 Compliant
   ],
   marital_status_ov: [
     { key: 'annulled' },

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -48,7 +48,7 @@ const elWhiteUser = async () => {
   return buildStandardUser([{ internal_id: TLP_WHITE.internal_id, standard_id: TLP_WHITE.standard_id }], ALL_TLP);
 };
 
-const VOCABULARY_COUNT = 341;
+const VOCABULARY_COUNT = 342;
 
 describe('Elasticsearch configuration test', () => {
   it('should configuration correct', async () => {
@@ -450,7 +450,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Tracking-Number')).toBe(1);
     expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
     expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
-    expect(data.edges.length).toEqual(528 + TESTING_ORGS.length + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
+    expect(data.edges.length).toEqual(187 + VOCABULARY_COUNT + TESTING_ORGS.length + TESTING_USERS.length + TESTING_ROLES.length + TESTING_GROUPS.length);
     const filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('ENTITY');
@@ -598,7 +598,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Tracking-Number')).toBe(1);
     expect(entityTypeMap.get('User')).toBe(TESTING_USERS.length + 1);
     expect(entityTypeMap.get('Vocabulary')).toBe(VOCABULARY_COUNT);
-    expect(data.edges.length).toEqual(537);
+    expect(data.edges.length).toEqual(538);
   });
   it('should entity paginate with field exist filter', async () => {
     const filters = {
@@ -735,7 +735,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('Label')).toBe(13);
     expect(entityTypeMap.get('Kill-Chain-Phase')).toBe(2);
     expect(entityTypeMap.get('External-Reference')).toBe(7);
-    expect(data.edges.length).toEqual(548);
+    expect(data.edges.length).toEqual(207 + VOCABULARY_COUNT);
     const createdDates = R.map((e) => e.node.created, data.edges);
     let previousCreatedDate = null;
     for (let index = 0; index < createdDates.length; index += 1) {

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -47,10 +47,10 @@ describe('Raw streams tests', () => {
       expect(createEventsByTypes.incident.length).toBe(2);
       expect(createEventsByTypes.report.length).toBe(31);
       expect(createEventsByTypes.tool.length).toBe(2);
-      // 328 created at init + 1 request access + 2 created in tests + 5 vocabulary organizations types + 7 persona
+      // 330 created at init + 1 request access + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vocabulary.length).toBe(VOCABULARY_NUMBERS);
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(832);
+      expect(createEvents.length).toBe(817);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();
@@ -99,7 +99,7 @@ describe('Raw streams tests', () => {
       }
       // 03 - CHECK DELETE EVENTS
       const deleteEvents = events.filter((e) => e.type === EVENT_TYPE_DELETE);
-      expect(deleteEvents.length).toBe(175);
+      expect(deleteEvents.length).toBe(158);
       // const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
       for (let delIndex = 0; delIndex < deleteEvents.length; delIndex += 1) {
         const { data: insideData, origin, type } = deleteEvents[delIndex];

--- a/opencti-platform/opencti-graphql/tests/04-sync/sync-utils.js
+++ b/opencti-platform/opencti-graphql/tests/04-sync/sync-utils.js
@@ -62,7 +62,7 @@ export const SYNC_START_QUERY = `mutation SynchronizerStart($id: ID!) {
     }
   `;
 
-export const VOCABULARY_NUMBERS = 344;
+export const VOCABULARY_NUMBERS = 345;
 export const INDICATOR_NUMBERS = 28;
 export const MALWARE_NUMBERS = 27;
 export const LABEL_NUMBERS = 17;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -23,8 +23,8 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1213;
-export const SYNC_LIVE_EVENTS_SIZE = 613;
+export const RAW_EVENTS_SIZE = 1178;
+export const SYNC_LIVE_EVENTS_SIZE = 619;
 
 export const PYTHON_PATH = './src/python/testing';
 export const API_URI = `http://localhost:${conf.get('app:port')}`;


### PR DESCRIPTION
This feature flag (`USG_EO_14168_COMPLIANT`) applies OpenCTI platform compliance to the (January 20, 2025) US Government Executive Order 14168 which mandates that US Government Agencies use `sex` instead of `gender` within deployed applications/forms/policies/etc. It additionally specifies vocabularies that can be used to define `sex`.

This feature flag is `disabled` by default. System Owners need to `enable` it if implementing and deploying OpenCTI to an environment that requires the application of the `USG_EO_14168_COMPLIANT` features.

### Proposed changes
Via the `USG_EO_14168_COMPLIANT` feature flag
* The form display of `Gender` is replaced with `Sex`.
* The vocabulary is updated to to remove the options of `nonbinary` and `other`.
* A new vocabulary entry of `unknown` is added. 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* There is a migration - `opencti-platform/opencti-graphql/src/migrations/_DISABLED-eo14168-vocabularies.js` - which must be manually renamed to update the respective vocabularies. Instructions are provided within the migration.
* Demographics to include `gender` was added to OpenCTI in 2023 via https://github.com/OpenCTI-Platform/opencti/pull/3997 by the same organization authoring this proposed change.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

N/A
