### PR TITLE
[frontend] add a fix height to fintel templates datatable

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatesGrid.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatesGrid.tsx
@@ -143,6 +143,7 @@ const FintelTemplatesGrid = ({ data }: FintelTemplatesGridProps) => {
             padding: theme.spacing(2),
             borderRadius: theme.spacing(0.5),
             position: 'relative',
+            height: '235px',
           }}
         >
           <div style={{ height: '100%', width: '100%' }} ref={(r) => setDataTableRef(r)}>


### PR DESCRIPTION
### Proposed changes

* add a fix height to fintel templates datatable

### Related issues

* when having more than 5 fintel templates, there was a strange height transition instead of restraining the height by default

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality