### PR TITLE
[backend/frontend] Auto creation of users on feed ingestion (#11047)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "Sie haben keinen Zugriff auf das Wissen dieser OpenCTI-Instanz.",
   "You have more than 50 values": "Sie haben mehr als 50 Werte",
   "You have no subscription for the moment.": "Sie haben im Moment kein Abonnement.",
+  "You have not defined a default group for ingestion users": "Sie haben keine Standardgruppe für Ingestion-Benutzer definiert",
   "You have successfully logged out.": "Sie haben sich erfolgreich abgemeldet.",
   "You have unsaved changes": "Sie haben ungespeicherte Änderungen",
   "You just need to try?": "Sie müssen es nur versuchen?",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "You do not have any access to the knowledge of this OpenCTI instance.",
   "You have more than 50 values": "You have more than 50 values",
   "You have no subscription for the moment.": "You have no subscription for the moment.",
+  "You have not defined a default group for ingestion users": "You have not defined a default group for ingestion users",
   "You have successfully logged out.": "You have successfully logged out.",
   "You have unsaved changes": "You have unsaved changes",
   "You just need to try?": "You just need to try?",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "No tienes acceso al conocimiento de esta instancia de OpenCTI.",
   "You have more than 50 values": "Tiene más de 50 valores",
   "You have no subscription for the moment.": "No tienes ninguna suscripción por el momento.",
+  "You have not defined a default group for ingestion users": "No ha definido un grupo por defecto para los usuarios de ingestión",
   "You have successfully logged out.": "Has cerrado sesión con éxito.",
   "You have unsaved changes": "Tiene cambios sin guardar",
   "You just need to try?": "¿Sólo necesita probar?",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "Vous n'avez aucun accès à la connaissance de cette instance OpenCTI.",
   "You have more than 50 values": "Vous avez plus de 50 valeurs",
   "You have no subscription for the moment.": "Vous n'avez aucune souscription pour le moment.",
+  "You have not defined a default group for ingestion users": "Vous n'avez pas défini de groupe par défaut pour les utilisateurs d'ingestion",
   "You have successfully logged out.": "Vous avez bien été déconnecté.",
   "You have unsaved changes": "Vous avez des modifications non enregistrées",
   "You just need to try?": "Il ne vous reste plus qu'à essayer ?",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "Non hai alcun accesso alla conoscenza di questa istanza OpenCTI.",
   "You have more than 50 values": "Hai più di 50 valori",
   "You have no subscription for the moment.": "Non hai abbonamenti al momento.",
+  "You have not defined a default group for ingestion users": "Non è stato definito un gruppo predefinito per gli utenti di ingestion",
   "You have successfully logged out.": "Hai effettuato il logout con successo.",
   "You have unsaved changes": "Hai modifiche non salvate",
   "You just need to try?": "Devi solo provare?",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "このOpenCTIインスタンスのナレッジデータにアクセスする権限がありません。",
   "You have more than 50 values": "50以上の値があります",
   "You have no subscription for the moment.": "現在、サブスクリプションはありません。",
+  "You have not defined a default group for ingestion users": "インジェスト・ユーザーのデフォルト・グループが定義されていません。",
   "You have successfully logged out.": "ログアウトが完了しました。",
   "You have unsaved changes": "未保存の変更があります",
   "You just need to try?": "試す必要がありますか？",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "이 OpenCTI 인스턴스의 지식에 액세스할 수 없습니다.",
   "You have more than 50 values": "50개 이상의 값이 있습니다",
   "You have no subscription for the moment.": "현재 구독이 없습니다.",
+  "You have not defined a default group for ingestion users": "수집 사용자에 대한 기본 그룹을 정의하지 않았습니다",
   "You have successfully logged out.": "성공적으로 로그아웃했습니다.",
   "You have unsaved changes": "저장되지 않은 변경 사항이 있습니다",
   "You just need to try?": "시도해 보시겠습니까?",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3765,6 +3765,7 @@
   "You do not have any access to the knowledge of this OpenCTI instance.": "您无权访问此OpenCTI实例的知识数据。",
   "You have more than 50 values": "您有超过 50 个值",
   "You have no subscription for the moment.": "您暂时没有订阅。",
+  "You have not defined a default group for ingestion users": "您没有为摄取用户定义默认组",
   "You have successfully logged out.": "您已成功注销。",
   "You have unsaved changes": "您有未保存的更改",
   "You just need to try?": "你只需要试试？",

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -26,6 +26,7 @@ interface ConfidenceFieldProps {
   name?: string;
   label?: string;
   variant?: string;
+  showAlert?: boolean;
   onSubmit?: (name: string, value: string) => void;
   onFocus?: (name: string, value: string) => void;
   editContext?: readonly (GenericContext | null)[] | null;
@@ -38,6 +39,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   name = 'confidence',
   label,
   variant,
+  showAlert = true,
   onFocus,
   onSubmit,
   editContext,
@@ -51,14 +53,14 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   const { getEffectiveConfidenceLevel } = useConfidenceLevel();
   const userEffectiveMaxConfidence = getEffectiveConfidenceLevel(entityType);
   return (
-    <Alert
-      classes={{ root: classes.alert, message: classes.message }}
+    <>{showAlert ? (<Alert
+      classes={{root: classes.alert, message: classes.message}}
       severity="info"
       icon={false}
       variant="outlined"
       style={{ position: 'relative' }}
       aria-label={finalLabel}
-    >
+                    >
       <Field
         component={InputSliderField}
         variant={variant}
@@ -74,7 +76,22 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
         disabled={disabled}
         maxLimit={userEffectiveMaxConfidence}
       />
-    </Alert>
+    </Alert>) : (<Field
+      component={InputSliderField}
+      variant={variant}
+      containerstyle={containerStyle}
+      fullWidth={true}
+      entityType={entityType}
+      attributeName={name}
+      name={name}
+      label={finalLabel}
+      onFocus={onFocus}
+      onSubmit={onSubmit}
+      editContext={editContext}
+      disabled={disabled}
+      maxLimit={userEffectiveMaxConfidence}
+                 />)
+}</>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ConfidenceField.tsx
@@ -54,7 +54,7 @@ const ConfidenceField: FunctionComponent<ConfidenceFieldProps> = ({
   const userEffectiveMaxConfidence = getEffectiveConfidenceLevel(entityType);
   return (
     <>{showAlert ? (<Alert
-      classes={{root: classes.alert, message: classes.message}}
+      classes={{ root: classes.alert, message: classes.message }}
       severity="info"
       icon={false}
       variant="outlined"

--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
@@ -21,6 +21,7 @@ interface CreatorFieldProps {
   showConfidence?: boolean;
   helpertext?: string;
   required?: boolean;
+  disabled?: boolean;
 }
 
 const CreatorFieldQuery = graphql`
@@ -56,6 +57,7 @@ const CreatorField: FunctionComponent<CreatorFieldProps> = ({
   containerStyle,
   onChange,
   showConfidence = false,
+  disabled=false
 }) => {
   const { t_i18n } = useFormatter();
   const isGrantedToUsers = useGranted([SETTINGS_SETACCESSES]);
@@ -118,6 +120,7 @@ const CreatorField: FunctionComponent<CreatorFieldProps> = ({
   return (
     <div style={{ width: '100%' }}>
       <Field
+        disabled={disabled}
         component={AutocompleteField}
         name={name}
         textfieldprops={{

--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
@@ -57,7 +57,7 @@ const CreatorField: FunctionComponent<CreatorFieldProps> = ({
   containerStyle,
   onChange,
   showConfidence = false,
-  disabled=false
+  disabled = false,
 }) => {
   const { t_i18n } = useFormatter();
   const isGrantedToUsers = useGranted([SETTINGS_SETACCESSES]);

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -28,6 +28,7 @@ import Tab from '@mui/material/Tab';
 import IngestionCsvInlineMapperForm from '@components/data/ingestionCsv/IngestionCsvInlineMapperForm';
 import IngestionCsvCreationUserHandling from '@components/data/ingestionCsv/IngestionCsvCreationUserHandling';
 import IngestionCsvInlineWrapper from '@components/data/ingestionCsv/IngestionCsvInlineWrapper';
+import { IngestionCsvCreationUsersQuery$data } from '@components/data/ingestionCsv/__generated__/IngestionCsvCreationUsersQuery.graphql';
 import Drawer, { DrawerControlledDialProps } from '../../common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
@@ -95,16 +96,9 @@ export const ingestionCsvCreationUsersQuery = graphql`
     query IngestionCsvCreationUsersQuery(
         $filters: FilterGroup
     ) {
-        users(
+        userAlreadyExists(
             filters: $filters
-        ) {
-            edges {
-                node {
-                    id
-                    name
-                }
-            }
-        }
+        )
     }
 `;
 
@@ -240,7 +234,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
         {
           key: ['name'],
           values: [
-            values.user_id.value,
+            (values.user_id as FieldOption).value,
           ],
         },
       ],
@@ -248,7 +242,7 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     } })
       .toPromise();
 
-    if (existingUsers.users.edges.length > 0) {
+    if ((existingUsers as IngestionCsvCreationUsersQuery$data)?.userAlreadyExists) {
       setSubmitting(false);
       setFieldError('user_id', t_i18n('This user already exists. Change the feed\'s name to change the automatically created user\'s name'));
       return;

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreationUserHandling.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreationUserHandling.tsx
@@ -8,7 +8,6 @@ import CreatorField from '@components/common/form/CreatorField';
 import {
   IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery,
 } from '@components/data/ingestionCsv/__generated__/IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery.graphql';
-import { groupSetDefaultGroupForIngestionUsersQuery } from '@components/settings/groups/GroupSetDefaultGroupForIngestionUsers';
 import { IngestionCsvAddInput } from '@components/data/ingestionCsv/IngestionCsvCreation';
 import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
@@ -18,17 +17,8 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader from '../../../../components/Loader';
 
 const ingestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery = graphql`
-    query IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery(
-        $filters: FilterGroup
-    ) {
-        groups(filters: $filters) {
-            edges {
-                node {
-                    id
-                    name
-                }
-            }
-        }
+    query IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery {
+        defaultIngestionGroupCount
     }
 `;
 interface IngestionCsvCreationUserHandlingComponentProps {
@@ -39,7 +29,7 @@ const IngestionCsvCreationUserHandlingComponent = ({ queryRef }: IngestionCsvCre
   const { t_i18n } = useFormatter();
   const { values, setFieldValue } = useFormikContext<IngestionCsvAddInput>();
   const [displayDefaultGroupWarning, setDisplayDefaultGroupWarning] = useState<boolean>(false);
-  const { groups } = usePreloadedQuery(groupSetDefaultGroupForIngestionUsersQuery, queryRef);
+  const data = usePreloadedQuery(ingestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery, queryRef);
 
   useEffect(() => {
     setFieldValue(
@@ -54,13 +44,12 @@ const IngestionCsvCreationUserHandlingComponent = ({ queryRef }: IngestionCsvCre
       'confidence_level',
       '50',
     );
-  }, [values.automatic_user]);
-
-  const handleSwitchChanged = () => {
-    if (groups?.edges?.length === 0) {
+    if (values.automatic_user !== false && data.defaultIngestionGroupCount === 0) {
       setDisplayDefaultGroupWarning(true);
+    } else {
+      setDisplayDefaultGroupWarning(false);
     }
-  };
+  }, [values.automatic_user]);
 
   return (<><Box sx={{ marginTop: 2 }}>
     <Field
@@ -68,7 +57,6 @@ const IngestionCsvCreationUserHandlingComponent = ({ queryRef }: IngestionCsvCre
       type="checkbox"
       name="automatic_user"
       checked={values.automatic_user ?? true}
-      onChange={handleSwitchChanged}
       label={'Automatically create a user'}
     />
     { displayDefaultGroupWarning && values.automatic_user && <Box sx={{ width: '100%', marginTop: 3 }}>
@@ -88,7 +76,7 @@ const IngestionCsvCreationUserHandlingComponent = ({ queryRef }: IngestionCsvCre
       containerStyle={fieldSpacingContainerStyle}
       showConfidence disabled={values.automatic_user !== false}
     />
-    {values.automatic_user !== false && <Box sx={{marginTop: '20px'}}>
+    {values.automatic_user !== false && <Box sx={{ marginTop: '20px' }}>
       <ConfidenceField
         name="confidence_level"
         entityType={'User'}
@@ -100,20 +88,7 @@ const IngestionCsvCreationUserHandlingComponent = ({ queryRef }: IngestionCsvCre
 };
 
 const IngestionCsvCreationUserHandling = () => {
-  const queryRef = useQueryLoading<IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery>(ingestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery, {
-    filters: {
-      mode: 'and',
-      filters: [
-        {
-          key: ['auto_integration_assignation'],
-          values: [
-            'global',
-          ],
-        },
-      ],
-      filterGroups: [],
-    },
-  });
+  const queryRef = useQueryLoading<IngestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery>(ingestionCsvCreationUserHandlingDefaultGroupForIngestionUsersQuery, {});
   return (
     <Suspense fallback={<Loader />}>
       {queryRef && <IngestionCsvCreationUserHandlingComponent queryRef={queryRef} />}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8321,6 +8321,8 @@ type Query {
   ingestionCsv(id: String!): IngestionCsv
   ingestionCsvs(first: Int, after: ID, orderBy: IngestionCsvOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionCsvConnection
   csvFeedAddInputFromImport(file: Upload!): CSVFeedAddInputFromImport!
+  defaultIngestionGroupCount: Int
+  userAlreadyExists(filters: FilterGroup): Boolean
   ingestionJson(id: String!): IngestionJson
   ingestionJsons(first: Int, after: ID, orderBy: IngestionJsonOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionJsonConnection
   indicator(id: String!): Indicator

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -12011,6 +12011,8 @@ input IngestionCsvAddInput {
   csv_mapper_type: IngestionCsvMapperType
   ingestion_running: Boolean
   user_id: String!
+  automatic_user: Boolean
+  confidence_level: String
   markings: [String!]
 }
 

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -39,7 +39,7 @@ export const findAll = async (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_GROUP], args);
 };
 
-export const findDefaultIngestionGroup = async (context, user) => {
+export const findDefaultIngestionGroups = async (context, user) => {
   return findAll(context, user, {
     filters: {
       mode: 'and',

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -39,6 +39,24 @@ export const findAll = async (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_GROUP], args);
 };
 
+export const findDefaultIngestionGroup = async (context) => {
+  return findAll(context, context.user, {
+    filters: {
+      mode: 'and',
+      filters: [
+        {
+          key: ['auto_integration_assignation'],
+          values: [
+            'global',
+          ],
+        },
+      ],
+      filterGroups: [],
+    },
+    connectionFormat: false,
+  });
+};
+
 export const groupAllowedMarkings = async (context, user, groupId) => {
   return listAllToEntitiesThroughRelations(context, user, groupId, RELATION_ACCESSES_TO, ENTITY_TYPE_MARKING_DEFINITION);
 };

--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -39,8 +39,8 @@ export const findAll = async (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_GROUP], args);
 };
 
-export const findDefaultIngestionGroup = async (context) => {
-  return findAll(context, context.user, {
+export const findDefaultIngestionGroup = async (context, user) => {
+  return findAll(context, user, {
     filters: {
       mode: 'and',
       filters: [

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -11343,6 +11343,8 @@ export type IngestionCsv = BasicObject & InternalObject & {
 export type IngestionCsvAddInput = {
   authentication_type: IngestionAuthType;
   authentication_value?: InputMaybe<Scalars['String']['input']>;
+  automatic_user?: InputMaybe<Scalars['Boolean']['input']>;
+  confidence_level?: InputMaybe<Scalars['String']['input']>;
   csv_mapper?: InputMaybe<Scalars['String']['input']>;
   csv_mapper_id?: InputMaybe<Scalars['String']['input']>;
   csv_mapper_type?: InputMaybe<IngestionCsvMapperType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -20540,6 +20540,7 @@ export type Query = {
   dataSources?: Maybe<DataSourceConnection>;
   decayRule?: Maybe<DecayRule>;
   decayRules?: Maybe<DecayRuleConnection>;
+  defaultIngestionGroupCount?: Maybe<Scalars['Int']['output']>;
   deleteOperation?: Maybe<DeleteOperation>;
   deleteOperations?: Maybe<DeleteOperationConnection>;
   disseminationList?: Maybe<DisseminationList>;
@@ -20816,6 +20817,7 @@ export type Query = {
   triggersKnowledge?: Maybe<TriggerConnection>;
   triggersKnowledgeCount?: Maybe<Scalars['Int']['output']>;
   user?: Maybe<User>;
+  userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
   users?: Maybe<UserConnection>;
   vocabularies?: Maybe<VocabularyConnection>;
   vocabulary?: Maybe<Vocabulary>;
@@ -23548,6 +23550,11 @@ export type QueryTriggersKnowledgeCountArgs = {
 
 export type QueryUserArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type QueryUserAlreadyExistsArgs = {
+  filters?: InputMaybe<FilterGroup>;
 };
 
 
@@ -41158,6 +41165,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   dataSources?: Resolver<Maybe<ResolversTypes['DataSourceConnection']>, ParentType, ContextType, Partial<QueryDataSourcesArgs>>;
   decayRule?: Resolver<Maybe<ResolversTypes['DecayRule']>, ParentType, ContextType, RequireFields<QueryDecayRuleArgs, 'id'>>;
   decayRules?: Resolver<Maybe<ResolversTypes['DecayRuleConnection']>, ParentType, ContextType, Partial<QueryDecayRulesArgs>>;
+  defaultIngestionGroupCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   deleteOperation?: Resolver<Maybe<ResolversTypes['DeleteOperation']>, ParentType, ContextType, RequireFields<QueryDeleteOperationArgs, 'id'>>;
   deleteOperations?: Resolver<Maybe<ResolversTypes['DeleteOperationConnection']>, ParentType, ContextType, Partial<QueryDeleteOperationsArgs>>;
   disseminationList?: Resolver<Maybe<ResolversTypes['DisseminationList']>, ParentType, ContextType, RequireFields<QueryDisseminationListArgs, 'id'>>;
@@ -41434,6 +41442,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   triggersKnowledge?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeArgs>>;
   triggersKnowledgeCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeCountArgs>>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
+  userAlreadyExists?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, Partial<QueryUserAlreadyExistsArgs>>;
   users?: Resolver<Maybe<ResolversTypes['UserConnection']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
   vocabularies?: Resolver<Maybe<ResolversTypes['VocabularyConnection']>, ParentType, ContextType, Partial<QueryVocabulariesArgs>>;
   vocabulary?: Resolver<Maybe<ResolversTypes['Vocabulary']>, ParentType, ContextType, RequireFields<QueryVocabularyArgs, 'id'>>;

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
@@ -60,7 +60,7 @@ export const findCsvMapperForIngestionById = (context: AuthContext, user: AuthUs
 };
 
 export const defaultIngestionGroupsCount = async (context: AuthContext) => {
-  // We use SYSTEM_USER because manage ingestion should be enough to create a CSV Feed
+  // We use SYSTEM_USER because manage ingestion should be enough to create an ingestion Feed
   const defaultGroupLength = await findDefaultIngestionGroups(context, SYSTEM_USER);
   return defaultGroupLength.length ?? 0;
 };

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
@@ -100,7 +100,9 @@ export const addIngestionCsv = async (context: AuthContext, user: AuthUser, inpu
       user_id: onTheFlyCreatedUser.id,
     };
   } else {
-    updatedInput = input;
+    updatedInput = {
+      ...((({ automatic_user: _, confidence_level: __, ...inputWithoutAutomaticFields }) => inputWithoutAutomaticFields)(input))
+    };
   }
 
   const { element, isCreation } = await createEntity(

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
@@ -6,12 +6,14 @@ import {
   csvFeedAddInputFromImport,
   csvFeedGetCsvMapper,
   csvFeedMapperExport,
+  defaultIngestionGroupsCount,
   deleteIngestionCsv,
   findAllPaginated,
   findById,
   ingestionCsvEditField,
   ingestionCsvResetState,
-  testCsvIngestionMapping
+  testCsvIngestionMapping,
+  userAlreadyExists
 } from './ingestion-csv-domain';
 
 const creatorLoader = batchLoader(batchCreator);
@@ -21,11 +23,13 @@ const ingestionCsvResolvers: Resolvers = {
     ingestionCsv: (_, { id }, context) => findById(context, context.user, id),
     ingestionCsvs: (_, args, context) => findAllPaginated(context, context.user, args),
     csvFeedAddInputFromImport: (_, { file }, context) => csvFeedAddInputFromImport(context, context.user, file),
+    defaultIngestionGroupCount: (_, __, context) => defaultIngestionGroupsCount(context),
+    userAlreadyExists: (_, filters, context) => userAlreadyExists(context, filters)
   },
   IngestionCsv: {
     user: (ingestionCsv, _, context) => creatorLoader.load(ingestionCsv.user_id, context, context.user),
     csvMapper: (ingestionCsv, _, context) => csvFeedGetCsvMapper(context, ingestionCsv),
-    toConfigurationExport: (ingestionCsv, _, context) => csvFeedMapperExport(context, context.user, ingestionCsv)
+    toConfigurationExport: (ingestionCsv, _, context) => csvFeedMapperExport(context, context.user, ingestionCsv),
   },
   Mutation: {
     ingestionCsvTester: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -76,6 +76,8 @@ type Query {
     csvFeedAddInputFromImport(
         file: Upload!
     ): CSVFeedAddInputFromImport! @auth(for: [INGESTION, CSVMAPPERS])
+    defaultIngestionGroupCount: Int @auth(for: [INGESTION])
+    userAlreadyExists(filters: FilterGroup): Boolean @auth(for: [INGESTION])
 }
 
 # Mutations

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -92,6 +92,8 @@ input IngestionCsvAddInput {
     csv_mapper_type: IngestionCsvMapperType
     ingestion_running: Boolean
     user_id: String!
+    automatic_user: Boolean
+    confidence_level: String
     markings: [String!]
 }
 

--- a/opencti-platform/opencti-graphql/src/types/store.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/store.d.ts
@@ -662,7 +662,7 @@ interface StoreEntityIdentity extends StoreEntity, BasicIdentityEntity {}
 
 interface BasicGroupEntity extends BasicStoreEntity {
   [RELATION_MEMBER_OF]: string[];
-  auto_integration_assignation: string[]; // TODO how to add FF here ?
+  auto_integration_assignation: string[];
 }
 
 interface BasicOrganizationEntity extends BasicStoreEntity {

--- a/opencti-platform/opencti-graphql/src/types/store.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/store.d.ts
@@ -662,6 +662,7 @@ interface StoreEntityIdentity extends StoreEntity, BasicIdentityEntity {}
 
 interface BasicGroupEntity extends BasicStoreEntity {
   [RELATION_MEMBER_OF]: string[];
+  auto_integration_assignation: string[]; // TODO how to add FF here ?
 }
 
 interface BasicOrganizationEntity extends BasicStoreEntity {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/ingestion-csv-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/ingestion-csv-domain-test.ts
@@ -5,7 +5,7 @@ import { type EditInput, IngestionAuthType, type IngestionCsvAddInput } from '..
 import { enableCEAndUnSetOrganization, enableEEAndSetOrganization } from '../../utils/testQueryHelper';
 import { getFakeAuthUser, getOrganizationEntity } from '../../utils/domainQueryHelper';
 import type { AuthContext, AuthUser } from '../../../src/types/user';
-import { findDefaultIngestionGroup, groupEditField } from '../../../src/domain/group';
+import { findDefaultIngestionGroups, groupEditField } from '../../../src/domain/group';
 import type { BasicGroupEntity } from '../../../src/types/store';
 import { findById as findUserById } from '../../../src/domain/user';
 import { executionContext, SYSTEM_USER } from '../../../src/utils/access';
@@ -30,7 +30,7 @@ describe('Ingestion CSV domain - create CSV Feed coverage', async () => {
   });
 
   it('should default group be set to Connector on startup', async () => {
-    const ingestionDefaultGroups: BasicGroupEntity[] = await findDefaultIngestionGroup(currentTestContext, ingestionUser) as BasicGroupEntity[];
+    const ingestionDefaultGroups: BasicGroupEntity[] = await findDefaultIngestionGroups(currentTestContext, ingestionUser) as BasicGroupEntity[];
     expect(ingestionDefaultGroups.length).toBe(1);
     expect(ingestionDefaultGroups[0].name).toBe('Connectors');
     expect(ingestionDefaultGroups[0].auto_integration_assignation).toStrictEqual(['global']);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/ingestion-csv-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/ingestion-csv-domain-test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { addIngestionCsv, deleteIngestionCsv } from '../../../src/modules/ingestion/ingestion-csv-domain';
+import { getOrganizationIdByName, PLATFORM_ORGANIZATION } from '../../utils/testQuery';
+import { IngestionAuthType, type IngestionCsvAddInput } from '../../../src/generated/graphql';
+import { enableCEAndUnSetOrganization, enableEEAndSetOrganization } from '../../utils/testQueryHelper';
+import { getFakeAuthUser } from '../../utils/domainQueryHelper';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
+import { findAll as findAllGroup } from '../../../src/domain/group';
+import type { BasicGroupEntity } from '../../../src/types/store';
+import { findById as findUserById } from '../../../src/domain/user';
+import { executionContext } from '../../../src/utils/access';
+
+describe('Ingestion CSV domain - create CSV Feed coverage', async () => {
+  const ingestionCreatedIds: string[] = [];
+  let ingestionUser: AuthUser;
+  let testContext: AuthContext;
+
+  beforeAll(async () => {
+    ingestionUser = getFakeAuthUser('CsvFeedIngestionDomain');
+    ingestionUser.capabilities = [{ name: 'KNOWLEDGE' }, { name: 'INGESTION_SETINGESTIONS' }];
+    testContext = executionContext('testContext', ingestionUser);
+  });
+
+  afterAll(async () => {
+    await enableCEAndUnSetOrganization();
+    for (let i = 0; i < ingestionCreatedIds.length; i += 1) {
+      await deleteIngestionCsv(testContext, ingestionUser, ingestionCreatedIds[i]);
+    }
+  });
+
+  it('should default group be set to Connector on startup', async () => {
+    const groups: BasicGroupEntity[] = await findAllGroup(testContext, ingestionUser, {
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: ['auto_integration_assignation'],
+            values: [
+              'global',
+            ],
+          },
+        ],
+        filterGroups: [],
+      },
+      connectionFormat: false
+    }) as BasicGroupEntity[];
+    expect(groups.length).toBe(1);
+    expect(groups[0].name).toBe('Connectors');
+    expect(groups[0].auto_integration_assignation).toStrictEqual(['global']);
+  });
+
+  it('should create a CSV Feed with auto user creation works fine without platform org', async () => {
+    const ingestionCsvInput: IngestionCsvAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'CSV Feed to test auto user creation without platform org',
+      uri: 'http://fakefeed.invalid',
+      user_id: '',
+      automatic_user: true
+    };
+    const ingestionCreated = await addIngestionCsv(testContext, ingestionUser, ingestionCsvInput);
+    expect(ingestionCreated.name).toBe('CSV Feed to test auto user creation without platform org');
+    ingestionCreatedIds.push(ingestionCreated.id);
+    expect(ingestionCreated.user_id).toBeDefined();
+
+    const createdUser = await findUserById(testContext, ingestionUser, ingestionCreated.user_id);
+    expect(createdUser.name).toBe('[F] CSV Feed to test auto user creation without platform org');
+    expect(createdUser.user_email).toBe('CSVFeedtotestautousercreationwithoutlatformorg@opencti.invalid');
+  });
+
+  it.todo('should create a CSV Feed with auto user creation works fine with platform org', async () => {
+    await enableEEAndSetOrganization(PLATFORM_ORGANIZATION);
+    // const platformOrganizationId = await getOrganizationIdByName(PLATFORM_ORGANIZATION.name);
+  });
+
+  it.todo('should create a CSV Feed with System user works fine', async () => {
+
+  });
+
+  it.todo('should create a CSV Feed with existing user works fine', async () => {
+
+  });
+
+  it.todo('should create a CSV Feed with a strange name works fine', async () => {
+    const ingestionCsvInput: IngestionCsvAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'MyFééd @ Testing @mail.fr 🌈🍅 - CSVフィードの作成',
+      uri: 'http://fakefeed.invalid',
+      user_id: '',
+      automatic_user: true
+    };
+  });
+
+  it.todo('should create a CSV Feed with auto user creation be refused when no default group', async () => {
+    // remove default group in config
+
+    // Create feed
+
+    // put back default group
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -264,7 +264,7 @@ describe('Relations listing', () => {
     expect(entityTypeMap.get('external-reference')).toBe(7);
     expect(entityTypeMap.get('object-marking')).toBe(29);
     expect(entityTypeMap.get('operating-system')).toBe(1);
-    expect(stixRefRelationships.edges.length).toEqual(130);
+    expect(stixRefRelationships.edges.length).toEqual(132);
   });
   it('should list relations with roles', async () => {
     const stixRelations = await listRelations(testContext, ADMIN_USER, 'uses', {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/middleware-test.js
@@ -264,7 +264,7 @@ describe('Relations listing', () => {
     expect(entityTypeMap.get('external-reference')).toBe(7);
     expect(entityTypeMap.get('object-marking')).toBe(29);
     expect(entityTypeMap.get('operating-system')).toBe(1);
-    expect(stixRefRelationships.edges.length).toEqual(132);
+    expect(stixRefRelationships.edges.length).toEqual(130);
   });
   it('should list relations with roles', async () => {
     const stixRelations = await listRelations(testContext, ADMIN_USER, 'uses', {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
@@ -1,6 +1,12 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, queryAsAdmin, testContext, USER_DISINFORMATION_ANALYST, USER_PARTICIPATE } from '../../utils/testQuery';
+import {
+  ADMIN_USER,
+  queryAsAdmin,
+  testContext,
+  USER_DISINFORMATION_ANALYST,
+  USER_PARTICIPATE,
+} from '../../utils/testQuery';
 import { createUploadFromTestDataFile, queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
 import { patchCsvIngestion } from '../../../src/modules/ingestion/ingestion-csv-domain';
 import { now } from '../../../src/utils/format';

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
@@ -75,7 +75,7 @@ describe('CSV ingestion resolver standard behavior', () => {
       csv_mapper: JSON.stringify(singleColumnCsvMapper),
       csv_mapper_type: IngestionCsvMapperType.Inline,
       automatic_user: true,
-      user_id: ''
+      user_id: '[F] Single column inline and auto user'
     };
 
     const createSingleColumnCsvFeedsIngesterQueryResult = await queryAsUserWithSuccess(USER_DISINFORMATION_ANALYST.client, {

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -50,7 +50,7 @@ describe('Raw streams tests', () => {
       // 328 created at init + 1 request access + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vocabulary.length).toBe(VOCABULARY_NUMBERS);
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(830);
+      expect(createEvents.length).toBe(832);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -23,7 +23,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1205;
+export const RAW_EVENTS_SIZE = 1207;
 export const SYNC_LIVE_EVENTS_SIZE = 624;
 
 export const PYTHON_PATH = './src/python/testing';

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -228,7 +228,7 @@ export const enableEEAndSetOrganization = async (organization: OrganizationTestD
   ];
   const settingsResult = await settingsEditField(testContext, ADMIN_USER, platformSettings.id, input);
 
-  expect(settingsResult.platform_organization).not.toBeUndefined();
+  expect(settingsResult.platform_organization).toBe(platformOrganizationId);
   resetCacheForEntity(ENTITY_TYPE_SETTINGS);
 };
 


### PR DESCRIPTION
### Proposed changes

* Automatically create a user when option is selected on CSV Feed ingestion

Counter updates:
- (2 times) when adding a user to an org, there is a relation "participate-to" in stream (same as user modified with UI in settings)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11047

### Checklist


- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

