### PR TITLE
[frontend] remove Manage Access button from Notes entities (#11312)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -101,7 +101,7 @@ const RootNote = () => {
                           </CollaborativeSecurity>
                         }
                         redirectToContent={false}
-                        disableAuthorizedMembers={false}
+                        disableAuthorizedMembers={true}
                         enableEnricher={true}
                         enableEnrollPlaybook={true}
                       />
@@ -116,7 +116,7 @@ const RootNote = () => {
                         </CollaborativeSecurity>
                       }
                       redirectToContent={false}
-                      disableAuthorizedMembers={false}
+                      disableAuthorizedMembers={true}
                       enableEnricher={true}
                       enableEnrollPlaybook={true}
                     />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Restricted members attribute dosen't exist on Note Entity.
* Button Manage Access has been removed


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/11312


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
