### PR TITLE
[frontend] fintel design available for built in html to pdf connector (#10284)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -398,11 +398,11 @@ const StixCoreObjectFileExportForm = ({
                     {((values.connector.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf')
                       || (values.connector.value === BUILT_IN_HTML_TO_PDF.value && values.fileToExport?.value.startsWith('fromTemplate/')))
                       && (
-                      <FintelDesignField
-                        name="fintelDesign"
-                        label={t_i18n('Fintel design')}
-                        style={fieldSpacingContainerStyle}
-                      />
+                        <FintelDesignField
+                          name="fintelDesign"
+                          label={t_i18n('Fintel design')}
+                          style={fieldSpacingContainerStyle}
+                        />
                       )}
                     {!isBuiltInConnector(values.connector.value) && (
                     <Field

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -395,13 +395,15 @@ const StixCoreObjectFileExportForm = ({
                       optionLength={80}
                     />
                     )}
-                    {values.connector.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf' && (
+                    {((values.connector.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf')
+                      || (values.connector.value === BUILT_IN_HTML_TO_PDF.value && values.fileToExport?.value.startsWith('fromTemplate/')))
+                      && (
                       <FintelDesignField
                         name="fintelDesign"
                         label={t_i18n('Fintel design')}
                         style={fieldSpacingContainerStyle}
                       />
-                    )}
+                      )}
                     {!isBuiltInConnector(values.connector.value) && (
                     <Field
                       component={SelectField}


### PR DESCRIPTION
### Proposed changes
In the content tab of a container, when doing a file export with the connector 'html file to pdf' : the 'fintel design' field should appear if the selected file is originated from a fintel template

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10284