### PR TITLE
[frontend] fix double reload cause by SavedFilters query

### DIFF
--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { SavedFiltersQuery, SavedFiltersQuery$variables } from 'src/components/saved_filters/__generated__/SavedFiltersQuery.graphql';
@@ -65,11 +65,13 @@ const SavedFilters = ({ currentSavedFilter, setCurrentSavedFilter }: SavedFilter
     <>
       {queryRef
         ? (
-          <SavedFiltersComponent
-            queryRef={queryRef}
-            currentSavedFilter={currentSavedFilter}
-            setCurrentSavedFilter={setCurrentSavedFilter}
-          />
+          <Suspense fallback={<SavedFiltersAutocomplete isDisabled/>}>
+            <SavedFiltersComponent
+              queryRef={queryRef}
+              currentSavedFilter={currentSavedFilter}
+              setCurrentSavedFilter={setCurrentSavedFilter}
+            />
+          </Suspense>
         )
         : <SavedFiltersAutocomplete isDisabled />
       }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Handle query loading in SavedFilters

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://www.notion.so/filigran/Milestone-6-7-issues-to-fix-before-release-1df8fce17f2a80769c38ed5702e66bcb?source=copy_link#2108fce17f2a8005a351e1aa1cbcbf24

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
