### PR TITLE
[frontend/backend] rework CSV Mapper in CSV Feed format

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCSVFeedUtils.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCSVFeedUtils.tsx
@@ -1,0 +1,24 @@
+import { useFragment } from 'react-relay';
+import { CsvMapperFormData } from '@components/data/csvMapper/CsvMapper';
+import { useCsvMappersData } from '@components/data/csvMapper/csvMappers.data';
+import {
+  CsvMapperRepresentationAttributesForm_allSchemaAttributes$key,
+} from '../csvMapper/representations/attributes/__generated__/CsvMapperRepresentationAttributesForm_allSchemaAttributes.graphql';
+import { CsvMapperRepresentationAttributesFormFragment } from '../csvMapper/representations/attributes/CsvMapperRepresentationAttributesForm';
+import { CsvMapperAddInput, csvMapperToFormData } from '../csvMapper/CsvMapperUtils';
+import { useComputeDefaultValues } from '../../../../utils/hooks/useDefaultValues';
+
+// eslint-disable-next-line import/prefer-default-export
+export const csvFeedCsvMapperToFormData = (csvMapper: CsvMapperAddInput): CsvMapperFormData => {
+  const computeDefaultValues = useComputeDefaultValues();
+  const { schemaAttributes } = useCsvMappersData();
+  const data = useFragment<CsvMapperRepresentationAttributesForm_allSchemaAttributes$key>(
+    CsvMapperRepresentationAttributesFormFragment,
+    schemaAttributes,
+  ) || { csvMapperSchemaAttributes: [] };
+  return csvMapperToFormData(
+    csvMapper,
+    data.csvMapperSchemaAttributes,
+    computeDefaultValues,
+  );
+};

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreationDeprecated.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreationDeprecated.tsx
@@ -41,6 +41,7 @@ import { BASIC_AUTH, CERT_AUTH, extractCA, extractCert, extractKey, extractPassw
 import useAuth from '../../../../utils/hooks/useAuth';
 import PasswordTextField from '../../../../components/PasswordTextField';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
+import { CsvMapperAddInput } from '../csvMapper/CsvMapperUtils';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -104,7 +105,7 @@ export interface IngestionCsvAddInput {
   scheduling_period?: string | null
   uri: string
   csv_mapper_type?: IngestionCsvMapperType
-  csv_mapper?: string
+  csv_mapper?: CsvMapperAddInput
   csv_mapper_id?: string | FieldOption
   authentication_type: IngestionAuthType | string
   authentication_value?: string | null
@@ -237,8 +238,8 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
     ...ingestionCsvData,
     name: `${ingestionCsvData.name}`,
     scheduling_period: ingestionCsvData.scheduling_period ?? 'PT1H',
-    csv_mapper_type: ingestionCsvData.csv_mapper_type ?? 'id',
-    csv_mapper: JSON.stringify(ingestionCsvData.csvMapper),
+    csv_mapper_type: 'id',
+    csv_mapper: undefined,
     csv_mapper_id: convertMapper(ingestionCsvData, 'csvMapper'),
     user_id: convertUser(ingestionCsvData, 'user'),
     username: ingestionCsvData.authentication_type === BASIC_AUTH ? extractUsername(ingestionCsvData.authentication_value) : undefined,

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
@@ -1,5 +1,5 @@
 import { graphql, useFragment } from 'react-relay';
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, useMemo } from 'react';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
@@ -9,7 +9,10 @@ import Box from '@mui/material/Box';
 import Alert from '@mui/material/Alert';
 import CreatorField from '@components/common/form/CreatorField';
 import CommitMessage from '@components/common/form/CommitMessage';
-import { IngestionCsvEditionFragment_ingestionCsv$key } from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionFragment_ingestionCsv.graphql';
+import {
+  IngestionCsvEditionFragment_ingestionCsv$data,
+  IngestionCsvEditionFragment_ingestionCsv$key,
+} from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionFragment_ingestionCsv.graphql';
 import CsvMapperField, { CsvMapperFieldOption, csvMapperQuery } from '@components/common/form/CsvMapperField';
 import Button from '@mui/material/Button';
 import IngestionCsvFeedTestDialog from '@components/data/ingestionCsv/IngestionCsvFeedTestDialog';
@@ -20,6 +23,7 @@ import IngestionSchedulingField from '@components/data/IngestionSchedulingField'
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import IngestionCsvInlineMapperForm from '@components/data/ingestionCsv/IngestionCsvInlineMapperForm';
+import { CsvMapperAddInput } from '@components/data/csvMapper/CsvMapperUtils';
 import { convertMapper, convertUser } from '../../../../utils/edition';
 import { useFormatter } from '../../../../components/i18n';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
@@ -37,6 +41,7 @@ import { USER_CHOICE_MARKING_CONFIG } from '../../../../utils/csvMapperUtils';
 import { BASIC_AUTH, BEARER_AUTH, CERT_AUTH, extractCA, extractCert, extractKey, extractPassword, extractUsername } from '../../../../utils/ingestionAuthentificationUtils';
 import PasswordTextField from '../../../../components/PasswordTextField';
 import SwitchField from '../../../../components/fields/SwitchField';
+import { RootMe_data$data } from '../../../__generated__/RootMe_data.graphql';
 import IngestionCsvInlineWrapper from './IngestionCsvInlineWrapper';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -50,6 +55,35 @@ const useStyles = makeStyles<Theme>((theme) => ({
     marginLeft: theme.spacing(2),
   },
 }));
+
+export const initIngestionValue = (ingestionCsvData: IngestionCsvEditionFragment_ingestionCsv$data, me : RootMe_data$data) => {
+  return {
+    name: ingestionCsvData.name,
+    description: ingestionCsvData.description,
+    scheduling_period: ingestionCsvData.scheduling_period ?? 'auto',
+    uri: ingestionCsvData.uri,
+    authentication_type: ingestionCsvData.authentication_type,
+    authentication_value: ingestionCsvData.authentication_type === BEARER_AUTH ? ingestionCsvData.authentication_value : undefined,
+    username: ingestionCsvData.authentication_type === BASIC_AUTH ? extractUsername(ingestionCsvData.authentication_value) : undefined,
+    password: ingestionCsvData.authentication_type === BASIC_AUTH ? extractPassword(ingestionCsvData.authentication_value) : undefined,
+    cert: ingestionCsvData.authentication_type === CERT_AUTH ? extractCert(ingestionCsvData.authentication_value) : undefined,
+    key: ingestionCsvData.authentication_type === CERT_AUTH ? extractKey(ingestionCsvData.authentication_value) : undefined,
+    ca: ingestionCsvData.authentication_type === CERT_AUTH ? extractCA(ingestionCsvData.authentication_value) : undefined,
+    ingestion_running: ingestionCsvData.ingestion_running,
+    // In case the csv_mapper_id is not know, that mean we are in the older model where we link to an id by default
+    csv_mapper_type: ingestionCsvData.csv_mapper_type === null ? true : ingestionCsvData.csv_mapper_type === 'id',
+    csv_mapper: ingestionCsvData.csv_mapper_type === 'inline' ? ingestionCsvData.csvMapper as CsvMapperAddInput : undefined,
+    csv_mapper_id: ingestionCsvData.csv_mapper_type === 'inline' ? null : convertMapper(ingestionCsvData, 'csvMapper'),
+    user_id: convertUser(ingestionCsvData, 'user'),
+    references: undefined,
+    markings: me.allowed_marking?.filter(
+      (marking) => ingestionCsvData.markings?.includes(marking.id),
+    ).map((marking) => ({
+      label: marking.definition ?? '',
+      value: marking.id,
+    })) ?? [],
+  };
+};
 
 export const ingestionCsvEditionPatch = graphql`
   mutation IngestionCsvEditionPatchMutation($id: ID!, $input: [EditInput!]!) {
@@ -112,6 +146,42 @@ export const ingestionCsvEditionFragment = graphql`
       name
     }
     markings
+    duplicateCsvMapper {
+      id
+      name
+      has_header
+      separator
+      skipLineChar
+      representations {
+        id
+        type
+        target {
+          entity_type
+          column_based {
+            column_reference
+            operator
+            value
+          }
+        }
+        attributes {
+          key
+          column {
+            column_name
+            configuration {
+              separator
+              pattern_date
+            }
+          }
+          default_values {
+            id
+            name
+          }
+          based_on {
+            representations
+          }
+        }
+      }
+    }
   }
 `;
 
@@ -134,7 +204,7 @@ interface IngestionCsvEditionForm {
   csv_mapper_id: string | FieldOption | null,
   user_id: string | FieldOption,
   markings: FieldOption[],
-  csv_mapper?: string,
+  csv_mapper?: CsvMapperAddInput,
   csv_mapper_type: boolean
 }
 
@@ -187,7 +257,7 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
     cert: Yup.string().nullable(),
     key: Yup.string().nullable(),
     ca: Yup.string().nullable(),
-    csv_mapper: Yup.string().nullable(),
+    csv_mapper: Yup.object().nullable(),
     csv_mapper_id: Yup.mixed().required(t_i18n('This field is required')),
     csv_mapper_type: Yup.string(),
     markings: Yup.array().required(),
@@ -219,13 +289,15 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
 
   const handleSubmitField = (
     name: string,
-    value: FieldOption | FieldOption[] | CsvMapperFieldOption | string | string[] | number | number[] | null,
+    value: FieldOption | FieldOption[] | CsvMapperFieldOption | string | string[] | number | number[] | null | CsvMapperAddInput,
+    formValues?: IngestionCsvEditionForm,
   ) => {
     let finalValue = value as string;
     let finalName = name;
-
+    const additionalValue: Record<'key' | 'value', string>[] = [];
     // region authentication -- If you change something here, please have a look at IngestionTaxiiEdition
     const backendAuthValue = ingestionCsvData.authentication_value;
+    const isExistingCsvMappers = value === 'true';
     // re-compose username:password
     if (name === 'username') {
       finalName = 'authentication_value';
@@ -255,7 +327,23 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
     // end region authentication
 
     if (name === 'csv_mapper_type') {
-      finalValue = value === 'true' ? 'id' : 'inline';
+      const usingExistingMapper = isExistingCsvMappers;
+
+      finalValue = usingExistingMapper ? 'id' : 'inline';
+
+      // Don't proceed if using an existing CSV mapper but no mapper ID is defined
+      const missingMapperId = usingExistingMapper && !formValues?.csv_mapper_id;
+      // Don't proceed if creating an inline CSV mapper but no mapper data is provided
+      const missingInlineMapper = !usingExistingMapper && !formValues?.csv_mapper;
+
+      // Avoid sending request if required mapper data is missing
+      if (missingMapperId || missingInlineMapper) {
+        return;
+      }
+    }
+    if (name === 'csv_mapper') {
+      finalValue = JSON.stringify(value);
+      additionalValue.push({ value: 'inline', key: 'csv_mapper_type' });
     }
     if (name === 'csv_mapper_id' || name === 'user_id') {
       finalValue = (value as FieldOption).value;
@@ -263,6 +351,7 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
     if (name === 'csv_mapper_id') {
       const hasUserChoiceCsvMapperRepresentations = resolveHasUserChoiceCsvMapper(value as CsvMapperFieldOption);
       setHasUserChoiceCsvMapper(hasUserChoiceCsvMapperRepresentations);
+      additionalValue.push({ key: 'csv_mapper_type', value: 'id' });
     }
     if (name === 'user_id') {
       onCreatorSelection(value as FieldOption).then();
@@ -273,41 +362,15 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
         commitUpdate({
           variables: {
             id: ingestionCsvData.id,
-            input: [{ key: finalName, value: finalValue || '' }],
+            input: [{ key: finalName, value: finalValue || '' }, ...additionalValue],
           },
         });
       })
       .catch(() => false);
   };
-  const initialValues = {
-    name: ingestionCsvData.name,
-    description: ingestionCsvData.description,
-    scheduling_period: ingestionCsvData.scheduling_period ?? 'auto',
-    uri: ingestionCsvData.uri,
-    authentication_type: ingestionCsvData.authentication_type,
-    authentication_value: ingestionCsvData.authentication_type === BEARER_AUTH ? ingestionCsvData.authentication_value : undefined,
-    username: ingestionCsvData.authentication_type === BASIC_AUTH ? extractUsername(ingestionCsvData.authentication_value) : undefined,
-    password: ingestionCsvData.authentication_type === BASIC_AUTH ? extractPassword(ingestionCsvData.authentication_value) : undefined,
-    cert: ingestionCsvData.authentication_type === CERT_AUTH ? extractCert(ingestionCsvData.authentication_value) : undefined,
-    key: ingestionCsvData.authentication_type === CERT_AUTH ? extractKey(ingestionCsvData.authentication_value) : undefined,
-    ca: ingestionCsvData.authentication_type === CERT_AUTH ? extractCA(ingestionCsvData.authentication_value) : undefined,
-    ingestion_running: ingestionCsvData.ingestion_running,
-    // In case the csv_mapper_id is not know, that mean we are in the older model where we link to an id by default
-    csv_mapper_type: ingestionCsvData.csv_mapper_type === null ? true : ingestionCsvData.csv_mapper_type === 'id',
-    csv_mapper: ingestionCsvData.csv_mapper_type === 'inline' ? JSON.stringify(ingestionCsvData.csvMapper) : undefined,
-    csv_mapper_id: ingestionCsvData.csv_mapper_type === 'inline' ? null : convertMapper(ingestionCsvData, 'csvMapper'),
-    user_id: convertUser(ingestionCsvData, 'user'),
-    references: undefined,
-    markings: me.allowed_marking?.filter(
-      (marking) => ingestionCsvData.markings?.includes(marking.id),
-    ).map((marking) => ({
-      label: marking.definition ?? '',
-      value: marking.id,
-    })) ?? [],
-  };
 
+  const initialValues = useMemo(() => initIngestionValue(ingestionCsvData, me), [ingestionCsvData.id]);
   const queryRef = useQueryLoading<CsvMapperFieldSearchQuery>(csvMapperQuery);
-
   const defaultMarkingOptions = (me.default_marking?.flatMap(({ values }) => (values ?? [{ id: '', definition: '' }])?.map(({ id, definition }) => ({ label: definition, value: id }))) ?? []) as FieldOption[];
   const updateCsvMapper = async (
     setFieldValue: (field: string, option: FieldOption, shouldValidate?: boolean) => Promise<void | FormikErrors<IngestionCsvEditionForm>>,
@@ -351,9 +414,10 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
           </Box>
           <Box sx={{ display: currentTab === 1 ? 'block' : 'none' }}>
             <IngestionCsvInlineWrapper>
-              <IngestionCsvInlineMapperForm csvMapper={values.csv_mapper ? JSON.parse(values.csv_mapper) : undefined} setCSVMapperFieldValue={handleSubmitField} />
+              <IngestionCsvInlineMapperForm csvMapper={values.csv_mapper as CsvMapperAddInput} setCSVMapperFieldValue={handleSubmitField} />
             </IngestionCsvInlineWrapper>
           </Box>
+
           <Form>
             <Box sx={{ display: currentTab === 0 ? 'block' : 'none' }}>
               <Field
@@ -399,7 +463,7 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
                   type="checkbox"
                   name="csv_mapper_type"
                   label={t_i18n('Existing csv mappers')}
-                  onChange={handleSubmitField}
+                  onChange={(name: string, value: string) => handleSubmitField(name, value, values)}
                 />
               </Box>
               {

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvFeedTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvFeedTestDialog.tsx
@@ -14,6 +14,7 @@ import { handleError } from '../../../../relay/environment';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { getAuthenticationValue } from '../../../../utils/ingestionAuthentificationUtils';
 import { FieldOption } from '../../../../utils/field';
+import { CsvMapperAddInput } from '../csvMapper/CsvMapperUtils';
 
 const ingestionCsvFeedTestMutation = graphql`
   mutation IngestionCsvFeedTestDialogMutation($input: IngestionCsvAddInput!) {
@@ -32,7 +33,7 @@ interface ingestionCsvFeedTestDialogProps {
     name: string,
     description?: string | null,
     authentication_type: string,
-    csv_mapper?: string,
+    csv_mapper?: CsvMapperAddInput,
     csv_mapper_type?: string,
     authentication_value?: string | null,
     uri: string,
@@ -75,7 +76,7 @@ const IngestionCsvFeedTestDialog: FunctionComponent<ingestionCsvFeedTestDialogPr
           ingestion_running: values.ingestion_running,
           user_id: typeof values.user_id === 'string' ? values.user_id : values.user_id.value,
           csv_mapper_id: typeof values.csv_mapper_id === 'string' ? values.csv_mapper_id : values.csv_mapper_id?.value,
-          csv_mapper: values.csv_mapper,
+          csv_mapper: values.csv_mapper ? JSON.stringify((values.csv_mapper)) : undefined,
           csv_mapper_type: values.csv_mapper_type,
           markings: values.markings.map((marking) => marking.value),
         },

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -12038,6 +12038,7 @@ type IngestionCsv implements InternalObject & BasicObject {
   last_execution_date: DateTime
   markings: [String!]
   toConfigurationExport: String!
+  duplicateCsvMapper: CsvMapper!
 }
 
 enum IngestionCsvOrdering {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -11324,6 +11324,7 @@ export type IngestionCsv = BasicObject & InternalObject & {
   current_state_date?: Maybe<Scalars['DateTime']['output']>;
   current_state_hash?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
+  duplicateCsvMapper: CsvMapper;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   ingestion_running?: Maybe<Scalars['Boolean']['output']>;
@@ -38348,6 +38349,7 @@ export type IngestionCsvResolvers<ContextType = any, ParentType extends Resolver
   current_state_date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   current_state_hash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  duplicateCsvMapper?: Resolver<ResolversTypes['CsvMapper'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   ingestion_running?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
@@ -5,6 +5,7 @@ import {
   addIngestionCsv,
   csvFeedAddInputFromImport,
   csvFeedGetCsvMapper,
+  csvFeedGetNewDuplicatedCsvMapper,
   csvFeedMapperExport,
   defaultIngestionGroupsCount,
   deleteIngestionCsv,
@@ -28,8 +29,9 @@ const ingestionCsvResolvers: Resolvers = {
   },
   IngestionCsv: {
     user: (ingestionCsv, _, context) => creatorLoader.load(ingestionCsv.user_id, context, context.user),
-    csvMapper: (ingestionCsv, _, context) => csvFeedGetCsvMapper(context, ingestionCsv),
+    csvMapper: (ingestionCsv, _, context) => csvFeedGetCsvMapper(context, context.user, ingestionCsv),
     toConfigurationExport: (ingestionCsv, _, context) => csvFeedMapperExport(context, context.user, ingestionCsv),
+    duplicateCsvMapper: (ingestionCsv, _, context) => csvFeedGetNewDuplicatedCsvMapper(context, context.user, ingestionCsv),
   },
   Mutation: {
     ingestionCsvTester: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -22,6 +22,7 @@ type IngestionCsv implements InternalObject & BasicObject {
     last_execution_date: DateTime
     markings: [String!]
     toConfigurationExport: String!
+    duplicateCsvMapper: CsvMapper!
 }
 
 enum IngestionCsvOrdering {

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -1,7 +1,14 @@
 import type { FileHandle } from 'fs/promises';
 import type { AuthContext, AuthUser } from '../../../types/user';
 import { internalFindByIdsMapped, listAllEntities, listEntitiesPaginated, storeLoadById } from '../../../database/middleware-loader';
-import { type BasicStoreEntityCsvMapper, type CsvMapperConfiguration, type CsvMapperRepresentation, ENTITY_TYPE_CSV_MAPPER, type StoreEntityCsvMapper } from './csvMapper-types';
+import {
+  type BasicStoreEntityCsvMapper,
+  type CsvMapperParsed,
+  type CsvMapperRepresentation,
+  type CsvMapperResolved,
+  ENTITY_TYPE_CSV_MAPPER,
+  type StoreEntityCsvMapper
+} from './csvMapper-types';
 import { type CsvMapperAddInput, type EditInput, FilterMode, type QueryCsvMappersArgs } from '../../../generated/graphql';
 import { createInternalObject, deleteInternalObject, editInternalObject } from '../../../domain/internalObject';
 import { type CsvBundlerTestOpts, getCsvTestObjects, removeHeaderFromFullFile } from '../../../parser/csv-bundler';
@@ -122,7 +129,7 @@ export const csvMapperExport = async (context: AuthContext, user: AuthUser, csvM
 
 const MINIMAL_COMPATIBLE_VERSION = '6.6.0';
 
-export const transformCsvMapperConfig = async (configuration: CsvMapperConfiguration, context: AuthContext, user: AuthUser) => {
+export const transformCsvMapperConfig = async (configuration: CsvMapperParsed, context: AuthContext, user: AuthUser): Promise<CsvMapperResolved> => {
   const { representations } = configuration;
   await convertRepresentationsIds(context, user, representations, 'stix');
   const csvMapper = {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-feed-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-feed-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { csvFeedGetCsvMapper } from '../../../src/modules/ingestion/ingestion-csv-domain';
 import type { BasicStoreEntityIngestionCsv } from '../../../src/modules/ingestion/ingestion-types';
-import type { AuthContext } from '../../../src/types/user';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
 import { IngestionCsvMapperType } from '../../../src/generated/graphql';
 
 // Mock the storeLoadById function
@@ -16,22 +16,28 @@ vi.mock('../../database/middleware-loader', async () => { // Adjust the path acc
 });
 
 describe('csvFeedGetCsvMapper', () => {
-  it('should return parsed CSV mapper when the type is inline', () => {
+  it('should return parsed CSV mapper when the type is inline', async () => {
     const ingestionCsv: BasicStoreEntityIngestionCsv = {
       id: 'test-id-inline',
       csv_mapper_type: IngestionCsvMapperType.Inline,
-      csv_mapper: '{"id":"1","openCTI_version":"6.6.6","type":"csvMapper"}',
+      csv_mapper: '{"id":"1","openCTI_version":"6.6.6","type":"csvMapper", "name": "Test", "has_header": true, "separator": ",", "skipLineChar": "", "representations": [] }',
       csv_mapper_id: 'some-id', // this won't be used
     } as unknown as BasicStoreEntityIngestionCsv;
 
-    const context: AuthContext = {} as unknown as AuthContext;
+    const context: AuthContext = { user: {} } as unknown as AuthContext;
+    const userContext: AuthUser = {} as unknown as AuthUser;
 
-    const result = csvFeedGetCsvMapper(context, ingestionCsv);
+    const result = await csvFeedGetCsvMapper(context, userContext, ingestionCsv);
 
     expect(result).toEqual({
       id: '1',
       type: 'csvMapper',
-      openCTI_version: '6.6.6'
+      openCTI_version: '6.6.6',
+      has_header: true,
+      name: 'Test',
+      representations: [],
+      separator: ',',
+      skipLineChar: ''
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/csv-mapper-test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import type { CsvMapperConfiguration } from '../../../src/modules/internal/csvMapper/csvMapper-types';
+import type { CsvMapperParsed } from '../../../src/modules/internal/csvMapper/csvMapper-types';
 import type { AuthContext, AuthUser } from '../../../src/types/user';
 import { transformCsvMapperConfig } from '../../../src/modules/internal/csvMapper/csvMapper-domain';
 
 describe('transformCsvMapperConfig', () => {
   it('should transform the CSV Mapper configuration successfully', async () => {
-    const configuration: CsvMapperConfiguration = {
+    const configuration: CsvMapperParsed = {
       id: 'debf1d1e-de97-4dd8-abb6-1b22e19468f6',
       name: 'Inline CSV Feed',
       has_header: false,
@@ -95,7 +95,7 @@ describe('transformCsvMapperConfig', () => {
         }
       ],
       skipLineChar: ''
-    } as unknown as CsvMapperConfiguration;
+    } as unknown as CsvMapperParsed;
 
     const context: AuthContext = {} as unknown as AuthContext; // Mock
     const user: AuthUser = {} as unknown as AuthUser; // Mock

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/ingestion-csv-test.ts
@@ -8,6 +8,8 @@ import { SYSTEM_USER } from '../../../src/utils/access';
 import pjson from '../../../package.json';
 import { IngestionAuthType, type IngestionCsvAddInput, IngestionCsvMapperType } from '../../../src/generated/graphql';
 import { findById as findUserById } from '../../../src/domain/user';
+import { regenerateCsvMapperUUID } from '../../../src/modules/ingestion/ingestion-converter';
+import type { CsvMapperResolved } from '../../../src/modules/internal/csvMapper/csvMapper-types';
 
 const DELETE_USER_QUERY = gql`
     mutation userDelete($id: ID!) {
@@ -42,6 +44,13 @@ describe('CSV ingestion resolver standard behavior', () => {
       skipLineChar: ''
     }
   };
+  const singleColumnCsvMapperForCsvFeedInline = JSON.stringify({
+    has_header: false,
+    name: 'Single column CSV mapper',
+    separator: ',',
+    representations: [{ id: '75c3c21c-0a92-497f-962d-4e6e1a488481', type: 'entity', target: { entity_type: 'IPv4-Addr' }, attributes: [{ key: 'value', column: { column_name: 'A' }, based_on: null }] }],
+    skipLineChar: ''
+  });
 
   beforeAll(async () => {
     const SINGLE_COLUMN_CSV_MAPPER = singleColumnCsvMapper;
@@ -105,7 +114,7 @@ describe('CSV ingestion resolver standard behavior', () => {
       authentication_type: IngestionAuthType.None,
       name: 'Single column inline and auto user',
       uri: 'https://lists.blocklist.de/lists/all.txt',
-      csv_mapper: JSON.stringify(singleColumnCsvMapper),
+      csv_mapper: singleColumnCsvMapperForCsvFeedInline,
       csv_mapper_type: IngestionCsvMapperType.Inline,
       automatic_user: true,
       user_id: '[F] Single column inline and auto user'
@@ -398,5 +407,276 @@ describe('CSV ingestion resolver standard behavior', () => {
     expect(queryResult.data?.csvFeedAddInputFromImport.csvMapper).toBeDefined();
     expect(queryResult.data?.csvFeedAddInputFromImport.csvMapper.name).toBe('Inline CSV Feed');
     expect(queryResult.data?.csvFeedAddInputFromImport.name).toBe('Test name');
+  });
+
+  it('should regenerate UUID of the CSVMapper', async () => {
+    const data: CsvMapperResolved = {
+      name: 'C2IntelFeeds',
+      has_header: true,
+      separator: ',',
+      skipLineChar: '',
+      representations: [
+        {
+          id: 'cd610730-daa2-4d97-ba12-e277b74569d3',
+          type: 'entity',
+          target: {
+            entity_type: 'IPv4-Addr',
+            column_based: null
+          },
+          attributes: [
+            {
+              key: 'value',
+              column: {
+                column_name: 'A',
+                configuration: null
+              },
+              based_on: null
+            },
+            {
+              key: 'x_opencti_description',
+              column: {
+                column_name: 'B',
+                configuration: null
+              },
+              based_on: null
+            }
+          ]
+        },
+        {
+          id: '90ab48b0-88ab-4165-b8e8-9232e6cfa566',
+          type: 'entity',
+          target: {
+            entity_type: 'Autonomous-System',
+            column_based: null
+          },
+          attributes: [
+            {
+              key: 'number',
+              column: {
+                column_name: 'C',
+                configuration: null
+              },
+              based_on: null
+            }
+          ]
+        },
+        {
+          id: '4c7165ef-12bd-48f0-aaf2-645d2186da0d',
+          type: 'entity',
+          target: {
+            entity_type: 'Kill-Chain-Phase',
+            column_based: null
+          },
+          attributes: [
+            {
+              key: 'kill_chain_name',
+              column: {
+                column_name: 'E',
+                configuration: null
+              },
+              based_on: null
+            },
+            {
+              key: 'phase_name',
+              column: {
+                column_name: 'E',
+                configuration: null
+              },
+              based_on: null
+            },
+            {
+              key: 'x_opencti_order',
+              column: {
+                column_name: 'I',
+                configuration: null
+              },
+              based_on: null
+            }
+          ]
+        },
+        {
+          id: '6cac2022-04bf-4b5a-b03f-0d2aa878609e',
+          type: 'entity',
+          target: {
+            entity_type: 'Report',
+            column_based: null
+          },
+          attributes: [
+            {
+              key: 'name',
+              column: {
+                column_name: 'D',
+                configuration: null
+              },
+              based_on: null
+            },
+            {
+              key: 'published',
+              column: {
+                column_name: 'E',
+                configuration: {
+                  pattern_date: 'DD.MM.YYYY',
+                  separator: null
+                }
+              },
+              default_values: [
+                {
+                  id: '2025-06-15T22:00:00.000Z',
+                  name: '2025-06-15T22:00:00.000Z'
+                }
+              ],
+              based_on: null
+            }
+          ]
+        },
+        {
+          id: 'e05fe3ac-1f15-49c2-bdb7-9062a6beb5aa',
+          type: 'relationship',
+          target: {
+            entity_type: 'belongs-to',
+            column_based: null
+          },
+          attributes: [
+            {
+              key: 'from',
+              column: null,
+              based_on: {
+                representations: [
+                  'cd610730-daa2-4d97-ba12-e277b74569d3'
+                ]
+              }
+            },
+            {
+              key: 'to',
+              column: null,
+              based_on: {
+                representations: [
+                  '90ab48b0-88ab-4165-b8e8-9232e6cfa566'
+                ]
+              }
+            },
+            {
+              key: 'killChainPhases',
+              column: {
+                column_name: null,
+                configuration: {
+                  pattern_date: null,
+                  separator: ','
+                }
+              },
+              based_on: {
+                representations: [
+                  '4c7165ef-12bd-48f0-aaf2-645d2186da0d'
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      id: '1f919f34-b610-40d6-b681-053cdb2fb026'
+    } as unknown as CsvMapperResolved;
+    const extractId = data.representations.map((r) => r.id);
+    const test = regenerateCsvMapperUUID(data);
+    // We verify that at least each id is different after regenerating UUID.
+    test.representations.forEach((r) => {
+      expect(extractId.includes(r.id)).toBeFalsy();
+      r.attributes.forEach((attr) => {
+        (attr?.based_on?.representations ?? []).forEach((rep) => {
+          expect(rep.includes(r.id)).toBeFalsy();
+        });
+      });
+    });
+  });
+
+  it('should duplicate with same CSV Mapper ID as we are link to an existing CSVMapper Id', async () => {
+    const CSV_FEED_INGESTER_TO_CREATE = {
+      input: {
+        authentication_type: 'none',
+        name: 'Single column',
+        uri: 'https://lists.blocklist.de/lists/all.txt',
+        csv_mapper_id: singleColumnCsvMapperId,
+        user_id: ADMIN_USER.id,
+        csv_mapper_type: 'id'
+      }
+    };
+    const createCsvFeedWithId = await queryAsAdmin({
+      query: gql`
+        mutation createSingleColumnCsvFeedsIngester($input: IngestionCsvAddInput!) {
+          ingestionCsvAdd(input: $input) {
+            id
+            entity_type
+            ingestion_running
+            csvMapper {
+              id
+            }
+          }
+        },
+      `,
+      variables: CSV_FEED_INGESTER_TO_CREATE
+    });
+    const csvFeedId = createCsvFeedWithId?.data?.ingestionCsvAdd?.id;
+    const csvMapperId = createCsvFeedWithId?.data?.ingestionCsvAdd?.csvMapper.id;
+
+    const getCsvFeedForDuplication = await queryAsAdmin({
+      query: gql`
+        query ingestionCsv($id: String!) {
+          ingestionCsv(id: $id) {
+            id
+            duplicateCsvMapper {
+              id
+            }
+          }
+        },
+      `,
+      variables: {
+        id: csvFeedId
+      }
+    });
+    expect(getCsvFeedForDuplication?.data?.ingestionCsv.duplicateCsvMapper.id).toEqual(csvMapperId);
+  });
+
+  it('should duplicate with different CSVMapperId as we inline CSVMapper', async () => {
+    const input : IngestionCsvAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'Single column inline and auto user',
+      uri: 'https://lists.blocklist.de/lists/all.txt',
+      csv_mapper: singleColumnCsvMapperForCsvFeedInline,
+      csv_mapper_type: IngestionCsvMapperType.Inline,
+      user_id: ADMIN_USER.id
+    };
+    const createCsvFeed = await queryAsAdmin({
+      query: gql`
+        mutation createSingleColumnCsvFeedsIngester($input: IngestionCsvAddInput!) {
+          ingestionCsvAdd(input: $input) {
+            id
+            entity_type
+            ingestion_running
+            csvMapper {
+              id
+            }
+          }
+        },
+      `,
+      variables: { input }
+    });
+    const csvFeedId = createCsvFeed?.data?.ingestionCsvAdd?.id;
+    const csvMapperId = createCsvFeed?.data?.ingestionCsvAdd?.csvMapper.id;
+
+    const getCsvFeedForDuplication = await queryAsAdmin({
+      query: gql`
+        query ingestionCsv($id: String!) {
+          ingestionCsv(id: $id) {
+            id
+            duplicateCsvMapper {
+              id
+            }
+          }
+        },
+      `,
+      variables: {
+        id: csvFeedId
+      }
+    });
+    expect(csvMapperId).not.toEqual(getCsvFeedForDuplication?.data?.ingestionCsv.duplicateCsvMapper.id);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix edition form when change csv_mapper id to inline and vice-versa
* Fix issue on wrong save config for CsvMapper inline
* Fix broken export on CsvMapper with default value (wrong configuration saved)
* Generate new UUID for entity in CSVMapper for duplicate and import

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10350 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
