### PR TITLE
[frontend] fix redirection after export for task, note, observed data (#11025)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -51,6 +51,7 @@ const TaskQuery = graphql`
       standard_id
       name
       x_opencti_graph_data
+      entity_type
       ...Tasks_tasks
       ...FileImportViewer_entity
       ...FileExportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -464,7 +464,8 @@ const ContainerHeader = (props) => {
     const fileParams = { currentFileId: fileName, contentSelected: false };
     const urlParams = new URLSearchParams(fileParams).toString();
     const entityLink = `${resolveLink(container.entity_type)}/${container.id}`;
-    navigate(`${entityLink}/content?${urlParams}`);
+    const targetTab = redirectToContent ? 'content' : 'files';
+    navigate(`${entityLink}/${targetTab}?${urlParams}`);
   };
 
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();


### PR DESCRIPTION
### Proposed changes

* get entity-type for tasks to resolve redirection url
* use the boolean `redirectToContent` to redirect to content or file (fix for note and observedData)

### Related issues

* #11025 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality