### PR TITLE
[backend] fix test for user on the fly creation #11047

### DIFF
--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -50,7 +50,7 @@ describe('Raw streams tests', () => {
       // 328 created at init + 1 request access + 2 created in tests + 5 vocabulary organizations types + 7 persona
       expect(createEventsByTypes.vocabulary.length).toBe(VOCABULARY_NUMBERS);
       expect(createEventsByTypes.vulnerability.length).toBe(7);
-      expect(createEvents.length).toBe(832);
+      expect(createEvents.length).toBe(833);
       for (let createIndex = 0; createIndex < createEvents.length; createIndex += 1) {
         const { data: insideData, origin, type } = createEvents[createIndex];
         expect(origin).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -23,7 +23,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const RAW_EVENTS_SIZE = 1207;
+export const RAW_EVENTS_SIZE = 1208;
 export const SYNC_LIVE_EVENTS_SIZE = 624;
 
 export const PYTHON_PATH = './src/python/testing';


### PR DESCRIPTION
### Proposed changes

* Add tests in backend when a user already exists
*

### Related issues

* https://github.com/OpenCTI-Platform/opencti/pull/11370
* #11047 

### Checklist

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

