### PR TITLE
[frontend] fix mode only with subtechniques (#4948)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixColumns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixColumns.tsx
@@ -218,7 +218,7 @@ const AttackPatternsMatrixColumns = ({
           isOverlapping: attackPatternIdsToOverlap?.includes(ap.attack_pattern_id),
           subAttackPatternsTotal: ap.subAttackPatterns?.length,
         }))
-        .filter((o) => (isModeOnlyActive ? o.isCovered : true))
+        .filter((ap) => (isModeOnlyActive ? ap.isCovered || isSubAttackPatternCovered(ap) : true))
         .sort((f, s) => f.name.localeCompare(s.name)),
     })), [attackPatternsMatrix, searchTerm, attackPatterns, attackPatternIdsToOverlap, isModeOnlyActive]);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* when a subtechnique is selected the parent doesn't appear in mode only 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/4948

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
