### PR TITLE
[frontend] No label filter should be displayed as 'label is empty' (#11378)

### DIFF
--- a/opencti-platform/opencti-front/src/components/fields/EntitySelectWithTypes.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/EntitySelectWithTypes.tsx
@@ -35,7 +35,7 @@ const EntitySelectWithTypes: FunctionComponent<EntitySelectWithTypesProps> = ({
   });
 
   const options = getOptionsFromEntities(entities, searchScope, 'id')
-    .filter((option) => !entitiesToExclude.includes(option.value));
+    .filter((option) => option.value === null || !entitiesToExclude.includes(option.value));
 
   return (
     <Autocomplete

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -8,7 +8,7 @@ import { Autocomplete, MenuItem, Select } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
 import SearchScopeElement from '@components/common/lists/SearchScopeElement';
 import Chip from '@mui/material/Chip';
-import { OptionValue } from '@components/common/lists/FilterAutocomplete';
+import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
 import { addDays, subDays } from 'date-fns';
 import { useTheme } from '@mui/material/styles';
 import {
@@ -108,7 +108,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     values: string[];
     operator?: string;
   }[]>(filter ? [filter] : []);
-  const [cacheEntities, setCacheEntities] = useState<Record<string, OptionValue[]>>({});
+  const [cacheEntities, setCacheEntities] = useState<Record<string, FilterOptionValue[]>>({});
   const [searchScope, setSearchScope] = useState<Record<string, string[]>>(
     availableRelationFilterTypes || {
       targets: [
@@ -132,15 +132,15 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     setInputValues,
     searchContext: { ...searchContext, entityTypes: [...(searchContext?.entityTypes ?? []), ...(entityTypes ?? [])] },
     searchScope,
-  }) as [Record<string, OptionValue[]>, (
+  }) as [Record<string, FilterOptionValue[]>, (
     filterKey: string,
-    cacheEntities: Record<string, OptionValue[]>,
-    setCacheEntities: Dispatch<Record<string, OptionValue[]>>,
+    cacheEntities: Record<string, FilterOptionValue[]>,
+    setCacheEntities: Dispatch<Record<string, FilterOptionValue[]>>,
     event: SyntheticEvent,
     isSubKey?: boolean,
-  ) => Record<string, OptionValue[]>,
+  ) => Record<string, FilterOptionValue[]>,
   ];
-  const handleChange = (checked: boolean, value: string, childKey?: string) => {
+  const handleChange = (checked: boolean, value: string | null, childKey?: string) => {
     if (childKey) {
       const childFilters = filter?.values.filter((val) => val.key === childKey) as Filter[];
       const childFilter = childFilters && childFilters.length > 0 ? childFilters[0] : undefined;
@@ -250,11 +250,11 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
       : getEntitiesOptions;
 
     const entitiesOptions = getOptions.filter((option) => !optionsValues.includes(option.value));
-    const selectedOptions: OptionValue[] = getSelectedOptions(getOptions, optionsValues, filtersRepresentativesMap, t_i18n);
+    const selectedOptions: FilterOptionValue[] = getSelectedOptions(getOptions, optionsValues, filtersRepresentativesMap, t_i18n);
 
     const options = [...selectedOptions, ...entitiesOptions];
 
-    const groupByEntities = (option: OptionValue, label?: string) => {
+    const groupByEntities = (option: FilterOptionValue, label?: string) => {
       return t_i18n(option?.group ? option?.group : label);
     };
     return (

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
@@ -36,7 +36,7 @@ interface ContentKnowledgeTimeLineBarProps {
   timeLineFunctionalDate: boolean;
   handleToggleTimeLineFunctionalDate: () => void;
   timeLineFilters: FilterGroup;
-  handleAddTimeLineFilter: (filterKeysSchema: Map<string, Map<string, FilterDefinition>>, key: string, id: string, op?: string, event?: SyntheticEvent) => void;
+  handleAddTimeLineFilter: (filterKeysSchema: Map<string, Map<string, FilterDefinition>>, key: string, id: string | null, op?: string, event?: SyntheticEvent) => void;
   handleRemoveTimeLineFilter: (key: string, id?: string) => void;
   handleSwitchFilterLocalMode: (filter: Filter) => void;
   handleSwitchFilterGlobalMode: () => void;
@@ -71,7 +71,7 @@ const ContentKnowledgeTimeLineBar: FunctionComponent<ContentKnowledgeTimeLineBar
       sub.unsubscribe();
     };
   });
-  const handleAddFilter = (key: string, id: string, op = 'eq', event?: SyntheticEvent) => {
+  const handleAddFilter = (key: string, id: string | null, op = 'eq', event?: SyntheticEvent) => {
     handleAddTimeLineFilter(filterKeysSchema, key, id, op, event);
   };
   return (

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -8,7 +8,6 @@ import useSearchEntities from '../../../../utils/filters/useSearchEntities';
 import type { Theme } from '../../../../components/Theme';
 import SearchScopeElement from './SearchScopeElement';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
-import { FieldOption } from '../../../../utils/field';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -25,7 +24,16 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-export interface OptionValue extends FieldOption {
+export interface FilterOption {
+  id?: string;
+  value: string | null;
+  label: string;
+  color?: string;
+  type?: string;
+  standard_id?: string;
+}
+
+export interface FilterOptionValue extends FilterOption {
   type: string;
   parentTypes?: string[];
   group?: string;

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -1,28 +1,13 @@
 import React, { Dispatch, FunctionComponent, SyntheticEvent, useState } from 'react';
 import TextField from '@mui/material/TextField';
 import MUIAutocomplete from '@mui/material/Autocomplete';
-import makeStyles from '@mui/styles/makeStyles';
 import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import useSearchEntities from '../../../../utils/filters/useSearchEntities';
 import type { Theme } from '../../../../components/Theme';
 import SearchScopeElement from './SearchScopeElement';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  icon: {
-    paddingTop: 4,
-    display: 'inline-block',
-    color: theme.palette.primary.main,
-  },
-  text: {
-    display: 'inline-block',
-    flexGrow: 1,
-    marginLeft: 10,
-  },
-}));
+import { useTheme } from '@mui/styles';
 
 export interface FilterOption {
   id?: string;
@@ -74,7 +59,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
     disabled,
   } = props;
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme<Theme>();
   const [searchScope, setSearchScope] = useState<Record<string, string[]>>(
     availableRelationFilterTypes || {
       targets: [
@@ -207,10 +192,18 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
       )}
       renderOption={(propsOption, option) => (
         <li {...propsOption}>
-          <div className={classes.icon}>
+          <div style={{
+            paddingTop: 4,
+            display: 'inline-block',
+            color: theme.palette.primary.main,
+          }}>
             <ItemIcon type={option.type} color={option.color}/>
           </div>
-          <div className={classes.text}>{option.label}</div>
+          <div style={{
+            display: 'inline-block',
+            flexGrow: 1,
+            marginLeft: 10,
+          }}>{option.label}</div>
         </li>
       )}
     />

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -1,13 +1,13 @@
 import React, { Dispatch, FunctionComponent, SyntheticEvent, useState } from 'react';
 import TextField from '@mui/material/TextField';
 import MUIAutocomplete from '@mui/material/Autocomplete';
+import { useTheme } from '@mui/styles';
 import ItemIcon from '../../../../components/ItemIcon';
 import { useFormatter } from '../../../../components/i18n';
 import useSearchEntities from '../../../../utils/filters/useSearchEntities';
 import type { Theme } from '../../../../components/Theme';
 import SearchScopeElement from './SearchScopeElement';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
-import { useTheme } from '@mui/styles';
 
 export interface FilterOption {
   id?: string;
@@ -196,14 +196,16 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
             paddingTop: 4,
             display: 'inline-block',
             color: theme.palette.primary.main,
-          }}>
+          }}
+          >
             <ItemIcon type={option.type} color={option.color}/>
           </div>
           <div style={{
             display: 'inline-block',
             flexGrow: 1,
             marginLeft: 10,
-          }}>{option.label}</div>
+          }}
+          >{option.label}</div>
         </li>
       )}
     />

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterAutocomplete.tsx
@@ -94,7 +94,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
     availableEntityTypes,
     availableRelationshipTypes,
   }) as [
-    Record<string, OptionValue[]>,
+    Record<string, FilterOptionValue[]>,
     (
       filterKey: string,
       cacheEntities: Record<
@@ -105,7 +105,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
       Record<string, { label: string; value: string; type: string }[]>
       >,
       event: SyntheticEvent,
-    ) => Record<string, OptionValue[]>,
+    ) => Record<string, FilterOptionValue[]>,
   ]; // change when useSearchEntities will be in TS
   const isStixObjectTypes = [
     'fromId',
@@ -115,7 +115,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
     'indicates',
     'contextEntityId',
   ].includes(filterKey);
-  const handleChange = (event: SyntheticEvent, value: OptionValue | null) => {
+  const handleChange = (event: SyntheticEvent, value: FilterOptionValue | null) => {
     if (value) {
       if (
         (event as unknown as MouseEvent).altKey
@@ -145,7 +145,7 @@ const FilterAutocomplete: FunctionComponent<FilterAutocompleteProps> = (props) =
       availableRelationFilterTypes={availableRelationFilterTypes}
     />
   );
-  let options: OptionValue[] = [];
+  let options: FilterOptionValue[] = [];
   if (isStixObjectTypes) {
     if (searchScope[filterKey] && searchScope[filterKey].length > 0) {
       options = (entities[filterKey] || [])

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
@@ -11,10 +11,9 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import { graphql } from 'react-relay';
 import { useNavigate } from 'react-router-dom';
-import {
-  WorkspaceTurnToContainerDialogMutation
-} from '@components/workspaces/__generated__/WorkspaceTurnToContainerDialogMutation.graphql';
+import { WorkspaceTurnToContainerDialogMutation } from '@components/workspaces/__generated__/WorkspaceTurnToContainerDialogMutation.graphql';
 import type { FilterOption } from '@components/common/lists/FilterAutocomplete';
+import { useTheme } from '@mui/styles';
 import Transition from '../../../components/Transition';
 import { useFormatter } from '../../../components/i18n';
 import ItemIcon from '../../../components/ItemIcon';
@@ -22,8 +21,7 @@ import { resolveLink } from '../../../utils/Entity';
 import { handleError } from '../../../relay/environment';
 import useSearchEntities, { EntityValue } from '../../../utils/filters/useSearchEntities';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
-import { useTheme } from '@mui/styles';
-import { Theme } from '../../../components/Theme';
+import type { Theme } from '../../../components/Theme';
 
 interface WorkspaceTurnToContainerDialogProps {
   workspace: { id: string | null };
@@ -217,13 +215,15 @@ const WorkspaceTurnToContainerDialog: FunctionComponent<WorkspaceTurnToContainer
                 display: 'inline-block',
                 paddingTop: 4,
                 marginRight: theme.spacing(1),
-              }}>
+              }}
+              >
                 <ItemIcon type={option.type} />
               </div>
               <div style={{
                 display: 'inline-block',
                 flexGrow: 1,
-              }}>{option.label}</div>
+              }}
+              >{option.label}</div>
             </li>
           )}
           disableClearable

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
@@ -12,7 +12,9 @@ import Dialog from '@mui/material/Dialog';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql } from 'react-relay';
 import { useNavigate } from 'react-router-dom';
-import { WorkspaceTurnToContainerDialogMutation } from '@components/workspaces/__generated__/WorkspaceTurnToContainerDialogMutation.graphql';
+import {
+  WorkspaceTurnToContainerDialogMutation
+} from '@components/workspaces/__generated__/WorkspaceTurnToContainerDialogMutation.graphql';
 import Transition from '../../../components/Transition';
 import { useFormatter } from '../../../components/i18n';
 import ItemIcon from '../../../components/ItemIcon';
@@ -21,7 +23,7 @@ import { handleError } from '../../../relay/environment';
 import type { Theme } from '../../../components/Theme';
 import useSearchEntities, { EntityValue } from '../../../utils/filters/useSearchEntities';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
-import { FieldOption } from '../../../utils/field';
+import type { FilterOption } from '@components/common/lists/FilterAutocomplete';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -48,7 +50,7 @@ interface ActionInputs {
   fieldType?: string;
   field?: string;
   inputValue?: string;
-  value?: FieldOption;
+  value?: FilterOption;
 }
 
 interface StixContainer {

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
@@ -9,35 +9,21 @@ import { AddOutlined } from '@mui/icons-material';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
-import makeStyles from '@mui/styles/makeStyles';
 import { graphql } from 'react-relay';
 import { useNavigate } from 'react-router-dom';
 import {
   WorkspaceTurnToContainerDialogMutation
 } from '@components/workspaces/__generated__/WorkspaceTurnToContainerDialogMutation.graphql';
+import type { FilterOption } from '@components/common/lists/FilterAutocomplete';
 import Transition from '../../../components/Transition';
 import { useFormatter } from '../../../components/i18n';
 import ItemIcon from '../../../components/ItemIcon';
 import { resolveLink } from '../../../utils/Entity';
 import { handleError } from '../../../relay/environment';
-import type { Theme } from '../../../components/Theme';
 import useSearchEntities, { EntityValue } from '../../../utils/filters/useSearchEntities';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
-import type { FilterOption } from '@components/common/lists/FilterAutocomplete';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  icon: {
-    display: 'inline-block',
-    paddingTop: 4,
-    marginRight: theme.spacing(1),
-  },
-  text: {
-    display: 'inline-block',
-    flexGrow: 1,
-  },
-}));
+import { useTheme } from '@mui/styles';
+import { Theme } from '../../../components/Theme';
 
 interface WorkspaceTurnToContainerDialogProps {
   workspace: { id: string | null };
@@ -74,8 +60,8 @@ const investigationToContainerMutation = graphql`
 `;
 
 const WorkspaceTurnToContainerDialog: FunctionComponent<WorkspaceTurnToContainerDialogProps> = ({ workspace, open, handleClose }) => {
-  const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const [containerCreation, setContainerCreation] = useState(false);
   const [actionsInputs, setActionsInputs] = useState<ActionInputs | null>(null);
   const [targetContainerId, setTargetContainerId] = useState('');
@@ -227,10 +213,17 @@ const WorkspaceTurnToContainerDialog: FunctionComponent<WorkspaceTurnToContainer
           onChange={(event, value) => handleChangeActionInputValues(event, value as EntityValue[])}
           renderOption={(props, option) => (
             <li {...props}>
-              <div className={classes.icon}>
+              <div style={{
+                display: 'inline-block',
+                paddingTop: 4,
+                marginRight: theme.spacing(1),
+              }}>
                 <ItemIcon type={option.type} />
               </div>
-              <div className={classes.text}>{option.label}</div>
+              <div style={{
+                display: 'inline-block',
+                flexGrow: 1,
+              }}>{option.label}</div>
             </li>
           )}
           disableClearable

--- a/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/SearchEntitiesUtil.ts
@@ -1,13 +1,13 @@
-import { OptionValue } from '@components/common/lists/FilterAutocomplete';
+import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
 import { isStixObjectTypes, ME_FILTER_VALUE } from './filtersUtils';
 
 // eslint-disable-next-line import/prefer-default-export
 export const getOptionsFromEntities = (
-  entities: Record<string, OptionValue[]>,
+  entities: Record<string, FilterOptionValue[]>,
   searchScope: Record<string, string[]>,
   filterKey: string,
-): OptionValue[] => {
-  let filteredOptions: OptionValue[] = [];
+): FilterOptionValue[] => {
+  let filteredOptions: FilterOptionValue[] = [];
   if (isStixObjectTypes.includes(filterKey)) {
     if (searchScope[filterKey] && searchScope[filterKey].length > 0) {
       filteredOptions = (entities[filterKey] || [])

--- a/opencti-platform/opencti-front/src/utils/filters/filtersHelpers-types.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersHelpers-types.ts
@@ -25,11 +25,11 @@ export type HandleOperatorFilter = (
 export interface handleFilterHelpers {
   handleSwitchGlobalMode: () => void;
   handleSwitchLocalMode: (filter: Filter) => void;
-  handleRemoveRepresentationFilter: (id: string, valueId: string | Filter | undefined) => void;
+  handleRemoveRepresentationFilter: (id: string, valueId: string | Filter | undefined | null) => void;
   handleRemoveFilterById: (id: string) => void;
   handleChangeOperatorFilters: HandleOperatorFilter;
   handleAddSingleValueFilter: (id: string, valueId?: string) => void;
-  handleAddRepresentationFilter: (id: string, valueId: string) => void;
+  handleAddRepresentationFilter: (id: string, valueId: string | null) => void;
   handleAddFilterWithEmptyValue: (filter: Filter) => void;
   handleClearAllFilters: (filters?: Filter[]) => void;
   getLatestAddFilterId: () => string | undefined;

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { v4 as uuid } from 'uuid';
-import { OptionValue } from '@components/common/lists/FilterAutocomplete';
+import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
 import React from 'react';
 import { subDays } from 'date-fns';
 import { useFormatter } from '../../components/i18n';
@@ -910,16 +910,16 @@ export const isStixObjectTypes = [
 ];
 
 export const getSelectedOptions = (
-  entitiesOptions: OptionValue[],
+  entitiesOptions: FilterOptionValue[],
   filterValues: string[],
   filtersRepresentativesMap: Map<string,
   FilterRepresentative>,
   t_i18n: (s: string) => string,
-): OptionValue[] => {
+): FilterOptionValue[] => {
   // we try to get first the element from the search
   // and if we did not find we tried one from filterRepresentative
   // Most of the time element from search should be sufficient
-  const mapFilterValues: OptionValue[] = [];
+  const mapFilterValues: FilterOptionValue[] = [];
   filterValues.forEach((value: string) => {
     const mapRepresentative = entitiesOptions.find((f) => f.value === value);
     if (mapRepresentative) {

--- a/opencti-platform/opencti-front/src/utils/filters/useFiltersState.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useFiltersState.tsx
@@ -33,7 +33,7 @@ const useFiltersState = (initFilters: FilterGroup | null = emptyFilterGroup, def
         latestAddFilterId: filter.id,
       }));
     },
-    handleAddRepresentationFilter: (id: string, value: string) => {
+    handleAddRepresentationFilter: (id: string, value: string | null) => {
       if (value === null) { // handle clicking on 'no label' in entities list
         const findCorrespondingFilter = filtersState.filters?.filters.find((f) => id === f.id);
         if (findCorrespondingFilter && ['objectLabel'].includes(findCorrespondingFilter.key)) {
@@ -88,7 +88,7 @@ const useFiltersState = (initFilters: FilterGroup | null = emptyFilterGroup, def
         latestAddFilterId: undefined,
       }));
     },
-    handleRemoveRepresentationFilter: (id: string, value: string | Filter | undefined) => {
+    handleRemoveRepresentationFilter: (id: string, value: string | Filter | undefined | null) => {
       setFiltersState((prevState) => ({
         ...prevState,
         filters: handleRemoveRepresentationFilterUtil({ filters: prevState.filters, id, value }),

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -26,7 +26,7 @@ import { killChainPhasesSearchQuery } from '@components/settings/KillChainPhases
 import { KillChainPhasesSearchQuery$data } from '@components/settings/__generated__/KillChainPhasesSearchQuery.graphql';
 import { triggersQueriesSearchQuery } from '@components/profile/triggers/TriggersQueries';
 import { TriggersQueriesSearchQuery$data } from '@components/profile/triggers/__generated__/TriggersQueriesSearchQuery.graphql';
-import { OptionValue } from '@components/common/lists/FilterAutocomplete';
+import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
 import { usersLinesSearchQuery } from '@components/settings/users/UsersLines';
 import { UsersLinesSearchQuery$data } from '@components/settings/users/__generated__/UsersLinesSearchQuery.graphql';
 import useAuth, { FilterDefinition } from '../hooks/useAuth';
@@ -247,7 +247,7 @@ const workspacesQuery = graphql`
   }
 `;
 
-export type EntityValue = OptionValue;
+export type EntityValue = FilterOptionValue;
 
 const useSearchEntities = ({
   availableEntityTypes,
@@ -291,8 +291,8 @@ const useSearchEntities = ({
 
   const searchEntities = (
     filterKey: string,
-    cacheEntities: Record< string, { label: string; value: string; type: string }[] >,
-    setCacheEntities: Dispatch< Record<string, { label: string; value: string; type: string }[]> >,
+    cacheEntities: Record< string, { label: string; value: string | null; type: string }[] >,
+    setCacheEntities: Dispatch< Record<string, { label: string; value: string | null; type: string }[]> >,
     event: BaseSyntheticEvent,
     isSubKey?: boolean,
   ) => {
@@ -352,7 +352,7 @@ const useSearchEntities = ({
           unionSetEntities(key, [
             {
               label: t_i18n('No label'),
-              value: '',
+              value: null,
               type: 'Label',
               color: theme.palette.mode === 'dark' ? '#ffffff' : '#000000',
             },

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -82,7 +82,7 @@ const localStorageToPaginationOptions = (
 
 export type HandleAddFilter = (
   k: string,
-  id: string,
+  id: string | null,
   op?: string,
   event?: SyntheticEvent
 ) => void;
@@ -408,7 +408,7 @@ export const usePaginationLocalStorage = <U>(
     },
     handleAddFilter: (
       k: string,
-      id: string,
+      id: string | null,
       defaultOp = 'eq',
       event?: SyntheticEvent,
     ) => {
@@ -583,7 +583,7 @@ export const usePaginationLocalStorage = <U>(
     },
     handleSwitchFilter: (
       k: string,
-      id: string,
+      id: string | null,
       op = 'eq',
       event?: SyntheticEvent,
     ) => {


### PR DESCRIPTION
### Proposed changes
In entities list, when a user add a filter via 'label = No label', the filter added should be 'label is empty' (instead of label = deleted)

Same logic when the user add a filter via 'label != No label', the filter added should be 'label is not empty'.

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11378