### PR TITLE
[frontend] Relationship icon direction updated in Observable Knowledge tab (#11227)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -107,6 +107,7 @@ class StixCyberObservableEntitiesLinesComponent extends Component {
             } else {
               targetEntityType = targetEntity.entity_type;
             }
+            const isReversed = node.from.id === stixCyberObservableId;
             // eslint-disable-next-line no-nested-ternary
             const link = !restricted
               ? targetEntity.parent_types.includes('stix-core-relationship')
@@ -146,7 +147,7 @@ class StixCyberObservableEntitiesLinesComponent extends Component {
                   disabled={restricted}
                 >
                   <ListItemIcon classes={{ root: classes.itemIcon }}>
-                    <ItemIcon type={node.entity_type} />
+                    <ItemIcon type={node.entity_type} isReversed={isReversed} />
                   </ListItemIcon>
                   <ListItemText
                     primary={

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -107,7 +107,7 @@ class StixCyberObservableEntitiesLinesComponent extends Component {
             } else {
               targetEntityType = targetEntity.entity_type;
             }
-            const isReversed = node.from.id === stixCyberObservableId;
+            const isReversed = node.from && node.from.id === stixCyberObservableId;
             // eslint-disable-next-line no-nested-ternary
             const link = !restricted
               ? targetEntity.parent_types.includes('stix-core-relationship')


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* isReversed param added on Item icon on observable knowledge tab

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11227 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
