### PR TITLE
[backend] fix pagination if no entities in investigation (#11421)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
@@ -110,7 +110,7 @@ export const objects = async (
   args: WorkspaceObjectsArgs,
 ) => {
   if (isEmptyField(investigated_entities_ids)) {
-    return buildPagination(0, null, [], 0);
+    return buildPagination(1, null, [], 0);
   }
   const filters = addFilter(
     args.filters,


### PR DESCRIPTION
### Proposed changes

* The function buildPagination was called with wrong arguments because when limit (here 0) is equal to the length of entities (here [] so 0) then hasNextPage is true, so in case of empty investigation the backend always returned that a next page exists.

### Related issues

* #11421

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality