### PR TITLE
[backend/frontend] Improve SSO error UI feedback when local strategy is disabled (#11353)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/Login.tsx
+++ b/opencti-platform/opencti-front/src/public/components/Login.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
+import { useCookies } from 'react-cookie';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/styles';
 import { Facebook, Github, Google, KeyOutline } from 'mdi-material-ui';
@@ -122,6 +123,7 @@ interface LoginProps {
   settings: LoginRootPublicQuery$data['settings'];
 }
 
+const FLASH_COOKIE = 'opencti_flash';
 const Login: FunctionComponent<LoginProps> = ({ type, settings }) => {
   const classes = useStyles();
   const theme = useTheme<Theme>();
@@ -130,6 +132,9 @@ const Login: FunctionComponent<LoginProps> = ({ type, settings }) => {
   const isEnterpriseEdition = settings.platform_enterprise_edition.license_validated;
   const [resetPassword, setResetPassword] = useState(false);
   const [email, setEmail] = useState('');
+  const [cookies, , removeCookie] = useCookies([FLASH_COOKIE]);
+  const flashError = cookies[FLASH_COOKIE] || '';
+  removeCookie(FLASH_COOKIE);
 
   const renderExternalAuthButton = (provider?: string | null) => {
     switch (provider) {
@@ -260,6 +265,21 @@ const Login: FunctionComponent<LoginProps> = ({ type, settings }) => {
           <Alert severity="warning">
             <AlertTitle style={{ textAlign: 'left' }}>Warning</AlertTitle>
             You were automatically logged out due to session expiration.
+          </Alert>
+        </Paper>
+      )}
+      {flashError && (
+        <Paper
+          classes={{ root: classes.paper }}
+          style={{
+            backgroundImage: 'none',
+            backgroundColor: 'transparent',
+            boxShadow: 'none',
+          }}
+        >
+          <Alert severity="error">
+            <AlertTitle style={{ textAlign: 'left' }}>Error</AlertTitle>
+            {flashError}
           </Alert>
         </Paper>
       )}

--- a/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
@@ -5,7 +5,6 @@ import Button from '@mui/material/Button';
 import { graphql } from 'react-relay';
 import * as R from 'ramda';
 import * as Yup from 'yup';
-import { useCookies } from 'react-cookie';
 import { FormikConfig } from 'formik/dist/types';
 import { RelayResponsePayload } from 'relay-runtime/lib/store/RelayStoreTypes';
 import { useTheme } from '@mui/styles';
@@ -39,13 +38,9 @@ interface LoginFormProps {
   setEmail: (value: string) => void;
 }
 
-const FLASH_COOKIE = 'opencti_flash';
 const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword, email, setEmail }) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
-  const [cookies, , removeCookie] = useCookies([FLASH_COOKIE]);
-  const flashError = cookies[FLASH_COOKIE] || '';
-  removeCookie(FLASH_COOKIE);
   const [commitLoginMutation] = useApiMutation(loginMutation);
   const onSubmit: FormikConfig<LoginFormValues>['onSubmit'] = (
     values,
@@ -77,8 +72,6 @@ const LoginForm: FunctionComponent<LoginFormProps> = ({ onClickForgotPassword, e
     <>
       <Formik
         initialValues={initialValues}
-        initialTouched={{ email: !R.isEmpty(flashError) }}
-        initialErrors={{ email: !R.isEmpty(flashError) ? t_i18n(flashError) : '' }}
         validationSchema={loginValidation(t_i18n)}
         onSubmit={onSubmit}
       >

--- a/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
+++ b/opencti-platform/opencti-front/src/public/components/LoginForm.tsx
@@ -3,7 +3,6 @@ import { Field, Form, Formik } from 'formik';
 import { TextField } from 'formik-mui';
 import Button from '@mui/material/Button';
 import { graphql } from 'react-relay';
-import * as R from 'ramda';
 import * as Yup from 'yup';
 import { FormikConfig } from 'formik/dist/types';
 import { RelayResponsePayload } from 'relay-runtime/lib/store/RelayStoreTypes';

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -33,7 +33,7 @@ import { createAuthenticatedContext } from './httpAuthenticatedContext';
 
 const setCookieError = (res, message) => {
   res.cookie('opencti_flash', message || 'Unknown error', {
-    maxAge: 5000,
+    maxAge: 10000,
     httpOnly: false,
     secure: booleanConf('app:https_cert:cookie_secure', false),
     sameSite: 'strict',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
The cookie error is shown with the `LoginForm`, which is only shown if at least one strategy with a form is enabled. In some configurations (such as those that only use OIDC, including demo.opencti.io), this is not the case, and errors will never be shown.

Also, it seems like sometimes the cookie was expiring before the page could fully load, even on localhost, so I bumped the expiry up to 10 seconds
*
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11353
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
