### PR TITLE
[frontend] Remove view icons from graph exported image (#10047)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -69,8 +69,11 @@ class ExportButtons extends Component {
     }
     setTimeout(() => {
       const container = document.getElementById(domElementId);
-      const buttons = document.getElementById('export-buttons');
-      buttons.setAttribute('style', 'display: none');
+      const exportButtons = document.getElementById('export-buttons');
+      const viewButtons = document.getElementById('container-view-buttons');
+      exportButtons.setAttribute('style', 'display: none');
+      viewButtons.setAttribute('style', 'display: none');
+
       const { offsetWidth, offsetHeight } = container;
       if (theme === currentTheme.palette.mode && this.adjust) {
         container.setAttribute('style', 'width:3840px; height:2160px');
@@ -93,7 +96,7 @@ class ExportButtons extends Component {
         ).then(() => {})
           .catch(() => MESSAGING$.notifyError(t('Dashboard cannot be exported to image')))
           .finally(() => {
-            buttons.setAttribute('style', 'display: block');
+            exportButtons.setAttribute('style', 'display: block');
             commitLocalUpdate((store) => {
               const me = store.getRoot().getLinkedRecord('me');
               me.setValue(false, 'exporting');

--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -97,6 +97,7 @@ class ExportButtons extends Component {
           .catch(() => MESSAGING$.notifyError(t('Dashboard cannot be exported to image')))
           .finally(() => {
             exportButtons.setAttribute('style', 'display: block');
+            viewButtons.setAttribute('style', 'display: block, marginLeft: theme.spacing(2)');
             commitLocalUpdate((store) => {
               const me = store.getRoot().getLinkedRecord('me');
               me.setValue(false, 'exporting');

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -585,7 +585,7 @@ const ContainerHeader = (props) => {
           </div>
         )}
         {modes && (
-          <div style={{ marginLeft: theme.spacing(2) }}>
+          <div style={{ marginLeft: theme.spacing(2) }} id="container-view-buttons">
             <ToggleButtonGroup size="small" exclusive={true}>
               {modes.includes('graph') && (
                 <Tooltip title={t_i18n('Graph view')}>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -585,8 +585,8 @@ const ContainerHeader = (props) => {
           </div>
         )}
         {modes && (
-          <div style={{ marginLeft: theme.spacing(2) }} id="container-view-buttons">
-            <ToggleButtonGroup size="small" exclusive={true}>
+          <div id="container-view-buttons">
+            <ToggleButtonGroup size="small" exclusive={true} style={{ marginLeft: theme.spacing(2) }}>
               {modes.includes('graph') && (
                 <Tooltip title={t_i18n('Graph view')}>
                   <ToggleButton


### PR DESCRIPTION
### Proposed changes
View buttons should not appear in export of container graph images in png

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10047