### PR TITLE
[ci] Add sleep 10 for e2e start too (#11507)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -432,6 +432,7 @@ services:
       SUBSCRIPTION_SCHEDULER__ENABLED: false
       PUBLISHER_MANAGER__ENABLED: false
     commands:
+      - sleep 10
       - apk add build-base git libffi-dev cargo
       - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/e2e-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

To avoid that
![image](https://github.com/user-attachments/assets/a3bf406c-362e-4b22-a414-ad8d9739bf62)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* relates to #11507

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
