### PR TITLE
[frontend] Verify did not work on Edit on switching to inline CSVMapper #11524

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvCreation.tsx
@@ -339,8 +339,10 @@ const IngestionCsvCreation: FunctionComponent<IngestionCsvCreationProps> = ({ pa
           </Box>
           <Box sx={{ display: currentTab === 1 ? 'block' : 'none' }}>
             <IngestionCsvInlineWrapper>
-              <IngestionCsvInlineMapperForm csvMapper={ingestionCsvData?.csv_mapper_type === 'inline' ? (ingestionCsvData.csvMapper as CsvMapperAddInput) : undefined}
-                setCSVMapperFieldValue={setFieldValue} returnCSVFormat={!!ingestionCsvData?.csvMapper}
+              <IngestionCsvInlineMapperForm
+                csvMapper={ingestionCsvData?.csv_mapper_type === 'inline' ? (ingestionCsvData.csvMapper as CsvMapperAddInput) : undefined}
+                setCSVMapperFieldValue={setFieldValue}
+                returnCSVFormat={ingestionCsvData?.csvMapper ? setFieldValue : undefined}
               />
             </IngestionCsvInlineWrapper>
           </Box>

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvEdition.tsx
@@ -371,6 +371,7 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
   };
 
   const initialValues = useMemo(() => initIngestionValue(ingestionCsvData, me), [ingestionCsvData.id]);
+  const [tempStateInlineCsv, setTempStateInlineCsv] = useState(initialValues.csv_mapper);
   const queryRef = useQueryLoading<CsvMapperFieldSearchQuery>(csvMapperQuery);
   const defaultMarkingOptions = (me.default_marking?.flatMap(({ values }) => (values ?? [{ id: '', definition: '' }])?.map(({ id, definition }) => ({ label: definition, value: id }))) ?? []) as FieldOption[];
   const updateCsvMapper = async (
@@ -415,7 +416,14 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
           </Box>
           <Box sx={{ display: currentTab === 1 ? 'block' : 'none' }}>
             <IngestionCsvInlineWrapper>
-              <IngestionCsvInlineMapperForm csvMapper={values.csv_mapper as CsvMapperAddInput} setCSVMapperFieldValue={handleSubmitField} />
+              <IngestionCsvInlineMapperForm
+                csvMapper={values.csv_mapper as CsvMapperAddInput}
+                setCSVMapperFieldValue={(name, value) => {
+                  handleSubmitField(name, value);
+                  setTempStateInlineCsv(value);
+                }}
+                returnCSVFormat={(_, value) => setTempStateInlineCsv(value)}
+              />
             </IngestionCsvInlineWrapper>
           </Box>
 
@@ -627,6 +635,7 @@ const IngestionCsvEdition: FunctionComponent<IngestionCsvEditionProps> = ({
               onClose={() => setOpen(false)}
               values={{
                 ...values,
+                csv_mapper: tempStateInlineCsv,
                 csv_mapper_type: values.csv_mapper_type ? 'id' : 'inline',
               }}
             />

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvInlineMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvInlineMapperForm.tsx
@@ -39,12 +39,11 @@ const defaultCsvMapperValue: CsvMapperFormData = {
 interface CsvMapperFormProps {
   csvMapper?: CsvMapperAddInput;
   setCSVMapperFieldValue: (field: string, value: CsvMapperAddInput) => void
-  returnCSVFormat?: boolean;
+  returnCSVFormat?: (field: string, value: CsvMapperAddInput) => void;
 }
 
 const IngestionCsvInlineMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, setCSVMapperFieldValue, returnCSVFormat }) => {
-  const [csvMapperFormData] = useState(csvMapper ? csvFeedCsvMapperToFormData(csvMapper) : defaultCsvMapperValue);
-
+  const csvMapperFormData = csvMapper ? csvFeedCsvMapperToFormData(csvMapper) : defaultCsvMapperValue;
   const { t_i18n } = useFormatter();
   // extracting available entities and relationships types from schema
   const { schema } = useAuth();
@@ -130,7 +129,7 @@ const IngestionCsvInlineMapperForm: FunctionComponent<CsvMapperFormProps> = ({ c
 
   useEffect(() => {
     if (returnCSVFormat) {
-      setCSVMapperFieldValue('csv_mapper', formDataToCsvMapper(csvMapperFormData) as unknown as CsvMapperAddInput);
+      returnCSVFormat('csv_mapper', formDataToCsvMapper(csvMapperFormData) as unknown as CsvMapperAddInput);
     }
   }, []);
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add an intermediate state to avoid rerender IngestionCsvInlineMapperForm
* Add the changing csvmapper value to the verify call

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11524

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
