### PR TITLE
[frontend] Wrong access warning when setting default dashboard for organization (#11240)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
@@ -130,7 +130,7 @@ const SettingsOrganization = ({
   const parentOrganizations = organization.parentOrganizations?.edges ?? [];
   const canAccessDashboard = (
     organization.default_dashboard?.authorizedMembers || []
-  ).some(({ id }) => ['ALL', organization.id].includes(id));
+  ).some(({ id }) => id.startsWith('ALL') || organization.id === id);
   const capabilitiesPerGroup = new Map(
     organization.grantable_groups?.map((group) => [
       group.id,


### PR DESCRIPTION
### Proposed changes

* Add a startsWith method for 'ALL' id, because it was logged as ALL_1 (don't know the reason). But if no access the ALL doesn't appears in log

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/11240