### PR TITLE
[frontend] No filters reset when changing between lines/cards view (#8428)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -660,13 +660,20 @@ export const usePaginationLocalStorage = <U>(
       }
     },
     handleChangeView: (value: string) => {
-      const newValue = {
-        ...viewStorage,
-        filters: initialValue.filters ?? emptyFilterGroup,
-        searchTerm: initialValue.searchTerm ?? '',
-        savedFilters: undefined,
-        view: value,
-      };
+      const oldValue = viewStorage.view;
+      const noReset = (oldValue === 'lines' && value === 'cards') || (oldValue === 'cards' && value === 'lines');
+      const newValue = noReset
+        ? {
+          ...viewStorage,
+          view: value,
+        }
+        : {
+          ...viewStorage,
+          filters: initialValue.filters ?? emptyFilterGroup,
+          searchTerm: initialValue.searchTerm ?? '',
+          savedFilters: undefined,
+          view: value,
+        };
       setValue(newValue);
       dispatch(`${key}_paginationStorage`, newValue);
     },


### PR DESCRIPTION
### Proposed changes
When changing between cards view and lines view (for instance in malwares list), the filtering and searching options should not be reset

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/8428