### PR TITLE
[frontend] prevent empty event_types to crash event edition (#11538)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -154,26 +154,19 @@ const EventEditionOverviewComponent = (props) => {
     }
   };
 
-  const initialValues = R.pipe(
-    R.assoc('start_time', buildDate(event.start_time)),
-    R.assoc('stop_time', buildDate(event.stop_time)),
-    R.assoc('createdBy', convertCreatedBy(event)),
-    R.assoc('objectMarking', convertMarkings(event)),
-    R.assoc('x_opencti_workflow_id', convertStatus(t_i18n, event)),
-    R.assoc('references', []),
-    R.pick([
-      'name',
-      'references',
-      'event_types',
-      'description',
-      'start_time',
-      'stop_time',
-      'confidence',
-      'createdBy',
-      'objectMarking',
-      'x_opencti_workflow_id',
-    ]),
-  )(event);
+  const initialValues = {
+    name: event.name,
+    references: event.references || [],
+    event_types: event.event_types || [],
+    description: event.description || '',
+    start_time: buildDate(event.start_time),
+    stop_time: buildDate(event.stop_time),
+    confidence: event.confidence,
+    createdBy: convertCreatedBy(event),
+    objectMarking: convertMarkings(event),
+    x_opencti_workflow_id: convertStatus(t_i18n, event),
+  };
+
   return (
     <Formik
       enableReinitialize={true}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Prevent some empty props in event edition

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes https://github.com/OpenCTI-Platform/opencti/issues/11538

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
