### PR TITLE
[frontend/backend] fintel template variable name checker should allow - and _ (#11392)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@mui/styles';
 import { graphql, useFragment } from 'react-relay';
 import { useFintelTemplateContext } from '@components/settings/sub_types/fintel_templates/FintelTemplateContext';
 import { useParams } from 'react-router-dom';
+import { fintelTemplateVariableNameChecker } from '@components/widgets/useWidgetConfigValidateForm';
 import useFintelTemplateEdit from './useFintelTemplateEdit';
 import { FintelTemplateWidgetsSidebar_template$key } from './__generated__/FintelTemplateWidgetsSidebar_template.graphql';
 import FintelTemplateWidgetsList, { FintelTemplateWidget } from './FintelTemplateWidgetsList';
@@ -154,7 +155,7 @@ const FintelTemplateWidgetsSidebar: FunctionComponent<FintelTemplateWidetsSideba
     } if (variableName.includes(' ')) {
       MESSAGING$.notifyError(t_i18n('The variable name should not contain spaces'));
       return false;
-    } if (!variableName.match(/^[A-Za-z0-9_-]+$/)) {
+    } if (!variableName.match(fintelTemplateVariableNameChecker)) {
       MESSAGING$.notifyError(t_i18n('The variable name should not contain special characters'));
       return false;
     }

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetAttributesInput.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetAttributesInput.tsx
@@ -11,7 +11,7 @@ import { useTheme } from '@mui/styles';
 import * as Yup from 'yup';
 import { Field, FieldArray, Form, Formik } from 'formik';
 import { InformationOutline } from 'mdi-material-ui';
-import useWidgetConfigValidateForm from '@components/widgets/useWidgetConfigValidateForm';
+import useWidgetConfigValidateForm, { fintelTemplateVariableNameChecker } from '@components/widgets/useWidgetConfigValidateForm';
 import { useWidgetConfigContext } from '@components/widgets/WidgetConfigContext';
 import FormHelperText from '@mui/material/FormHelperText';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
@@ -150,7 +150,7 @@ const WidgetAttributesInput: FunctionComponent<WidgetCreationAttributesProps> = 
       Yup.object().shape({
         variableName: Yup.string()
           .test('no-space', 'This field cannot contain spaces', (v) => !v?.includes(' '))
-          .matches(/^[A-Za-z0-9_-]+$/, t_i18n('The variable name should not contain special characters'))
+          .matches(fintelTemplateVariableNameChecker, t_i18n('The variable name should not contain special characters'))
           .required(t_i18n('This field is required')),
       }),
     ),

--- a/opencti-platform/opencti-front/src/private/components/widgets/useWidgetConfigValidateForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/useWidgetConfigValidateForm.tsx
@@ -1,6 +1,8 @@
 import { useWidgetConfigContext } from './WidgetConfigContext';
 import { getCurrentAvailableParameters } from '../../../utils/widget/widgetUtils';
 
+export const fintelTemplateVariableNameChecker = /^[A-Za-z0-9_-]+$/;
+
 const useWidgetConfigValidateForm = () => {
   const { context, config, step, fintelWidgets } = useWidgetConfigContext();
   const { type, parameters, dataSelection } = config.widget;
@@ -48,7 +50,7 @@ const useWidgetConfigValidateForm = () => {
   // Check variable name is valid in case of fintel
   const isVariableNameValid = (
     !config.fintelVariableName
-    || /^[A-Za-z0-9]+$/.test(config.fintelVariableName)
+    || fintelTemplateVariableNameChecker.test(config.fintelVariableName)
   );
 
   // Check title is filled in case of fintel

--- a/opencti-platform/opencti-graphql/src/modules/fintelTemplate/fintelTemplate-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/fintelTemplate/fintelTemplate-domain.ts
@@ -25,6 +25,7 @@ import { isCompatibleVersionWithMinimal } from '../../utils/version';
 import pjson from '../../../package.json';
 import { convertWidgetsIds } from '../workspace/workspace-utils';
 import { SELF_ID, widgetAttackPatterns, widgetContainerObservables, widgetIndicators } from '../../utils/fintelTemplate/__fintelTemplateWidgets';
+import { fintelTemplateVariableNameChecker } from '../../utils/syntax';
 
 // to customize a template we need : EE, FF enabled
 // but also to have the SETTINGS_SETCUSTOMIZATION capability !!
@@ -49,10 +50,9 @@ export const findById = async (context: AuthContext, user: AuthUser, id: string)
 // check validity of variable_name of fintel template widgets
 export const checkFintelTemplateWidgetsValidity = (fintelTemplateWidgets: FintelTemplateWidget[]) => {
   const invalidVariableNames: string[] = [];
-  const regex = /^[A-Za-z0-9_-]+$/;
   (fintelTemplateWidgets ?? [])
     .forEach(({ variable_name, widget }) => {
-      if (!regex.test(variable_name)) {
+      if (!fintelTemplateVariableNameChecker.test(variable_name)) {
         invalidVariableNames.push(variable_name);
       }
       if (widget.type === 'attribute') {
@@ -61,7 +61,7 @@ export const checkFintelTemplateWidgetsValidity = (fintelTemplateWidgets: Fintel
             .forEach((c) => {
               if (!c.variableName) {
                 throw FunctionalError('Attributes should all have a variable name', { variableNameOfTheWidget: variable_name });
-              } else if (!regex.test(c.variableName)) {
+              } else if (!fintelTemplateVariableNameChecker.test(c.variableName)) {
                 invalidVariableNames.push(c.variableName);
               }
             });

--- a/opencti-platform/opencti-graphql/src/utils/syntax.js
+++ b/opencti-platform/opencti-graphql/src/utils/syntax.js
@@ -142,6 +142,7 @@ export const ipv6Checker = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA
 export const macAddrChecker = /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/;
 export const ipv4Checker = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?:\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
 export const cpeChecker = /^cpe:\/\/[a-zA-Z0-9_./:-]+|^cpe:\/[a-zA-Z0-9_./:-]+$/;
+export const fintelTemplateVariableNameChecker = /^[A-Za-z0-9_-]+$/;
 
 export const checkObservableSyntax = (observableType, observableData) => {
   switch (observableType) {


### PR DESCRIPTION
### Proposed changes
No error message should be displayed at widget creation in a fintel template if the name contains - or _

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11392