### PR TITLE
[frontend] Enable merge for same entity types in Victimology section (#11412)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1823,7 +1823,7 @@ class DataTableToolBar extends Component {
           const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes, stixDomainObjectSubTypes);
           // Some filter types are high level, we do not want to check them as "Different"
           // We might need to add some other types here before refactoring the toolbar
-          const elementsTypes = selectedElementsList && selectedElementsList.length > 0
+          const elementsTypes = selectedElementsList.length > 0
             ? R.uniq(selectedElementsList.map((e) => e.entity_type))
             : selectedTypes;
           const typesAreDifferent = elementsTypes.filter((type) => !['Stix-Core-Object', 'Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type)).length > 1;

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1823,7 +1823,10 @@ class DataTableToolBar extends Component {
           const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes, stixDomainObjectSubTypes);
           // Some filter types are high level, we do not want to check them as "Different"
           // We might need to add some other types here before refactoring the toolbar
-          const typesAreDifferent = (selectedTypes.filter((type) => !['Stix-Core-Object', 'Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type))).length > 1;
+          const elementsTypes = selectedElementsList && selectedElementsList.length > 0
+            ? R.uniq(selectedElementsList.map((e) => e.entity_type))
+            : selectedTypes;
+          const typesAreDifferent = elementsTypes.filter((type) => !['Stix-Core-Object', 'Stix-Domain-Object', 'stix-core-relationship', 'Stix-Cyber-Observable'].includes(type)).length > 1;
           const preventMerge = selectedTypes.at(0) === 'Vocabulary'
               && Object.values(selectedElements).some(({ builtIn }) => Boolean(builtIn));
           // region update


### PR DESCRIPTION
### Proposed changes
Merge button of toolbar should not be disabled in an entity victimology section if entities are of same type*

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11412