### PR TITLE
[backend] feat(search): support defanged IOCs in global search (#3142)(#8799)(#11213)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -119,6 +119,7 @@ import { isSingleRelationsRef, } from '../schema/stixEmbeddedRelationship';
 import { now, runtimeFieldObservableValueScript } from '../utils/format';
 import { ENTITY_TYPE_KILL_CHAIN_PHASE, ENTITY_TYPE_MARKING_DEFINITION, isStixMetaObject } from '../schema/stixMetaObject';
 import { getEntitiesListFromCache, getEntityFromCache } from './cache';
+import { refang } from '../utils/refang';
 import { ENTITY_TYPE_MIGRATION_STATUS, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS, ENTITY_TYPE_USER, isInternalObject } from '../schema/internalObject';
 import { meterManager, telemetry } from '../config/tracing';
 import {
@@ -1834,10 +1835,10 @@ function processSearch(search, args) {
   const { useWildcardPrefix = ES_DEFAULT_WILDCARD_PREFIX } = args;
   let decodedSearch;
   try {
-    decodedSearch = decodeURIComponent(search)
+    decodedSearch = decodeURIComponent(refang(search))
       .trim();
   } catch (e) {
-    decodedSearch = search.trim();
+    decodedSearch = refang(search).trim();
   }
   let remainingSearch = decodedSearch;
   const exactSearch = (decodedSearch.match(/"[^"]+"/g) || []) //

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -18,11 +18,6 @@ export function refang(input) {
   // Trim first
   let output = input.trim();
 
-  // Normalize Unicode (NFKC)
-  if (typeof output.normalize === 'function') {
-    output = output.normalize('NFKC');
-  }
-
   // Refang common obfuscations (all patterns from both functions)
   output = output
     // Replace [.] and (.) and [dot] or (dot) with .
@@ -53,11 +48,10 @@ export function refang(input) {
     // eslint-disable-next-line no-useless-escape
     .replace(/\[:\/\]/g, '/')
     // Remove literal ellipsis character
-    .replace(/\u2026/g, '');
-
-  // Remove common placeholder endings (e.g., trailing [.] or ...)
-  // eslint-disable-next-line no-useless-escape
-  output = output.replace(/(\[\.\]|\.{2,}|…)+$/g, '');
+    .replace(/\u2026/g, '')
+    // Remove common placeholder endings (e.g., trailing [.] or ...)
+    // eslint-disable-next-line no-useless-escape
+    .replace(/(\[\.\]|\.{2,}|…)+$/g, '');
 
   // Extract valid URL if present and sanitize
   const urlRegex = /https?:\/\/[^\s'"<>[\](){},;!?…]+/gi;

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -16,9 +16,7 @@ export function refang(input) {
   if (!input || typeof input !== 'string') return input;
 
   // Trim first
-  input = input.trim();
-
-  let output = input;
+  let output = input.trim();
 
   // Normalize Unicode (NFKC)
   if (typeof output.normalize === 'function') {
@@ -28,10 +26,13 @@ export function refang(input) {
   // Refang common obfuscations (all patterns from both functions)
   output = output
     // Replace [.] and (.) and [dot] or (dot) with .
+    // eslint-disable-next-line no-useless-escape
     .replace(/\[(\.|dot)\]|\((\.|dot)\)/gi, '.')
     // Replace [at] or (at) with @
+    // eslint-disable-next-line no-useless-escape
     .replace(/\[at\]|\(at\)/gi, '@')
     // Replace [dash] or (dash) with -
+    // eslint-disable-next-line no-useless-escape
     .replace(/\[dash\]|\(dash\)/gi, '-')
     // Replace hxxp/hxp/hxxps/hxps (with optional brackets/colons) -> http/https
     .replace(/(\s*)h([x]{1,2})p([s]?)[\[\]:]*\/\//gi, (m, pre, xx, s) => `${pre}http${s}://`)
@@ -73,12 +74,18 @@ export function refang(input) {
       const safeQuery = encodeURIComponent(decodedQuery).replace(/%3D/g, '=').replace(/%26/g, '&');
 
       // Rebuild URL
-      output = parsed.protocol + '//' + parsed.hostname +
-        (safePath.startsWith('/') ? safePath : '/' + safePath) +
-        (safeQuery ? '?' + safeQuery : '');
+      output = `${
+                    parsed.protocol
+                  }//${
+                    parsed.hostname
+                  }${
+                    (safePath.startsWith('/') ? safePath : '/' + safePath)
+                  }${
+                    safeQuery ? '?' + safeQuery : ''
+                  }`;
     } catch (e) {
       // On URL parse error, return the original input (not null)
-      return input;
+      return input.trim();
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -85,9 +85,15 @@ export function refang(input) {
       }//${
         parsed.hostname
       }${
-        (safePath.startsWith('/') ? safePath : `/${safePath}`)
+        parsed.port ? `:${parsed.port}` : ''
       }${
-        safeQuery ? `?${safeQuery}` : ''
+        parsed.username || parsed.password ? `@${parsed.username || ''}${parsed.password ? `:${parsed.password}` : ''}` : ''
+      }${
+        safePath.startsWith('/') ? '' : '/'
+      }${
+        safePath.endsWith('/') ? safePath.slice(0, -1) : safePath
+      }${
+        safeQuery && safeQuery.length > 0 ? `?${safeQuery}` : ''
       }`;
     } catch (e) {
       // On URL parse error, return the original input (not null)

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -47,8 +47,8 @@ export function refang(input) {
     // [:/] should map to /
     // eslint-disable-next-line no-useless-escape
     .replace(/\[:\/\]/g, '/')
-    // Remove literal ellipsis character
-    .replace(/\u2026/g, '')
+    // // Remove literal ellipsis character
+    // .replace(/\u2026/g, '')
     // Remove common placeholder endings (e.g., trailing [.] or ...)
     // eslint-disable-next-line no-useless-escape
     .replace(/(\[\.\]|\.{2,}|…)+$/g, '');

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -80,7 +80,7 @@ export function refang(input) {
       const safeQuery = encodeURIComponent(decodedQuery).replace(/%3D/g, '=').replace(/%26/g, '&');
 
       // Rebuild URL
-      output = `${
+      const rebuilturl = `${
         parsed.protocol
       }//${
         parsed.hostname
@@ -95,6 +95,9 @@ export function refang(input) {
       }${
         safeQuery && safeQuery.length > 0 ? `?${safeQuery}` : ''
       }`;
+
+      // Replace original URL in output with rebuilt URL
+      output = output.replace(urlMatch[0], rebuilturl);
     } catch (e) {
       // On URL parse error, return the original input (not null)
       return input.trim();

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -1,0 +1,86 @@
+// Utility to refang defanged IOCs (Indicators of Compromise)
+// Supports common defanging techniques: [.] -> ., hxxp -> http, etc.
+
+import { URL } from 'url';
+
+/**
+ * Refang, clean, normalize, and optionally truncate an indicator value for Defender API submission.
+ * - Refangs common obfuscations
+ * - Extracts and sanitizes URLs
+ * - Encodes path/query safely
+ * - Strips trailing garbage and punctuation
+ * @param {string} input - The potentially defanged string.
+ * @returns {string} - The refanged string.
+ */
+export function refang(input) {
+  if (!input || typeof input !== 'string') return input;
+
+  // Trim first
+  input = input.trim();
+
+  let output = input;
+
+  // Normalize Unicode (NFKC)
+  if (typeof output.normalize === 'function') {
+    output = output.normalize('NFKC');
+  }
+
+  // Refang common obfuscations (all patterns from both functions)
+  output = output
+    // Replace [.] and (.) and [dot] or (dot) with .
+    .replace(/\[(\.|dot)\]|\((\.|dot)\)/gi, '.')
+    // Replace [at] or (at) with @
+    .replace(/\[at\]|\(at\)/gi, '@')
+    // Replace [dash] or (dash) with -
+    .replace(/\[dash\]|\(dash\)/gi, '-')
+    // Replace hxxp/hxp/hxxps/hxps (with optional brackets/colons) -> http/https
+    .replace(/(\s*)h([x]{1,2})p([s]?)[\[\]:]*\/\//gi, (m, pre, xx, s) => `${pre}http${s}://`)
+    // Replace fxp/sfxp/fxps (with optional brackets/colons) -> ftp/ftps
+    .replace(/(\s*)(s?)fxp(s?)[\[\]:]*\/\//gi, (m, pre, s1, s2) => `${pre}${s1}ftp${s2}://`)
+    // Replace (protocol)[://] or similar -> protocol://
+    .replace(/(\s*)\(([-.+a-zA-Z0-9]{1,12})\)[\[\]:]*\/\//gi, (m, pre, proto) => `${pre}${proto}://`)
+    // Replace [://] or similar with ://
+    .replace(/\[:\/]{3,}/g, '://')
+    // Remove any stray brackets around single characters
+    .replace(/\[([a-zA-Z0-9])\]/g, '$1')
+    // Remove literal ellipsis character
+    .replace(/\u2026/g, '');
+
+  // Remove common placeholder endings (e.g., trailing [.] or ...)
+  output = output.replace(/(\[\.\]|\.{2,}|…)+$/g, '');
+
+  // Extract valid URL if present and sanitize
+  const urlMatch = output.match(/https?:\/\/[^\s'"<>]+/i);
+  if (urlMatch) {
+    try {
+      let extractedUrl = urlMatch[0];
+      // Clean trailing punctuation early
+      extractedUrl = extractedUrl.replace(/[.,;!?…]+$/, '');
+
+      const parsed = new URL(extractedUrl);
+      if (!parsed.protocol || !parsed.hostname) return null;
+
+      // Decode and normalize
+      let decodedPath = decodeURIComponent(parsed.pathname || '');
+      let decodedQuery = decodeURIComponent(parsed.search ? parsed.search.slice(1) : '');
+
+      // Remove dangerous or non-printable chars from path/query
+      decodedPath = decodedPath.replace(/[^\x20-\x7E/]/g, '');
+      decodedQuery = decodedQuery.replace(/[^\x20-\x7E\-=&]/g, '');
+
+      // Encode path/query safely
+      const safePath = encodeURI(decodedPath);
+      const safeQuery = encodeURIComponent(decodedQuery).replace(/%3D/g, '=').replace(/%26/g, '&');
+
+      // Rebuild URL
+      output = parsed.protocol + '//' + parsed.hostname +
+        (safePath.startsWith('/') ? safePath : '/' + safePath) +
+        (safeQuery ? '?' + safeQuery : '');
+    } catch (e) {
+      // On URL parse error, return the original input (not null)
+      return input;
+    }
+  }
+
+  return output;
+}

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -35,19 +35,25 @@ export function refang(input) {
     // eslint-disable-next-line no-useless-escape
     .replace(/\[dash\]|\(dash\)/gi, '-')
     // Replace hxxp/hxp/hxxps/hxps (with optional brackets/colons) -> http/https
+    // eslint-disable-next-line no-useless-escape
     .replace(/(\s*)h([x]{1,2})p([s]?)[\[\]:]*\/\//gi, (m, pre, xx, s) => `${pre}http${s}://`)
     // Replace fxp/sfxp/fxps (with optional brackets/colons) -> ftp/ftps
+    // eslint-disable-next-line no-useless-escape
     .replace(/(\s*)(s?)fxp(s?)[\[\]:]*\/\//gi, (m, pre, s1, s2) => `${pre}${s1}ftp${s2}://`)
     // Replace (protocol)[://] or similar -> protocol://
+    // eslint-disable-next-line no-useless-escape
     .replace(/(\s*)\(([-.+a-zA-Z0-9]{1,12})\)[\[\]:]*\/\//gi, (m, pre, proto) => `${pre}${proto}://`)
     // Replace [://] or similar with ://
+    // eslint-disable-next-line no-useless-escape
     .replace(/\[:\/]{3,}/g, '://')
     // Remove any stray brackets around single characters
+    // eslint-disable-next-line no-useless-escape
     .replace(/\[([a-zA-Z0-9])\]/g, '$1')
     // Remove literal ellipsis character
     .replace(/\u2026/g, '');
 
   // Remove common placeholder endings (e.g., trailing [.] or ...)
+  // eslint-disable-next-line no-useless-escape
   output = output.replace(/(\[\.\]|\.{2,}|…)+$/g, '');
 
   // Extract valid URL if present and sanitize
@@ -75,14 +81,14 @@ export function refang(input) {
 
       // Rebuild URL
       output = `${
-                    parsed.protocol
-                  }//${
-                    parsed.hostname
-                  }${
-                    (safePath.startsWith('/') ? safePath : '/' + safePath)
-                  }${
-                    safeQuery ? '?' + safeQuery : ''
-                  }`;
+        parsed.protocol
+      }//${
+        parsed.hostname
+      }${
+        (safePath.startsWith('/') ? safePath : `/${safePath}`)
+      }${
+        safeQuery ? `?${safeQuery}` : ''
+      }`;
     } catch (e) {
       // On URL parse error, return the original input (not null)
       return input.trim();

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { refang } from '../../../src/utils/refang';
+
+describe('refang tests', () => {
+  it('should leave clean URLs unchanged', () => {
+    const input = 'http://example.com/path?query=123';
+    const output = refang(input);
+    expect(output).toBe(input);
+  });
+
+  it('should refang common IOC patterns', () => {
+    const input = 'Visit hxxp://evil[.]com/path?q=1';
+    const output = refang(input);
+    expect(output).toBe('Visit http://evil.com/path?q=1');
+  });
+
+  it('should restore multiple defanged elements in a string', () => {
+    const input = 'Report from (at)example(dot)com and hxxps[:]//bad[.]site[:/]index';
+    const output = refang(input);
+    expect(output).toContain('http');
+    expect(output).toContain('bad.site');
+    expect(output).toContain('index');
+    expect(output).toContain('@example.com');
+  });
+
+  it('should preserve surrounding words when refanging', () => {
+    const input = 'indicator hxxp://test[.]com/data';
+    const output = refang(input);
+    expect(output).toMatch(/^indicator http:\/\/test\.com\/data$/);
+  });
+
+  it('should not throw on malformed URL with invalid percent encoding', () => {
+    const malformed = 'check hxxp://evil[.]com/%E0%A4%A';
+    const output = refang(malformed);
+    expect(output).toContain('evil.com');
+  });
+
+  it('should strip trailing garbage characters from URLs', () => {
+    const input = 'hxxp://site[.]com...';
+    const output = refang(input);
+    expect(output).toBe('http://site.com');
+  });
+
+  it('should handle mixed defanging styles in a single string', () => {
+    const input = 'hxxp://example[.]com and hxxps://secure[.]site/path';
+    const output = refang(input);
+    expect(output).toBe('http://example.com and https://secure.site/path');
+  });
+
+  it('should return empty string when input is empty', () => {
+    const input = '';
+    const output = refang(input);
+    expect(output).toBe('');
+  });
+
+  it('should return the original string if there is no defanging', () => {
+    const input = 'Just a normal string without any defanging.';
+    const output = refang(input);
+    expect(output).toBe(input);
+  });
+
+  it('should refang URLs with query parameters', () => {
+    const input = 'Check this hxxp://example[.]com/path?query=1&other=2';
+    const output = refang(input);
+    expect(output).toBe('Check this http://example.com/path?query=1&other=2');
+  });
+
+  it('should handle URLs with different defanging styles', () => {
+    const input = 'Visit hxxps[:]//malicious(dot)site[.]com[:/]login';
+    const output = refang(input);
+    expect(output).toBe('Visit https://malicious.site.com/login');
+  });
+
+  it('should refang obfuscated email addresses', () => {
+    const input = 'Contact us at contact(at)domain(dot)com for more info.';
+    const output = refang(input);
+    expect(output).toBe('Contact us at contact@domain.com for more info.');
+  });
+
+  it('should handle multiple mixed indicators in a sentence', () => {
+    const input = 'For more info, visit hxxp://example[.]com or contact us at support(at)domain(dot)com.';
+    const output = refang(input);
+    expect(output).toBe('For more info, visit http://example.com or contact us at support@domain.com.');
+  });
+
+  it('should refang IP addresses with defanging', () => {
+    const input = 'Connect to the server at 192[.]168[.]1[.]1 or hxxp://10[.]0[.]0[.]1/path';
+    const output = refang(input);
+    expect(output).toBe('Connect to the server at 192.168.1.1 or http://10.0.0.1/path');
+  });
+
+  it('should handle mixed protocols in URLs', () => {
+    const input = 'Check both hxxp://example[.]com and hxxps://secure[.]site/path for updates.';
+    const output = refang(input);
+    expect(output).toBe('Check both http://example.com and https://secure.site/path for updates.');
+  });
+
+  it('should correctly refang domains with multiple subdomains', () => {
+    const input = 'Access sub[.]domain[.]example[.]com for details';
+    const output = refang(input);
+    expect(output).toBe('Access sub.domain.example.com for details');
+  });
+
+  it('should refang URLs with unicode characters in the path', () => {
+    const input = 'hxxps://example[.]com/p%C3%A1th';
+    const output = refang(input);
+    expect(output).toBe('https://example.com/p%C3%A1th');
+  });
+
+  it('should refang email addresses with unicode local part', () => {
+    const input = 'Contact jöhn(at)domain(dot)com for support';
+    const output = refang(input);
+    expect(output).toBe('Contact jöhn@domain.com for support');
+  });
+
+  it('should refang defanged URLs surrounded by punctuation', () => {
+    const input = 'See: (hxxp://test[.]com), or [hxxps://secure[.]site/path].';
+    const output = refang(input);
+    expect(output).toBe('See: (http://test.com), or [https://secure.site/path].');
+  });
+
+  it('should refang defanged email in the middle of a sentence with punctuation', () => {
+    const input = 'Please email john(dot)doe(at)mail(dot)com, thanks!';
+    const output = refang(input);
+    expect(output).toBe('Please email john.doe@mail.com, thanks!');
+  });
+});


### PR DESCRIPTION
- Detects and refangs standard defanging techniques (such as square brackets in IOCs) before processing global search queries. This allows analysts to paste defanged indicators directly into a search without manual refanging, improving usability and accuracy.


### Proposed changes

* Adds a reusable refang() utility function on the backend
* Hooks the refang() utility into processSearch() on the backend

### Related issues

* Resolves #3142  
* Resolves #8799 
* Resolves #11213 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The code was put into a utility function for easy reuse in other backend functions and extensively tested on defanged indicators.