### PR TITLE
[backend] fix relationship name duplicated in update and delete events (#10939)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -467,8 +467,8 @@ export const loadElementsWithDependencies = async (context, user, elements, opts
         // Auto deletion of the invalid relation
         await elDeleteElements(context, SYSTEM_USER, [element]);
       } else {
-        const from = R.mergeRight(element, { ...rawFrom, ...depsElementsMap.get(element.fromId) });
-        const to = R.mergeRight(element, { ...rawTo, ...depsElementsMap.get(element.toId) });
+        const from = { ...rawFrom, ...depsElementsMap.get(element.fromId) };
+        const to = { ...rawTo, ...depsElementsMap.get(element.toId) };
         // Check relations marking access.
         const canAccessFrom = await isUserCanAccessStoreElement(context, user, from);
         const canAccessTo = await isUserCanAccessStoreElement(context, user, to);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we spread the element in the from. It caused the from element contained attributes from the relationship element.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/10939


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
