### PR TITLE
[frontend] New shared Organisations drawer (#11246)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { graphql, createFragmentContainer } from 'react-relay';
-import * as R from 'ramda';
+import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -14,6 +13,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import ItemEntityType from '../../../../components/ItemEntityType';
+import stopEvent from '../../../../utils/domEvent';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -45,13 +45,18 @@ const ContainerAddStixCoreObjectsLineComponent = ({
   onLabelClick,
   onToggleEntity,
   addedElements,
+  disableToggle,
 }) => {
   const classes = useStyles();
   return (
     <ListItemButton
       classes={{ root: classes.item }}
       divider={true}
-      onClick={(event) => onToggleEntity(node, event)}
+      style={disableToggle ? { pointerEvents: 'none' } : {}}
+      onClick={(event) => {
+        stopEvent(event);
+        onToggleEntity(node, event);
+      }}
     >
       <ListItemIcon style={{ paddingLeft: 10 }}>
         {node.id in (addedElements || {}) ? (
@@ -86,7 +91,7 @@ const ContainerAddStixCoreObjectsLineComponent = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.createdBy.width }}
             >
-              {R.pathOr('', ['createdBy', 'name'], node)}
+              {node.createdBy ? node.createdBy?.name : '-'}
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -10,8 +10,9 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { useTheme } from '@mui/styles';
 import { Box } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
+import StixCoreObjectSharedOrganisations from '../stix_core_objects/StixCoreObjectSharedOrganisations';
+import StixCoreObjectSharedOrganisationsDrawer from './StixCoreObjectSharedOrganisationsDrawer';
 import StixCoreObjectMenuItemUnderEE from '../stix_core_objects/StixCoreObjectMenuItemUnderEE';
-import StixCoreObjectSharingList from '../stix_core_objects/StixCoreObjectSharingList';
 import StixCoreObjectBackgroundTasks from '../stix_core_objects/StixCoreObjectActiveBackgroundTasks';
 import StixCoreObjectEnrollPlaybook from '../stix_core_objects/StixCoreObjectEnrollPlaybook';
 import StixCoreObjectFileExportButton from '../stix_core_objects/StixCoreObjectFileExportButton';
@@ -26,7 +27,6 @@ import Security from '../../../../utils/Security';
 import { useFormatter } from '../../../../components/i18n';
 import { truncate } from '../../../../utils/String';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
-import StixCoreObjectSharing from '../stix_core_objects/StixCoreObjectSharing';
 import useGranted, {
   KNOWLEDGE_KNENRICHMENT,
   KNOWLEDGE_KNGETEXPORT_KNASKEXPORT,
@@ -670,21 +670,11 @@ const ContainerHeader = (props) => {
                 actionsFilter={['SHARE', 'UNSHARE', 'SHARE_MULTIPLE', 'UNSHARE_MULTIPLE']}
               />
             )}
+            {displaySharing && (
+              <StixCoreObjectSharedOrganisations disabled={isSharingDisabled} data={container}/>
+            )}
             {enableQuickSubscription && (
               <StixCoreObjectSubscribers triggerData={triggerData} />
-            )}
-            {displaySharing && (
-              <>
-                <StixCoreObjectSharingList data={container} inContainer={true} />
-                <StixCoreObjectSharing
-                  elementId={container.id}
-                  open={openSharing}
-                  variant="header"
-                  disabled={isSharingDisabled}
-                  handleClose={displaySharingButton ? undefined : handleCloseSharing}
-                  inContainer={true}
-                />
-              </>
             )}
             {displayAuthorizedMembers && (
               <FormAuthorizedMembersDialog
@@ -785,6 +775,13 @@ const ContainerHeader = (props) => {
                     </Box>
                   )}
                 </PopoverMenu>
+                {openSharing && (
+                  <StixCoreObjectSharedOrganisationsDrawer
+                    data={container}
+                    open={openSharing}
+                    handleClose={displaySharingButton ? undefined : handleCloseSharing}
+                  />
+                )}
                 {EditComponent}
                 <DeleteComponent isOpen={openDelete} onClose={handleCloseDelete} />
               </>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectSharedOrganisationsDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectSharedOrganisationsDrawer.tsx
@@ -1,0 +1,218 @@
+import React, { FunctionComponent, Suspense, useState } from 'react';
+import { PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
+import {
+  StixCoreObjectSharingListFragment$data,
+  StixCoreObjectSharingListFragment$key,
+} from '@components/common/stix_core_objects/__generated__/StixCoreObjectSharingListFragment.graphql';
+import { objectOrganizationFragment } from '@components/common/stix_core_objects/StixCoreObjectSharingList';
+import { useFormatter } from '../../../../components/i18n';
+import ListLines from '../../../../components/list_lines/ListLines';
+import { PaginationLocalStorage, usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
+import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { removeEmptyFields } from '../../../../utils/utils';
+import { ContainerAddStixCoreObjectsLinesQuery, ContainerAddStixCoreObjectsLinesQuery$variables } from './__generated__/ContainerAddStixCoreObjectsLinesQuery.graphql';
+import ContainerAddStixCoreObjectsLines, { containerAddStixCoreObjectsLinesQuery } from './ContainerAddStixCoreObjectsLines';
+import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
+import { DataColumns } from '../../../../components/list_lines';
+import Drawer from '../drawer/Drawer';
+
+interface StixCoreObjectSharedOrganisationsLoaderProps {
+  queryRef: PreloadedQuery<ContainerAddStixCoreObjectsLinesQuery>
+  containerId: string
+  buildColumns: () => DataColumns
+  knowledgeGraph?: boolean
+  selectedElements: ReadonlyArray<{
+    readonly id: string;
+    readonly name: string;
+  }>
+  handleSelect?: (o: { id: string, name: string }) => void
+  handleDeselect?: (o: { id: string, name: string }) => void
+  helpers: PaginationLocalStorage['helpers']
+  enableReferences?: boolean
+  disableToggle?: boolean
+}
+
+const StixCoreObjectSharedOrganisationsLoader = ({
+  queryRef,
+  containerId,
+  buildColumns,
+  knowledgeGraph,
+  selectedElements,
+  handleSelect,
+  handleDeselect,
+  helpers,
+  enableReferences,
+  disableToggle = false,
+}: StixCoreObjectSharedOrganisationsLoaderProps) => {
+  const data = usePreloadedQuery(containerAddStixCoreObjectsLinesQuery, queryRef);
+  return (
+    <ContainerAddStixCoreObjectsLines
+      data={data}
+      containerId={containerId}
+      dataColumns={buildColumns()}
+      initialLoading={data === null}
+      knowledgeGraph={knowledgeGraph}
+      containerStixCoreObjects={selectedElements}
+      onAdd={handleSelect}
+      onDelete={handleDeselect}
+      setNumberOfElements={helpers.handleSetNumberOfElements}
+      enableReferences={enableReferences}
+      onLabelClick={helpers.handleAddFilter}
+      disableToggle={disableToggle}
+    />
+  );
+};
+
+interface StixCoreObjectSharedOrganisationsDrawerProps {
+  data: StixCoreObjectSharingListFragment$key,
+  onAdd?: (node: { id: string }) => void,
+  onClose?: () => void,
+  onDelete?: (node: { id: string }) => void,
+  open: boolean,
+  selectedText?: string,
+  enableReferences?: boolean,
+  knowledgeGraph?: boolean,
+  disableEdit?: boolean,
+}
+
+const StixCoreObjectSharedOrganisationsDrawer: FunctionComponent<StixCoreObjectSharedOrganisationsDrawerProps> = ({
+  data,
+  onAdd,
+  onClose,
+  onDelete,
+  open,
+  selectedText,
+  enableReferences = false,
+  knowledgeGraph = false,
+  disableEdit = false,
+}) => {
+  const { t_i18n } = useFormatter();
+  const {
+    platformModuleHelpers: { isRuntimeFieldEnable },
+  } = useAuth();
+
+  const {
+    objectOrganization,
+    id,
+  } = useFragment<StixCoreObjectSharingListFragment$key>(objectOrganizationFragment, data);
+  const targetStixCoreObjectTypes = ['Organization'];
+  const LOCAL_STORAGE_KEY = `container-${id}-add-${targetStixCoreObjectTypes}`;
+  const { viewStorage, helpers, paginationOptions } = usePaginationLocalStorage<
+  ContainerAddStixCoreObjectsLinesQuery$variables
+  >(
+    LOCAL_STORAGE_KEY,
+    {
+      searchTerm: '',
+      sortBy: '_score',
+      orderAsc: false,
+      filters: emptyFilterGroup,
+      types: targetStixCoreObjectTypes,
+    },
+    true,
+  );
+  const {
+    sortBy,
+    orderAsc,
+    searchTerm,
+    filters,
+    numberOfElements,
+  } = viewStorage;
+  const [selectedElements, setSelectedElements] = useState<NonNullable<StixCoreObjectSharingListFragment$data['objectOrganization']>>(objectOrganization ?? []);
+  const handleSelect = (node: { id: string, name: string }) => {
+    setSelectedElements([
+      ...selectedElements,
+      { id: node.id, name: node.name },
+    ]);
+    if (typeof onAdd === 'function') onAdd(node);
+  };
+  const handleDeselect = (node: { id: string }) => {
+    setSelectedElements(selectedElements.filter((e) => e.id !== node.id));
+    if (typeof onDelete === 'function') onDelete(node);
+  };
+  const keyword = (searchTerm ?? '').length === 0 ? selectedText : searchTerm;
+  const buildColumns = () => {
+    return {
+      entity_type: {
+        label: 'Type',
+        width: '15%',
+        isSortable: true,
+      },
+      value: {
+        label: 'Name',
+        width: '32%',
+        isSortable: true,
+      },
+      createdBy: {
+        label: 'Author',
+        width: '15%',
+        isSortable: isRuntimeFieldEnable(),
+      },
+      objectLabel: {
+        label: 'Labels',
+        width: '22%',
+        isSortable: false,
+      },
+      objectMarking: {
+        label: 'Marking',
+        width: '15%',
+        isSortable: isRuntimeFieldEnable(),
+      },
+    };
+  };
+  const { count: _, ...paginationOptionsNoCount } = paginationOptions;
+  const searchPaginationOptions = removeEmptyFields({
+    ...paginationOptionsNoCount,
+    search: keyword,
+  });
+  const queryRef = useQueryLoading<ContainerAddStixCoreObjectsLinesQuery>(containerAddStixCoreObjectsLinesQuery, { count: 100, ...searchPaginationOptions });
+  return (
+    <Drawer
+      open={open}
+      title={t_i18n('Organizations')}
+      onClose={onClose}
+    >
+      <ListLines
+        helpers={helpers}
+        sortBy={sortBy}
+        orderAsc={orderAsc}
+        dataColumns={buildColumns()}
+        handleSearch={helpers.handleSearch}
+        keyword={keyword}
+        handleSort={helpers.handleSort}
+        handleAddFilter={helpers.handleAddFilter}
+        handleRemoveFilter={helpers.handleRemoveFilter}
+        handleSwitchLocalMode={helpers.handleSwitchLocalMode}
+        handleSwitchGlobalMode={helpers.handleSwitchGlobalMode}
+        disableCards={true}
+        filters={filters}
+        paginationOptions={searchPaginationOptions}
+        numberOfElements={numberOfElements}
+        iconExtension={true}
+        parametersWithPadding={true}
+        disableExport={true}
+        availableEntityTypes={targetStixCoreObjectTypes}
+        entityTypes={targetStixCoreObjectTypes}
+      >
+        {(queryRef) && (
+          <Suspense>
+            <StixCoreObjectSharedOrganisationsLoader
+              queryRef={queryRef}
+              containerId={id}
+              buildColumns={buildColumns}
+              knowledgeGraph={knowledgeGraph}
+              selectedElements={selectedElements}
+              handleSelect={handleSelect}
+              handleDeselect={handleDeselect}
+              helpers={helpers}
+              enableReferences={enableReferences}
+              disableToggle={disableEdit}
+            />
+          </Suspense>
+        )}
+      </ListLines>
+    </Drawer>
+  );
+};
+
+export default StixCoreObjectSharedOrganisationsDrawer;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharedOrganisations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharedOrganisations.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import Button from '@mui/material/Button';
+import { useFragment } from 'react-relay';
+import { StixCoreObjectSharingListFragment$key } from '@components/common/stix_core_objects/__generated__/StixCoreObjectSharingListFragment.graphql';
+import { objectOrganizationFragment } from '@components/common/stix_core_objects/StixCoreObjectSharingList';
+import { useFormatter } from '../../../../components/i18n';
+import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
+import StixCoreObjectSharedOrganisationsDrawer from '../containers/StixCoreObjectSharedOrganisationsDrawer';
+
+interface ContainerHeaderSharedProps {
+  data: StixCoreObjectSharingListFragment$key
+  disabled?: boolean
+}
+
+const StixCoreObjectSharedOrganisations = ({
+  data,
+  disabled,
+}: ContainerHeaderSharedProps) => {
+  const { t_i18n } = useFormatter();
+  const [openSharedOrganizations, setOpenSharedOrganizations] = useState(false);
+  const hasSetAccess = useGranted([SETTINGS_SETACCESSES]);
+
+  const {
+    objectOrganization,
+  } = useFragment<StixCoreObjectSharingListFragment$key>(objectOrganizationFragment, data);
+
+  if (objectOrganization?.length === 0) {
+    return (<div/>);
+  }
+  return (
+    <React.Fragment>
+      <Button
+        size="small"
+        variant="text"
+        color={hasSetAccess ? 'primary' : 'inherit'}
+        style={{
+          cursor: hasSetAccess ? 'pointer' : 'default',
+          marginRight: 10,
+          whiteSpace: 'nowrap',
+        }}
+        sx={!hasSetAccess ? {
+          '&.MuiButtonBase-root:hover': {
+            bgcolor: 'transparent',
+          },
+        } : undefined}
+        onClick={() => (hasSetAccess ? setOpenSharedOrganizations(true) : null)}
+        disableRipple={!hasSetAccess}
+      >
+        {objectOrganization?.length} {t_i18n('Organizations')}
+      </Button>
+      {(hasSetAccess && openSharedOrganizations) && (
+        <StixCoreObjectSharedOrganisationsDrawer
+          data={data}
+          open={openSharedOrganizations}
+          onClose={() => setOpenSharedOrganizations(false)}
+          disableEdit={disabled}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+export default StixCoreObjectSharedOrganisations;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
@@ -84,7 +84,7 @@ const containerHeaderSharedQueryGroupDeleteMutation = graphql`
   }
 `;
 
-const containerHeaderSharedGroupAddMutation = graphql`
+export const containerHeaderSharedGroupAddMutation = graphql`
   mutation StixCoreObjectSharingGroupAddMutation(
     $id: ID!
     $organizationId: [ID!]!

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -11,7 +11,7 @@ import useDraftContext from '../../../../utils/hooks/useDraftContext';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { useFormatter } from '../../../../components/i18n';
 
-const objectOrganizationFragment = graphql`
+export const objectOrganizationFragment = graphql`
   fragment StixCoreObjectSharingListFragment on StixCoreObject {
     id
     objectOrganization {
@@ -21,7 +21,7 @@ const objectOrganizationFragment = graphql`
   }
 `;
 
-const objectOrganizationDeleteMutation = graphql`
+export const objectOrganizationDeleteMutation = graphql`
   mutation StixCoreObjectSharingListDeleteMutation($id: ID!, $organizationId: [ID!]!) {
     stixCoreObjectEdit(id: $id) {
       restrictionOrganizationDelete(organizationId: $organizationId) {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -25,8 +25,9 @@ import * as Yup from 'yup';
 import { useTheme } from '@mui/styles';
 import { useNavigate } from 'react-router-dom';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
+import StixCoreObjectSharedOrganisationsDrawer from '../containers/StixCoreObjectSharedOrganisationsDrawer';
+import StixCoreObjectSharedOrganisations from '../stix_core_objects/StixCoreObjectSharedOrganisations';
 import StixCoreObjectMenuItemUnderEE from '../stix_core_objects/StixCoreObjectMenuItemUnderEE';
-import StixCoreObjectSharingList from '../stix_core_objects/StixCoreObjectSharingList';
 import { DraftChip } from '../draft/DraftChip';
 import StixCoreObjectEnrollPlaybook from '../stix_core_objects/StixCoreObjectEnrollPlaybook';
 import StixCoreObjectFileExportButton from '../stix_core_objects/StixCoreObjectFileExportButton';
@@ -48,7 +49,6 @@ import useGranted, {
   SETTINGS_SETACCESSES,
 } from '../../../../utils/hooks/useGranted';
 import CommitMessage from '../form/CommitMessage';
-import StixCoreObjectSharing from '../stix_core_objects/StixCoreObjectSharing';
 import { truncate } from '../../../../utils/String';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import StixCoreObjectQuickSubscription from '../stix_core_objects/StixCoreObjectQuickSubscription';
@@ -639,19 +639,11 @@ const StixDomainObjectHeader = (props) => {
         </div>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <div style={{ display: 'flex' }}>
+            {disableSharing !== true && (
+            <StixCoreObjectSharedOrganisations data={stixDomainObject}/>
+            )}
             {enableQuickSubscription && (
               <StixCoreObjectSubscribers triggerData={triggerData} />
-            )}
-            {disableSharing !== true && (
-              <StixCoreObjectSharingList data={stixDomainObject} />
-            )}
-            {disableSharing !== true && (
-              <StixCoreObjectSharing
-                elementId={stixDomainObject.id}
-                open={isSharingOpen}
-                variant="header"
-                handleClose={displaySharingButton ? undefined : handleCloseSharing}
-              />
             )}
             <Security needs={[KNOWLEDGE_KNGETEXPORT_KNASKEXPORT]}>
               <StixCoreObjectFileExport
@@ -920,13 +912,12 @@ const StixDomainObjectHeader = (props) => {
           )}
         </Formik>
       )}
-      {disableSharing !== true && (
-        <StixCoreObjectSharing
-          open={isSharingOpen}
-          handleClose={handleCloseSharing}
-          elementId={stixDomainObject.id}
-          variant="header"
-        />
+      {(disableSharing !== true && isSharingOpen) && (
+      <StixCoreObjectSharedOrganisationsDrawer
+        data={stixDomainObject}
+        open={isSharingOpen}
+        onClose={handleCloseSharing}
+      />
       )}
     </React.Suspense>
   );

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -3,19 +3,19 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
-import StixCoreObjectSharingList from '../../common/stix_core_objects/StixCoreObjectSharingList';
+import StixCoreObjectSharedOrganisations from '../../common/stix_core_objects/StixCoreObjectSharedOrganisations';
 import { DraftChip } from '../../common/draft/DraftChip';
 import StixCoreObjectEnrollPlaybook from '../../common/stix_core_objects/StixCoreObjectEnrollPlaybook';
 import StixCoreObjectContainer from '../../common/stix_core_objects/StixCoreObjectContainer';
 import { truncate } from '../../../../utils/String';
 import StixCoreObjectEnrichment from '../../common/stix_core_objects/StixCoreObjectEnrichment';
-import StixCoreObjectSharing from '../../common/stix_core_objects/StixCoreObjectSharing';
 import useGranted, { KNOWLEDGE_KNENRICHMENT, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE, KNOWLEDGE_KNUPDATE_KNORGARESTRICT } from '../../../../utils/hooks/useGranted';
 import StixCyberObservableEdition from './StixCyberObservableEdition';
 import Security from '../../../../utils/Security';
 import PopoverMenu from '../../../../components/PopoverMenu';
 import StixCoreObjectMenuItemUnderEE from '../../common/stix_core_objects/StixCoreObjectMenuItemUnderEE';
 import { useFormatter } from '../../../../components/i18n';
+import StixCoreObjectSharedOrganisationsDrawer from '../../common/containers/StixCoreObjectSharedOrganisationsDrawer';
 
 const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteComponent }) => {
   const [openSharing, setOpenSharing] = useState(false);
@@ -40,7 +40,7 @@ const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteCompone
 
       <div>
         <div style={{ display: 'flex' }}>
-          <StixCoreObjectSharingList data={stixCyberObservable} />
+          <StixCoreObjectSharedOrganisations data={stixCyberObservable}/>
 
           {isKnowledgeUpdater && (
             <StixCoreObjectContainer elementId={stixCyberObservable.id} />
@@ -78,11 +78,10 @@ const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteCompone
           </Security>
           <DeleteComponent isOpen={openDelete} onClose={handleCloseDelete} />
 
-          <StixCoreObjectSharing
-            elementId={stixCyberObservable.id}
+          <StixCoreObjectSharedOrganisationsDrawer
+            data={stixCyberObservable}
             open={openSharing}
-            variant="header"
-            handleClose={() => setOpenSharing(false)}
+            onClose={() => setOpenSharing(false)}
           />
         </div>
       </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add new sharing organisations button and counter
<img width="906" height="164" alt="image" src="https://github.com/user-attachments/assets/117f132a-6a9a-49c6-b029-fe3b1bd51bb6" />

* Add new sharing organisations drawer
<img width="3352" height="1970" alt="image" src="https://github.com/user-attachments/assets/9d85ca28-9a1a-4505-ae5c-2e8278c469dd" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/11246

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
