### PR TITLE
[frontend] fix missing name for target based-on relationships (#11600)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.jsx
@@ -215,6 +215,9 @@ const SimpleStixObjectOrStixRelationshipStixCoreRelationshipLineFragment = creat
           }
           from {
             ... on StixDomainObject {
+              representative {
+                main
+              }
               id
               draftVersion {
                 draft_id
@@ -423,6 +426,9 @@ const SimpleStixObjectOrStixRelationshipStixCoreRelationshipLineFragment = creat
             }
             ... on StixCoreRelationship {
               relationship_type
+              representative {
+                main
+              }
               from {
                 ... on BasicObject {
                   id
@@ -468,6 +474,9 @@ const SimpleStixObjectOrStixRelationshipStixCoreRelationshipLineFragment = creat
           to {
             ... on StixDomainObject {
               id
+              representative {
+                main
+              }
               draftVersion {
                 draft_id
                 draft_operation
@@ -675,6 +684,9 @@ const SimpleStixObjectOrStixRelationshipStixCoreRelationshipLineFragment = creat
             }
             ... on StixCoreRelationship {
               relationship_type
+              representative {
+                main
+              }
             }
           }
           toId

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.jsx
@@ -131,7 +131,7 @@ class SimpleStixObjectOrStixRelationshipStixCoreRelationshipLineComponent extend
                   className={classes.bodyItem}
                   style={{ width: dataColumns.name.width }}
                 >
-                  {element.name}
+                  {element.representative.main}
                   {element.draftVersion && (<DraftChip/>)}
                 </div>
                 <div


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* display representative instead of name for `based-on` relationships 


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes : https://github.com/OpenCTI-Platform/opencti/issues/11600


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
