### PR TITLE
[backend] Map ".yara" file extension to mime type "text/yara+plain" by default

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -45,7 +45,8 @@
     },
     "filename_to_mimes": {
       "pdf_report": "application/pdf",
-      ".yar": "text/yara+plain"
+      ".yar": "text/yara+plain",
+      ".yara": "text/yara+plain"
     },
     "audit_logs": {
       "logs_files": true,


### PR DESCRIPTION
### Proposed changes

* We have a logic in OpenCTI for mapping certain file extensions to mime types, and this must be correctly handled by specific import connectors. When importing YARA rules, the “.yar” extension is associated with the correct mime type, but not the “.yara” file extension.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/11635

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
