### PR TITLE
[CI] Automate deployment on PIR test instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,6 +778,15 @@ jobs:
       - kubernetes/install-kubectl
       - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_DEV -n customer-dev rollout restart deployment -l app=opencti
 
+# Automation of deployment on PIR instance during dev of https://github.com/OpenCTI-Platform/opencti/issues/11149
+  deploy_pir:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run: kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_PIR -n customer-pir rollout restart deployment -l app=opencti
+
   notify_rolling:
     docker:
       - image: "cimg/base:stable"
@@ -962,11 +971,18 @@ workflows:
           requires:
             - docker_build_platform_prerelease
             - docker_build_worker_prerelease
+# Automation of deployment on PIR instance during dev of https://github.com/OpenCTI-Platform/opencti/issues/11149
+      - deploy_pir:
+          requires:
+            - docker_build_platform_prerelease
+            - docker_build_worker_prerelease
       - notify_rolling:
           requires:
             - deploy_testing
             - deploy_prerelease
             - deploy_dev
+# Automation of deployment on PIR instance during dev of https://github.com/OpenCTI-Platform/opencti/issues/11149
+            - deploy_pir
             - docker_build_platform_fips_rolling
             - docker_build_worker_fips_rolling
             - package_rolling


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add automatic deployment for pir instance of the last version builded on `release/current` (similar to dev and prerelease deployment)


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/11149
* https://github.com/FiligranHQ/platform/issues/1191

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
