### PR TITLE
[ci] Automate the verification about signed commit in PRs. (#11714)

### DIFF
--- a/.github/workflows/check-verified-commit.yml
+++ b/.github/workflows/check-verified-commit.yml
@@ -1,0 +1,19 @@
+name: Check signed commits in PR 
+on: [pull_request,pull_request_target]
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Information about how to sign commits see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+      # "with comment" below does not work for forks.
+      run: |
+        echo "If you need to sign commits, Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+    - name: Check signed commits in PR on fail see above information.
+      uses: 1Password/check-signed-commits-action@v1
+      with:
+        comment: |
+          Thank you for your contribution, but we need you to sign your commits. Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ For general suggestions or questions about the project or the documentation, you
   * worker
   * doc
 
+* All commit must be signed, if you need to configure your git environement please see [Github documentation on signed commit][https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits]
+
 ### How can you get in touch for other questions?
 
 If you need support or you wish to engage a discussion about the OpenCTI platform, feel free to join us on our [Slack channel](https://community.filigran.io). You can also send us an [email](mailto:contact@opencti.io).


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Automatically verify that commit are signed.
* Using a verified github action from github marketplace: https://github.com/marketplace/actions/check-signed-commits-in-pr

#### On PR from branch error is
<img width="962" height="199" alt="image" src="https://github.com/user-attachments/assets/d971a439-34db-43f9-8ee2-76ec54a5f83b" />


<img width="1835" height="538" alt="image" src="https://github.com/user-attachments/assets/8cecf259-8cd7-4690-ab9d-62038c5746d2" />


#### On fork the error is
<img width="1836" height="884" alt="image" src="https://github.com/user-attachments/assets/ee697796-7be6-4cb7-8b17-f5eef88339df" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #11714 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
