### PR TITLE
[backend] deselected entities in background tasks (#11723)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -57,7 +57,7 @@ export const findAll = (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_BACKGROUND_TASK], args);
 };
 
-export const buildQueryFilters = async (context, user, filters, search, taskPosition, scope, orderMode) => {
+export const buildQueryFilters = async (context, user, filters, search, taskPosition, scope, orderMode, excludedIds) => {
   let inputFilters = filters ? JSON.parse(filters) : undefined;
   if (scope === BackgroundTaskScope.Import) {
     const entityIdFilters = inputFilters.filters.findIndex(({ key }) => key.includes('entity_id'));
@@ -95,6 +95,10 @@ export const buildQueryFilters = async (context, user, filters, search, taskPosi
     types = [ENTITY_TYPE_WORKSPACE];
   } else if (scope === BackgroundTaskScope.Playbook) {
     types = [ENTITY_TYPE_PLAYBOOK];
+  }
+  // Remove eventual excluded ids
+  if (excludedIds.length > 0) {
+    inputFilters = addFilter(inputFilters, 'internal_id', excludedIds, 'not_eq', 'and');
   }
   // Construct filters
   return {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -50,7 +50,6 @@ import {
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { BackgroundTaskScope } from '../generated/graphql';
 import { getDraftContext } from '../utils/draftContext';
-import { addFilter } from '../utils/filtering/filtering-utils';
 import { getBestBackgroundConnectorId, pushToWorkerForConnector } from '../database/rabbitmq';
 import { updateExpectationsNumber, updateProcessedTime } from '../domain/work';
 import { convertStoreToStix, convertTypeToStixType } from '../database/stix-2-1-converter';
@@ -113,10 +112,7 @@ export const taskRule = async (context, user, task, callback) => {
 
 export const taskQuery = async (context, user, task, callback) => {
   const { task_position, task_filters, task_search = null, task_excluded_ids = [], scope, task_order_mode } = task;
-  const options = await buildQueryFilters(context, user, task_filters, task_search, task_position, scope, task_order_mode);
-  if (task_excluded_ids.length > 0) {
-    options.filters = addFilter(options.filters, 'id', task_excluded_ids, 'not_eq');
-  }
+  const options = await buildQueryFilters(context, user, task_filters, task_search, task_position, scope, task_order_mode, task_excluded_ids);
   const finalOpts = { ...options, connectionFormat: false, baseData: true, callback };
   await elList(context, user, READ_DATA_INDICES, finalOpts);
 };


### PR DESCRIPTION
### Proposed changes
excluded_ids should be added in a filter with not_eq operator and 'and' filter mode to be effectively excluded from the targeted ids in a background task

### Related issues
[nCTI-Platform/opencti/issues/11723)](https://github.com/OpenCTI-Platform/opencti/issues/11723)