### PR TITLE
[frontend] fix Note content default value field (#11702)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/DefaultValueField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/DefaultValueField.tsx
@@ -196,7 +196,7 @@ const DefaultValueField = ({
     );
   }
   // Handle single string - Markdown
-  if (attribute.name === 'description') {
+  if (attribute.name === 'description' || (attribute.name === 'content' && entityType === 'Note')) {
     return (
       <Field
         component={MarkdownField}


### PR DESCRIPTION
### Proposed changes

* In customization, the field for rich html was used instead of markdown field

### Related issues

* #11702

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality