### PR TITLE
[frontend] toolbar spacing for notifications (#11660)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
@@ -32,7 +32,6 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
     removeSelectAll,
     startsWithAction,
     startsWithIcon,
-    startColumnWidth,
     endsWithAction,
     useDataTablePaginationLocalStorage: {
       viewStorage: { sortBy, orderAsc },
@@ -64,7 +63,7 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
     background: hasSelectedElements && !removeSelectAll
       ? theme.palette.background.accent
       : 'transparent',
-    minWidth: startColumnWidth,
+    minWidth: SELECT_COLUMN_SIZE,
   };
 
   const showToolbar = numberOfSelectedElements > 0 && !disableToolBar;


### PR DESCRIPTION
### Proposed changes
Fix the spacing before the number of selected entities in the toolbar for Notifications (and entities with an icon)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11660