### PR TITLE
[frontend] add attributes in widget column selection for Vulnerabilities and Organizations (#11546)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -1283,6 +1283,15 @@ const defaultColumns: DataTableProps['dataColumns'] = {
       return <ItemCvssScore score={value} />;
     },
   },
+  x_opencti_cvss_v4_base_score: {
+    id: 'x_opencti_cvss_v4_base_score',
+    label: 'CVSS4 - Score',
+    percentWidth: 15,
+    render: ({ x_opencti_cvss_v4_base_score }) => {
+      const value = x_opencti_cvss_v4_base_score ? Math.trunc(x_opencti_cvss_v4_base_score * 10) / 10 : null;
+      return <ItemCvssScore score={value} />;
+    },
+  },
   x_opencti_cisa_kev: {
     id: 'x_opencti_cisa_kev',
     label: 'CISA KEV',
@@ -1321,6 +1330,18 @@ const defaultColumns: DataTableProps['dataColumns'] = {
       <ItemSeverity
         severity={x_opencti_cvss_base_severity}
         label={x_opencti_cvss_base_severity || t_i18n('Unknown')}
+      />
+    ),
+  },
+  x_opencti_cvss_v4_base_severity: {
+    id: 'x_opencti_cvss_v4_base_severity',
+    label: 'CVSS4 - Severity',
+    percentWidth: 15,
+    isSortable: true,
+    render: ({ x_opencti_cvss_v4_base_severity }, { t_i18n }) => (
+      <ItemSeverity
+        severity={x_opencti_cvss_v4_base_severity}
+        label={x_opencti_cvss_v4_base_severity || t_i18n('Unknown')}
       />
     ),
   },

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.jsx
@@ -121,6 +121,7 @@ export const stixCoreObjectsListQuery = graphql`
             modified
             x_opencti_aliases
             x_opencti_organization_type
+            x_opencti_score
           }
           ... on Sector {
             name
@@ -236,6 +237,8 @@ export const stixCoreObjectsListQuery = graphql`
             x_opencti_aliases
             x_opencti_cvss_base_score
             x_opencti_cvss_base_severity
+            x_opencti_cvss_v4_base_score
+            x_opencti_cvss_v4_base_severity
             x_opencti_cisa_kev
             x_opencti_epss_score
             x_opencti_epss_percentile

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
@@ -123,6 +123,8 @@ const availableWidgetColumns: Record<string, WidgetColumn[]> = {
   Vulnerability: [
     { attribute: 'x_opencti_cvss_base_score', label: 'CVSS3 - Score' },
     { attribute: 'x_opencti_cvss_base_severity', label: 'CVSS3 - Severity' },
+    { attribute: 'x_opencti_cvss_v4_base_score', label: 'CVSS4 - Score' },
+    { attribute: 'x_opencti_cvss_v4_base_severity', label: 'CVSS4 - Severity' },
     { attribute: 'x_opencti_cisa_kev', label: 'CISA - KEV' },
     { attribute: 'x_opencti_epss_score', label: 'EPSS Score' },
     { attribute: 'x_opencti_epss_percentile', label: 'EPSS Percentile' },
@@ -138,6 +140,7 @@ const availableWidgetColumns: Record<string, WidgetColumn[]> = {
   ],
   Organization: [
     { attribute: 'x_opencti_organization_type', label: 'Organization type' },
+    { attribute: 'x_opencti_score', label: 'Score' },
   ],
 };
 

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsList.tsx
@@ -122,6 +122,7 @@ const publicStixCoreObjectsListQuery = graphql`
             modified
             x_opencti_aliases
             x_opencti_organization_type
+            x_opencti_score
           }
           ... on SecurityPlatform {
             name
@@ -242,6 +243,8 @@ const publicStixCoreObjectsListQuery = graphql`
             x_opencti_aliases
             x_opencti_cvss_base_score
             x_opencti_cvss_base_severity
+            x_opencti_cvss_v4_base_score
+            x_opencti_cvss_v4_base_severity
             x_opencti_cisa_kev
             x_opencti_epss_score
             x_opencti_epss_percentile


### PR DESCRIPTION
### Proposed changes
In list widgets
- if filter is entityType = Vulnerability, add in the possible columns to select: CVSS4 Score, CVSS4 Severity
- if filter is entityType = Organization, add in the possible columns to select: Score

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11546