### PR TITLE
[frontend] (customDasbhoard) - AutoImport in one click (#11296) 

### DIFF
--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3926,7 +3926,7 @@
   "You are about to switch to Draft mode. All your OpenCTI platform will be in draft. The selected Draft will be the draft by default.": "Vous êtes sur le point de passer en mode \"Brouillon\". Toute votre plateforme OpenCTI sera en brouillon. Le brouillon sélectionné sera le brouillon par défaut.",
   "You are about to validate this mapping, it will add suggested entities to your container.": "Vous êtes sur le point de valider ce mapping, cela ajoutera les entités suggérées à votre conteneur.",
   "You are not allowed to do this": "Vous n'êtes pas autorisé à le faire",
-  "You are not allowed to do this.": "Vous n'ête pas autorisés à faire cette action.",
+  "You are not allowed to do this.": "Vous n'êtes pas autorisé à faire cette action.",
   "You are not authorized to see this data.": "Vous n'êtes pas autorisé à voir ces données.",
   "You are now in Draft Mode": "Vous êtes maintenant en mode brouillon",
   "You are trying to check the security posture of your organization against this threat intelligence set of knowledge using the OpenBAS platform.": "Vous essayez de vérifier la position de sécurité de votre organisation par rapport à cet ensemble de connaissances sur les menaces à l'aide de la plate-forme OpenBAS.",

--- a/opencti-platform/opencti-front/src/private/Index.tsx
+++ b/opencti-platform/opencti-front/src/private/Index.tsx
@@ -39,6 +39,7 @@ const RootWorkspaces = lazy(() => import('./components/workspaces/Root'));
 const RootSettings = lazy(() => import('./components/settings/Root'));
 const RootAudit = lazy(() => import('./components/settings/activity/audit/Root'));
 const RootPir = lazy(() => import('./components/pir/Root'));
+const RootXTMHub = lazy(() => import('./components/xtm-hub/Root'));
 
 interface IndexProps {
   settings: RootSettings$data
@@ -127,6 +128,7 @@ const Index = ({ settings }: IndexProps) => {
               <Route path="/audits/*" element={boundaryWrapper(RootAudit)}/>
               <Route path="/profile/*" element={boundaryWrapper(RootProfile)}/>
               <Route path="/observations/*" element={boundaryWrapper(RootObservations)}/>
+              <Route path="/xtm-hub/*" element={boundaryWrapper(RootXTMHub)}/>
               <Route path="/*" element={<NoMatch/>}/>
             </Routes>
           </Suspense>

--- a/opencti-platform/opencti-front/src/private/components/xtm-hub/DeployCustomDashboard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm-hub/DeployCustomDashboard.tsx
@@ -1,0 +1,58 @@
+import React, { useContext, useEffect } from 'react';
+import { importMutation } from '@components/workspaces/WorkspaceCreation';
+import { useNavigate, useParams } from 'react-router-dom';
+import { WorkspaceCreationImportMutation } from '@components/workspaces/__generated__/WorkspaceCreationImportMutation.graphql';
+import { resolveLink } from '../../../utils/Entity';
+import { MESSAGING$ } from '../../../relay/environment';
+import useApiMutation from '../../../utils/hooks/useApiMutation';
+import Loader from '../../../components/Loader';
+import { UserContext } from '../../../utils/hooks/useAuth';
+
+const DeployCustomDashboard = () => {
+  const navigate = useNavigate();
+  const { settings } = useContext(UserContext);
+  const { serviceInstanceId, fileId } = useParams();
+  const [commitImportMutation] = useApiMutation<WorkspaceCreationImportMutation>(importMutation);
+  const sendImportToBack = (importedFile: File) => {
+    commitImportMutation({
+      variables: { file: importedFile },
+      onCompleted: (data) => {
+        navigate(
+          `${resolveLink('Dashboard')}/${data.workspaceConfigurationImport}`,
+        );
+        MESSAGING$.notifySuccess('Dashboard successfully imported');
+      },
+      onError: () => {
+        navigate('/dashboard');
+        MESSAGING$.notifyError('An error occured while importing dashboard');
+      },
+    });
+  };
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          `${settings?.platform_xtmhub_url}/document/get/${serviceInstanceId}/${fileId}`,
+          {
+            method: 'GET',
+            credentials: 'include',
+          },
+        );
+
+        const blob = await response.blob();
+        const file = new File([blob], 'downloaded.json', {
+          type: 'application/json',
+        });
+
+        sendImportToBack(file);
+      } catch (e) {
+        navigate('/dashboard');
+        MESSAGING$.notifyError('An error occured while importing dashboard. You have been redirected to home page.');
+      }
+    };
+    fetchData();
+  }, [serviceInstanceId, fileId]);
+
+  return <Loader />;
+};
+export default DeployCustomDashboard;

--- a/opencti-platform/opencti-front/src/private/components/xtm-hub/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm-hub/Root.tsx
@@ -1,0 +1,20 @@
+import React, { Suspense, lazy } from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { boundaryWrapper } from '../Error';
+
+const DeployCustomDashboards = lazy(() => import('./DeployCustomDashboard'));
+
+const Root = () => {
+  return (
+    <Suspense>
+      <Routes>
+        <Route
+          path="/deploy-custom-dashboard/:serviceInstanceId/:fileId"
+          element={boundaryWrapper(DeployCustomDashboards)}
+        />
+      </Routes>
+    </Suspense>
+  );
+};
+
+export default Root;


### PR DESCRIPTION
### Proposed changes

* With the new feature from XTMHub "OneClick Deploy' this PR creates a frontend page that display a loader while get data to import from XTM Hub and send it to OpenCTI backend to OneCLick deploy a dashboard. 
*

### Related issues
* XTMHub : issue 312, linked PR on XTMHub : https://github.com/FiligranHQ/xtm-hub/pull/791
* #11296 

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [X] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
