### PR TITLE
[backend] Display all internal connectors (#11666)

### DIFF
--- a/opencti-platform/opencti-graphql/src/connector/connector-domain.ts
+++ b/opencti-platform/opencti-graphql/src/connector/connector-domain.ts
@@ -2,15 +2,15 @@ import { importCsvConnector, importCsvConnectorRuntime } from './importCsv/impor
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENABLED_IMPORT_CSV_BUILT_IN_CONNECTOR } from './importCsv/importCsv-configuration';
 import { DRAFT_VALIDATION_CONNECTOR, draftValidationConnectorRuntime } from '../modules/draftWorkspace/draftWorkspace-connector';
-import { getInternalPlaybookQueues, getInternalQueues, getInternalSyncQueues } from '../database/rabbitmq';
+import { getInternalBackgroundTaskQueues, getInternalPlaybookQueues, getInternalSyncQueues } from '../database/rabbitmq';
 import type { Connector } from './internalConnector';
 
 const builtInInternalConnectors = async (context: AuthContext, user: AuthUser) => {
   const builtInInternalConnectorsList: Connector[] = [];
-  const internalQueues = getInternalQueues();
+  const backgroundTaskQueues = getInternalBackgroundTaskQueues();
   const playbookQueues = await getInternalPlaybookQueues(context, user);
   const syncQueues = await getInternalSyncQueues(context, user);
-  const allInternalQueues = [...internalQueues, ...playbookQueues, ...syncQueues];
+  const allInternalQueues = [...backgroundTaskQueues, ...playbookQueues, ...syncQueues];
   for (let i = 0; i < allInternalQueues.length; i += 1) {
     const internalQueue = allInternalQueues[i];
     builtInInternalConnectorsList.push({

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -248,17 +248,28 @@ export const registerConnectorQueues = async (id, name, type, scope) => {
   });
   return connectorConfig(id);
 };
+const CONNECTOR_QUEUE_PLAYBOOK = { id: 'playbook', name: '[PLAYBOOK] Internal playbook manager', type: 'internal', scope: 'playbook' };
+const CONNECTOR_QUEUE_SYNC = { id: 'sync', name: '[SYNC] Internal sync manager', type: 'internal', scope: 'sync' };
+export const getInternalQueues = () => {
+  const backgroundTaskConnectorQueues = [];
+  for (let i = 0; i < BACKGROUND_TASK_QUEUES; i += 1) {
+    backgroundTaskConnectorQueues.push(
+      { id: `background-task-${i}`, name: `[TASK] Internal task processing #${i}`, type: 'internal', scope: ENTITY_TYPE_BACKGROUND_TASK }
+    );
+  }
+  return [CONNECTOR_QUEUE_PLAYBOOK, CONNECTOR_QUEUE_SYNC, ...backgroundTaskConnectorQueues];
+};
 
 export const initializeInternalQueues = async () => {
   // region deprecated fixed queues
   /** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
   await registerConnectorQueues('playbook', 'Internal playbook manager', 'internal', 'playbook');
-  await registerConnectorQueues('sync', 'Internal sync manager', 'internal', 'sync');
-  // endregion
-  // Background task queues
-  for (let i = 0; i < BACKGROUND_TASK_QUEUES; i += 1) {
-    await registerConnectorQueues(`background-task-${i}`, `Background ${i} queue`, 'internal', ENTITY_TYPE_BACKGROUND_TASK);
+  const internalQueues = getInternalQueues();
+  for (let i = 0; i < internalQueues.length; i += 1) {
+    const internalQueue = internalQueues[i];
+    await registerConnectorQueues(internalQueue.id, internalQueue.name, internalQueue.type, internalQueue.scope);
   }
+  // endregion
 };
 
 // This method reinitialize the expected queues in rabbitmq

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -248,6 +248,8 @@ export const registerConnectorQueues = async (id, name, type, scope) => {
   });
   return connectorConfig(id);
 };
+// region deprecated fixed queues
+/** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
 const CONNECTOR_QUEUE_PLAYBOOK = { id: 'playbook', name: '[PLAYBOOK] Internal playbook manager', type: 'internal', scope: 'playbook' };
 const CONNECTOR_QUEUE_SYNC = { id: 'sync', name: '[SYNC] Internal sync manager', type: 'internal', scope: 'sync' };
 export const getInternalQueues = () => {
@@ -261,9 +263,6 @@ export const getInternalQueues = () => {
 };
 
 export const initializeInternalQueues = async () => {
-  // region deprecated fixed queues
-  /** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
-  await registerConnectorQueues('playbook', 'Internal playbook manager', 'internal', 'playbook');
   const internalQueues = getInternalQueues();
   for (let i = 0; i < internalQueues.length; i += 1) {
     const internalQueue = internalQueues[i];

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -248,18 +248,26 @@ export const registerConnectorQueues = async (id, name, type, scope) => {
   });
   return connectorConfig(id);
 };
-// region deprecated fixed queues
-/** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
-const CONNECTOR_QUEUE_PLAYBOOK = { id: 'playbook', name: '[PLAYBOOK] Internal playbook manager', type: 'internal', scope: 'playbook' };
-const CONNECTOR_QUEUE_SYNC = { id: 'sync', name: '[SYNC] Internal sync manager', type: 'internal', scope: 'sync' };
-export const getInternalQueues = () => {
+
+export const getInternalBackgroundTaskQueues = () => {
   const backgroundTaskConnectorQueues = [];
   for (let i = 0; i < BACKGROUND_TASK_QUEUES; i += 1) {
     backgroundTaskConnectorQueues.push(
       { id: `background-task-${i}`, name: `[TASK] Internal task processing #${i}`, type: 'internal', scope: ENTITY_TYPE_BACKGROUND_TASK }
     );
   }
-  return [CONNECTOR_QUEUE_PLAYBOOK, CONNECTOR_QUEUE_SYNC, ...backgroundTaskConnectorQueues];
+  return backgroundTaskConnectorQueues;
+};
+// region deprecated fixed queues
+// we have now dedicated queues for each playbook and each sync (see getInternalPlaybookQueues & getInternalSyncQueues)
+const CONNECTOR_QUEUE_PLAYBOOK = { id: 'playbook', name: 'Internal playbook manager', type: 'internal', scope: 'playbook' };
+const CONNECTOR_QUEUE_SYNC = { id: 'sync', name: 'Internal sync manager', type: 'internal', scope: 'sync' };
+/** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
+const DEPRECATED_INTERNAL_QUEUES = [CONNECTOR_QUEUE_PLAYBOOK, CONNECTOR_QUEUE_SYNC];
+// endregion
+export const getInternalQueues = () => {
+  const backgroundTaskConnectorQueues = getInternalBackgroundTaskQueues();
+  return [...DEPRECATED_INTERNAL_QUEUES, ...backgroundTaskConnectorQueues];
 };
 
 export const initializeInternalQueues = async () => {
@@ -268,7 +276,6 @@ export const initializeInternalQueues = async () => {
     const internalQueue = internalQueues[i];
     await registerConnectorQueues(internalQueue.id, internalQueue.name, internalQueue.type, internalQueue.scope);
   }
-  // endregion
 };
 
 export const getInternalPlaybookQueues = async (context, user) => {

--- a/opencti-platform/opencti-graphql/src/database/repository.js
+++ b/opencti-platform/opencti-graphql/src/database/repository.js
@@ -31,7 +31,7 @@ export const connector = async (context, user, id) => {
     .then((conn) => completeConnector(conn));
   if (isEmptyField(element)) {
     // Built in connector
-    const conn = builtInConnector(id);
+    const conn = await builtInConnector(context, user, id);
     return completeConnector(conn);
   }
   return element;

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-test.ts
@@ -2,7 +2,11 @@ import { expect, it, describe, afterAll, beforeAll } from 'vitest';
 import gql from 'graphql-tag';
 import { queryAsAdmin, USER_CONNECTOR, USER_EDITOR } from '../../utils/testQuery';
 import { queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
-import type { ConnectorInfo } from '../../../src/generated/graphql';
+import type { ConnectorInfo, Connector } from '../../../src/generated/graphql';
+import { BACKGROUND_TASK_QUEUES } from '../../../src/database/rabbitmq';
+import { ENTITY_TYPE_BACKGROUND_TASK } from '../../../src/schema/internalObject';
+import { IMPORT_CSV_CONNECTOR } from '../../../src/connector/importCsv/importCsv';
+import { DRAFT_VALIDATION_CONNECTOR } from '../../../src/modules/draftWorkspace/draftWorkspace-connector';
 
 const CREATE_WORK_QUERY = gql`
   mutation workAdd($connectorId: String!, $friendlyName: String) {
@@ -76,6 +80,22 @@ const CREATE_CONNECTOR_QUERY = gql`
   }
 `;
 
+const LIST_CONNECTORS_QUERY = gql`
+  query ListConnectors {
+    connectors {
+      id
+      name
+      active
+      auto
+      only_contextual
+      connector_type
+      connector_scope
+      connector_state
+      built_in
+    }
+  }
+`;
+
 const READ_CONNECTOR_QUERY = gql`
   query GetConnectors($id: String!) {
     connector(id: $id) {
@@ -135,6 +155,19 @@ beforeAll(async () => {
 
 describe('Connector resolver standard behaviour', () => {
   let workId: string;
+  it('should list all connectors', async () => {
+    const queryResult = await queryAsUserWithSuccess(USER_CONNECTOR.client, { query: LIST_CONNECTORS_QUERY, variables: {} });
+    expect(queryResult.data.connectors).toBeDefined();
+    expect(queryResult.data.connectors.length).toEqual(7); // 1 created (TestConnector) + 6 built-in connectors (4 background tasks + import csv + draft validation)
+    // TestConnector created above is the only not built_in connector
+    expect(queryResult.data.connectors.filter((c: Connector) => !c.built_in).length).toEqual(1);
+    // check background tasks built_in connectors
+    expect(queryResult.data.connectors.filter((c: Connector) => c.connector_scope?.includes(ENTITY_TYPE_BACKGROUND_TASK)).length).toEqual(BACKGROUND_TASK_QUEUES);
+    // check built_in csv connector
+    expect(queryResult.data.connectors.filter((c: Connector) => c.id === IMPORT_CSV_CONNECTOR.id).length).toEqual(1);
+    // check built_in draft validation connector
+    expect(queryResult.data.connectors.filter((c: Connector) => c.id === DRAFT_VALIDATION_CONNECTOR.id).length).toEqual(1);
+  });
   it('should create work', async () => {
     const WORK_TO_CREATE = {
       connectorId: TEST_CN_ID,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Get all internal queues to list internal connectors (background tasks, playbooks, syncs). We have a dedicated queue for each playbook and sync.
* Update internal queue names for better display in list

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11666

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
<img width="1379" height="539" alt="image" src="https://github.com/user-attachments/assets/fb916c55-05ce-4446-8f9b-bd85494c370c" />

