### PR TITLE
[frontend] create entity button in Sighting creation from entity (#11754)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -805,7 +805,7 @@ const StixDomainObjectCreation = ({
   open,
   speeddial,
   controlledDialStyles = {},
-  controlledDialSize,
+  controlledDialSize = undefined,
   handleClose,
   paginationKey,
   paginationOptions,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -849,7 +849,7 @@ const StixDomainObjectCreation = ({
     <>
       {!speeddial && (
         <CreateEntityControlledDial
-          entityType={stixDomainObjectTypes}
+          entityType={stixDomainObjectTypes.length === 1 ? stixDomainObjectTypes[0] : 'Stix-Domain-Object'}
           onOpen={stateHandleOpen}
           onClose={() => {}}
           style={controlledDialStyles}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectCreation.jsx
@@ -805,6 +805,7 @@ const StixDomainObjectCreation = ({
   open,
   speeddial,
   controlledDialStyles = {},
+  controlledDialSize,
   handleClose,
   paginationKey,
   paginationOptions,
@@ -853,6 +854,7 @@ const StixDomainObjectCreation = ({
           onOpen={stateHandleOpen}
           onClose={() => {}}
           style={controlledDialStyles}
+          size={controlledDialSize}
         />
       )}
       <div style={{ display: display ? 'block' : 'none' }}>

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
@@ -315,6 +315,7 @@ const StixSightingRelationshipCreationFromEntity = ({
           inputValue={search}
           paginationOptions={stixDomainObjectsPaginationOptions}
           stixDomainObjectTypes={stixCoreObjectTypes}
+          controlledDialStyles={{ margin: 2 }}
         />
       </div>
     );

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntity.jsx
@@ -50,12 +50,6 @@ const useStyles = makeStyles((theme) => ({
     right: 30,
     zIndex: 1001,
   },
-  title: {
-    float: 'left',
-  },
-  search: {
-    float: 'right',
-  },
   header: {
     backgroundColor: theme.palette.background.nav,
     padding: '20px 20px 20px 60px',
@@ -177,6 +171,12 @@ const StixSightingRelationshipCreationFromEntity = ({
     undefined,
     { successMessage: `${t_i18n('entity_Sighting')} ${t_i18n('successfully created')}` },
   );
+  const stixDomainObjectsPaginationOptions = {
+    search,
+    types: stixCoreObjectTypes,
+    orderBy: 'created_at',
+    orderMode: 'desc',
+  };
 
   const handleOpen = () => {
     setOpen(true);
@@ -281,13 +281,6 @@ const StixSightingRelationshipCreationFromEntity = ({
       return null;
     }
 
-    const stixDomainObjectsPaginationOptions = {
-      search,
-      types: stixCoreObjectTypes,
-      orderBy: 'created_at',
-      orderMode: 'desc',
-    };
-
     return (
       <div>
         <QueryRenderer
@@ -309,13 +302,6 @@ const StixSightingRelationshipCreationFromEntity = ({
             }
             return renderFakeList();
           }}
-        />
-        <StixDomainObjectCreation
-          display={open}
-          inputValue={search}
-          paginationOptions={stixDomainObjectsPaginationOptions}
-          stixDomainObjectTypes={stixCoreObjectTypes}
-          controlledDialStyles={{ margin: 2 }}
         />
       </div>
     );
@@ -381,16 +367,17 @@ const StixSightingRelationshipCreationFromEntity = ({
           >
             <Close fontSize="small" color="primary" />
           </IconButton>
-          <Typography variant="h6" classes={{ root: classes.title }}>
+          <Typography variant="h6" style={{ float: 'left' }}>
             {t_i18n('Create a sighting')}
           </Typography>
-          <div className={classes.search}>
-            <SearchInput
-              variant="inDrawer"
-              keyword={search}
-              onSubmit={handleSearch}
-            />
-          </div>
+          <StixDomainObjectCreation
+            display={open}
+            inputValue={search}
+            paginationOptions={stixDomainObjectsPaginationOptions}
+            stixDomainObjectTypes={stixCoreObjectTypes}
+            controlledDialStyles={{ float: 'right' }}
+            controlledDialSize="small"
+          />
           <div className="clearfix" />
         </div>
         <div className={classes.container}>
@@ -406,6 +393,14 @@ const StixSightingRelationshipCreationFromEntity = ({
               )}
             </Alert>
           )}
+          <div style={{ float: 'left', marginLeft: 15, marginTop: 15 }}>
+            <SearchInput
+              variant="inDrawer"
+              keyword={search}
+              onSubmit={handleSearch}
+            />
+          </div>
+          <div className="clearfix"/>
           {renderSearchResults()}
         </div>
       </div>

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
@@ -42,13 +42,7 @@ const styles = (theme) => ({
     color: theme.palette.primary.main,
   },
   noResult: {
-    top: 95,
-    left: 16,
-    right: 0,
-    position: 'absolute',
-    color: theme.palette.text.primary,
-    fontSize: 15,
-    zIndex: -5,
+    padding: 20,
   },
 });
 


### PR DESCRIPTION
### Proposed changes
In Sighting creation form from an entity Knowledge tab, the 'create entity' button should 
- be situated at the top right of the screen (like in other creation form from entity knowledge tab)
- have the label 'create entity' 

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11754