### PR TITLE
[backend] replace the “Too many values” log error with a warn only (#11682)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -4188,7 +4188,7 @@ export const prepareElementForIndexing = async (element) => {
         }
         // Prevent event loop locking more than MAX_EVENT_LOOP_PROCESSING_TIME
         if (new Date().getTime() - innerProcessingTime > MAX_EVENT_LOOP_PROCESSING_TIME) {
-          // If we extends the preparation 5 times, log an error
+          // If we extends the preparation 5 times, log a warn
           // It will help to understand what kind of key have so much elements
           if (extendLoopSplit === 5) {
             logApp.warn('[ENGINE] Element preparation too many values', { id: element.id, key, size: value.length });

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -4191,7 +4191,7 @@ export const prepareElementForIndexing = async (element) => {
           // If we extends the preparation 5 times, log an error
           // It will help to understand what kind of key have so much elements
           if (extendLoopSplit === 5) {
-            logApp.error('[ENGINE] Element preparation too many values', { id: element.id, key, size: value.length });
+            logApp.warn('[ENGINE] Element preparation too many values', { id: element.id, key, size: value.length });
           }
           extendLoopSplit += 1;
           innerProcessingTime = new Date().getTime();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* warn log replacing log error

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11682 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
