### PR TITLE
[frontend/backend] Prevent making several actions on the same key in the same task (#11798)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -1000,7 +1000,8 @@ class DataTableToolBar extends Component {
               <MenuItem
                 key={n.value}
                 value={n.value}
-                disabled={selectedFields.includes(n.value) && actionsInputs[i]?.field !== n.value}  // disable already selected fields to prevent making several actions on the same key
+                disabled={selectedFields.includes(n.value)
+                  && actionsInputs[i]?.field !== n.value} // disable already selected fields to prevent making several actions on the same key
               >
                 {n.label}
               </MenuItem>

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -985,6 +985,8 @@ class DataTableToolBar extends Component {
 
     const sortedOptions = options.sort((a, b) => a.label.localeCompare(b.label));
 
+    const selectedFields = actionsInputs.map((a) => a.field).filter(Boolean);
+
     return (
       <Select
         variant="standard"
@@ -995,7 +997,11 @@ class DataTableToolBar extends Component {
         {sortedOptions.length > 0 ? (
           sortedOptions.map(
             (n) => (
-              <MenuItem key={n.value} value={n.value}>
+              <MenuItem
+                key={n.value}
+                value={n.value}
+                disabled={selectedFields.includes(n.value) && actionsInputs[i]?.field !== n.value}  // disable already selected fields to prevent making several actions on the same key
+              >
                 {n.label}
               </MenuItem>
             ),

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -60,7 +60,7 @@ const areParentTypesKnowledge = (parentTypes) => parentTypes && parentTypes.flat
 export const checkActionValidity = async (context, user, input, scope, taskType) => {
   const { actions, filters: baseFilterString, ids } = input;
   // check actions validity
-  const actionsFields = actions.map((a) => a.field);
+  const actionsFields = actions.map((a) => a.field).filter(Boolean);
   if (actionsFields.length !== uniq(actionsFields).length) {
     throw FunctionalError('A single task cannot perform several actions on the same field.', { data: actionsFields });
   }

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -15,7 +15,7 @@ import {
   SYSTEM_USER
 } from '../utils/access';
 import { isKnowledge, KNOWLEDGE_DELETE, KNOWLEDGE_UPDATE } from '../schema/general';
-import { ForbiddenAccess, UnsupportedError } from '../config/errors';
+import { ForbiddenAccess, FunctionalError, UnsupportedError } from '../config/errors';
 import { elIndex } from '../database/engine';
 import { INDEX_INTERNAL_OBJECTS } from '../database/utils';
 import { ENTITY_TYPE_NOTIFICATION } from '../modules/notification/notification-types';
@@ -59,6 +59,12 @@ const areParentTypesKnowledge = (parentTypes) => parentTypes && parentTypes.flat
 // check a user has the right to create a list or a query background task
 export const checkActionValidity = async (context, user, input, scope, taskType) => {
   const { actions, filters: baseFilterString, ids } = input;
+  // check actions validity
+  const actionsFields = actions.map((a) => a.field);
+  if (actionsFields.length !== uniq(actionsFields).length) {
+    throw FunctionalError('A single task cannot perform several actions on the same field.', { data: actionsFields });
+  }
+  // check rights
   const baseFilterObject = baseFilterString ? JSON.parse(baseFilterString) : undefined;
   const filters = isFilterGroupNotEmpty(baseFilterObject)
     ? (baseFilterObject?.filters ?? [])

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -61,8 +61,8 @@ describe('Background task validity check (checkActionValidity)', () => {
     const type = TASK_TYPE_QUERY;
     const input = {
       actions: [
-        { type: ACTION_TYPE_ADD, field: 'label', value: ['label1'] },
-        { type: ACTION_TYPE_ADD, field: 'label', value: ['label2'] }
+        { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label1'] },
+        { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label2'] }
       ],
       filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
     };

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -56,7 +56,7 @@ describe('Background task validity check (checkActionValidity)', () => {
     { name: 'INVESTIGATION_INUPDATE_INDELETE' },
   ]);
 
-  it('should throw an error if task QUERY and filter is not PublicDashboard', async () => {
+  it('should throw an error if there are several actions on the same field', async () => {
     const user = userEditor;
     const type = TASK_TYPE_QUERY;
     const input = {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -7,6 +7,7 @@ import { ENTITY_TYPE_WORKSPACE } from '../../../src/modules/workspace/workspace-
 import { ENTITY_TYPE_NOTIFICATION } from '../../../src/modules/notification/notification-types';
 import { TYPE_FILTER, USER_ID_FILTER } from '../../../src/utils/filtering/filtering-constants';
 import { BackgroundTaskScope } from '../../../src/generated/graphql';
+import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
 
 const filterEntityType = (entityType: string) => {
   return JSON.stringify({
@@ -54,6 +55,21 @@ describe('Background task validity check (checkActionValidity)', () => {
     { name: 'EXPLORE_EXUPDATE_PUBLISH' },
     { name: 'INVESTIGATION_INUPDATE_INDELETE' },
   ]);
+
+  it('should throw an error if task QUERY and filter is not PublicDashboard', async () => {
+    const user = userEditor;
+    const type = TASK_TYPE_QUERY;
+    const input = {
+      actions: [
+        { type: ACTION_TYPE_ADD, field: 'label', value: ['label1'] },
+        { type: ACTION_TYPE_ADD, field: 'label', value: ['label2'] }
+      ],
+      filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
+    };
+    await expect(async () => {
+      await checkActionValidity(testContext, user, input, BackgroundTaskScope.Knowledge, type);
+    }).rejects.toThrowError('A single task cannot perform several actions on the same field.');
+  });
 
   describe('Scope SETTINGS', () => {
     const scope = BackgroundTaskScope.Settings;


### PR DESCRIPTION
### Proposed changes
Prevent doing several actions on the same key in a background task (because it can cause task errors):
- prevent selecting several times the same field when creating a task from the UI
- raise an error at the creation of a task with several actions on the same field in the backend for tasks created from the API

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11798