### PR TITLE
[frontend/backend] PIR: Threat types filter, tests and refinements (#11149)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/pir/PirPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/PirPopover.tsx
@@ -58,6 +58,7 @@ const PirPopover = ({ data }: PirPopoverProps) => {
         aria-haspopup="true"
         className="icon-outlined"
         variant="outlined"
+        aria-label={t_i18n('Popover of actions')}
       >
         <MoreVert fontSize="small" />
       </Button>

--- a/opencti-platform/opencti-front/src/private/components/pir/pir-history-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir-history-utils.ts
@@ -13,7 +13,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { PirHistoryLogFragment$data } from '@components/pir/pir_history/__generated__/PirHistoryLogFragment.graphql';
 import { GqlFilterGroup, sanitizeFilterGroupKeysForFrontend } from '../../../utils/filters/filtersUtils';
 
 export const pirHistoryFilterGroup = (pirId: string): GqlFilterGroup => {

--- a/opencti-platform/opencti-front/src/private/components/pir/pir-history-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir-history-utils.ts
@@ -13,9 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { GqlFilterGroup } from '../../../utils/filters/filtersUtils';
+import { PirHistoryLogFragment$data } from '@components/pir/pir_history/__generated__/PirHistoryLogFragment.graphql';
+import { GqlFilterGroup, sanitizeFilterGroupKeysForFrontend } from '../../../utils/filters/filtersUtils';
 
-// eslint-disable-next-line import/prefer-default-export
 export const pirHistoryFilterGroup = (pirId: string): GqlFilterGroup => {
   return {
     mode: 'and',
@@ -64,4 +64,29 @@ export const pirHistoryFilterGroup = (pirId: string): GqlFilterGroup => {
       },
     ],
   };
+};
+
+export const pirLogRedirectUri = (
+  pirId: string,
+  context: {
+    readonly entity_id: string | null | undefined
+    readonly entity_name: string | null | undefined
+    readonly entity_type: string | null | undefined
+    readonly message: string
+  } | null | undefined,
+) => {
+  const isAddInPir = /adds .+ in `In PIR`/.test(context?.message ?? '');
+  let redirectURI = `/dashboard/id/${context?.entity_id}`;
+  if (isAddInPir && context?.entity_id) {
+    const filter = encodeURIComponent(JSON.stringify(sanitizeFilterGroupKeysForFrontend({
+      mode: 'and',
+      filters: [{
+        key: ['fromId'],
+        values: [context.entity_id],
+      }],
+      filterGroups: [],
+    })));
+    redirectURI = `/dashboard/pirs/${pirId}/threats?filters=${filter}`;
+  }
+  return redirectURI;
 };

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
@@ -19,7 +19,8 @@ import Tooltip from '@mui/material/Tooltip';
 import { PirHistoryLogsFragment$data } from './__generated__/PirHistoryLogsFragment.graphql';
 import { PirHistoryLogsQuery, PirHistoryLogsQuery$variables } from './__generated__/PirHistoryLogsQuery.graphql';
 import { PirHistoryFragment$key } from './__generated__/PirHistoryFragment.graphql';
-import { pirHistoryFilterGroup } from '../pir-history-utils';
+import { PirHistoryLogFragment$data } from './__generated__/PirHistoryLogFragment.graphql';
+import { pirHistoryFilterGroup, pirLogRedirectUri } from '../pir-history-utils';
 import PirHistoryMessage from '../PirHistoryMessage';
 import { useFormatter } from '../../../../components/i18n';
 import { emptyFilterGroup, useBuildEntityTypeBasedFilterContext } from '../../../../utils/filters/filtersUtils';
@@ -201,6 +202,9 @@ const PirHistory = ({ data }: PirHistoryProps) => {
         toolbarFilters={contextFilters}
         lineFragment={pirHistoryLogFragment}
         entityTypes={['History']}
+        useComputeLink={({ context_data }: PirHistoryLogFragment$data) => {
+          return pirLogRedirectUri(id, context_data);
+        }}
         searchContextFinal={{ entityTypes: ['History'] }}
         availableFilterKeys={[
           'timestamp',

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewCounts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewCounts.tsx
@@ -81,7 +81,12 @@ const PirOverviewCount = ({ label, value, value24h, size }: PirOverviewCountProp
           gap: theme.spacing(1),
         }}
         >
-          <div style={{ fontSize: 40, lineHeight: 1 }}>{n(value)}</div>
+          <div
+            data-testid={`pir-overview-count-${label}`}
+            style={{ fontSize: 40, lineHeight: 1 }}
+          >
+            {n(value)}
+          </div>
           <NumberDifference
             value={value24h}
             description={t_i18n('24 hours')}

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewCounts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewCounts.tsx
@@ -13,7 +13,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import React, { Suspense } from 'react';
+import React, { CSSProperties, Suspense } from 'react';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
@@ -21,13 +21,28 @@ import { useTheme } from '@mui/material/styles';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { PirOverviewCountsQuery, PirOverviewCountsQuery$variables } from './__generated__/PirOverviewCountsQuery.graphql';
 import { PirOverviewCountsFragment$key } from './__generated__/PirOverviewCountsFragment.graphql';
-import Loader from '../../../../components/Loader';
 import Paper from '../../../../components/Paper';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
 import NumberDifference from '../../../../components/NumberDifference';
 import type { Theme } from '../../../../components/Theme';
 import ItemIcon from '../../../../components/ItemIcon';
+
+const PirOverviewCountsDummy = () => {
+  const theme = useTheme<Theme>();
+  const dummyStyle: CSSProperties = {
+    height: 97,
+    background: theme.palette.background.paper,
+  };
+  return (
+    <>
+      <Grid size={{ xs: 6 }} style={dummyStyle}></Grid>
+      <Grid size={{ xs: 6 }} style={dummyStyle}></Grid>
+      <Grid size={{ xs: 6 }} style={dummyStyle}></Grid>
+      <Grid size={{ xs: 6 }} style={dummyStyle}></Grid>
+    </>
+  );
+};
 
 const countsFragment = graphql`
   fragment PirOverviewCountsFragment on Pir {
@@ -53,15 +68,14 @@ interface PirOverviewCountProps {
   label: string
   value: number
   value24h: number
-  size: number
 }
 
-const PirOverviewCount = ({ label, value, value24h, size }: PirOverviewCountProps) => {
+const PirOverviewCount = ({ label, value, value24h }: PirOverviewCountProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n, n } = useFormatter();
 
   return (
-    <Grid key={label} size={{ xs: size }}>
+    <Grid key={label} size={{ xs: 6 }}>
       <Paper style={{ padding: theme.spacing(1.5), paddingTop: theme.spacing(1) }}>
         <div style={{ display: 'flex', alignItems: 'start' }}>
           <Typography
@@ -106,8 +120,6 @@ const PirOverviewCountsComponent = ({
   countsQueryRef,
   counts24hQueryRef,
 }: PirOverviewCountsComponentProps) => {
-  const { t_i18n } = useFormatter();
-
   const resultAll = usePreloadedQuery(countsQuery, countsQueryRef);
   const result24h = usePreloadedQuery(countsQuery, counts24hQueryRef);
 
@@ -134,37 +146,28 @@ const PirOverviewCountsComponent = ({
   const threatActor24h = threatActorIndividuals24h + threatActorGroups24h;
 
   return (
-    <Grid size={{ xs: 12 }}>
-      <Typography variant="h4">
-        {t_i18n('Number of threats')}
-      </Typography>
-      <Grid container spacing={3}>
-        <PirOverviewCount
-          size={6}
-          label="Malware"
-          value={malwares}
-          value24h={malwares24h}
-        />
-        <PirOverviewCount
-          size={6}
-          label="Campaign"
-          value={campaigns}
-          value24h={campaigns24h}
-        />
-        <PirOverviewCount
-          size={6}
-          label="Intrusion-Set"
-          value={instrusionSets}
-          value24h={instrusionSets24h}
-        />
-        <PirOverviewCount
-          size={6}
-          label="Threat-Actor"
-          value={threatActor}
-          value24h={threatActor24h}
-        />
-      </Grid>
-    </Grid>
+    <>
+      <PirOverviewCount
+        label="Malware"
+        value={malwares}
+        value24h={malwares24h}
+      />
+      <PirOverviewCount
+        label="Campaign"
+        value={campaigns}
+        value24h={campaigns24h}
+      />
+      <PirOverviewCount
+        label="Intrusion-Set"
+        value={instrusionSets}
+        value24h={instrusionSets24h}
+      />
+      <PirOverviewCount
+        label="Threat-Actor"
+        value={threatActor}
+        value24h={threatActor24h}
+      />
+    </>
   );
 };
 
@@ -173,6 +176,7 @@ interface PirOverviewCountsProps {
 }
 
 const PirOverviewCounts = ({ data }: PirOverviewCountsProps) => {
+  const { t_i18n } = useFormatter();
   const { id } = useFragment(countsFragment, data);
 
   const filters: PirOverviewCountsQuery$variables['filters'] = {
@@ -199,14 +203,21 @@ const PirOverviewCounts = ({ data }: PirOverviewCountsProps) => {
   );
 
   return (
-    <Suspense fallback={<Loader />}>
-      {countsQueryRef && counts24hQueryRef && (
-        <PirOverviewCountsComponent
-          countsQueryRef={countsQueryRef}
-          counts24hQueryRef={counts24hQueryRef}
-        />
-      )}
-    </Suspense>
+    <Grid size={{ xs: 12 }}>
+      <Typography variant="h4">
+        {t_i18n('Number of threats')}
+      </Typography>
+      <Grid container spacing={3}>
+        <Suspense fallback={<PirOverviewCountsDummy />}>
+          {countsQueryRef && counts24hQueryRef && (
+          <PirOverviewCountsComponent
+            countsQueryRef={countsQueryRef}
+            counts24hQueryRef={counts24hQueryRef}
+          />
+          )}
+        </Suspense>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewHistory.tsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@mui/material/styles';
+import { pirLogRedirectUri } from '@components/pir/pir-history-utils';
 import PirHistoryMessage from '../PirHistoryMessage';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
@@ -28,7 +29,6 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { PirOverviewHistoryPirFragment$key } from './__generated__/PirOverviewHistoryPirFragment.graphql';
 import { PirOverviewHistoryFragment$key } from './__generated__/PirOverviewHistoryFragment.graphql';
 import Paper from '../../../../components/Paper';
-import { sanitizeFilterGroupKeysForFrontend } from '../../../../utils/filters/filtersUtils';
 
 const pirFragment = graphql`
   fragment PirOverviewHistoryPirFragment on Pir {
@@ -94,21 +94,7 @@ const PirOverviewHistory = ({ dataHistory, dataPir }: PirOverviewHistoryProps) =
 
         {history.map((historyItem) => {
           const { id, context_data, timestamp } = historyItem;
-          const isAddInPir = /adds .+ in `In PIR`/.test(context_data?.message ?? '');
-          let redirectURI = `/dashboard/id/${context_data?.entity_id}`;
-          if (isAddInPir) {
-            const addInPirFilters = context_data?.entity_id
-              ? JSON.stringify(sanitizeFilterGroupKeysForFrontend({
-                mode: 'and',
-                filters: [{
-                  key: ['fromId'],
-                  values: [context_data.entity_id],
-                }],
-                filterGroups: [],
-              }))
-              : '';
-            redirectURI = `/dashboard/pirs/${pir.id}/threats?filters=${encodeURIComponent(addInPirFilters)}`;
-          }
+          const redirectURI = pirLogRedirectUri(pir.id, context_data);
 
           return (
             <Box

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewTopSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewTopSources.tsx
@@ -81,7 +81,10 @@ const PirOverviewTopSources = ({ data }: PirOverviewTopSourcesProps) => {
   return (
     <Grid container spacing={3}>
       <Grid size={{ xs: 6 }}>
-        <Paper title={t_i18n('Top authors of threat entities')}>
+        <Paper
+          data-testid="pir-top-authors-entities"
+          title={t_i18n('Top authors of threat entities')}
+        >
           <StixCoreObjectsDonut
             dataSelection={flaggedEntitiesTopSourcesDataSelection}
             variant="inLine"
@@ -94,7 +97,10 @@ const PirOverviewTopSources = ({ data }: PirOverviewTopSourcesProps) => {
         </Paper>
       </Grid>
       <Grid size={{ xs: 6 }}>
-        <Paper title={t_i18n('Top authors of relationships from threats')}>
+        <Paper
+          data-testid="pir-top-authors-relationships"
+          title={t_i18n('Top authors of relationships from threats')}
+        >
           <StixRelationshipsDonut
             dataSelection={relationshipsTopSourcesDataSelection}
             variant="inLine"

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewTopSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewTopSources.tsx
@@ -81,10 +81,7 @@ const PirOverviewTopSources = ({ data }: PirOverviewTopSourcesProps) => {
   return (
     <Grid container spacing={3}>
       <Grid size={{ xs: 6 }}>
-        <Paper
-          data-testid="pir-top-authors-entities"
-          title={t_i18n('Top authors of threat entities')}
-        >
+        <Paper title={t_i18n('Top authors of threat entities')}>
           <StixCoreObjectsDonut
             dataSelection={flaggedEntitiesTopSourcesDataSelection}
             variant="inLine"
@@ -97,10 +94,7 @@ const PirOverviewTopSources = ({ data }: PirOverviewTopSourcesProps) => {
         </Paper>
       </Grid>
       <Grid size={{ xs: 6 }}>
-        <Paper
-          data-testid="pir-top-authors-relationships"
-          title={t_i18n('Top authors of relationships from threats')}
-        >
+        <Paper title={t_i18n('Top authors of relationships from threats')}>
           <StixRelationshipsDonut
             dataSelection={relationshipsTopSourcesDataSelection}
             variant="inLine"

--- a/opencti-platform/opencti-front/src/utils/Charts.jsx
+++ b/opencti-platform/opencti-front/src/utils/Charts.jsx
@@ -66,7 +66,9 @@ const multipleDataTooltip = (theme) => ({ seriesIndex, dataPointIndex, w }) => {
   const containerColors = `background:${theme.palette.background.nav}; color:${theme.palette.text.primary};`;
   const containerLayout = 'padding: 2px 6px; font-size: 12px; display:flex; flex-direction:column;';
   const { group } = w.config.series[seriesIndex].data[dataPointIndex].meta;
-  const rows = group.map((data) => `
+  const max = 10;
+  const hasMore = group.length > max;
+  const rows = group.slice(0, max).map((data) => `
     <div style="display:flex; align-items:center; gap:4px">
       <div style="width:10px; height:10px; background:${itemColor(data.type)}; border-radius:10px;"></div>
       <span>${data.name}: ${data.score}%</span>
@@ -75,6 +77,7 @@ const multipleDataTooltip = (theme) => ({ seriesIndex, dataPointIndex, w }) => {
   return (`
     <div style="${containerColors}${containerLayout}">
       ${rows}
+      ${hasMore ? '<div>...</div>' : ''}
     </div>
   `);
 };

--- a/opencti-platform/opencti-front/tests_e2e/dataForTesting/query-utils.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dataForTesting/query-utils.ts
@@ -1,0 +1,8 @@
+import { APIRequestContext } from '@playwright/test';
+
+// eslint-disable-next-line import/prefer-default-export
+export async function graphqlQuery(request: APIRequestContext, query: string) {
+  return request.post('/graphql', {
+    data: { query },
+  });
+}

--- a/opencti-platform/opencti-front/tests_e2e/dataForTesting/relationship.data.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dataForTesting/relationship.data.ts
@@ -1,0 +1,30 @@
+import { APIRequestContext } from '@playwright/test';
+import { graphqlQuery } from './query-utils';
+
+interface AddRelationshipInput {
+  relationship_type: string
+  fromId: string
+  toId: string
+  createdBy: string
+}
+
+const addRelationshipMutation = (input: AddRelationshipInput) => `
+  mutation {
+    stixCoreRelationshipAdd(input: {
+      relationship_type: "${input.relationship_type}",
+      fromId: "${input.fromId}",
+      toId: "${input.toId}",
+      createdBy: "${input.createdBy}",
+    }) {
+      id
+    }
+  }
+`;
+
+// eslint-disable-next-line import/prefer-default-export
+export const addRelationship = async (
+  request: APIRequestContext,
+  input: AddRelationshipInput,
+) => {
+  return graphqlQuery(request, addRelationshipMutation(input));
+};

--- a/opencti-platform/opencti-front/tests_e2e/model/DataTable.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/DataTable.pageModel.ts
@@ -1,6 +1,8 @@
 import { Page } from '@playwright/test';
 
 export default class DataTablePage {
+  container = this.page.locator('.datatable-container').first();
+
   constructor(private page: Page) {}
 
   getNumberElements(nbElements: number) {

--- a/opencti-platform/opencti-front/tests_e2e/model/form/pirForm.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/form/pirForm.pageModel.ts
@@ -32,6 +32,6 @@ export default class PirFormPageModel {
   }
 
   selectType(type: 'threat landscape') {
-    return this.page.getByText(type).click();
+    return this.formLocator.getByText(type).click();
   }
 }

--- a/opencti-platform/opencti-front/tests_e2e/model/form/pirForm.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/form/pirForm.pageModel.ts
@@ -1,0 +1,37 @@
+import { Page } from '@playwright/test';
+import TextFieldPageModel from '../field/TextField.pageModel';
+import SelectFieldPageModel from '../field/SelectField.pageModel';
+import AutocompleteFieldPageModel from '../field/AutocompleteField.pageModel';
+
+export default class PirFormPageModel {
+  formTitle = 'Create priority intelligence requirement';
+  formLocator = this.page.getByRole('heading', { name: this.formTitle }).locator('../..');
+
+  nameField = new TextFieldPageModel(this.page, 'Name', 'text', this.formLocator);
+  descriptionField = new TextFieldPageModel(this.page, 'Description', 'text-area', this.formLocator);
+  rescanPeriodField = new SelectFieldPageModel(this.page, 'Rescan period (days)', false, this.formLocator);
+  locationsField = new AutocompleteFieldPageModel(this.page, 'Targeted locations', true, this.formLocator);
+  industriesField = new AutocompleteFieldPageModel(this.page, 'Targeted industries', true, this.formLocator);
+
+  constructor(private page: Page) {}
+
+  getCreateTitle() {
+    return this.page.getByRole('heading', { name: this.formTitle });
+  }
+
+  getCreateButton() {
+    return this.page.getByRole('button', { name: 'Create', exact: true });
+  }
+
+  getNextButton() {
+    return this.page.getByRole('button', { name: 'Next', exact: true });
+  }
+
+  getCancelButton() {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  selectType(type: 'threat landscape') {
+    return this.page.getByText(type).click();
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/model/pir.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pir.pageModel.ts
@@ -1,0 +1,29 @@
+import { Page } from '@playwright/test';
+import LeftBarPage from './menu/leftBar.pageModel';
+
+export default class PirPage {
+  pageUrl = '/dashboard/pirs';
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto(this.pageUrl);
+  }
+
+  async navigateFromMenu() {
+    const leftBarPage = new LeftBarPage(this.page);
+    await leftBarPage.open();
+    await leftBarPage.clickOnMenu('PIR');
+  }
+
+  getCreateButton() {
+    return this.page.getByRole('button', { name: 'Create PIR', exact: true });
+  }
+
+  openCreateForm() {
+    return this.getCreateButton().click();
+  }
+
+  getItemFromList(name: string) {
+    return this.page.getByTestId(name);
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -37,4 +37,11 @@ export default class PirDetailsPageModel {
       .locator('../..')
       .getByText(author);
   }
+
+  getNewsFeedItem(news: string) {
+    return this.page
+      .getByRole('heading', { name: 'News feed' })
+      .locator('../..')
+      .getByText(news);
+  }
 }

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test';
+import PirTabsPage from './pirTabs.pageModel';
+
+export default class PirDetailsPageModel {
+  tabs = new PirTabsPage(this.page);
+
+  constructor(private page: Page) {}
+
+  getTitle(name: string) {
+    return this.page.getByRole('heading', { name });
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -23,4 +23,12 @@ export default class PirDetailsPageModel {
   getEntityTypeCount(label: string) {
     return this.page.getByTestId(`pir-overview-count-${label}`);
   }
+
+  getTopAuthorEntities(author: string) {
+    return this.page.getByTestId('pir-top-authors-entities').getByText(author);
+  }
+
+  getTopAuthorRelationships(author: string) {
+    return this.page.getByTestId('pir-top-authors-relationships').getByText(author);
+  }
 }

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -9,4 +9,18 @@ export default class PirDetailsPageModel {
   getTitle(name: string) {
     return this.page.getByRole('heading', { name });
   }
+
+  getDescription(description: string) {
+    return this.page.getByText(description, { exact: true });
+  }
+
+  async delete() {
+    await this.page.getByRole('button', { name: 'Popover of actions' }).click();
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    return this.page.getByRole('dialog').getByRole('button', { name: 'Confirm' }).click();
+  }
+
+  getEntityTypeCount(label: string) {
+    return this.page.getByTestId(`pir-overview-count-${label}`);
+  }
 }

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -25,10 +25,16 @@ export default class PirDetailsPageModel {
   }
 
   getTopAuthorEntities(author: string) {
-    return this.page.getByTestId('pir-top-authors-entities').getByText(author);
+    return this.page
+      .getByRole('heading', { name: 'Top authors of threat entities' })
+      .locator('../..')
+      .getByText(author);
   }
 
   getTopAuthorRelationships(author: string) {
-    return this.page.getByTestId('pir-top-authors-relationships').getByText(author);
+    return this.page
+      .getByRole('heading', { name: 'Top authors of relationships from threats' })
+      .locator('../..')
+      .getByText(author);
   }
 }

--- a/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirDetails.pageModel.ts
@@ -1,8 +1,10 @@
 import { Page } from '@playwright/test';
 import PirTabsPage from './pirTabs.pageModel';
+import DataTablePage from './DataTable.pageModel';
 
 export default class PirDetailsPageModel {
   tabs = new PirTabsPage(this.page);
+  dataTable = new DataTablePage(this.page);
 
   constructor(private page: Page) {}
 

--- a/opencti-platform/opencti-front/tests_e2e/model/pirTabs.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/pirTabs.pageModel.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export default class PirTabsPage {
+  constructor(private page: Page) {}
+
+  goToOverviewTab() {
+    return this.page.getByRole('tab', { name: 'Overview' }).click();
+  }
+
+  goToThreatsTab() {
+    return this.page.getByRole('tab', { name: 'Threats' }).click();
+  }
+
+  goToAnalysesTab() {
+    return this.page.getByRole('tab', { name: 'Analyses' }).click();
+  }
+
+  goToHistoryTab() {
+    return this.page.getByRole('tab', { name: 'History' }).click();
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -79,6 +79,12 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
     createdBy: 'identity--7b82b010-b1c0-4dae-981f-7756374a17df',
   });
 
+  // ---------
+  // endregion
+
+  // region Control tab Overview after flagging
+  // ------------------------------------------
+
   const waitForFlagging = async () => {
     await pirPage.navigateFromMenu();
     await pirPage.getItemFromList(pirName).click();
@@ -102,12 +108,31 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
   // ---------
   // endregion
 
+  // region Control tab Threats after flagging
+  // -----------------------------------------
+
+  await pirDetails.tabs.goToThreatsTab();
+  await expect(pirDetails.dataTable.container.getByText('E2E dashboard - Malware - month ago')).toBeVisible();
+  await expect(pirDetails.dataTable.container.getByText('50')).toBeVisible();
+
+  // ---------
+  // endregion
+
+  // region Control tab History after flagging
+  // -----------------------------------------
+
+  await pirDetails.tabs.goToHistoryTab();
+  await expect(pirDetails.dataTable.container.getByText(historyItemName)).toBeVisible();
+
+  // ---------
+  // endregion
+
   // region Delete the report
   // ------------------------
 
-  // await pirDetails.delete();
-  // await pirPage.navigateFromMenu();
-  // await expect(pirPage.getItemFromList(pirName)).toBeHidden();
+  await pirDetails.delete();
+  await pirPage.navigateFromMenu();
+  await expect(pirPage.getItemFromList(pirName)).toBeHidden();
 
   // ---------
   // endregion

--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -79,16 +79,25 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
     createdBy: 'identity--7b82b010-b1c0-4dae-981f-7756374a17df',
   });
 
-  const waitForManager = async () => {
-    await pirDetails.tabs.goToHistoryTab();
-    await pirDetails.tabs.goToOverviewTab();
+  const waitForFlagging = async () => {
+    await pirPage.navigateFromMenu();
+    await pirPage.getItemFromList(pirName).click();
     const text = await pirDetails.getEntityTypeCount('Malware').innerText();
     return text === '1';
   };
-  await awaitUntilCondition(waitForManager, 5000, 20);
+  await awaitUntilCondition(waitForFlagging, 5000, 20);
   await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('1');
   await expect(pirDetails.getTopAuthorEntities('John Doe')).toBeVisible();
   await expect(pirDetails.getTopAuthorRelationships('ANSSI')).toBeVisible();
+
+  const historyItemName = 'Malware E2E dashboard - Malware - month ago added to PIR';
+  const waitForHistory = async () => {
+    await pirPage.navigateFromMenu();
+    await pirPage.getItemFromList(pirName).click();
+    return pirDetails.getNewsFeedItem(historyItemName).isVisible();
+  };
+  await awaitUntilCondition(waitForHistory, 5000, 20);
+  await expect(pirDetails.getNewsFeedItem(historyItemName)).toBeVisible();
 
   // ---------
   // endregion

--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -4,8 +4,18 @@ import LeftBarPage from '../model/menu/leftBar.pageModel';
 import PirPage from '../model/pir.pageModel';
 import PirFormPageModel from '../model/form/pirForm.pageModel';
 import PirDetailsPageModel from '../model/pirDetails.pageModel';
+import { addRelationship } from '../dataForTesting/relationship.data';
+import { awaitUntilCondition } from '../utils';
 
-test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page }) => {
+/**
+ * Content of the test
+ * -------------------
+ * Create a PIR
+ * Navigate through PIR tabs
+ * Test flag entities
+ * Delete PIR
+ */
+test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
   const leftNavigation = new LeftBarPage(page);
   const pirPage = new PirPage(page);
   const pirForm = new PirFormPageModel(page);
@@ -21,18 +31,28 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page }) => {
 
   await pirPage.openCreateForm();
   await expect(pirForm.getCreateTitle()).toBeVisible();
-
+  // Step 1
   const pirName = `PIR - ${uuid()}`;
   await pirForm.selectType('threat landscape');
   await pirForm.getNextButton().click();
+  // Step 2
+  await pirForm.nameField.fill('');
+  await expect(pirForm.getNextButton()).toBeDisabled();
   await pirForm.nameField.fill(pirName);
+  await expect(pirForm.getNextButton()).toBeEnabled();
+  await pirForm.descriptionField.fill('e2e PIR description');
+  await pirForm.rescanPeriodField.selectOption('No rescan');
   await pirForm.getNextButton().click();
+  // Step 3
+  await expect(pirForm.getCreateButton()).toBeDisabled();
   await pirForm.locationsField.selectOption('France');
+  await expect(pirForm.getCreateButton()).toBeEnabled();
   await pirForm.industriesField.selectOption('Agriculture');
   await pirForm.getCreateButton().click();
 
   await pirPage.getItemFromList(pirName).click();
   await expect(pirDetails.getTitle(pirName)).toBeVisible();
+  await expect(pirDetails.getDescription('e2e PIR description')).toBeVisible();
 
   // ---------
   // endregion
@@ -44,6 +64,39 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page }) => {
   await pirDetails.tabs.goToAnalysesTab();
   await pirDetails.tabs.goToHistoryTab();
   await pirDetails.tabs.goToOverviewTab();
+
+  // ---------
+  // endregion
+
+  // region Create a relation that flags entity
+  // ------------------------------------------
+
+  await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('0');
+  await addRelationship(request, {
+    relationship_type: 'targets',
+    toId: 'location--5acd8b26-51c2-4608-86ed-e9edd43ad971',
+    fromId: 'malware--48534a79-a9d7-4c34-a292-f5f102d26dea',
+    createdBy: 'identity--7b82b010-b1c0-4dae-981f-7756374a17df',
+  });
+
+  const waitForManager = async () => {
+    await pirDetails.tabs.goToHistoryTab();
+    await pirDetails.tabs.goToOverviewTab();
+    const text = await pirDetails.getEntityTypeCount('Malware').innerText();
+    return text === '1';
+  };
+  await awaitUntilCondition(waitForManager, 5000);
+  await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('1');
+
+  // ---------
+  // endregion
+
+  // region Delete the report
+  // ------------------------
+
+  await pirDetails.delete();
+  await pirPage.navigateFromMenu();
+  await expect(pirPage.getItemFromList(pirName)).toBeHidden();
 
   // ---------
   // endregion

--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -1,0 +1,50 @@
+import { v4 as uuid } from 'uuid';
+import { expect, test } from '../fixtures/baseFixtures';
+import LeftBarPage from '../model/menu/leftBar.pageModel';
+import PirPage from '../model/pir.pageModel';
+import PirFormPageModel from '../model/form/pirForm.pageModel';
+import PirDetailsPageModel from '../model/pirDetails.pageModel';
+
+test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page }) => {
+  const leftNavigation = new LeftBarPage(page);
+  const pirPage = new PirPage(page);
+  const pirForm = new PirFormPageModel(page);
+  const pirDetails = new PirDetailsPageModel(page);
+
+  await pirPage.goto();
+  await pirPage.navigateFromMenu();
+  // open nav bar once and for all
+  await leftNavigation.open();
+
+  // region Create PIR
+  // -----------------
+
+  await pirPage.openCreateForm();
+  await expect(pirForm.getCreateTitle()).toBeVisible();
+
+  const pirName = `PIR - ${uuid()}`;
+  await pirForm.selectType('threat landscape');
+  await pirForm.getNextButton().click();
+  await pirForm.nameField.fill(pirName);
+  await pirForm.getNextButton().click();
+  await pirForm.locationsField.selectOption('France');
+  await pirForm.industriesField.selectOption('Agriculture');
+  await pirForm.getCreateButton().click();
+
+  await pirPage.getItemFromList(pirName).click();
+  await expect(pirDetails.getTitle(pirName)).toBeVisible();
+
+  // ---------
+  // endregion
+
+  // region Navigate through tabs
+  // ----------------------------
+
+  await pirDetails.tabs.goToThreatsTab();
+  await pirDetails.tabs.goToAnalysesTab();
+  await pirDetails.tabs.goToHistoryTab();
+  await pirDetails.tabs.goToOverviewTab();
+
+  // ---------
+  // endregion
+});

--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -85,8 +85,10 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
     const text = await pirDetails.getEntityTypeCount('Malware').innerText();
     return text === '1';
   };
-  await awaitUntilCondition(waitForManager, 5000);
+  await awaitUntilCondition(waitForManager, 5000, 20);
   await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('1');
+  await expect(pirDetails.getTopAuthorEntities('John Doe')).toBeVisible();
+  await expect(pirDetails.getTopAuthorRelationships('ANSSI')).toBeVisible();
 
   // ---------
   // endregion
@@ -94,9 +96,9 @@ test('Pir CRUD', { tag: ['@pir', '@mutation'] }, async ({ page, request }) => {
   // region Delete the report
   // ------------------------
 
-  await pirDetails.delete();
-  await pirPage.navigateFromMenu();
-  await expect(pirPage.getItemFromList(pirName)).toBeHidden();
+  // await pirDetails.delete();
+  // await pirPage.navigateFromMenu();
+  // await expect(pirPage.getItemFromList(pirName)).toBeHidden();
 
   // ---------
   // endregion

--- a/opencti-platform/opencti-front/tests_e2e/utils.ts
+++ b/opencti-platform/opencti-front/tests_e2e/utils.ts
@@ -27,7 +27,23 @@ export const sleep = (ms: number) => {
   });
 };
 
-export const awaitUntilCondition = async (conditionPromise: () => Promise<boolean>, sleepTimeBetweenLoop = 1000, loopCount = 10, expectToBeTrue = true) => {
+/**
+ * Function that help waiting for something.
+ * /!\ Be cautious using this function. The framework Playwright already has
+ * a system to wait modification on the UI. So this function should be used
+ * only for very particular use cases, it is not the norm.
+ *
+ * @param conditionPromise A function checking if the condition is verified.
+ * @param sleepTimeBetweenLoop Time to wait between each loop in ms.
+ * @param loopCount Max loop to do.
+ * @param expectToBeTrue The expecting result of the condition.
+ */
+export const awaitUntilCondition = async (
+  conditionPromise: () => Promise<boolean>,
+  sleepTimeBetweenLoop = 1000,
+  loopCount = 10,
+  expectToBeTrue = true,
+) => {
   let isConditionOk = await conditionPromise();
   let loopCurrent = 0;
   while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {

--- a/opencti-platform/opencti-graphql/src/modules/pir/pir-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/pir/pir-utils.ts
@@ -107,9 +107,11 @@ export const arePirExplanationsEqual = (
 ) => {
   const sameRelationships = explanation1.dependencies.map((d1) => d1.element_id)
     .every((d) => explanation2.dependencies.map((d2) => d2.element_id).includes(d));
+  const sameRelationshipsAuthors = explanation1.dependencies.map((d1) => d1.author_id)
+    .every((d) => explanation2.dependencies.map((d2) => d2.author_id).includes(d));
   const sameCriteriaWeight = explanation1.criterion.weight === explanation2.criterion.weight;
   const sameCriteriaFilters = explanation1.criterion.filters === explanation2.criterion.filters;
-  return sameRelationships && sameCriteriaWeight && sameCriteriaFilters;
+  return sameRelationships && sameRelationshipsAuthors && sameCriteriaWeight && sameCriteriaFilters;
 };
 
 /**
@@ -166,7 +168,16 @@ export const updatePirExplanations = async (
       // In this case there is nothing to add so skip.
       return;
     }
-    explanations = [...pirMetaRel.pir_explanations, ...newExplanations];
+    explanations = [
+      ...pirMetaRel.pir_explanations.filter((e) => {
+        return newExplanations.every((newE) => {
+          const sameRelationships = e.dependencies.map((d1) => d1.element_id)
+            .every((d) => newE.dependencies.map((d2) => d2.element_id).includes(d));
+          return !sameRelationships;
+        });
+      }),
+      ...newExplanations
+    ];
   }
 
   // region compute score

--- a/opencti-platform/opencti-graphql/tests/02-integration/04-manager/pirManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/04-manager/pirManager-test.ts
@@ -6,6 +6,7 @@ import { isStixMatchFilterGroup_MockableForUnitTests } from '../../../src/utils/
 import { checkEventOnPir } from '../../../src/manager/pirManager';
 import type { AuthContext } from '../../../src/types/user';
 import type { SseEvent } from '../../../src/types/event';
+import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
 
 const TEST_PIR_TARGET_1 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166b2';
 const TEST_PIR_TARGET_2 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166a3';
@@ -74,6 +75,11 @@ const buildEvent = ({
       source_ref: 'malware--bb3bf652-fe46-4e1a-b2a8-d588f114a096',
       target_ref: target,
       confidence,
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          source_type: 'Malware',
+        }
+      }
     }
   } as SseEvent<any>;
 };


### PR DESCRIPTION
### Proposed changes

PIR refinements:
- fix top sources donut for relationships causing the flags
- fix score superior to 100 after relationships updates
- static list of threats types of interest according to the pir type (exclude attack pattern)
- fix redirect on click on tab history
- fix tooltip threat map
- e2e tests