### PR TITLE
[frontend](feat) Be able to see at first sight if the connector is deployed by the manager (#7328)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -70,7 +70,7 @@ const useStyles = makeStyles<Theme>({
 const inlineStyles: Record<string, CSSProperties> = {
   name: {
     float: 'left',
-    width: '25%',
+    width: '20%',
     height: 20,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -105,6 +105,14 @@ const inlineStyles: Record<string, CSSProperties> = {
     width: '15%',
   },
   updated_at: {
+    float: 'left',
+    width: '15%',
+    height: 20,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  manager_deployment: {
     float: 'left',
     width: '15%',
     height: 20,
@@ -307,6 +315,11 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
         valueB = -1;
       }
     }
+    // is_managed is a boolean, convert to number for sorting
+    if (sortBy === 'is_managed') {
+      valueA = valueA ? 1 : 0;
+      valueB = valueB ? 1 : 0;
+    }
     if (orderAsc) {
       return valueA < valueB ? -1 : 1;
     }
@@ -390,7 +403,7 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
                     width: '100%',
                   }}
                   >
-                    <div style={{ width: '25%' }}>
+                    <div style={{ width: '20%' }}>
                       <SortConnectorsHeader field="name" label="Name" isSortable orderAsc={orderAsc} sortBy={sortBy} reverseBy={reverseBy} />
                     </div>
                     <div style={{ width: '10%' }}>
@@ -407,6 +420,9 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
                     </div>
                     <div style={{ width: '15%' }}>
                       <SortConnectorsHeader field="updated_at" label="Modified" isSortable orderAsc={orderAsc} sortBy={sortBy} reverseBy={reverseBy} />
+                    </div>
+                    <div style={{ width: '15%' }}>
+                      <SortConnectorsHeader field="is_managed" label="Manager Deployment" isSortable orderAsc={orderAsc} sortBy={sortBy} reverseBy={reverseBy} />
                     </div>
                   </div>
                 }
@@ -511,6 +527,16 @@ const ConnectorsStatusComponent: FunctionComponent<ConnectorsStatusComponentProp
                             style={inlineStyles.updated_at}
                           >
                             {nsdt(connector.updated_at)}
+                          </div>
+                          <div
+                            className={classes.bodyItem}
+                            style={inlineStyles.manager_deployment}
+                          >
+                            <ItemBoolean
+                              label={connector.is_managed ? 'TRUE' : 'FALSE'}
+                              status={connector.is_managed}
+                              variant="inList"
+                            />
                           </div>
                         </div>
                       }

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/SortConnectorsHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/SortConnectorsHeader.tsx
@@ -43,6 +43,11 @@ const sortHeaderStyle: Record<string, CSSProperties> = {
     fontSize: 12,
     fontWeight: '700',
   },
+  is_managed: {
+    float: 'left',
+    fontSize: 12,
+    fontWeight: '700',
+  },
 };
 
 interface SortConnectorsHeaderProps {


### PR DESCRIPTION
### Proposed changes

* Add a new "Manager Deployment" column to the connectors list table to display the managed status of connectors
* Display the managed status as a non-clickable outlined button (green for TRUE, red for FALSE) based on the `connector.is_managed` property

### Related issues
* #7328 
* Feature request: Display connector managed status in the connectors list view
* Improve visibility of composer-managed connectors

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This PR adds a new column "Manager Deployment" to the connectors status table that clearly indicates whether a connector is managed by the composer or not. 