### PR TITLE
[frontend] remove id from filters contained in dynamicRegardingOf (#11897)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -821,7 +821,10 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
         delete newFilter.id;
         if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
           const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
-            .map((dynamic) => dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)));
+            .map((dynamic) => ({
+              ...dynamic,
+              values: dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)),
+            }));
           const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
           newFilter.values = [...dynamicValues, ...relationshipTypeValues];
         }

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -777,33 +777,6 @@ export const useAvailableFilterKeysForEntityTypes = (entityTypes: string[]) => {
   return generateUniqueItemsArray(filterKeysMap.keys() ?? []);
 };
 
-const notCleanableFilterKeys = ['entity_type', 'authorized_members.id', 'user_id', 'internal_id', 'entity_id'];
-
-export const useRemoveIdAndIncorrectKeysFromFilterGroupObject = (filters?: FilterGroup | null, entityTypes = ['Stix-Core-Object']): FilterGroup | undefined => {
-  const availableFilterKeys = useAvailableFilterKeysForEntityTypes(entityTypes).concat(notCleanableFilterKeys);
-  if (!filters) {
-    return undefined;
-  }
-  return {
-    mode: filters.mode,
-    filters: filters.filters
-      .filter((f) => availableFilterKeys.includes(f.key) || f.key === 'ids')
-      .filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0)
-      .map((f) => {
-        const newFilter = { ...f };
-        delete newFilter.id; // remove id of the filter
-        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
-          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
-            .map((dynamic) => dynamic.values.map((dynamicFilter: FilterGroup) => useRemoveIdAndIncorrectKeysFromFilterGroupObject(dynamicFilter)));
-          const otherValues = newFilter.values.filter((value) => value.key === 'relationship_type');
-          newFilter.values = [...dynamicValues, ...otherValues];
-        }
-        return newFilter;
-      }),
-    filterGroups: filters.filterGroups.map((group) => useRemoveIdAndIncorrectKeysFromFilterGroupObject(group, entityTypes)) as FilterGroup[],
-  };
-};
-
 export const removeIdFromFilterGroupObject = (filters?: FilterGroup | null): FilterGroup | undefined => {
   if (!filters) {
     return undefined;
@@ -815,11 +788,22 @@ export const removeIdFromFilterGroupObject = (filters?: FilterGroup | null): Fil
       .map((f) => {
         const newFilter = { ...f };
         delete newFilter.id;
+        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
+          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
+            .map((dynamic) => ({
+              ...dynamic,
+              values: dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)),
+            }));
+          const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
+          newFilter.values = [...dynamicValues, ...relationshipTypeValues];
+        }
         return newFilter;
       }),
     filterGroups: filters.filterGroups.map((group) => removeIdFromFilterGroupObject(group)) as FilterGroup[],
   };
 };
+
+const notCleanableFilterKeys = ['ids', 'entity_type', 'authorized_members.id', 'user_id', 'internal_id', 'entity_id'];
 
 // TODO use useRemoveIdAndIncorrectKeysFromFilterGroupObject instead when all the calling files are in pure function
 export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGroup | null | undefined, availableFilterKeys: string[]): FilterGroup | undefined => {
@@ -835,10 +819,21 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
       .map((f) => {
         const newFilter = { ...f };
         delete newFilter.id;
+        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
+          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
+            .map((dynamic) => dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)));
+          const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
+          newFilter.values = [...dynamicValues, ...relationshipTypeValues];
+        }
         return newFilter;
       }),
-    filterGroups: filters.filterGroups.map((group) => removeIdAndIncorrectKeysFromFilterGroupObject(group, fullAvailableFilterKeys)) as FilterGroup[],
+    filterGroups: filters.filterGroups.map((group) => removeIdAndIncorrectKeysFromFilterGroupObject(group, availableFilterKeys)) as FilterGroup[],
   };
+};
+
+export const useRemoveIdAndIncorrectKeysFromFilterGroupObject = (filters?: FilterGroup | null, entityTypes = ['Stix-Core-Object']): FilterGroup | undefined => {
+  const availableFilterKeys = useAvailableFilterKeysForEntityTypes(entityTypes).concat(notCleanableFilterKeys);
+  return removeIdAndIncorrectKeysFromFilterGroupObject(filters, availableFilterKeys);
 };
 
 export const useBuildEntityTypeBasedFilterContext = (

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -791,7 +791,13 @@ export const useRemoveIdAndIncorrectKeysFromFilterGroupObject = (filters?: Filte
       .filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0)
       .map((f) => {
         const newFilter = { ...f };
-        delete newFilter.id;
+        delete newFilter.id; // remove id of the filter
+        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
+          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
+            .map((dynamic) => dynamic.values.map((dynamicFilter: FilterGroup) => useRemoveIdAndIncorrectKeysFromFilterGroupObject(dynamicFilter)));
+          const otherValues = newFilter.values.filter((value) => value.key === 'relationship_type');
+          newFilter.values = [...dynamicValues, ...otherValues];
+        }
         return newFilter;
       }),
     filterGroups: filters.filterGroups.map((group) => useRemoveIdAndIncorrectKeysFromFilterGroupObject(group, entityTypes)) as FilterGroup[],


### PR DESCRIPTION
### Proposed changes
Remove 'id' attribute from dynamic filters of dynamicRegardingOf filter in the queries sent from frontend to backend

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11897