### PR TITLE
[CI] Wait for client-python to be checkout before license step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
       - git log -n 1
 
   - name: backend-verify-licenses
-    image: nikolaik/python-nodejs:python3.11-nodejs20-alpine
+    image: nikolaik/python-nodejs:python3.11-nodejs22-alpine
     commands:
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools
@@ -38,6 +38,8 @@ steps:
       - cd "$DRONE_WORKSPACE/opencti-platform/opencti-graphql"
       - yarn install
       - yarn verify-licenses
+    depends_on:
+      - dependencies-checkout
 
   - name: frontend-verify-licenses
     image: node:22.14.0
@@ -45,6 +47,8 @@ steps:
       - cd ./opencti-platform/opencti-front
       - yarn install
       - yarn verify-licenses
+    depends_on:
+      - dependencies-checkout
 
   - name: generate-licenses
     image: node:22.14.0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* wait for client python clone to run license since python is required.

Fixes =>
<img width="1735" height="322" alt="image" src="https://github.com/user-attachments/assets/cf05fc53-6546-4890-bb8b-acc7d3c7fb49" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
