### PR TITLE
[backend/frontend] authorize several bulk actions on the same key if no replace action (#11932)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -986,6 +986,7 @@ class DataTableToolBar extends Component {
     const sortedOptions = options.sort((a, b) => a.label.localeCompare(b.label));
 
     const selectedFields = actionsInputs.map((a) => a.field).filter(Boolean);
+    const replaceSelectedFields = actionsInputs.filter((a) => a.type === 'REPLACE').map((a) => a.field).filter(Boolean);
 
     return (
       <Select
@@ -996,16 +997,20 @@ class DataTableToolBar extends Component {
       >
         {sortedOptions.length > 0 ? (
           sortedOptions.map(
-            (n) => (
-              <MenuItem
-                key={n.value}
-                value={n.value}
-                disabled={selectedFields.includes(n.value)
-                  && actionsInputs[i]?.field !== n.value} // disable already selected fields to prevent making several actions on the same key
-              >
-                {n.label}
-              </MenuItem>
-            ),
+            (n) => {
+              // disable some fields to prevent making several actions on the same key if one of them is a replace
+              const disabled = (replaceSelectedFields.includes(n.value) && actionsInputs[i]?.field !== n.value)
+                || (selectedFields.includes(n.value) && actionsInputs[i]?.type === 'REPLACE');
+              return (
+                <MenuItem
+                  key={n.value}
+                  value={n.value}
+                  disabled={disabled}
+                >
+                  {n.label}
+                </MenuItem>
+              );
+            },
           )
         ) : (
           <MenuItem value="none">{t('None')}</MenuItem>

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -999,13 +999,13 @@ class DataTableToolBar extends Component {
           sortedOptions.map(
             (n) => {
               // disable some fields to prevent making several actions on the same key if one of them is a replace
-              const disabled = (replaceSelectedFields.includes(n.value) && actionsInputs[i]?.field !== n.value)
+              const disableField = (replaceSelectedFields.includes(n.value) && actionsInputs[i]?.field !== n.value)
                 || (selectedFields.includes(n.value) && actionsInputs[i]?.type === 'REPLACE');
               return (
                 <MenuItem
                   key={n.value}
                   value={n.value}
-                  disabled={disabled}
+                  disabled={disableField}
                 >
                   {n.label}
                 </MenuItem>

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -32,14 +32,19 @@ import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
 import { TYPE_FILTER, USER_ID_FILTER } from '../utils/filtering/filtering-constants';
 import { createWork } from './work';
 import { getBestBackgroundConnectorId } from '../database/rabbitmq';
-import { ACTION_TYPE_REPLACE } from "./backgroundTask";
 
 export const TASK_TYPE_QUERY = 'QUERY';
 export const TASK_TYPE_RULE = 'RULE';
 export const TASK_TYPE_LIST = 'LIST';
 
+export const ACTION_TYPE_ADD = 'ADD';
 export const ACTION_TYPE_DELETE = 'DELETE';
+export const ACTION_TYPE_REMOVE = 'REMOVE';
+export const ACTION_TYPE_REPLACE = 'REPLACE';
 export const ACTION_TYPE_RESTORE = 'RESTORE';
+export const ACTION_TYPE_MERGE = 'MERGE';
+export const ACTION_TYPE_PROMOTE = 'PROMOTE';
+export const ACTION_TYPE_ENRICHMENT = 'ENRICHMENT';
 export const ACTION_TYPE_COMPLETE_DELETE = 'COMPLETE_DELETE';
 export const ACTION_TYPE_SHARE = 'SHARE';
 export const ACTION_TYPE_UNSHARE = 'UNSHARE';
@@ -51,6 +56,9 @@ export const ACTION_TYPE_ADD_ORGANIZATIONS = 'ADD_ORGANIZATIONS';
 export const ACTION_TYPE_REMOVE_ORGANIZATIONS = 'REMOVE_ORGANIZATIONS';
 export const ACTION_TYPE_ADD_GROUPS = 'ADD_GROUPS';
 export const ACTION_TYPE_REMOVE_GROUPS = 'REMOVE_GROUPS';
+export const ACTION_TYPE_RULE_APPLY = 'RULE_APPLY';
+export const ACTION_TYPE_RULE_CLEAR = 'RULE_CLEAR';
+export const ACTION_TYPE_RULE_ELEMENT_RESCAN = 'RULE_ELEMENT_RESCAN';
 
 const isDeleteRestrictedAction = ({ type }) => {
   return type === ACTION_TYPE_DELETE || type === ACTION_TYPE_RESTORE || type === ACTION_TYPE_COMPLETE_DELETE;

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -40,16 +40,6 @@ export const DEFAULT_ALLOWED_TASK_ENTITY_TYPES = [
 
 export const MAX_TASK_ELEMENTS = 500;
 
-export const ACTION_TYPE_ADD = 'ADD';
-export const ACTION_TYPE_REMOVE = 'REMOVE';
-export const ACTION_TYPE_REPLACE = 'REPLACE';
-export const ACTION_TYPE_MERGE = 'MERGE';
-export const ACTION_TYPE_PROMOTE = 'PROMOTE';
-export const ACTION_TYPE_ENRICHMENT = 'ENRICHMENT';
-export const ACTION_TYPE_RULE_APPLY = 'RULE_APPLY';
-export const ACTION_TYPE_RULE_CLEAR = 'RULE_CLEAR';
-export const ACTION_TYPE_RULE_ELEMENT_RESCAN = 'RULE_ELEMENT_RESCAN';
-
 export const findById = async (context, user, taskId) => {
   return storeLoadById(context, user, taskId, ENTITY_TYPE_BACKGROUND_TASK);
 };

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -4,20 +4,7 @@ import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/dynamic
 import * as R from 'ramda';
 import { Promise as BluePromise } from 'bluebird';
 import { lockResources } from '../lock/master-lock';
-import {
-  ACTION_TYPE_ADD,
-  ACTION_TYPE_ENRICHMENT,
-  ACTION_TYPE_MERGE,
-  ACTION_TYPE_PROMOTE,
-  ACTION_TYPE_REMOVE,
-  ACTION_TYPE_REPLACE,
-  ACTION_TYPE_RULE_APPLY,
-  ACTION_TYPE_RULE_CLEAR,
-  ACTION_TYPE_RULE_ELEMENT_RESCAN,
-  buildQueryFilters,
-  findAll,
-  updateTask
-} from '../domain/backgroundTask';
+import { buildQueryFilters, findAll, updateTask } from '../domain/backgroundTask';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { resolveUserByIdFromCache } from '../domain/user';
 import { storeLoadByIdsWithRefs } from '../database/middleware';
@@ -33,15 +20,24 @@ import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { isStixCyberObservable } from '../schema/stixCyberObservable';
 import { generateIndicatorFromObservable } from '../domain/stixCyberObservable';
 import {
+  ACTION_TYPE_ADD,
   ACTION_TYPE_ADD_GROUPS,
   ACTION_TYPE_ADD_ORGANIZATIONS,
   ACTION_TYPE_COMPLETE_DELETE,
   ACTION_TYPE_DELETE,
+  ACTION_TYPE_ENRICHMENT,
+  ACTION_TYPE_MERGE,
+  ACTION_TYPE_PROMOTE,
+  ACTION_TYPE_REMOVE,
   ACTION_TYPE_REMOVE_AUTH_MEMBERS,
   ACTION_TYPE_REMOVE_FROM_DRAFT,
   ACTION_TYPE_REMOVE_GROUPS,
   ACTION_TYPE_REMOVE_ORGANIZATIONS,
+  ACTION_TYPE_REPLACE,
   ACTION_TYPE_RESTORE,
+  ACTION_TYPE_RULE_APPLY,
+  ACTION_TYPE_RULE_CLEAR,
+  ACTION_TYPE_RULE_ELEMENT_RESCAN,
   ACTION_TYPE_SHARE,
   ACTION_TYPE_SHARE_MULTIPLE,
   ACTION_TYPE_UNSHARE,

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { ACTION_TYPE_DELETE, checkActionValidity, TASK_TYPE_QUERY } from '../../../src/domain/backgroundTask-common';
+import { ACTION_TYPE_ADD, ACTION_TYPE_REPLACE, ACTION_TYPE_DELETE, checkActionValidity, TASK_TYPE_QUERY } from '../../../src/domain/backgroundTask-common';
 import { buildStandardUser, testContext } from '../../utils/testQuery';
-import { ACTION_TYPE_ADD, ACTION_TYPE_REPLACE } from '../../../src/domain/backgroundTask';
 import { ENTITY_TYPE_VOCABULARY } from '../../../src/modules/vocabulary/vocabulary-types';
 import { ENTITY_TYPE_WORKSPACE } from '../../../src/modules/workspace/workspace-types';
 import { ENTITY_TYPE_NOTIFICATION } from '../../../src/modules/notification/notification-types';

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/backgroundTask-common-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ACTION_TYPE_DELETE, checkActionValidity, TASK_TYPE_QUERY } from '../../../src/domain/backgroundTask-common';
 import { buildStandardUser, testContext } from '../../utils/testQuery';
-import { ACTION_TYPE_ADD } from '../../../src/domain/backgroundTask';
+import { ACTION_TYPE_ADD, ACTION_TYPE_REPLACE } from '../../../src/domain/backgroundTask';
 import { ENTITY_TYPE_VOCABULARY } from '../../../src/modules/vocabulary/vocabulary-types';
 import { ENTITY_TYPE_WORKSPACE } from '../../../src/modules/workspace/workspace-types';
 import { ENTITY_TYPE_NOTIFICATION } from '../../../src/modules/notification/notification-types';
@@ -56,19 +56,49 @@ describe('Background task validity check (checkActionValidity)', () => {
     { name: 'INVESTIGATION_INUPDATE_INDELETE' },
   ]);
 
-  it('should throw an error if there are several actions on the same field', async () => {
+  describe('Check actions validity', () => {
     const user = userEditor;
     const type = TASK_TYPE_QUERY;
-    const input = {
-      actions: [
-        { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label1'] },
-        { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label2'] }
-      ],
-      filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
-    };
-    await expect(async () => {
-      await checkActionValidity(testContext, user, input, BackgroundTaskScope.Knowledge, type);
-    }).rejects.toThrowError('A single task cannot perform several actions on the same field.');
+
+    it('should not throw an error if there are several actions on the same field and none of these actions is a replace', async () => {
+      const input = {
+        actions: [
+          { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label1'] },
+          { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label2'] },
+          { type: ACTION_TYPE_REPLACE, field: 'object-marking', value: ['markingA'] }
+        ],
+        filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
+      };
+      expect(async () => {
+        await checkActionValidity(testContext, user, input, BackgroundTaskScope.Knowledge, type);
+      }).not.toThrowError();
+    });
+
+    it('should throw an error if there are several actions on the same field and one action is a replace', async () => {
+      const input = {
+        actions: [
+          { type: ACTION_TYPE_ADD, field: 'object-label', value: ['label1'] },
+          { type: ACTION_TYPE_REPLACE, field: 'object-label', value: ['label2'] }
+        ],
+        filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
+      };
+      await expect(async () => {
+        await checkActionValidity(testContext, user, input, BackgroundTaskScope.Knowledge, type);
+      }).rejects.toThrowError('A single task cannot perform several actions on the same field if one action is a replace.');
+    });
+
+    it('should throw an error if there are several replace actions on the same field', async () => {
+      const input = {
+        actions: [
+          { type: ACTION_TYPE_REPLACE, field: 'object-label', value: ['label1'] },
+          { type: ACTION_TYPE_REPLACE, field: 'object-label', value: ['label2'] }
+        ],
+        filters: filterEntityType(ENTITY_TYPE_CONTAINER_REPORT)
+      };
+      await expect(async () => {
+        await checkActionValidity(testContext, user, input, BackgroundTaskScope.Knowledge, type);
+      }).rejects.toThrowError('A single task cannot perform several actions on the same field if one action is a replace.');
+    });
   });
 
   describe('Scope SETTINGS', () => {


### PR DESCRIPTION

### Proposed changes
Authorize bulk update on the same key if there is no 'replace' actions among them


### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11932