### PR TITLE
[backend/frontend] Take args into account at ref relationship creation (#10846)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipEditionOverview.tsx
@@ -26,6 +26,10 @@ const StixNestedRefRelationshipEditionFragment = graphql`
     start_time
     stop_time
     relationship_type
+    creators {
+      id
+      name
+    }
     editContext {
       name
       focusOn

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
@@ -18,6 +18,7 @@ import { getMainRepresentative } from '../../../../utils/defaultRepresentatives'
 import { TEN_SECONDS } from '../../../../utils/Time';
 import { stixCyberObservableEntitiesLinesQuery } from './StixCyberObservableEntitiesLines';
 import ItemEntityType from '../../../../components/ItemEntityType';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const interval$ = interval(TEN_SECONDS);
 
@@ -130,9 +131,11 @@ class StixCyberObservableNestedEntitiesLinesComponent extends Component {
                             className={classes.bodyItem}
                             style={{ width: '12%' }}
                           >
-                            {(stixCoreObject.creators ?? [])
-                              .map((c) => c?.name)
-                              .join(', ')}
+                            <FieldOrEmpty source={stixCoreObject.creators}>
+                              {(stixCoreObject.creators ?? [])
+                                .map((c) => c?.name)
+                                .join(', ')}
+                            </FieldOrEmpty>
                           </div>
                           <div
                             className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesLines.jsx
@@ -131,8 +131,8 @@ class StixCyberObservableNestedEntitiesLinesComponent extends Component {
                             className={classes.bodyItem}
                             style={{ width: '12%' }}
                           >
-                            <FieldOrEmpty source={stixCoreObject.creators}>
-                              {(stixCoreObject.creators ?? [])
+                            <FieldOrEmpty source={stixNestedRefRelationship.creators}>
+                              {(stixNestedRefRelationship.creators ?? [])
                                 .map((c) => c?.name)
                                 .join(', ')}
                             </FieldOrEmpty>

--- a/opencti-platform/opencti-graphql/src/domain/stixRefRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRefRelationship.js
@@ -1,10 +1,5 @@
 import { dissoc, uniq } from 'ramda';
-import {
-  createRelation,
-  storeLoadByIdWithRefs,
-  updateAttribute,
-  updateAttributeFromLoadedWithRefs
-} from '../database/middleware';
+import { createRelation, storeLoadByIdWithRefs, updateAttribute, updateAttributeFromLoadedWithRefs } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
 import { notify } from '../database/redis';
 import {

--- a/opencti-platform/opencti-graphql/src/domain/stixRefRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRefRelationship.js
@@ -17,7 +17,7 @@ import { schemaTypesDefinition } from '../schema/schema-types';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { findById as findStixObjectOrStixRelationshipById } from './stixObjectOrStixRelationship';
 import { elCount } from '../database/engine';
-import { READ_INDEX_STIX_CYBER_OBSERVABLE_RELATIONSHIPS, READ_INDEX_STIX_META_RELATIONSHIPS, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE } from '../database/utils';
+import { READ_INDEX_STIX_CYBER_OBSERVABLE_RELATIONSHIPS, READ_INDEX_STIX_META_RELATIONSHIPS, UPDATE_OPERATION_REMOVE } from '../database/utils';
 import { findAll as findSubTypes } from './subType';
 
 // Query
@@ -50,6 +50,7 @@ export const schemaRefRelationships = async (context, user, id, toType) => {
       return { entity, from, to };
     });
 };
+
 // return the possible types with which an entity type can have a nested relation ref
 export const schemaRefRelationshipsPossibleTypes = async (context, user, entityType) => {
   const registeredTypes = schemaRelationsRefDefinition.getRegisteredTypes();
@@ -101,7 +102,7 @@ export const addStixRefRelationship = async (context, user, stixRefRelationship)
       to_missing: !to
     });
   }
-  await createRelation(context, user, stixRefRelationship);
+  return createRelation(context, user, stixRefRelationship);
 };
 export const stixRefRelationshipEditField = async (context, user, stixRefRelationshipId, input) => {
   // Not use ABSTRACT_STIX_REF_RELATIONSHIP to have compatibility on parent type with ABSTRACT_STIX_CYBER_OBSERVABLE_RELATIONSHIP type

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixRefRelationships-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixRefRelationships-test.js
@@ -17,6 +17,7 @@ describe('StixRefRelationship', () => {
                     spec_version
                     created_at
                     updated_at
+                    confidence
                     from {
                         ... on Malware {
                             id
@@ -32,6 +33,7 @@ describe('StixRefRelationship', () => {
         fromId: 'malware--c6006dd5-31ca-45c2-8ae0-4e428e712f88',
         toId: 'software--b0debdba-74e7-4463-ad2a-34334ee66d8d',
         relationship_type: 'operating-system',
+        confidence: 90,
       },
     };
     const stixRefRelationship = await queryAsAdmin({
@@ -42,6 +44,7 @@ describe('StixRefRelationship', () => {
     expect(stixRefRelationship.data.stixRefRelationshipAdd).not.toBeNull();
     expect(stixRefRelationship.data.stixRefRelationshipAdd.created_at).toEqual(stixRefRelationship.data.stixRefRelationshipAdd.updated_at);
     expect(stixRefRelationship.data.stixRefRelationshipAdd.spec_version).toEqual('2.1');
+    expect(stixRefRelationship.data.stixRefRelationshipAdd.confidence).toEqual(90);
     expect(stixRefRelationship.data.stixRefRelationshipAdd.from.x_opencti_stix_ids[0]).toEqual('malware--c6006dd5-31ca-45c2-8ae0-4e428e712f88');
     stixRefRelationshipInternalId = stixRefRelationship.data.stixRefRelationshipAdd.id;
     stixRefRelationshipCreatedAt = stixRefRelationship.data.stixRefRelationshipAdd.created_at;


### PR DESCRIPTION

### Proposed changes
- When creating a nested relation from an observable, start_time and stop_time must be taken into account
- When using stixRefRelationshipAdd from API, the input start_time, stop_time and confidence must be taken into account
- In an observable Knowledge tab, in the Nested objects panel, the creator of the nested relationship should be displayed

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/10846