### PR TITLE
[backend] fix issue in buildContainersElementsBundle when withNeighbours was activated (#11976)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -319,19 +319,19 @@ export const buildContainersElementsBundle = async (context, user, containers, e
     const element = elements[index];
     elementIds.add(element.internal_id);
     elementStandardIds.add(element.standard_id);
-    if (withNeighbours) {
-      if (element.fromId) elementIds.add(element.fromId);
-      if (element.toId) elementIds.add(element.toId);
-      const callback = (relations) => {
-        relations.forEach((relation) => {
-          elementIds.add(relation.fromId);
-          elementIds.add(relation.toId);
-          elementIds.add(relation.id);
-        });
-      };
-      const args = { fromOrToId: Array.from(elementIds), baseData: true, callback };
-      await listAllRelations(context, user, ABSTRACT_STIX_CORE_RELATIONSHIP, args);
-    }
+    if (element.fromId) elementIds.add(element.fromId);
+    if (element.toId) elementIds.add(element.toId);
+  }
+  if (withNeighbours) {
+    const callback = (relations) => {
+      relations.forEach((relation) => {
+        elementIds.add(relation.fromId);
+        elementIds.add(relation.toId);
+        elementIds.add(relation.id);
+      });
+    };
+    const args = { fromOrToId: Array.from(elementIds), baseData: true, callback };
+    await listAllRelations(context, user, ABSTRACT_STIX_CORE_RELATIONSHIP, args);
   }
   // Build limited stix object to limit memory footprint
   const containerOperations = [{


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* when withNeighbours is activated, we now list the neighbours outside the for loop instead of inside. Doing it inside the for loop was incorrect: we were refetching the relations each time we added a new element to the list of container elements to add, causing too many neighbors to be fetched
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11976
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
