### PR TITLE
[frontend] refactor: rename query param for hub resource redirection

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -35,7 +35,7 @@ const IngestionCsv = () => {
   const classes = useStyles();
   const { settings } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?octi_instance_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?opencti_platform_id=${settings.id}`
     : '';
 
   const { t_i18n } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -61,7 +61,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   const inputRef = useRef();
   const { settings } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?octi_instance_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?opencti_platform_id=${settings.id}`
     : '';
 
   const [commitImportMutation] = useApiMutation(importMutation);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* rename query param used for resource redirection on XTM Hub

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Relates #11296

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
