### PR TITLE
[backend/frontend] feat: check XTM Hub connectivity on Experience page load

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -1,15 +1,17 @@
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import { List, ListItem, ListItemText, Typography } from '@mui/material';
 import { Theme } from '@mui/material/styles/createTheme';
 import XtmHubTab from '@components/settings/xtm-hub/XtmHubTab';
 import makeStyles from '@mui/styles/makeStyles';
+import Skeleton from '@mui/material/Skeleton';
 import { useFormatter } from '../../../../components/i18n';
 import { XtmHubSettingsQuery } from './__generated__/XtmHubSettingsQuery.graphql';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import useGranted, { SETTINGS_SETMANAGEXTMHUB } from '../../../../utils/hooks/useGranted';
 import GradientButton from '../../../../components/GradientButton';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
@@ -33,7 +35,15 @@ export const xtmHubSettingsQuery = graphql`
   }
 `;
 
-const XtmHubSettings = () => {
+export const checkHubConnectivity = graphql`
+  mutation XtmHubSettingsCheckConnectivityMutation {
+    checkXTMHubConnectivity {
+      status
+    }
+  }
+`;
+
+const XtmHubSettingsComponent = () => {
   const { t_i18n, fd } = useFormatter();
   const classes = useStyles();
   const { settings: xtmHubSettings } = useLazyLoadQuery<XtmHubSettingsQuery>(
@@ -123,6 +133,29 @@ const XtmHubSettings = () => {
       </Paper>
     </>
   );
+};
+
+const XtmHubSettings: React.FC = () => {
+  const [commitCheckConnectivity] = useApiMutation(checkHubConnectivity);
+  const [isCheckDone, setIsCheckDone] = useState(false);
+
+  useEffect(() => {
+    commitCheckConnectivity({ variables: {},
+      onCompleted: () => {
+        setIsCheckDone(true);
+      } });
+  }, []);
+
+  if (!isCheckDone) {
+    return <Skeleton
+      animation="wave"
+      variant="rectangular"
+      width="100%"
+      height="100%"
+           />;
+  }
+
+  return <XtmHubSettingsComponent />;
 };
 
 export default XtmHubSettings;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9389,6 +9389,7 @@ type Mutation {
   emailTemplateDelete(id: ID!): ID
   emailTemplateFieldPatch(id: ID!, input: [EditInput!]!): EmailTemplate
   emailTemplateTestSend(id: ID!): Boolean
+  checkXTMHubConnectivity: CheckXTMHubConnectivityResponse!
 }
 
 type Channel implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
@@ -13641,4 +13642,8 @@ input EmailTemplateAddInput {
   email_object: String!
   sender_email: String!
   template_body: String!
+}
+
+type CheckXTMHubConnectivityResponse {
+  status: XTMHubRegistrationStatus
 }

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -1,0 +1,105 @@
+import ejs from 'ejs';
+import { getEntityFromCache } from '../database/cache';
+import type { BasicStoreSettings } from '../types/settings';
+import type { AuthContext, AuthUser } from '../types/user';
+import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
+import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
+import { XtmHubRegistrationStatus } from '../generated/graphql';
+import { updateAttribute } from '../database/middleware';
+import conf, { BUS_TOPICS, getBaseUrl, logApp } from '../config/conf';
+import { findUserWithCapabilities } from './user';
+import { BYPASS, HUB_REGISTRATION_MANAGER_USER, SETTINGS_SETMANAGEXTMHUB } from '../utils/access';
+import { OCTI_EMAIL_TEMPLATE } from '../utils/emailTemplates/octiEmailTemplate';
+import type { SendMailArgs } from '../types/smtp';
+import { sendMail } from '../database/smtp';
+import { getSettings } from './settings';
+import { notify } from '../database/redis';
+
+const MAX_EMAIL_LIST_SIZE = conf.get('smtp:email_max_cc_size') || 500;
+const TO_EMAIL = conf.get('xtm:xtmhub_to_email') || 'no-reply@filigran.io';
+
+const EMAIL_BODY = `
+  <p>We wanted to inform you that the connectivity between OpenCTI and the XTM Hub has been lost. As a result, the integration is currently inactive.</p>
+  <p>To restore functionality, please navigate to the <strong>Settings</strong> section and re-initiate the registration process for the OpenCTI platform. This will re-establish the connection and allow continued use of the integrated features.</p>
+  <p>If you need assistance during the process, don’t hesitate to reach out.</p>
+  <p>
+    <a href="${getBaseUrl()}">Access OpenCTI</a><br />
+    Best,<br />
+    Filigran Team<br />
+  </p>
+`;
+
+const loadAdministratorsList = async (context: AuthContext) => {
+  const administrators = (await findUserWithCapabilities(context, HUB_REGISTRATION_MANAGER_USER, [BYPASS, SETTINGS_SETMANAGEXTMHUB])) as AuthUser[];
+  if (administrators.length > MAX_EMAIL_LIST_SIZE) {
+    logApp.warn(`Administrators list too large, loading only ${MAX_EMAIL_LIST_SIZE} first administrators.`);
+    return administrators.slice(0, MAX_EMAIL_LIST_SIZE);
+  }
+
+  return administrators;
+};
+
+const sendAdministratorsLostConnectivityEmail = async (context: AuthContext, settings: BasicStoreSettings) => {
+  const administrators = await loadAdministratorsList(context);
+  const subject = 'Action Required: Re-register OpenCTI Platform Due to Lost Connectivity with XTM Hub';
+  const html = ejs.render(OCTI_EMAIL_TEMPLATE, { settings, body: EMAIL_BODY });
+
+  const sendMailArgs: SendMailArgs = {
+    from: `${settings.platform_title} <${settings.platform_email}>`,
+    to: TO_EMAIL,
+    bcc: administrators.map((administrator) => administrator.user_email),
+    subject,
+    html,
+  };
+
+  await sendMail(sendMailArgs, { category: 'hub-registration' });
+};
+
+export const checkXTMHubConnectivity = async (context: AuthContext, user: AuthUser, { mustSendEmail }: { mustSendEmail: boolean }) => {
+  const settings = await getEntityFromCache<BasicStoreSettings>(context, user, ENTITY_TYPE_SETTINGS);
+  if (!settings.xtm_hub_token) {
+    return;
+  }
+
+  const status = await xtmHubClient.loadRegistrationStatus({ platformId: settings.id, token: settings.xtm_hub_token });
+  if (status === 'active') {
+    const attributeUpdates: { key: string, value: unknown[] }[] = [{
+      key: 'xtm_hub_last_connectivity_check', value: [new Date()]
+    }];
+    if (settings.xtm_hub_registration_status !== XtmHubRegistrationStatus.Registered) {
+      attributeUpdates.push({
+        key: 'xtm_hub_registration_status',
+        value: [XtmHubRegistrationStatus.Registered]
+      });
+    }
+    await updateAttribute(
+      context,
+      user,
+      settings.id,
+      ENTITY_TYPE_SETTINGS,
+      attributeUpdates
+    );
+  } else {
+    if (settings.xtm_hub_registration_status !== XtmHubRegistrationStatus.LostConnectivity) {
+      await updateAttribute(
+        context,
+        user,
+        settings.id,
+        ENTITY_TYPE_SETTINGS,
+        [
+          {
+            key: 'xtm_hub_registration_status',
+            value: [XtmHubRegistrationStatus.LostConnectivity]
+          }
+        ]
+      );
+    }
+
+    if (settings.xtm_hub_registration_status === XtmHubRegistrationStatus.Registered && mustSendEmail) {
+      await sendAdministratorsLostConnectivityEmail(context, settings);
+    }
+  }
+
+  const updatedSettings = await getSettings(context);
+  await notify(BUS_TOPICS.Settings.EDIT_TOPIC, updatedSettings, HUB_REGISTRATION_MANAGER_USER);
+};

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3506,6 +3506,11 @@ export enum ChannelsOrdering {
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
+export type CheckXtmHubConnectivityResponse = {
+  __typename?: 'CheckXTMHubConnectivityResponse';
+  status?: Maybe<XtmHubRegistrationStatus>;
+};
+
 export enum CitiesOrdering {
   Score = '_score',
   Aliases = 'aliases',
@@ -14214,6 +14219,7 @@ export type Mutation = {
   channelFieldPatch?: Maybe<Channel>;
   channelRelationAdd?: Maybe<StixRefRelationship>;
   channelRelationDelete?: Maybe<Channel>;
+  checkXTMHubConnectivity: CheckXtmHubConnectivityResponse;
   cityAdd?: Maybe<City>;
   cityEdit?: Maybe<CityEditMutations>;
   containerEdit?: Maybe<ContainerEditMutations>;
@@ -32994,6 +33000,7 @@ export type ResolversTypes = ResolversObject<{
   ChannelConnection: ResolverTypeWrapper<Omit<ChannelConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversTypes['ChannelEdge']>>> }>;
   ChannelEdge: ResolverTypeWrapper<Omit<ChannelEdge, 'node'> & { node: ResolversTypes['Channel'] }>;
   ChannelsOrdering: ChannelsOrdering;
+  CheckXTMHubConnectivityResponse: ResolverTypeWrapper<CheckXtmHubConnectivityResponse>;
   CitiesOrdering: CitiesOrdering;
   City: ResolverTypeWrapper<Omit<City, 'administrativeArea' | 'avatar' | 'cases' | 'connectors' | 'containers' | 'country' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { administrativeArea?: Maybe<ResolversTypes['AdministrativeArea']>, avatar?: Maybe<ResolversTypes['OpenCtiFile']>, cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, country?: Maybe<ResolversTypes['Country']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, status?: Maybe<ResolversTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   CityAddInput: CityAddInput;
@@ -33958,6 +33965,7 @@ export type ResolversParentTypes = ResolversObject<{
   ChannelAddInput: ChannelAddInput;
   ChannelConnection: Omit<ChannelConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['ChannelEdge']>>> };
   ChannelEdge: Omit<ChannelEdge, 'node'> & { node: ResolversParentTypes['Channel'] };
+  CheckXTMHubConnectivityResponse: CheckXtmHubConnectivityResponse;
   City: Omit<City, 'administrativeArea' | 'avatar' | 'cases' | 'connectors' | 'containers' | 'country' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { administrativeArea?: Maybe<ResolversParentTypes['AdministrativeArea']>, avatar?: Maybe<ResolversParentTypes['OpenCtiFile']>, cases?: Maybe<ResolversParentTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, country?: Maybe<ResolversParentTypes['Country']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, status?: Maybe<ResolversParentTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   CityAddInput: CityAddInput;
   CityConnection: Omit<CityConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['CityEdge']>>> };
@@ -35841,6 +35849,11 @@ export type ChannelConnectionResolvers<ContextType = any, ParentType extends Res
 export type ChannelEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['ChannelEdge'] = ResolversParentTypes['ChannelEdge']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<ResolversTypes['Channel'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type CheckXtmHubConnectivityResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CheckXTMHubConnectivityResponse'] = ResolversParentTypes['CheckXTMHubConnectivityResponse']> = ResolversObject<{
+  status?: Resolver<Maybe<ResolversTypes['XTMHubRegistrationStatus']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -39782,6 +39795,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   channelFieldPatch?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, RequireFields<MutationChannelFieldPatchArgs, 'id' | 'input'>>;
   channelRelationAdd?: Resolver<Maybe<ResolversTypes['StixRefRelationship']>, ParentType, ContextType, RequireFields<MutationChannelRelationAddArgs, 'id' | 'input'>>;
   channelRelationDelete?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, RequireFields<MutationChannelRelationDeleteArgs, 'id' | 'relationship_type' | 'toId'>>;
+  checkXTMHubConnectivity?: Resolver<ResolversTypes['CheckXTMHubConnectivityResponse'], ParentType, ContextType>;
   cityAdd?: Resolver<Maybe<ResolversTypes['City']>, ParentType, ContextType, RequireFields<MutationCityAddArgs, 'input'>>;
   cityEdit?: Resolver<Maybe<ResolversTypes['CityEditMutations']>, ParentType, ContextType, RequireFields<MutationCityEditArgs, 'id'>>;
   containerEdit?: Resolver<Maybe<ResolversTypes['ContainerEditMutations']>, ParentType, ContextType, RequireFields<MutationContainerEditArgs, 'id'>>;
@@ -44926,6 +44940,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Channel?: ChannelResolvers<ContextType>;
   ChannelConnection?: ChannelConnectionResolvers<ContextType>;
   ChannelEdge?: ChannelEdgeResolvers<ContextType>;
+  CheckXTMHubConnectivityResponse?: CheckXtmHubConnectivityResponseResolvers<ContextType>;
   City?: CityResolvers<ContextType>;
   CityConnection?: CityConnectionResolvers<ContextType>;
   CityEdge?: CityEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
@@ -1,63 +1,11 @@
-import ejs from 'ejs';
 import { type ManagerDefinition, registerManager } from './managerModule';
-import conf, { booleanConf, BUS_TOPICS, getBaseUrl, logApp } from '../config/conf';
-import { BYPASS, executionContext, HUB_REGISTRATION_MANAGER_USER, SETTINGS_SETMANAGEXTMHUB } from '../utils/access';
-import { getEntityFromCache } from '../database/cache';
-import type { BasicStoreSettings } from '../types/settings';
-import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
-import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
-import { findUserWithCapabilities } from '../domain/user';
-import type { AuthContext, AuthUser } from '../types/user';
-import { OCTI_EMAIL_TEMPLATE } from '../utils/emailTemplates/octiEmailTemplate';
-import type { SendMailArgs } from '../types/smtp';
-import { sendMail } from '../database/smtp';
-import { updateAttribute } from '../database/middleware';
-import { notify } from '../database/redis';
-import { getSettings } from '../domain/settings';
-import { XtmHubRegistrationStatus } from '../generated/graphql';
+import conf, { booleanConf } from '../config/conf';
+import { executionContext, HUB_REGISTRATION_MANAGER_USER } from '../utils/access';
+import { checkXTMHubConnectivity } from '../domain/xtm-hub';
 
 const HUB_REGISTRATION_MANAGER_ENABLED = booleanConf('hub_registration_manager:enabled', true);
 const HUB_REGISTRATION_MANAGER_KEY = conf.get('hub_registration_manager:lock_key') || 'hub_registration_manager_lock';
 const SCHEDULE_TIME = conf.get('hub_registration_manager:interval') || 60 * 60 * 1000; // 1 hour
-const MAX_EMAIL_LIST_SIZE = conf.get('smtp:email_max_cc_size') || 500;
-const TO_EMAIL = conf.get('xtm:xtmhub_to_email') || 'no-reply@filigran.io';
-
-const EMAIL_BODY = `
-  <p>We wanted to inform you that the connectivity between OpenCTI and the XTM Hub has been lost. As a result, the integration is currently inactive.</p>
-  <p>To restore functionality, please navigate to the <strong>Settings</strong> section and re-initiate the registration process for the OpenCTI platform. This will re-establish the connection and allow continued use of the integrated features.</p>
-  <p>If you need assistance during the process, don’t hesitate to reach out.</p>
-  <p>
-    <a href="${getBaseUrl()}">Access OpenCTI</a><br />
-    Best,<br />
-    Filigran Team<br />
-  </p>
-`;
-
-const loadAdministratorsList = async (context: AuthContext) => {
-  const administrators = (await findUserWithCapabilities(context, HUB_REGISTRATION_MANAGER_USER, [BYPASS, SETTINGS_SETMANAGEXTMHUB])) as AuthUser[];
-  if (administrators.length > MAX_EMAIL_LIST_SIZE) {
-    logApp.warn(`Administrators list too large, loading only ${MAX_EMAIL_LIST_SIZE} first administrators.`);
-    return administrators.slice(0, MAX_EMAIL_LIST_SIZE);
-  }
-
-  return administrators;
-};
-
-const sendAdministratorsLostConnectivityEmail = async (context: AuthContext, settings: BasicStoreSettings) => {
-  const administrators = await loadAdministratorsList(context);
-  const subject = 'Action Required: Re-register OpenCTI Platform Due to Lost Connectivity with XTM Hub';
-  const html = ejs.render(OCTI_EMAIL_TEMPLATE, { settings, body: EMAIL_BODY });
-
-  const sendMailArgs: SendMailArgs = {
-    from: `${settings.platform_title} <${settings.platform_email}>`,
-    to: TO_EMAIL,
-    bcc: administrators.map((administrator) => administrator.user_email),
-    subject,
-    html,
-  };
-
-  await sendMail(sendMailArgs, { category: 'hub-registration' });
-};
 
 /**
  * If platform is registered, calls XTM Hub backend to check if the registration data is still valid
@@ -65,52 +13,7 @@ const sendAdministratorsLostConnectivityEmail = async (context: AuthContext, set
  */
 export const hubRegistrationManager = async () => {
   const context = executionContext('hub_registration_manager');
-  const settings = await getEntityFromCache<BasicStoreSettings>(context, HUB_REGISTRATION_MANAGER_USER, ENTITY_TYPE_SETTINGS);
-  if (!settings.xtm_hub_token) {
-    return;
-  }
-
-  const status = await xtmHubClient.loadRegistrationStatus({ platformId: settings.id, token: settings.xtm_hub_token });
-  if (status === 'active') {
-    const attributeUpdates: { key: string, value: unknown[] }[] = [{
-      key: 'xtm_hub_last_connectivity_check', value: [new Date()]
-    }];
-    if (settings.xtm_hub_registration_status !== XtmHubRegistrationStatus.Registered) {
-      attributeUpdates.push({
-        key: 'xtm_hub_registration_status',
-        value: [XtmHubRegistrationStatus.Registered]
-      });
-    }
-    await updateAttribute(
-      context,
-      HUB_REGISTRATION_MANAGER_USER,
-      settings.id,
-      ENTITY_TYPE_SETTINGS,
-      attributeUpdates
-    );
-  } else {
-    if (settings.xtm_hub_registration_status !== XtmHubRegistrationStatus.LostConnectivity) {
-      await updateAttribute(
-        context,
-        HUB_REGISTRATION_MANAGER_USER,
-        settings.id,
-        ENTITY_TYPE_SETTINGS,
-        [
-          {
-            key: 'xtm_hub_registration_status',
-            value: [XtmHubRegistrationStatus.LostConnectivity]
-          }
-        ]
-      );
-    }
-
-    if (settings.xtm_hub_registration_status === XtmHubRegistrationStatus.Registered) {
-      await sendAdministratorsLostConnectivityEmail(context, settings);
-    }
-  }
-
-  const updatedSettings = await getSettings(context);
-  await notify(BUS_TOPICS.Settings.EDIT_TOPIC, updatedSettings, HUB_REGISTRATION_MANAGER_USER);
+  await checkXTMHubConnectivity(context, HUB_REGISTRATION_MANAGER_USER, { mustSendEmail: true });
 };
 
 const HUB_REGISTRATION_MANAGER_DEFINITION: ManagerDefinition = {

--- a/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
@@ -13,7 +13,7 @@ const SCHEDULE_TIME = conf.get('hub_registration_manager:interval') || 60 * 60 *
  */
 export const hubRegistrationManager = async () => {
   const context = executionContext('hub_registration_manager');
-  await checkXTMHubConnectivity(context, HUB_REGISTRATION_MANAGER_USER, { mustSendEmail: true });
+  await checkXTMHubConnectivity(context, HUB_REGISTRATION_MANAGER_USER);
 };
 
 const HUB_REGISTRATION_MANAGER_DEFINITION: ManagerDefinition = {

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -141,4 +141,5 @@ import './fintelDesign/fintelDesign-graphql';
 import './securityPlatform/securityPlatform-graphql';
 import './auth/auth-graphql';
 import './emailTemplate/emailTemplate-graphql';
+import './xtm/hub/xtm-hub-graphql';
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-graphql.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-graphql.ts
@@ -1,0 +1,8 @@
+import { registerGraphqlSchema } from '../../../graphql/schema';
+import xtmHubTypeDefs from './xtm-hub.graphql';
+import xtmHubResolvers from './xtm-hub-resolver';
+
+registerGraphqlSchema({
+  schema: xtmHubTypeDefs,
+  resolver: xtmHubResolvers,
+});

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-resolver.ts
@@ -1,0 +1,10 @@
+import type { Resolvers } from '../../../generated/graphql';
+import { checkXTMHubConnectivity } from '../../../domain/xtm-hub';
+
+const xtmHubResolvers: Resolvers = {
+  Mutation: {
+    checkXTMHubConnectivity: (_, __, context) => checkXTMHubConnectivity(context, context.user),
+  },
+};
+
+export default xtmHubResolvers;

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub.graphql
@@ -1,0 +1,8 @@
+
+type CheckXTMHubConnectivityResponse {
+  status: XTMHubRegistrationStatus
+}
+
+type Mutation {
+  checkXTMHubConnectivity: CheckXTMHubConnectivityResponse! @auth
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* move connectivity check to new xtm hub domain
* add a new mutation to check connectivity
* use this mutation on Experience page load before XTM Hub settings are loaded

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Relates https://github.com/FiligranHQ/xtm-hub/issues/758
* Relates #12079

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
