### PR TITLE
[backend] User without user_service_account also filtered (#8754)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -159,6 +159,7 @@ import {
   RELATION_TYPE_FILTER,
   SOURCE_RELIABILITY_FILTER,
   TYPE_FILTER,
+  USER_SERVICE_ACCOUNT_FILTER,
   WORKFLOW_FILTER,
   X_OPENCTI_WORKFLOW_ID
 } from '../utils/filtering/filtering-constants';
@@ -3099,6 +3100,23 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
             { key: 'pir_id', values: [pirId], operator: FilterOperator.Eq },
           ]
         });
+      }
+      if (filterKey === USER_SERVICE_ACCOUNT_FILTER) {
+        // key USER_SERVICE_ACCOUNT_FILTER === nul also filtered
+        if ((filter.values.includes('false') && filter.operator === FilterOperator.Eq)
+        || (filter.values.includes('true') && filter.operator === FilterOperator.NotEq)) {
+          const newFilterGroup = {
+            mode: 'or',
+            filters: [{
+              key: USER_SERVICE_ACCOUNT_FILTER,
+              values: [],
+              operator: FilterOperator.Nil,
+            },
+            filter],
+            filterGroups: [],
+          };
+          finalFilterGroups.push(newFilterGroup);
+        }
       }
     } else if (arrayKeys.some((filterKey) => isObjectAttribute(filterKey)) && !arrayKeys.some((filterKey) => filterKey === 'connections')) {
       if (arrayKeys.length > 1) {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -91,6 +91,9 @@ export const IS_INFERRED_FILTER = 'is_inferred'; // if an entity or relationship
 
 export const PIR_SCORE_FILTER_PREFIX = 'pir_score';
 
+// for users
+export const USER_SERVICE_ACCOUNT_FILTER = 'user_service_account';
+
 const COMPLEX_CONVERSION_FILTER_KEYS = [
   IDS_FILTER, // values should match any id (internal_id, standard_id, or stix_id)
   TYPE_FILTER, // values should match any parent_types
@@ -114,6 +117,7 @@ const COMPLEX_CONVERSION_FILTER_KEYS = [
   RELATION_TO_ROLE_FILTER, // nested relation for the to role of a relationship
   ALIAS_FILTER, // key that target both the 'aliases' and 'x_opencti_aliases' attributes
   IS_INFERRED_FILTER, // if an entity or relationship is inferred
+  USER_SERVICE_ACCOUNT_FILTER, // if the user is technical or not
   'authorized_members', // nested filter on restricted members => kept for retro compatibility (TODO remove after renaming)
   'authorized_members.id', // nested filter on restricted members => kept for retro compatibility (TODO remove after renaming)
   'restricted_members.id', // nested filter on restricted members

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import { ADMIN_USER, queryAsAdmin, testContext } from '../../utils/testQuery';
 import { addAllowedMarkingDefinition } from '../../../src/domain/markingDefinition';
-import { distributionRelations } from '../../../src/database/middleware';
+import { deleteElementById, distributionRelations } from '../../../src/database/middleware';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 import { RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship';
 import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_CORE_OBJECT, ENTITY_TYPE_CONTAINER, ENTITY_TYPE_LOCATION, ID_INTERNAL } from '../../../src/schema/general';
@@ -17,6 +17,10 @@ import {
   SOURCE_RELIABILITY_FILTER
 } from '../../../src/utils/filtering/filtering-constants';
 import { storeLoadById } from '../../../src/database/middleware-loader';
+import { addUser, findById } from '../../../src/domain/user';
+import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+import { getFakeAuthUser } from '../../utils/domainQueryHelper';
+import { SETTINGS_SET_ACCESSES } from '../../../src/utils/access';
 
 // test queries involving dynamic filters
 
@@ -99,7 +103,7 @@ const READ_MARKING_QUERY = gql`
     }
 `;
 
-describe('Complex filters combinations for elastic queries', () => {
+describe.skip('Complex filters combinations for elastic queries', () => {
   let report1InternalId;
   let report2InternalId;
   let report3InternalId;
@@ -2231,5 +2235,167 @@ describe('Complex filters combinations for elastic queries', () => {
     queryResult = await queryAsAdmin({ query: READ_MARKING_QUERY, variables: { id: marking2StixId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.markingDefinition).toBeNull();
+  });
+});
+
+describe('User filter tests', () => {
+  const LIST_USERS_QUERY = gql`
+    query users(
+      $first: Int
+      $after: ID
+      $orderBy: UsersOrdering
+      $orderMode: OrderingMode
+      $filters: FilterGroup
+      $search: String
+    ) {
+      users(
+        first: $first
+        after: $after
+        orderBy: $orderBy
+        orderMode: $orderMode
+        filters: $filters
+        search: $search
+      ) {
+        edges {
+          node {
+            id
+            name
+            user_service_account
+          }
+        }
+      }
+    }
+  `;
+  const authUser = getFakeAuthUser('Platform administrator');
+  authUser.capabilities = [{ name: SETTINGS_SET_ACCESSES }];
+  const createdUsers = [];
+
+  beforeAll(async () => {
+    const serviceAccountUser = {
+      user_email: 'serviceAccountUser@opencti',
+      name: 'Service account',
+      user_service_account: true,
+      groups: [],
+      objectOrganization: [],
+    };
+    const serviceAccountUserAddResult = await addUser(testContext, authUser, serviceAccountUser);
+    const serviceAccountUserCreated = await findById(testContext, authUser, serviceAccountUserAddResult.id);
+    createdUsers.push(serviceAccountUserCreated);
+
+    const user = {
+      user_email: 'user@opencti',
+      name: 'user',
+      user_service_account: false,
+      groups: [],
+      objectOrganization: [],
+      password: 'password1',
+    };
+    const userAddResult = await addUser(testContext, authUser, user);
+    const userCreated = await findById(testContext, authUser, userAddResult.id);
+    createdUsers.push(userCreated);
+
+    const userBeforeServiceAccount = {
+      user_email: 'userBeforeServiceAccount@opencti',
+      name: 'userBeforeServiceAccount',
+      groups: [],
+      objectOrganization: [],
+      password: 'password2',
+    };
+    const userBeforeServiceAccountAddResult = await addUser(testContext, authUser, userBeforeServiceAccount);
+    const userBeforeServiceAccountCreated = await findById(testContext, authUser, userBeforeServiceAccountAddResult.id);
+    createdUsers.push(userBeforeServiceAccountCreated);
+  });
+
+  afterAll(async () => {
+    for (let i = 0; i < createdUsers.length; i += 1) {
+      const userId = createdUsers[i].id;
+      // Delete Users
+      await deleteElementById(testContext, authUser, userId, ENTITY_TYPE_USER);
+    }
+  });
+  it('should list one User service account', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_USERS_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: 'user_service_account',
+            values: ['true'],
+            operator: 'eq',
+            mode: 'or'
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.users.edges.length).toEqual(1);
+  });
+  it('should list Users with no service account', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_USERS_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: 'user_service_account',
+            values: ['false'],
+            operator: 'eq',
+            mode: 'or'
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.users.edges.length).toEqual(9); // 7 + 2 created above
+  });
+  it('should list Users with no service account', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_USERS_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: 'user_service_account',
+            values: ['true'],
+            operator: 'not_eq',
+            mode: 'or'
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.users.edges.length).toEqual(9); // 7 + 2 created above
+  });
+  it('should list Users with or without service account === all Users', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_USERS_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: 'user_service_account',
+            values: ['true', 'false'],
+            operator: 'eq',
+            mode: 'or'
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.users.edges.length).toEqual(10); // 7 + 3 created above
+  });
+  it('should list Users with and without service account === No User', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_USERS_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: 'user_service_account',
+            values: ['true', 'false'],
+            operator: 'eq',
+            mode: 'and'
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.users.edges.length).toEqual(0);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -103,7 +103,7 @@ const READ_MARKING_QUERY = gql`
     }
 `;
 
-describe.skip('Complex filters combinations for elastic queries', () => {
+describe('Complex filters combinations for elastic queries', () => {
   let report1InternalId;
   let report2InternalId;
   let report3InternalId;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  special filter key user_service_account: Users with no user_service_account are now filtered if  filter is user_service_account === false"

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8754

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
