### PR TITLE
[frontend] Expand fields observables (#10480)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemCopy.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCopy.tsx
@@ -1,6 +1,7 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useRef, useState, useEffect } from 'react';
 import { ContentCopyOutlined } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
+import Tooltip from '@mui/material/Tooltip';
 import { useFormatter } from './i18n';
 import { copyToClipboard } from '../utils/utils';
 import type { Theme } from './Theme';
@@ -67,15 +68,27 @@ const ItemCopy: FunctionComponent<ItemCopyProps> = ({
   const classes = useStyles();
   const textToCopy = value || content;
 
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const textElement = textRef.current;
+    if (textElement) {
+      setIsTruncated(textElement.scrollWidth > textElement.clientWidth);
+    }
+  }, [content]);
+
   const classNameVariant = () => {
     if (variant === 'inLine') return classes.containerInline;
     if (variant === 'wrap') return classes.containerWrap;
     return classes.container;
   };
 
-  return (
-    <div className={classNameVariant()}>
-      {limit ? truncate(content, limit) : content}
+  const textToShow = limit ? truncate(content, limit) : content;
+
+  const textElement = (
+    <div ref={textRef} className={classNameVariant()}>
+      {textToShow}
       <span
         className={variant === 'inLine' ? classes.iconInline : classes.icon}
         onClick={(event) => {
@@ -91,5 +104,14 @@ const ItemCopy: FunctionComponent<ItemCopyProps> = ({
       </span>
     </div>
   );
+
+  return isTruncated || limit ? (
+    <Tooltip title={content} placement="bottom-start">
+      {textElement}
+    </Tooltip>
+  ) : (
+    textElement
+  );
 };
+
 export default ItemCopy;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.jsx
@@ -3,14 +3,14 @@ import { dissoc, filter, includes, map, pipe, toPairs } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import Grid from '@mui/material/Grid';
+import Grid from '@mui/material/Grid2';
 import { GetAppOutlined } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
-import makeStyles from '@mui/styles/makeStyles';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/styles';
 import StixCyberObservableNestedEntities from './StixCyberObservableNestedEntities';
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
@@ -22,32 +22,101 @@ import useVocabularyCategory from '../../../../utils/hooks/useVocabularyCategory
 import StixCyberObservableMalwareAnalyses from './StixCyberObservableMalwareAnalyses';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles((theme) => ({
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: '15px',
-    borderRadius: 4,
-  },
-}));
+const reorderMediaContentObservablesAttributes = (data) => {
+  const desiredOrder = ['content', 'title', 'media_category', 'url', 'publication_date'];
 
-const StixCyberObservableDetailsComponent = ({ stixCyberObservable }) => {
-  const classes = useStyles();
-  const { t_i18n, b, fldt } = useFormatter();
-  const { isVocabularyField, fieldToCategory } = useVocabularyCategory();
-  const { dateAttributes, ignoredAttributes } = useAttributes();
+  return desiredOrder
+    .map((key) => data.find((item) => item.key === key))
+    .filter(Boolean);
+};
+
+const transformValue = (value, key, dateAttributes, formatter) => {
+  const result = includes(key, dateAttributes) ? formatter(value) : value;
+
+  if (result === true) return 'TRUE';
+  if (result === false) return 'FALSE';
+  if (Array.isArray(result)) return result.join('\n');
+  if (typeof result === 'number') return result.toString();
+
+  return result;
+};
+
+const DownloadFileButtonMenu = ({ file, encodedFilePath }) => {
+  const { t_i18n } = useFormatter();
+
   const [anchorEl, setAnchorEl] = useState(null);
+
   const handleOpen = (event) => {
     setAnchorEl(event.currentTarget);
   };
+
   const handleClose = () => {
     setAnchorEl(null);
   };
+
   const handleLink = (url) => {
     handleClose();
     window.location.pathname = url;
   };
+
+  return (
+    <>
+      <Typography variant="h3" gutterBottom={true}>{t_i18n('File')}</Typography>
+
+      <Button
+        variant="outlined"
+        color="secondary"
+        size="small"
+        startIcon={<GetAppOutlined />}
+        onClick={handleOpen}
+      >
+        {t_i18n('Download')} ({(file.size)})
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem
+          dense={true}
+          onClick={() => handleLink(
+            `${APP_BASE_PATH}/storage/encrypted/${encodedFilePath}`,
+          )}
+        >
+          {t_i18n('Encrypted archive')}
+        </MenuItem>
+        <MenuItem
+          dense={true}
+          onClick={() => handleLink(
+            `${APP_BASE_PATH}/storage/get/${encodedFilePath}`,
+          )}
+        >
+          {t_i18n('Raw file')}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+const LabelItemCopy = ({ label, value }) => {
+  return (
+    <>
+      <Typography variant="h3" gutterBottom={true}>{label}</Typography>
+      <pre>
+        <ItemCopy content={value} />
+      </pre>
+    </>
+  );
+};
+
+const StixCyberObservableDetailsComponent = ({ stixCyberObservable }) => {
+  const theme = useTheme();
+
+  const { t_i18n, fldt } = useFormatter();
+  const { isVocabularyField, fieldToCategory } = useVocabularyCategory();
+  const { dateAttributes, ignoredAttributes } = useAttributes();
+
   const observableAttributes = pipe(
     dissoc('id'),
     dissoc('entity_type'),
@@ -60,10 +129,12 @@ const StixCyberObservableDetailsComponent = ({ stixCyberObservable }) => {
         && !n.key.startsWith('__'),
     ),
   )(stixCyberObservable);
+
   const file = stixCyberObservable.importFiles
-    && stixCyberObservable.importFiles.edges.length > 0
+  && stixCyberObservable.importFiles.edges.length > 0
     ? stixCyberObservable.importFiles.edges[0].node
     : null;
+
   const isObservableAnalysable = [
     'StixFile',
     'Domain-Name',
@@ -72,55 +143,31 @@ const StixCyberObservableDetailsComponent = ({ stixCyberObservable }) => {
     'Artifact',
     'Network-Traffic',
   ].includes(stixCyberObservable.entity_type);
+
   const encodedFilePath = file && encodeURIComponent(file.id);
+
+  let orderedObservableAttributes = observableAttributes;
+  if (stixCyberObservable.entity_type === 'Media-Content') {
+    orderedObservableAttributes = reorderMediaContentObservablesAttributes(observableAttributes);
+  }
+
   return (
     <div style={{ height: '100%' }} className="break">
-      <Typography variant="h4" gutterBottom={true}>
-        {t_i18n('Details')}
-      </Typography>
-      <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
+      <Typography variant="h4" gutterBottom={true}>{t_i18n('Details')}</Typography>
+
+      <Paper
+        sx={{ padding: '15px', marginTop: theme.spacing(1) }}
+        className={'paper-for-grid'}
+        variant="outlined"
+      >
         <Grid container={true} spacing={3} style={{ marginBottom: 10 }}>
           {file && (
-            <Grid item xs={6}>
-              <Typography variant="h3" gutterBottom={true}>
-                {t_i18n('File')}
-              </Typography>
-              <Button
-                variant="outlined"
-                color="secondary"
-                size="small"
-                startIcon={<GetAppOutlined />}
-                onClick={handleOpen}
-              >
-                {t_i18n('Download')} ({b(file.size)})
-              </Button>
-              <Menu
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={handleClose}
-              >
-                <MenuItem
-                  dense={true}
-                  onClick={() => handleLink(
-                    `${APP_BASE_PATH}/storage/encrypted/${encodedFilePath}`,
-                  )
-                  }
-                >
-                  {t_i18n('Encrypted archive')}
-                </MenuItem>
-                <MenuItem
-                  dense={true}
-                  onClick={() => handleLink(
-                    `${APP_BASE_PATH}/storage/get/${encodedFilePath}`,
-                  )
-                  }
-                >
-                  {t_i18n('Raw file')}
-                </MenuItem>
-              </Menu>
+            <Grid item size={6}>
+              <DownloadFileButtonMenu file={file} encodedFilePath={encodedFilePath} />
             </Grid>
           )}
-          <Grid item xs={6}>
+
+          <Grid item size={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Description')}
             </Typography>
@@ -129,93 +176,87 @@ const StixCyberObservableDetailsComponent = ({ stixCyberObservable }) => {
               limit={400}
             />
           </Grid>
-          {observableAttributes.map((observableAttribute) => {
-            if (observableAttribute.key === 'hashes') {
-              return observableAttribute.value.filter(({ hash }) => hash !== '').map((hash) => (
-                <Grid key={hash.algorithm} item xs={6}>
-                  <Typography variant="h3" gutterBottom={true}>
-                    {hash.algorithm} - hashes
-                  </Typography>
-                  <pre>
-                    <ItemCopy content={hash.hash} />
-                  </pre>
+
+          {orderedObservableAttributes.map((observableAttribute) => {
+            const { key, value } = observableAttribute;
+
+            if (key === 'hashes') {
+              return value.filter(({ hash }) => hash !== '').map((hash) => (
+                <Grid key={hash.algorithm} item size={6}>
+                  <LabelItemCopy label={`${hash.algorithm} - hashes`} value={hash.hash} />
                 </Grid>
               ));
             }
-            if (observableAttribute.key === 'startup_info') {
-              return observableAttribute.value.map((hash) => (
-                <Grid key={hash.key} item xs={6}>
-                  <Typography variant="h3" gutterBottom={true}>
-                    {hash.key} - startup_info
-                  </Typography>
-                  <pre>
-                    <ItemCopy content={hash.value} />
-                  </pre>
+
+            if (key === 'startup_info') {
+              return value.map((hash) => (
+                <Grid key={hash.key} item size={6}>
+                  <LabelItemCopy label={`${hash.key} - startup_info`} value={hash.value} />
                 </Grid>
               ));
             }
-            if (
-              isVocabularyField(
-                stixCyberObservable.entity_type,
-                observableAttribute.key,
-              )
-            ) {
+
+            if (isVocabularyField(stixCyberObservable.entity_type, key)) {
               return (
-                <Grid key={observableAttribute.key} item xs={6}>
+                <Grid key={key} item size={6}>
                   <Typography variant="h3" gutterBottom={true}>
-                    {t_i18n(observableAttribute.key)}
+                    {t_i18n(key)}
                   </Typography>
                   <ItemOpenVocab
                     small={false}
                     type={fieldToCategory(
                       stixCyberObservable.entity_type,
-                      observableAttribute.key,
+                      key,
                     )}
-                    value={observableAttribute.value}
+                    value={value}
                   />
                 </Grid>
               );
             }
-            let finalValue = observableAttribute.value;
-            if (includes(observableAttribute.key, dateAttributes)) {
-              finalValue = fldt(finalValue);
+
+            if (key === 'content') {
+              return (
+                <Grid key={key} item size={6}>
+                  <Typography variant="h3" gutterBottom={true}>
+                    {t_i18n('Content')}
+                  </Typography>
+                  <ExpandableMarkdown
+                    source={value}
+                    limit={400}
+                  />
+                </Grid>
+              );
             }
-            if (finalValue === true) {
-              finalValue = 'TRUE';
-            } else if (finalValue === false) {
-              finalValue = 'FALSE';
-            }
-            if (Array.isArray(finalValue)) {
-              finalValue = finalValue.join('\n');
-            }
+
+            const finalValue = transformValue(value, key, dateAttributes, fldt);
+
             return (
-              <Grid key={observableAttribute.key} item xs={6}>
-                <Typography variant="h3" gutterBottom={true}>
-                  {t_i18n(observableAttribute.key.replace('attribute_', ''))}
-                </Typography>
-                <pre>
-                  <ItemCopy content={finalValue || '-'} />
-                </pre>
+              <Grid key={key} item size={6}>
+                <LabelItemCopy label={t_i18n(key.replace('attribute_', ''))} value={finalValue} />
               </Grid>
             );
           })}
         </Grid>
+
         <Divider/>
+
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, marginTop: 2.5 }}>
           {stixCyberObservable.entity_type === 'Network-Traffic' && (
-          <StixCyberObservableNestedEntities
-            entityId={stixCyberObservable.id}
-            entityType={stixCyberObservable.entity_type}
-            variant="inLine"
-          />
+            <StixCyberObservableNestedEntities
+              entityId={stixCyberObservable.id}
+              entityType={stixCyberObservable.entity_type}
+              variant="inLine"
+            />
           )}
+
           <StixCyberObservableIndicators
             stixCyberObservable={stixCyberObservable}
           />
+
           {isObservableAnalysable && (
-          <StixCyberObservableMalwareAnalyses
-            observableId={stixCyberObservable.id}
-          />
+            <StixCyberObservableMalwareAnalyses
+              observableId={stixCyberObservable.id}
+            />
           )}
         </Box>
       </Paper>
@@ -227,256 +268,256 @@ const StixCyberObservableDetails = createFragmentContainer(
   StixCyberObservableDetailsComponent,
   {
     stixCyberObservable: graphql`
-      fragment StixCyberObservableDetails_stixCyberObservable on StixCyberObservable {
-        id
-        entity_type
-        x_opencti_score
-        x_opencti_description
-        observable_value
-        ... on AutonomousSystem {
-          number
-          observableName: name
-          rir
-        }
-        ... on Directory {
-          path
-          path_enc
-          ctime
-          mtime
-          atime
-        }
-        ... on DomainName {
-          value
-        }
-        ... on EmailAddr {
-          value
-          display_name
-        }
-        ... on EmailMessage {
-          is_multipart
-          attribute_date
-          content_type
-          message_id
-          subject
-          received_lines
-          body
-        }
-        ... on Artifact {
-          x_opencti_additional_names
-          mime_type
-          payload_bin
-          url
-          encryption_algorithm
-          decryption_key
-          hashes {
-            algorithm
-            hash
-          }
-          importFiles(first: 500) {
-            edges {
-              node {
-                id
-                name
-                size
-                metaData {
-                  mimetype
-                }
-              }
-            }
-          }
-        }
-        ... on StixFile {
-          extensions
-          size
-          observableName: name
-          name_enc
-          magic_number_hex
-          mime_type
-          ctime
-          mtime
-          atime
-          x_opencti_additional_names
-          obsContent {
+        fragment StixCyberObservableDetails_stixCyberObservable on StixCyberObservable {
             id
-          }
-          hashes {
-            algorithm
-            hash
-          }
+            entity_type
+            x_opencti_score
+            x_opencti_description
+            observable_value
+            ... on AutonomousSystem {
+                number
+                observableName: name
+                rir
+            }
+            ... on Directory {
+                path
+                path_enc
+                ctime
+                mtime
+                atime
+            }
+            ... on DomainName {
+                value
+            }
+            ... on EmailAddr {
+                value
+                display_name
+            }
+            ... on EmailMessage {
+                is_multipart
+                attribute_date
+                content_type
+                message_id
+                subject
+                received_lines
+                body
+            }
+            ... on Artifact {
+                x_opencti_additional_names
+                mime_type
+                payload_bin
+                url
+                encryption_algorithm
+                decryption_key
+                hashes {
+                    algorithm
+                    hash
+                }
+                importFiles(first: 500) {
+                    edges {
+                        node {
+                            id
+                            name
+                            size
+                            metaData {
+                                mimetype
+                            }
+                        }
+                    }
+                }
+            }
+            ... on StixFile {
+                extensions
+                size
+                observableName: name
+                name_enc
+                magic_number_hex
+                mime_type
+                ctime
+                mtime
+                atime
+                x_opencti_additional_names
+                obsContent {
+                    id
+                }
+                hashes {
+                    algorithm
+                    hash
+                }
+            }
+            ... on X509Certificate {
+                is_self_signed
+                version
+                serial_number
+                signature_algorithm
+                issuer
+                subject
+                subject_public_key_algorithm
+                subject_public_key_modulus
+                subject_public_key_exponent
+                validity_not_before
+                validity_not_after
+                hashes {
+                    algorithm
+                    hash
+                }
+                basic_constraints
+                name_constraints
+                policy_constraints
+                key_usage
+                extended_key_usage
+                subject_key_identifier
+                authority_key_identifier
+                subject_alternative_name
+                issuer_alternative_name
+                subject_directory_attributes
+                crl_distribution_points
+                inhibit_any_policy
+                private_key_usage_period_not_before
+                private_key_usage_period_not_after
+                certificate_policies
+                policy_mappings
+            }
+            ... on IPv4Addr {
+                value
+            }
+            ... on IPv6Addr {
+                value
+            }
+            ... on MacAddr {
+                value
+            }
+            ... on Mutex {
+                observableName: name
+            }
+            ... on NetworkTraffic {
+                extensions
+                start
+                end
+                is_active
+                src_port
+                dst_port
+                protocols
+                src_byte_count
+                dst_byte_count
+                src_packets
+                dst_packets
+            }
+            ... on Process {
+                extensions
+                is_hidden
+                pid
+                created_time
+                cwd
+                command_line
+                environment_variables
+                ## windows-process-ext
+                aslr_enabled
+                dep_enabled
+                priority
+                owner_sid
+                window_title
+                startup_info {
+                    key
+                    value
+                }
+                integrity_level
+                ## windows-service-ext
+                service_name
+                descriptions
+                display_name
+                group_name
+                start_type
+                service_type
+                service_status
+            }
+            ... on Software {
+                observableName: name
+                cpe
+                swid
+                languages
+                vendor
+                version
+                x_opencti_product
+            }
+            ... on Url {
+                value
+            }
+            ... on UserAccount {
+                extensions
+                user_id
+                credential
+                account_login
+                account_type
+                display_name
+                is_service_account
+                is_privileged
+                can_escalate_privs
+                is_disabled
+                account_created
+                account_expires
+                credential_last_changed
+                account_first_login
+                account_last_login
+            }
+            ... on WindowsRegistryKey {
+                attribute_key
+                modified_time
+                number_of_subkeys
+            }
+            ... on WindowsRegistryValueType {
+                observableName: name
+                data
+                data_type
+            }
+            ... on Hostname {
+                value
+            }
+            ... on CryptographicKey {
+                value
+            }
+            ... on CryptocurrencyWallet {
+                value
+            }
+            ... on Text {
+                value
+            }
+            ... on UserAgent {
+                value
+            }
+            ... on BankAccount {
+                iban
+                bic
+                account_number
+            }
+            ... on Credential {
+                value
+            }
+            ... on TrackingNumber {
+                value
+            }
+            ... on PhoneNumber {
+                value
+            }
+            ... on PaymentCard {
+                card_number
+                expiration_date
+                cvv
+                holder_name
+            }
+            ... on MediaContent {
+                title
+                content
+                media_category
+                url
+                publication_date
+            }
+            ... on Persona {
+                persona_name
+                persona_type
+            }
+            ...StixCyberObservableIndicators_stixCyberObservable
         }
-        ... on X509Certificate {
-          is_self_signed
-          version
-          serial_number
-          signature_algorithm
-          issuer
-          subject
-          subject_public_key_algorithm
-          subject_public_key_modulus
-          subject_public_key_exponent
-          validity_not_before
-          validity_not_after
-          hashes {
-            algorithm
-            hash
-          }
-          basic_constraints
-          name_constraints
-          policy_constraints
-          key_usage
-          extended_key_usage
-          subject_key_identifier
-          authority_key_identifier
-          subject_alternative_name
-          issuer_alternative_name
-          subject_directory_attributes
-          crl_distribution_points
-          inhibit_any_policy
-          private_key_usage_period_not_before
-          private_key_usage_period_not_after
-          certificate_policies
-          policy_mappings
-        }
-        ... on IPv4Addr {
-          value
-        }
-        ... on IPv6Addr {
-          value
-        }
-        ... on MacAddr {
-          value
-        }
-        ... on Mutex {
-          observableName: name
-        }
-        ... on NetworkTraffic {
-          extensions
-          start
-          end
-          is_active
-          src_port
-          dst_port
-          protocols
-          src_byte_count
-          dst_byte_count
-          src_packets
-          dst_packets
-        }
-        ... on Process {
-          extensions
-          is_hidden
-          pid
-          created_time
-          cwd
-          command_line
-          environment_variables
-          ## windows-process-ext
-          aslr_enabled
-          dep_enabled
-          priority
-          owner_sid
-          window_title
-          startup_info {
-            key
-            value
-          }
-          integrity_level
-          ## windows-service-ext
-          service_name
-          descriptions
-          display_name
-          group_name
-          start_type
-          service_type
-          service_status
-        }
-        ... on Software {
-          observableName: name
-          cpe
-          swid
-          languages
-          vendor
-          version
-          x_opencti_product
-        }
-        ... on Url {
-          value
-        }
-        ... on UserAccount {
-          extensions
-          user_id
-          credential
-          account_login
-          account_type
-          display_name
-          is_service_account
-          is_privileged
-          can_escalate_privs
-          is_disabled
-          account_created
-          account_expires
-          credential_last_changed
-          account_first_login
-          account_last_login
-        }
-        ... on WindowsRegistryKey {
-          attribute_key
-          modified_time
-          number_of_subkeys
-        }
-        ... on WindowsRegistryValueType {
-          observableName: name
-          data
-          data_type
-        }
-        ... on Hostname {
-          value
-        }
-        ... on CryptographicKey {
-          value
-        }
-        ... on CryptocurrencyWallet {
-          value
-        }
-        ... on Text {
-          value
-        }
-        ... on UserAgent {
-          value
-        }
-        ... on BankAccount {
-          iban
-          bic
-          account_number
-        }
-        ... on Credential {
-          value
-        }
-        ... on TrackingNumber {
-          value
-        }
-        ... on PhoneNumber {
-          value
-        }
-        ... on PaymentCard {
-          card_number
-          expiration_date
-          cvv
-          holder_name
-        }
-        ... on MediaContent {
-          title
-          content
-          media_category
-          url
-          publication_date
-        }
-        ... on Persona {
-          persona_name
-          persona_type
-        }
-        ...StixCyberObservableIndicators_stixCyberObservable
-      }
     `,
   },
 );


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* In media-content observable details, content value is now displayed aligned to the description block, and is expandable
* ItemCopy displays a tooltip when the content exceeds the container width or when truncated


https://github.com/user-attachments/assets/047ecafa-cb7b-4c23-869d-2bf878531aab



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
[Expand fields in observables #10480]

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
