### PR TITLE
[frontend] Add browse more button and set connector name default values (#7328)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "Lesezeichen werden in öffentlichen Dashboards nicht unterstützt",
   "Both latitude and longitude must be provided together": "Sowohl Breiten- als auch Längengrad müssen zusammen angegeben werden",
   "Browse files": "Dateien durchsuchen",
+  "Browse more": "Mehr lesen",
   "Browse the link": "Den Link durchsuchen",
   "Buffering: ": "Pufferung:",
   "Built-in: HTML template to PDF": "Eingebaut: HTML-Vorlage zu PDF",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "Bookmarks are not supported in public dashboards",
   "Both latitude and longitude must be provided together": "Both latitude and longitude must be provided together",
   "Browse files": "Browse files",
+  "Browse more": "Browse more",
   "Browse the link": "Browse the link",
   "Buffering: ": "Buffering: ",
   "Built-in: HTML template to PDF": "Built-in: HTML template to PDF",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "No se admiten marcadores en los cuadros de mando públicos",
   "Both latitude and longitude must be provided together": "Tanto la latitud como la longitud deben indicarse juntas",
   "Browse files": "Buscar archivos",
+  "Browse more": "Ver más",
   "Browse the link": "Visitar el enlace",
   "Buffering: ": "Buffering:",
   "Built-in: HTML template to PDF": "Integrado: plantilla HTML a PDF",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "Les signets ne sont pas pris en charge dans les tableaux de bord publics",
   "Both latitude and longitude must be provided together": "La latitude et la longitude doivent être indiquées ensemble",
   "Browse files": "Parcourir les fichiers",
+  "Browse more": "Parcourir plus",
   "Browse the link": "Naviguer vers le lien",
   "Buffering: ": "Mise en mémoire tampon :",
   "Built-in: HTML template to PDF": "Intégré : modèle HTML vers PDF",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "I segnalibri non sono supportati nelle dashboard pubbliche",
   "Both latitude and longitude must be provided together": "Sia la latitudine che la longitudine devono essere fornite congiuntamente",
   "Browse files": "Sfogliare i file",
+  "Browse more": "Per saperne di più",
   "Browse the link": "Sfoglia il link",
   "Buffering: ": "Precaricamento: ",
   "Built-in: HTML template to PDF": "Built-in: template da HTML a PDF",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "ブックマークはパブリックダッシュボードではサポートされていません。",
   "Both latitude and longitude must be provided together": "緯度と経度の両方を記入しなければならない。",
   "Browse files": "ファイル閲覧",
+  "Browse more": "もっと見る",
   "Browse the link": "リンクを閲覧する",
   "Buffering: ": "バッファリング",
   "Built-in: HTML template to PDF": "組み込み: HTMLテンプレートからPDFへ",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "공개 대시보드에서는 북마크가 지원되지 않습니다",
   "Both latitude and longitude must be provided together": "위도와 경도를 모두 함께 제공해야 합니다",
   "Browse files": "파일 찾아보기",
+  "Browse more": "자세히 보기",
   "Browse the link": "링크 탐색",
   "Buffering: ": "버퍼링:",
   "Built-in: HTML template to PDF": "기본 제공: HTML 템플릿을 PDF로 내보내기",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "Закладки не поддерживаются в публичных панелях инструментов",
   "Both latitude and longitude must be provided together": "Необходимо указать и широту, и долготу",
   "Browse files": "Просмотр файлов",
+  "Browse more": "Подробнее",
   "Browse the link": "Перейдите по ссылке",
   "Buffering: ": "Буферизация:",
   "Built-in: HTML template to PDF": "Встроенная функция: преобразование HTML-шаблона в PDF",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -367,6 +367,7 @@
   "Bookmarks are not supported in public dashboards": "公共仪表盘不支持书签",
   "Both latitude and longitude must be provided together": "必须同时提供经度和纬度",
   "Browse files": "浏览文件",
+  "Browse more": "浏览更多",
   "Browse the link": "浏览链接",
   "Buffering: ": "缓冲：",
   "Built-in: HTML template to PDF": "内置：HTML 模板到 PDF",

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -11,6 +11,8 @@ import Loader, { LoaderVariant } from '../../../components/Loader';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import ListCardsContent from '../../../components/list_cards/ListCardsContent';
 import { MESSAGING$ } from '../../../relay/environment';
+import GradientButton from '../../../components/GradientButton';
+import SearchInput from '../../../components/SearchInput';
 
 export const ingestionCatalogQuery = graphql`
   query IngestionCatalogQuery {
@@ -114,6 +116,19 @@ const IngestionCatalogComponent = ({
       <IngestionMenu />
       <PageContainer withRightMenu withGap>
         <Breadcrumbs elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('Catalog'), current: true }]} />
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <SearchInput disabled />
+          <GradientButton
+            size="small"
+            sx={{ marginLeft: 1 }}
+            href={'https://filigran.notion.site/OpenCTI-Ecosystem-868329e9fb734fca89692b2ed6087e76'}
+            target="_blank"
+            title={t_i18n('Browse more')}
+          >
+            {t_i18n('Browse more').toUpperCase()}
+          </GradientButton>
+
+        </div>
         {catalogsParsed.map((catalog) => {
           return catalog.contracts.length > 0 && (
             <ListCardsContent

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -115,9 +115,7 @@ const IngestionCatalogComponent = ({
     <>
       <IngestionMenu />
       <PageContainer withRightMenu withGap>
-
         <Breadcrumbs elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('Catalog'), current: true }]} />
-
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <SearchInput disabled />
           <GradientButton
@@ -130,7 +128,6 @@ const IngestionCatalogComponent = ({
             {t_i18n('Browse more').toUpperCase()}
           </GradientButton>
         </div>
-
         {catalogsParsed.map((catalog) => {
           return catalog.contracts.length > 0 && (
             <ListCardsContent
@@ -145,7 +142,6 @@ const IngestionCatalogComponent = ({
             />
           );
         })}
-        
       </PageContainer>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -115,7 +115,9 @@ const IngestionCatalogComponent = ({
     <>
       <IngestionMenu />
       <PageContainer withRightMenu withGap>
+
         <Breadcrumbs elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('Catalog'), current: true }]} />
+
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <SearchInput disabled />
           <GradientButton
@@ -127,8 +129,8 @@ const IngestionCatalogComponent = ({
           >
             {t_i18n('Browse more').toUpperCase()}
           </GradientButton>
-
         </div>
+
         {catalogsParsed.map((catalog) => {
           return catalog.contracts.length > 0 && (
             <ListCardsContent
@@ -143,6 +145,7 @@ const IngestionCatalogComponent = ({
             />
           );
         })}
+        
       </PageContainer>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -116,6 +116,7 @@ const IngestionCatalogConnectorCreation = ({ connector, open, onClose, catalogId
     } else {
       optionalPropertiesArray.push(property);
     }
+    if (key === 'CONNECTOR_NAME') defaultValuesArray.push(['name', value.default]);
     if (value.default) defaultValuesArray.push([key, value.default]);
   });
   const requiredProperties: JsonSchema = { properties: Object.fromEntries(requiredPropertiesArray), required: connector.config_schema.required };


### PR DESCRIPTION
### Proposed changes

* Add browse more button to navigate to the ecosystem doc page
* Set default value for the connector name on the Creation form

### Related issues

* #7328

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

- I add a disabled SearchInput, beacause I need a component to have the good place for my button Browse more into a flexbox div.
- This SearchInput will be enable in the next PR