### PR TITLE
[backend] Service account can login with token (#8754)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1646,7 +1646,7 @@ export const userRenewToken = async (context, user, userId) => {
 const validateUser = (user, settings) => {
   // Check organization consistency
   const hasSetAccessCapability = isUserHasCapability(user, SETTINGS_SET_ACCESSES);
-  if (!hasSetAccessCapability && settings.platform_organization && user.organizations.length === 0) {
+  if (!hasSetAccessCapability && settings.platform_organization && user.organizations.length === 0 && !user.user_service_account) {
     throw AuthenticationFailure('You can\'t login without an organization');
   }
   // Check account expiration date

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
@@ -315,12 +315,8 @@ describe('Service account with platform organization coverage', async () => {
     expect(userCreated.password).toBeUndefined();
 
     // WHEN user log in with token
-    // TODO fix this :(
-    const loggedInUser = await authenticateUserByTokenOrUserId(testContext, { headers: [
-      { attribute: 'Content-Type', value: 'application/json' },
-      { attribute: 'X-API-Key', value: userCreated.api_token },
-      { attribute: 'Accept', value: 'application/json' },
-    ] }, userCreated.api_token);
+    const fakeReq = { headers: () => { return undefined; }, header: () => { return undefined; }, socket: { remoteAddress: '::1' } };
+    const loggedInUser = await authenticateUserByTokenOrUserId(testContext, fakeReq, userCreated.api_token);
     expect(loggedInUser).toBeDefined();
 
     await deleteElementById(testContext, authUser, userAddResult.id, ENTITY_TYPE_USER);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { ADMIN_USER, AMBER_STRICT_GROUP, GREEN_GROUP, PLATFORM_ORGANIZATION, TEST_ORGANIZATION, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, AMBER_STRICT_GROUP, generateBasicAuth, GREEN_GROUP, PLATFORM_ORGANIZATION, TEST_ORGANIZATION, testContext } from '../../utils/testQuery';
 import { generateStandardId } from '../../../src/schema/identifier';
 import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
 import type { AuthContext, AuthUser } from '../../../src/types/user';
@@ -313,13 +313,15 @@ describe('Service account with platform organization coverage', async () => {
     const userAddResult = await addUser(testContext, authUser, userAddInput);
     const userCreated: any = await storeLoadById(testContext, authUser, userAddResult.id, ENTITY_TYPE_USER);
     expect(userCreated.password).toBeUndefined();
-    console.log('userCreated:', userCreated);
 
     // WHEN user log in with token
-    const loggedInUser = await authenticateUserByTokenOrUserId(testContext, { headers: [] }, userCreated.api_token);
-
-    // THEN despite having no org it's allowed
-    console.log('loggedInUser:', loggedInUser);
+    // TODO fix this :(
+    const loggedInUser = await authenticateUserByTokenOrUserId(testContext, { headers: [
+      { attribute: 'Content-Type', value: 'application/json' },
+      { attribute: 'X-API-Key', value: userCreated.api_token },
+      { attribute: 'Accept', value: 'application/json' },
+    ] }, userCreated.api_token);
+    expect(loggedInUser).toBeDefined();
 
     await deleteElementById(testContext, authUser, userAddResult.id, ENTITY_TYPE_USER);
   });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/user-domain-test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { ADMIN_USER, AMBER_STRICT_GROUP, generateBasicAuth, GREEN_GROUP, PLATFORM_ORGANIZATION, TEST_ORGANIZATION, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, AMBER_STRICT_GROUP, GREEN_GROUP, PLATFORM_ORGANIZATION, TEST_ORGANIZATION, testContext } from '../../utils/testQuery';
 import { generateStandardId } from '../../../src/schema/identifier';
 import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
 import type { AuthContext, AuthUser } from '../../../src/types/user';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `validateUser` does not throw error for service account user with no org in case of org segregagtion


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #8754


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
to test:
* create a connector ingestion > catalog > Mitre attack (for instance)
* go to Connectors screen
* find you newly created connector
* go to associated User
* copy paste token 
* use it in a python script to reach api
