### PR TITLE
[frontend] truncate text in NavToolbarMenu when text exceeds width container (#7328)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -1,29 +1,31 @@
-import React, { FunctionComponent, ReactElement } from 'react';
+import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Drawer from '@mui/material/Drawer';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
-import makeStyles from '@mui/styles/makeStyles';
 import ListItemIcon from '@mui/material/ListItemIcon';
-import EEMenu from '@components/common/entreprise_edition/EEMenu';
+import { styled } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import EEChip from '@components/common/entreprise_edition/EEChip';
+import { Stack } from '@mui/material';
+import Box from '@mui/material/Box';
 import { useFormatter } from '../../../../components/i18n';
-import type { Theme } from '../../../../components/Theme';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  drawer: {
+const StyledDrawer = styled(Drawer)(() => ({
+  '& .MuiDrawer-paper': {
     minHeight: '100vh',
     width: 200,
     position: 'fixed',
     overflow: 'auto',
     padding: 0,
-    backgroundColor: theme.palette.background.nav,
   },
-  toolbar: theme.mixins.toolbar,
+}));
+
+const ToolbarSpacer = styled('div')(({ theme }) => ({
+  ...theme.mixins.toolbar,
 }));
 
 export interface MenuEntry {
@@ -33,17 +35,64 @@ export interface MenuEntry {
   isEE?: boolean;
 }
 
+const TruncatedText: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const textElement = textRef.current;
+    if (textElement) {
+      setIsTruncated(textElement.scrollWidth > textElement.clientWidth);
+    }
+  }, [children]);
+
+  const content = (
+    <Box
+      sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+      ref={textRef}
+    >
+      {children}
+    </Box>
+  );
+
+  if (isTruncated) {
+    return (
+      <Tooltip title={children} arrow placement="left-start">
+        {content}
+      </Tooltip>
+    );
+  }
+
+  return content;
+};
+
 const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({ entries }) => {
-  const classes = useStyles();
   const { t_i18n } = useFormatter();
   const location = useLocation();
   const { bannerSettings } = useAuth();
-  const bannerHeight = bannerSettings.bannerHeightNumber;
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
 
+  const bannerHeight = bannerSettings.bannerHeightNumber;
+
+  const renderLabel = (entry: MenuEntry) => {
+    const translatedLabel = t_i18n(entry.label);
+
+    if (entry.isEE) {
+      return (
+        <Stack direction="row">
+          <TruncatedText>{translatedLabel}</TruncatedText>
+          <EEChip />
+        </Stack>
+      );
+    }
+
+    return <TruncatedText>{translatedLabel}</TruncatedText>;
+  };
+
   return (
-    <Drawer variant="permanent" anchor="right" classes={{ paper: classes.drawer }}>
-      <div className={classes.toolbar} />
+    <StyledDrawer variant="permanent" anchor="right">
+      <ToolbarSpacer />
+
       <MenuList component="nav" style={{ marginTop: bannerHeight + settingsMessagesBannerHeight, marginBottom: bannerHeight }}>
         {entries.map((entry, idx) => {
           return (
@@ -55,16 +104,14 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({ entries }
               dense={false}
             >
               {entry.icon && (
-              <ListItemIcon>
-                {entry.icon}
-              </ListItemIcon>
+                <ListItemIcon>{entry.icon}</ListItemIcon>
               )}
-              <ListItemText primary={entry.isEE ? <EEMenu><span>{t_i18n(entry.label)}</span></EEMenu> : t_i18n(entry.label)} />
+              <ListItemText primary={renderLabel(entry)} />
             </MenuItem>
           );
         })}
       </MenuList>
-    </Drawer>
+    </StyledDrawer>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Text can be long on the right nav bar menu, and the EE Chip may be hidden because of it, thus, crop the text when it overflows the container to handle long texts.

https://github.com/user-attachments/assets/c5fa3346-1b36-4e1a-b8ee-205916c7f869




### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7328

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
