### PR TITLE
[frontend] Check XTM Hub connectivity with /health instead of the hom…

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -380,7 +380,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
   const platformModuleHelpers = platformModuleHelper(settings);
   const platformAnalyticsConfiguration = generateAnalyticsConfig(settings);
 
-  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
+  const { isReachable } = useNetworkCheck(`${settings?.platform_xtmhub_url}/health`);
   return (
     <UserContext.Provider
       value={{


### PR DESCRIPTION
…epage #12164

### Proposed changes

* Check XTM Hub connectivity with `/health` instead of `/`


### Related issues
#12164 

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
