### PR TITLE
[backend] do not run playbookManager when not EE (#12147)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -43,6 +43,7 @@ import { elPaginate } from '../database/engine';
 import { stixLoadById } from '../database/middleware';
 import { convertRelationRefsFilterKeys } from '../utils/filtering/filtering-utils';
 import type { ExecutionEnvelop, ExecutionEnvelopStep } from '../types/playbookExecution';
+import { isEnterpriseEdition } from '../enterprise-edition/ee';
 
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
 const PLAYBOOK_CRON_KEY = conf.get('playbook_manager:lock_cron_key');
@@ -236,6 +237,10 @@ const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEven
       return;
     }
     const context = executionContext('playbook_manager');
+    const isEE = await isEnterpriseEdition(context);
+    if (!isEE) {
+      return;
+    }
     const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
     for (let index = 0; index < streamEvents.length; index += 1) {
       const streamEvent = streamEvents[index];
@@ -419,6 +424,10 @@ const initPlaybookManager = () => {
   };
   const handlePlaybookCrons = async (context: AuthContext) => {
     const baseDate = utcDate().startOf('minutes');
+    const isEE = await isEnterpriseEdition(context);
+    if (!isEE) {
+      return;
+    }
     // Get playbook crons that need to be executed
     const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
     for (let playbookIndex = 0; playbookIndex < playbooks.length; playbookIndex += 1) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* do not run playbook manager processes when in CE
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12147
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
