### PR TITLE
[backend] Set a configurable SSO/SAML payload body size to handle enterprises that have large envelopes of data (#11284)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -20,7 +20,6 @@
     "enabled": true,
     "enabled_ui": true,
     "enabled_dev_features": [],
-    "auth_payload_body_size": "100kb",
     "https_cert": {
       "ca": [],
       "key": null,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -20,6 +20,7 @@
     "enabled": true,
     "enabled_ui": true,
     "enabled_dev_features": [],
+    "auth_payload_body_size": "100kb",
     "https_cert": {
       "ca": [],
       "key": null,

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -103,7 +103,7 @@ nconf.file('default', resolveEnvFile('default'));
 
 // Setup SSO/SAML auth_payload_body_size
 // Default limit is '100kb' based on https://expressjs.com/en/resources/middleware/body-parser.html
-export const AUTH_PAYLOAD_BODY_SIZE = nconf.get('app:auth_payload_body_size') ?? '100kb';
+export const AUTH_PAYLOAD_BODY_SIZE = nconf.get('app:auth_payload_body_size') ?? null;
 
 // Setup application logApp
 const appLogLevel = nconf.get('app:app_logs:logs_level');

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -101,6 +101,10 @@ if (externalConfigurationFile) {
 nconf.file(environment, configurationFile);
 nconf.file('default', resolveEnvFile('default'));
 
+// Setup SSO/SAML auth_payload_body_size
+// Default limit is '100kb' based on https://expressjs.com/en/resources/middleware/body-parser.html
+export const AUTH_PAYLOAD_BODY_SIZE = nconf.get('app:auth_payload_body_size') ?? '100kb';
+
 // Setup application logApp
 const appLogLevel = nconf.get('app:app_logs:logs_level');
 const appLogFileTransport = booleanConf('app:app_logs:logs_files', true);

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -13,7 +13,7 @@ import validator from 'validator';
 import archiverZipEncrypted from 'archiver-zip-encrypted';
 import rateLimit from 'express-rate-limit';
 import contentDisposition from 'content-disposition';
-import { basePath, booleanConf, DEV_MODE, ENABLED_UI, logApp, OPENCTI_SESSION } from '../config/conf';
+import { basePath, booleanConf, DEV_MODE, ENABLED_UI, logApp, OPENCTI_SESSION, AUTH_PAYLOAD_BODY_SIZE } from '../config/conf';
 import passport, { isStrategyActivated, STRATEGY_CERT } from '../config/providers';
 import { HEADERS_AUTHENTICATORS, loginFromProvider, sessionAuthenticateUser, userWithOrigin } from '../domain/user';
 import { downloadFile, getFileContent, isStorageAlive, loadFile } from '../database/file-storage';
@@ -448,7 +448,8 @@ const createApp = async (app) => {
   });
 
   // -- Passport callback
-  const urlencodedParser = bodyParser.urlencoded({ extended: true });
+  // -- Default limit is '100kb' based on https://expressjs.com/en/resources/middleware/body-parser.html
+  const urlencodedParser = bodyParser.urlencoded({ extended: true, limit: AUTH_PAYLOAD_BODY_SIZE });
   app.all(`${basePath}/auth/:provider/callback`, urlencodedParser, async (req, res, next) => {
     const referer = req.body.RelayState ?? req.session.referer;
     const { provider } = req.params;

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -449,7 +449,7 @@ const createApp = async (app) => {
 
   // -- Passport callback
   // -- Default limit is '100kb' based on https://expressjs.com/en/resources/middleware/body-parser.html
-  const urlencodedParser = bodyParser.urlencoded({ extended: true, limit: AUTH_PAYLOAD_BODY_SIZE });
+  const urlencodedParser = AUTH_PAYLOAD_BODY_SIZE ? bodyParser.urlencoded({ extended: true, limit: AUTH_PAYLOAD_BODY_SIZE }) : bodyParser.urlencoded({ extended: true });
   app.all(`${basePath}/auth/:provider/callback`, urlencodedParser, async (req, res, next) => {
     const referer = req.body.RelayState ?? req.session.referer;
     const { provider } = req.params;


### PR DESCRIPTION
By default the Express body-parse payload limit is set to '100kb' (https://expressjs.com/en/resources/middleware/body-parser.html). This limit will cause the issue (PayloadTooLargeError) noted in (https://github.com/OpenCTI-Platform/opencti/issues/11284) if your Enterprise has a large amount of data in the SSO/SAML payload body envelope.

This PR seeks to solve this issue in a configurable manner. The default is set to the current value of `'100kb'`, but if you choose to - you can now use the `auth_payload_body_size` setting to increase the payload size to your required need for your Enterprise.

### Proposed changes

* Add configurable 'auth_payload_body_size' setting for the APP.
* Solves (PayloadTooLargeError) for Enterpises with payloads that exceed the `'100kb'` default limit.

### Related issues
* (https://github.com/OpenCTI-Platform/opencti/issues/11284) 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [X] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None
