### PR TITLE
[backend] add filter on base_type for external references (#12245)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/domain/externalReference.js
@@ -17,7 +17,8 @@ export const findById = (context, user, externalReferenceId) => {
 };
 
 export const findAll = (context, user, args) => {
-  return listEntities(context, user, [ENTITY_TYPE_EXTERNAL_REFERENCE], args);
+  const filters = addFilter(args.filters, 'base_type', 'ENTITY');
+  return listEntities(context, user, [ENTITY_TYPE_EXTERNAL_REFERENCE], { ...args, filters });
 };
 
 export const references = async (context, user, externalReferenceId, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/domain/externalReference.js
@@ -5,7 +5,7 @@ import { internalLoadById, listEntities, storeLoadById } from '../database/middl
 import conf, { BUS_TOPICS } from '../config/conf';
 import { FunctionalError, ValidationError } from '../config/errors';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../schema/stixMetaObject';
-import { ABSTRACT_STIX_REF_RELATIONSHIP, buildRefRelationKey } from '../schema/general';
+import { ABSTRACT_STIX_REF_RELATIONSHIP, BASE_TYPE_ENTITY, buildRefRelationKey } from '../schema/general';
 import { isStixRefRelationship, RELATION_EXTERNAL_REFERENCE } from '../schema/stixRefRelationship';
 import { isEmptyField } from '../database/utils';
 import { BYPASS, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../utils/access';
@@ -17,7 +17,7 @@ export const findById = (context, user, externalReferenceId) => {
 };
 
 export const findAll = (context, user, args) => {
-  const filters = addFilter(args.filters, 'base_type', 'ENTITY');
+  const filters = addFilter(args.filters, 'base_type', BASE_TYPE_ENTITY);
   return listEntities(context, user, [ENTITY_TYPE_EXTERNAL_REFERENCE], { ...args, filters });
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Both external reference entity and external reference ref have the same entity_type name: "External-Reference" for the entity and "external-reference" for the ref. 
This can particularly cause an issue when in a draft: queryting the entity_type "External-Reference" will return both the entities and the refs, because they are all stored in the same index. This usually doesn't cause an issue outside of drafts, because we only target the READ_INDEX_STIX_META_OBJECTS index when looking up external references.

The fix here is to also add a filter on base_type when querying external references, this way we don't retrieve the external reference refs when loading in the draft index


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12245
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
