### PR TITLE
[frontend] render marking icon color depending on theme color (#12238)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
@@ -10,8 +10,8 @@ import DialogContentText from '@mui/material/DialogContentText';
 import { ObjectMarkingFieldAllowedMarkingQuery$data } from '@components/common/form/__generated__/ObjectMarkingFieldAllowedMarkingQuery.graphql';
 import { ObjectMarkingFieldOtherUserAllowedMarkingsQuery$data } from '@components/common/form/__generated__/ObjectMarkingFieldOtherUserAllowedMarkingsQuery.graphql';
 import DialogTitle from '@mui/material/DialogTitle';
+import { useTheme } from '@mui/material/styles';
 import useAuth from '../../../../utils/hooks/useAuth';
-import ItemIcon from '../../../../components/ItemIcon';
 import Transition from '../../../../components/Transition';
 import AutocompleteField from '../../../../components/AutocompleteField';
 import { RenderOption } from '../../../../components/list_lines';
@@ -21,6 +21,8 @@ import { filterMarkingsOutFor } from '../../../../utils/markings/markingsFilteri
 import { isEmptyField } from '../../../../utils/utils';
 import { fetchQuery } from '../../../../relay/environment';
 import { FieldOption } from '../../../../utils/field';
+import type { Theme } from '../../../../components/Theme';
+import MarkingIcon from '../../../../utils/MarkingIcon';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -131,6 +133,7 @@ const ObjectMarkingField: FunctionComponent<ObjectMarkingFieldProps> = ({
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const [newMarking, setNewMarking] = useState<
   FieldOption[] | OptionValues | undefined
   >(undefined);
@@ -246,7 +249,7 @@ const ObjectMarkingField: FunctionComponent<ObjectMarkingFieldProps> = ({
   const renderOption: RenderOption = (props, option) => (
     <li {...props} key={option.value}>
       <div className={classes.icon} style={{ color: option.color }}>
-        <ItemIcon type="Marking-Definition" color={option.color} />
+        <MarkingIcon theme={theme} color={option.color}/>
       </div>
       <div className={classes.text}>{option.label}</div>
     </li>

--- a/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { graphql } from 'react-relay';
 import Tooltip from '@mui/material/Tooltip';
 import { MarkingDefinitionsLine_node$data } from '@components/settings/__generated__/MarkingDefinitionsLine_node.graphql';
 import DangerZoneChip from '@components/common/danger_zone/DangerZoneChip';
+import { useTheme } from '@mui/material/styles';
 import { MarkingDefinitionsLinesPaginationQuery } from './__generated__/MarkingDefinitionsLinesPaginationQuery.graphql';
 import MarkingDefinitionPopover from './marking_definitions/MarkingDefinitionPopover';
 import AccessesMenu from './AccessesMenu';
@@ -19,7 +20,8 @@ import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloade
 import useSensitiveModifications from '../../../utils/hooks/useSensitiveModifications';
 import { Truncate } from '../../../components/dataGrid/dataTableUtils';
 import type { DataTableColumn } from '../../../components/dataGrid/dataTableTypes';
-import ItemIcon from '../../../components/ItemIcon';
+import type { Theme } from '../../../components/Theme';
+import MarkingIcon from '../../../utils/MarkingIcon';
 
 const LOCAL_STORAGE_KEY = 'MarkingDefinitions';
 
@@ -97,6 +99,7 @@ const markingDefinitionsLinesFragment = graphql`
 
 const MarkingDefinitions = () => {
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('Marking Definitions | Security | Settings'));
 
@@ -128,18 +131,6 @@ const MarkingDefinitions = () => {
           {isSensitive && <DangerZoneChip />}
         </div>
       </Tooltip>
-    );
-  };
-
-  const iconRender = (
-    data: MarkingDefinitionsLine_node$data,
-  ) : ReactNode => {
-    const { x_opencti_color } = data;
-    return (
-      <ItemIcon
-        type="Marking-Definition"
-        color={x_opencti_color ?? undefined}
-      />
     );
   };
 
@@ -185,7 +176,12 @@ const MarkingDefinitions = () => {
           toolbarFilters={contextFilters}
           lineFragment={markingDefinitionLineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
-          icon={iconRender}
+          icon={(data) => {
+            const { x_opencti_color } = data;
+            return (
+              <MarkingIcon theme={theme} color={x_opencti_color}/>
+            );
+          }}
           actions={(markingDefinition) => (
             <MarkingDefinitionPopover
               markingDefinition={markingDefinition}

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -16,6 +16,7 @@ import { Link } from 'react-router-dom';
 import GroupConfidenceLevel from '@components/settings/groups/GroupConfidenceLevel';
 import { uniq } from 'ramda';
 import { ListItemButton } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import { useFormatter } from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
@@ -28,6 +29,7 @@ import GroupHiddenTypesChipList from './GroupHiddenTypesChipList';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { checkIsMarkingAllowed } from '../../../../utils/markings/markingsFiltering';
 import type { Theme } from '../../../../components/Theme';
+import MarkingIcon from '../../../../utils/MarkingIcon';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -114,6 +116,7 @@ const groupFragment = graphql`
 const Group = ({ groupData }: { groupData: Group_group$key }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
 
   const group = useFragment<Group_group$key>(groupFragment, groupData);
 
@@ -311,10 +314,7 @@ const Group = ({ groupData }: { groupData: Group_group$key }) => {
 
                       >
                         <ListItemIcon>
-                          <ItemIcon
-                            type="Marking-Definition"
-                            color={marking?.x_opencti_color ?? undefined}
-                          />
+                          <MarkingIcon theme={theme} color={marking?.x_opencti_color}/>
                         </ListItemIcon>
                         <ListItemText
                           primary={truncate(marking?.definition, 40)}
@@ -338,10 +338,7 @@ const Group = ({ groupData }: { groupData: Group_group$key }) => {
 
                       >
                         <ListItemIcon>
-                          <ItemIcon
-                            type="Marking-Definition"
-                            color={marking?.x_opencti_color ?? undefined}
-                          />
+                          <MarkingIcon theme={theme} color={marking?.x_opencti_color}/>
                         </ListItemIcon>
                         <ListItemText
                           primary={truncate(marking?.definition, 40)}
@@ -377,10 +374,7 @@ const Group = ({ groupData }: { groupData: Group_group$key }) => {
                             {isMarkingAllowed
                               ? <>
                                 <ListItemIcon>
-                                  <ItemIcon
-                                    type="Marking-Definition"
-                                    color={marking.x_opencti_color ?? undefined}
-                                  />
+                                  <MarkingIcon theme={theme} color={marking?.x_opencti_color}/>
                                 </ListItemIcon>
                                 <ListItemText
                                   primary={truncate(marking.definition, 40)}

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionMarkings.tsx
@@ -11,16 +11,18 @@ import { Field, Form, Formik } from 'formik';
 import Typography from '@mui/material/Typography';
 import MaxShareableMarkingsSelectField from '@components/common/form/MaxShareableMarkingsSelectField';
 import { MarkingDefinitionsQuerySearchQuery$data } from '@components/settings/__generated__/MarkingDefinitionsQuerySearchQuery.graphql';
+import { useTheme } from '@mui/material/styles';
 import { QueryRenderer } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';
 import { GroupEditionMarkings_group$data } from './__generated__/GroupEditionMarkings_group.graphql';
 import AutocompleteField from '../../../../components/AutocompleteField';
-import ItemIcon from '../../../../components/ItemIcon';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { convertMarking } from '../../../../utils/edition';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { checkIsMarkingAllowed } from '../../../../utils/markings/markingsFiltering';
 import { markingDefinitionsLinesSearchQuery } from '../MarkingDefinitionsQuery';
+import type { Theme } from '../../../../components/Theme';
+import MarkingIcon from '../../../../utils/MarkingIcon';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -97,6 +99,7 @@ const GroupEditionMarkingsComponent = ({
   group: GroupEditionMarkings_group$data;
 }) => {
   const classes = useStyles();
+  const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const groupMarkingDefinitions = group.allowed_marking || [];
   const groupDefaultMarkingDefinitions = group.default_marking || [];
@@ -263,10 +266,7 @@ const GroupEditionMarkingsComponent = ({
                         }
                       >
                         <ListItemIcon>
-                          <ItemIcon
-                            type="Marking-Definition"
-                            color={markingDefinition.x_opencti_color ?? undefined}
-                          />
+                          <MarkingIcon theme={theme} color={markingDefinition.x_opencti_color}/>
                         </ListItemIcon>
                         <ListItemText primary={markingDefinition.definition} />
                       </ListItem>
@@ -321,10 +321,7 @@ const GroupEditionMarkingsComponent = ({
                               className={classes.icon}
                               style={{ color: option.color }}
                             >
-                              <ItemIcon
-                                type="Marking-Definition"
-                                color={option.color}
-                              />
+                              <MarkingIcon theme={theme} color={option.color}/>
                             </div>
                             <div className={classes.text}>{option.label}</div>
                           </li>

--- a/opencti-platform/opencti-front/src/utils/MarkingIcon.tsx
+++ b/opencti-platform/opencti-front/src/utils/MarkingIcon.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ItemIcon from '../components/ItemIcon';
+import type { Theme } from '../components/Theme';
+
+interface MarkingIconProps {
+  color: string | undefined | null;
+  theme: Theme
+}
+const MarkingIcon = ({ color, theme }: MarkingIconProps) : React.ReactNode => {
+  if (color === 'transparent') {
+    const transparentColor = theme.palette.mode === 'light' ? '#2b2b2b' : '#ffffff';
+    return (
+      <ItemIcon
+        type="Marking-Definition"
+        color={transparentColor}
+      />
+    );
+  }
+  if (theme.palette.mode === 'light' && color === '#ffffff') {
+    // White alternative for light mode.
+    return (
+      <ItemIcon
+        type="Marking-Definition"
+        color={'#2b2b2b'}
+      />
+    );
+  }
+  return (
+    <ItemIcon
+      type="Marking-Definition"
+      color={color}
+    />
+  );
+};
+
+export default MarkingIcon;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* create a component that take in consideration background color


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/12238


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
