### PR TITLE
[frontend] Restricted relationships icon and redirection (#12149)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemEntityType.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemEntityType.tsx
@@ -89,7 +89,7 @@ const ItemEntityType: FunctionComponent<ItemEntityTypeProps> = ({
       return (
         <ItemIcon
           variant="inline"
-          type={isRestricted ? 'restricted' : entityType}
+          type={isRestricted ? 'Restricted' : entityType}
         />
       );
     }

--- a/opencti-platform/opencti-front/src/components/ItemIcon.jsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.jsx
@@ -134,18 +134,16 @@ const iconSelector = (type, variant, fontSize, color, isReversed) => {
   }
 
   switch (type?.toLowerCase()) {
+    case 'restricted':
+      return <HelpOutlined style={style} fontSize={fontSize} role="img" />;
     case 'unauthorized':
-      return (
-        <ReportProblemOutlined style={style} fontSize={fontSize} role="img" />
-      );
+      return <ReportProblemOutlined style={style} fontSize={fontSize} role="img" />;
     case 'global':
       return <PublicOutlined style={style} fontSize={fontSize} role="img" />;
     case 'trigger':
       return <CampaignOutlined style={style} fontSize={fontSize} role="img" />;
     case 'admin':
-      return (
-        <ManageAccountsOutlined style={style} fontSize={fontSize} role="img" />
-      );
+      return <ManageAccountsOutlined style={style} fontSize={fontSize} role="img" />;
     case 'search':
       return <BiotechOutlined style={style} fontSize={fontSize} role="img" />;
     case 'login':

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as PropTypes from 'prop-types';
 import {
   AccountBalanceOutlined,
   AlternateEmailOutlined,
@@ -26,6 +25,7 @@ import {
   FactCheckOutlined,
   FilterAltOutlined,
   FlagOutlined,
+  HelpOutlined,
   LayersClearOutlined,
   LinkOutlined,
   LocalOfferOutlined,
@@ -112,7 +112,7 @@ import {
 import TableViewIcon from '@mui/icons-material/TableView';
 import { itemColor } from '../utils/Colors';
 
-const iconSelector = (type, variant, fontSize, color, isReversed) => {
+const iconSelector = (type?: string, variant?: string, fontSize?: string, color?: string, isReversed?: boolean) => {
   let style;
   switch (variant) {
     case 'inline':
@@ -585,18 +585,17 @@ const iconSelector = (type, variant, fontSize, color, isReversed) => {
   }
 };
 
-const ItemIcon = (props) => {
-  const { type, size, variant, color = null, isReversed = false } = props;
+interface ItemIconProps {
+  type: string,
+  size?: string,
+  variant?: string,
+  color?: string,
+  isReversed?: boolean,
+}
+
+const ItemIcon = ({ type, size, variant, color = null, isReversed = false }: ItemIconProps) => {
   const fontSize = size || 'medium';
   return iconSelector(type, variant, fontSize, color, isReversed);
-};
-
-ItemIcon.propTypes = {
-  type: PropTypes.string,
-  size: PropTypes.string,
-  variant: PropTypes.string,
-  color: PropTypes.string,
-  isReversed: PropTypes.bool,
 };
 
 export default ItemIcon;

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -592,7 +592,7 @@ const iconSelector = (
 };
 
 interface ItemIconProps {
-  type?: string,
+  type?: string | null,
   size?: 'inherit' | 'large' | 'medium' | 'small',
   variant?: string,
   color?: string | null,

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -113,10 +113,10 @@ import TableViewIcon from '@mui/icons-material/TableView';
 import { itemColor } from '../utils/Colors';
 
 const iconSelector = (
-  type: string | undefined,
+  type: string | null | undefined,
   variant: string | undefined,
   fontSize: 'inherit' | 'large' | 'medium' | 'small',
-  color: string | null,
+  color?: string | null,
   isReversed?: boolean,
 ) => {
   let style: React.CSSProperties;

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -112,8 +112,14 @@ import {
 import TableViewIcon from '@mui/icons-material/TableView';
 import { itemColor } from '../utils/Colors';
 
-const iconSelector = (type?: string, variant?: string, fontSize?: string, color?: string, isReversed?: boolean) => {
-  let style;
+const iconSelector = (
+  type: string | undefined,
+  variant: string | undefined,
+  fontSize: 'inherit' | 'large' | 'medium' | 'small',
+  color: string | null,
+  isReversed?: boolean,
+) => {
+  let style: React.CSSProperties;
   switch (variant) {
     case 'inline':
       style = {
@@ -586,16 +592,15 @@ const iconSelector = (type?: string, variant?: string, fontSize?: string, color?
 };
 
 interface ItemIconProps {
-  type: string,
-  size?: string,
+  type?: string,
+  size?: 'inherit' | 'large' | 'medium' | 'small',
   variant?: string,
-  color?: string,
+  color?: string | null,
   isReversed?: boolean,
 }
 
-const ItemIcon = ({ type, size, variant, color = null, isReversed = false }: ItemIconProps) => {
-  const fontSize = size || 'medium';
-  return iconSelector(type, variant, fontSize, color, isReversed);
+const ItemIcon = ({ type, size = 'medium', variant, color = null, isReversed = false }: ItemIconProps) => {
+  return iconSelector(type, variant, size, color, isReversed);
 };
 
 export default ItemIcon;

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetDistributionList.tsx
@@ -43,7 +43,7 @@ const WidgetDistributionList = ({
         {data.map((entry, key) => {
           const label = getMainRepresentative(entry.entity) || entry.label;
 
-          let link: string | null = null;
+          let link: string | undefined;
           if (!publicWidget && (entry.type !== 'User' || hasSettingAccess)) {
             const node: {
               id: string;
@@ -54,7 +54,7 @@ const WidgetDistributionList = ({
               id: entry.id,
               entity_type: entry.type,
             };
-            link = entry.id && entry.label !== 'Restricted' ? computeLink(node) : null;
+            link = entry.id && entry.label !== 'Restricted' ? computeLink(node) : undefined;
           }
           let linkProps = {};
           if (link) {

--- a/opencti-platform/opencti-front/src/utils/Colors.js
+++ b/opencti-platform/opencti-front/src/utils/Colors.js
@@ -32,6 +32,11 @@ export const stringToColour = (str, reversed = false) => {
 
 export const itemColor = (type, dark = false, reversed = false) => {
   switch (type) {
+    case 'Restricted':
+      if (dark) {
+        return '#424242';
+      }
+      return '#B0B0B0';
     case 'Attack-Pattern':
       if (dark) {
         return '#d4e157';

--- a/opencti-platform/opencti-front/src/utils/Entity.ts
+++ b/opencti-platform/opencti-front/src/utils/Entity.ts
@@ -151,17 +151,26 @@ export const computeLink = (node: {
   entity_type: string;
   relationship_type?: string;
   from?: { entity_type: string; id: string };
+  to?: { entity_type: string; id: string };
   type?: string;
-}): string => {
+}): string | undefined => {
   let redirectLink;
   if (node.relationship_type === 'stix-sighting-relationship' && node.from) {
     redirectLink = `${resolveLink(node.from.entity_type)}/${
       node.from.id
     }/knowledge/sightings/${node.id}`;
-  } else if (node.relationship_type && node.from) {
-    redirectLink = `${resolveLink(node.from.entity_type)}/${
-      node.from.id
-    }/knowledge/relations/${node.id}`;
+  } else if (node.relationship_type) {
+    if (node.from) { // 'from' not restricted
+      redirectLink = `${resolveLink(node.from.entity_type)}/${
+        node.from.id
+      }/knowledge/relations/${node.id}`;
+    } else if (node.to) { // if 'from' is restricted, redirect to the knowledge relationship tab of 'to'
+      redirectLink = `${resolveLink(node.to.entity_type)}/${
+        node.to.id
+      }/knowledge/relations/${node.id}`;
+    } else {
+      redirectLink = undefined; // no redirection if from and to are restricted
+    }
   } else if (node.entity_type === 'Workspace') {
     redirectLink = `${resolveLink(node.type)}/${node.id}`;
   } else {


### PR DESCRIPTION
### Proposed changes
In relationships list, if a source or target entity is restricted
- the icon should be '?' and the 'restricted' entity type icon displayed in grey
- the redirection should be done to the not-restricted entity (or no redirection if both side are restricted)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/12149