### PR TITLE
[backend] automatically stale PR after 3 months of inactivity (#12277)

### DIFF
--- a/.github/workflows/auto-stale-pr.yml
+++ b/.github/workflows/auto-stale-pr.yml
@@ -1,0 +1,28 @@
+name: Mark stale pull requests
+
+on: pull_request
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-stale: 90
+          days-before-close: 30
+          stale-pr-message: |
+            Hello, this pull request has been inactive for 3 months.
+            It has been marked as stale with the "no-pr-activity" label and will be automatically closed in 1 month if no activity is detected.
+
+            To keep it open, you can:
+
+            * add a comment explaining the status or next steps
+            * push new commits
+            * apply an exemption label (e.g., "keep-open"), if available
+            * Any recent activity will reset the stale status.
+            * If this PR is no longer relevant, please close it.
+          stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add github actions to automaticaly stale PR after 3 months of inactivity


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/12277


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
