### PR TITLE
[frontend] Avoid full re-render on analyses tab selection (#9491)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -218,7 +218,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
                 path="/"
                 element={
                   <Malware malwareData={malware}/>
-                  }
+                }
               />
               <Route
                 path="/knowledge"

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainers.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import Box from '@mui/material/Box';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -326,12 +326,14 @@ const StixCoreObjectOrStixCoreRelationshipContainers = ({
   };
 
   return (
-    <div
-      className={view === 'lines' ? classes.container : classes.containerGraph}
-    >
-      {view === 'lines' ? renderLines() : ''}
-      {view === 'graph' ? renderGraph() : ''}
-    </div>
+    <Suspense>
+      <div
+        className={view === 'lines' ? classes.container : classes.containerGraph}
+      >
+        {view === 'lines' ? renderLines() : ''}
+        {view === 'graph' ? renderGraph() : ''}
+      </div>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Suspense added on StixCoreObjectOrStixCoreRelationshipContainers.jsx

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #9491 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
