### PR TITLE
[frontend] Add platform OpenCTI version when registering hub

### DIFF
--- a/opencti-platform/opencti-front/src/app.test.tsx
+++ b/opencti-platform/opencti-front/src/app.test.tsx
@@ -26,7 +26,7 @@ const me = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const UserContextValue: any = { me, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {} };
+const UserContextValue: any = { me, settings: {}, bannerSettings: {}, entitySettings: {}, platformModuleHelpers: {}, schema: {}, about: {} };
 
 describe('App', () => {
   afterEach(cleanup);

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -349,6 +349,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
     schemaRelationsTypesMapping,
     schemaRelationsRefTypesMapping,
     filterKeysSchema,
+    about,
   } = queryData;
   const settings = useFragment<RootSettings$key>(rootSettingsFragment, settingsFragment);
   const me = useFragment<RootMe_data$key>(meUserFragment, meFragment);
@@ -391,6 +392,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
         platformModuleHelpers,
         schema,
         isXTMHubAccessible: isReachable,
+        about,
       }}
     >
       <StyledEngineProvider injectFirst={true}>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -35,7 +35,7 @@ const IngestionCsv = () => {
   const classes = useStyles();
   const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?opencti_platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?platform_id=${settings.id}`
     : '';
 
   const { t_i18n } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
@@ -51,7 +51,7 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus }) => {
   const theme = useTheme<Theme>();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
-  const { settings } = useContext(UserContext);
+  const { settings, about } = useContext(UserContext);
   const isEnterpriseEdition = useEnterpriseEdition();
   const registrationHubUrl = settings?.platform_xtmhub_url ?? 'https://hub.filigran.io/app';
   const [processStep, setProcessStep] = useState<ProcessSteps>(
@@ -85,6 +85,7 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus }) => {
     platform_title: settings?.platform_title ?? 'OpenCTI Platform',
     platform_id: settings?.id ?? '',
     platform_contract: isEnterpriseEdition ? 'EE' : 'CE',
+    platform_version: about?.version ?? '',
   };
   const queryParamsOCTIInformations = new URLSearchParams(
     OCTIInformations,
@@ -201,15 +202,30 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus }) => {
 
   const config = useMemo(() => {
     const isUnregister = operationType === OperationType.UNREGISTER;
-    return {
-      dialogTitle: t_i18n(isUnregister ? 'Unregistering your platform...' : 'Registering your platform...'),
-      errorMessage: t_i18n('Sorry, we have an issue, please retry'),
-      canceledMessage: t_i18n(isUnregister ? 'You have canceled the unregistration process' : 'You have canceled the registration process'),
-      loaderButtonText: t_i18n(isUnregister ? 'Continue to unregister' : 'Continue to register'),
-      confirmationTitle: t_i18n(isUnregister ? 'Close unregistration process?' : 'Close registration process?'),
-      confirmationMessage: t_i18n(isUnregister ? 'unregistration_confirmation_dialog' : 'registration_confirmation_dialog'),
-      continueButtonText: t_i18n(isUnregister ? 'Continue unregistration' : 'Continue registration'),
-      instructionKey: isUnregister ? 'unregistration_instruction_paragraph' : 'registration_instruction_paragraph' };
+    const messages = {
+      register: {
+        dialogTitle: t_i18n('Registering your platform...'),
+        errorMessage: t_i18n('Sorry, we have an issue, please retry'),
+        canceledMessage: t_i18n('You have canceled the registration process'),
+        loaderButtonText: t_i18n('Continue to register'),
+        confirmationTitle: t_i18n('Close registration process?'),
+        confirmationMessage: t_i18n('registration_confirmation_dialog'),
+        continueButtonText: t_i18n('Continue registration'),
+        instructionKey: 'registration_instruction_paragraph',
+      },
+      unregister: {
+        dialogTitle: t_i18n('Unregistering your platform...'),
+        errorMessage: t_i18n('Sorry, we have an issue, please retry'),
+        canceledMessage: t_i18n('You have canceled the unregistration process'),
+        loaderButtonText: t_i18n('Continue to unregister'),
+        confirmationTitle: t_i18n('Close unregistration process?'),
+        confirmationMessage: t_i18n('unregistration_confirmation_dialog'),
+        continueButtonText: t_i18n('Continue unregistration'),
+        instructionKey: 'unregistration_instruction_paragraph',
+      },
+    };
+
+    return isUnregister ? messages.unregister : messages.register;
   }, [operationType, t_i18n]);
 
   const renderDialogContent = () => {

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -61,7 +61,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   const inputRef = useRef();
   const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?opencti_platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?platform_id=${settings.id}`
     : '';
 
   const [commitImportMutation] = useApiMutation(importMutation);

--- a/opencti-platform/opencti-front/src/utils/hooks/useAuth.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAuth.test.ts
@@ -10,6 +10,7 @@ describe('Hook: useAuth', () => {
     entitySettings: { entitySettings: 'entitySettings' },
     platformModuleHelpers: { platformModuleHelpers: 'platformModuleHelpers' },
     settings: { settings: 'settings' },
+    about: { version: '6.7.17' },
   } as unknown as UserContextType;
 
   it('should throw an error if "me" undefined', () => {
@@ -39,5 +40,6 @@ describe('Hook: useAuth', () => {
     expect(data.entitySettings).toEqual({ entitySettings: 'entitySettings' });
     expect(data.platformModuleHelpers).toEqual({ platformModuleHelpers: 'platformModuleHelpers' });
     expect(data.settings).toEqual({ settings: 'settings' });
+    expect(data.about.version).toEqual('6.7.17');
   });
 });

--- a/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
@@ -41,6 +41,7 @@ export interface UserContextType {
   platformModuleHelpers: ModuleHelper | undefined;
   schema: SchemaType | undefined;
   isXTMHubAccessible: boolean | null | undefined;
+  about: RootPrivateQuery$data['about'] | undefined;
 }
 
 const defaultContext = {
@@ -51,6 +52,7 @@ const defaultContext = {
   platformModuleHelpers: undefined,
   schema: undefined,
   isXTMHubAccessible: undefined,
+  about: undefined,
 };
 export const UserContext = React.createContext<UserContextType>(defaultContext);
 
@@ -63,11 +65,12 @@ const useAuth = () => {
     platformModuleHelpers,
     schema,
     isXTMHubAccessible,
+    about,
   } = useContext(UserContext);
-  if (!me || !settings || !bannerSettings || !entitySettings || !platformModuleHelpers || !schema) {
+  if (!me || !settings || !bannerSettings || !entitySettings || !platformModuleHelpers || !schema || !about) {
     throw new Error('Invalid user context !');
   }
-  return { me, settings, bannerSettings, entitySettings, platformModuleHelpers, schema, isXTMHubAccessible };
+  return { me, settings, bannerSettings, entitySettings, platformModuleHelpers, schema, isXTMHubAccessible, about };
 };
 
 export default useAuth;

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -56,6 +56,9 @@ export const createMockUserContext = (options?: CreateUserContextOptions): UserC
     platformModuleHelpers: (platformModuleHelpers ?? {}) as UserContextType['platformModuleHelpers'],
     schema: (schema ?? {}) as UserContextType['schema'],
     isXTMHubAccessible: true,
+    about: {
+      version: '6.7.17',
+    },
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
@@ -6,10 +6,10 @@ type RegistrationStatus = 'active' | 'inactive';
 const HUB_BACKEND_URL = conf.get('xtm:xtmhub_api_override_url') ?? conf.get('xtm:xtmhub_url');
 
 export const xtmHubClient = {
-  loadRegistrationStatus: async ({ platformId, token }: { platformId: string, token: string }): Promise<RegistrationStatus> => {
+  refreshRegistrationStatus: async ({ platformId, token, platformVersion }: { platformId: string, token: string, platformVersion: string }): Promise<RegistrationStatus> => {
     const query = `
-      query PlatformRegistrationConnectivityStatus($input: PlatformRegistrationConnectivityStatusInput!) {
-        platformRegistrationConnectivityStatus(input: $input) {
+      mutation RefreshPlatformRegistrationConnectivityStatus($input: RefreshPlatformRegistrationConnectivityStatusInput!) {
+        refreshPlatformRegistrationConnectivityStatus(input: $input) {
           status
         }
       }
@@ -18,7 +18,8 @@ export const xtmHubClient = {
     const variables = {
       input: {
         platformId,
-        token
+        token,
+        platformVersion
       }
     };
     const httpClient = getHttpClient({
@@ -28,7 +29,7 @@ export const xtmHubClient = {
 
     try {
       const response = await httpClient.post('/graphql-api', { query, variables });
-      return response.data.data.platformRegistrationConnectivityStatus.status;
+      return response.data.data.refreshPlatformRegistrationConnectivityStatus.status;
     } catch (error) {
       logApp.warn('XTM Hub is unreachable', { reason: error });
       return 'inactive';

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
@@ -8,8 +8,8 @@ const HUB_BACKEND_URL = conf.get('xtm:xtmhub_api_override_url') ?? conf.get('xtm
 export const xtmHubClient = {
   loadRegistrationStatus: async ({ platformId, token }: { platformId: string, token: string }): Promise<RegistrationStatus> => {
     const query = `
-      query OpenCTIPlatformRegistrationStatus($input: OpenCTIPlatformRegistrationStatusInput!) {
-        openCTIPlatformRegistrationStatus(input: $input) {
+      query PlatformRegistrationConnectivityStatus($input: PlatformRegistrationConnectivityStatusInput!) {
+        platformRegistrationConnectivityStatus(input: $input) {
           status
         }
       }
@@ -28,7 +28,7 @@ export const xtmHubClient = {
 
     try {
       const response = await httpClient.post('/graphql-api', { query, variables });
-      return response.data.data.openCTIPlatformRegistrationStatus.status;
+      return response.data.data.platformRegistrationConnectivityStatus.status;
     } catch (error) {
       logApp.warn('XTM Hub is unreachable', { reason: error });
       return 'inactive';

--- a/opencti-platform/opencti-graphql/src/types/store.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/store.d.ts
@@ -122,6 +122,7 @@ interface BasicStoreBase extends BasicStoreIdentifier {
   // representative
   representative: Representative
   restricted_members?: Array<AuthorizedMember>;
+  platformVersion: string;
 }
 
 interface StoreMarkingDefinition extends BasicStoreEntity {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When registering OpenCTI instance, send platform version information
* Send platform version information with the checked connectivity with the hub to keep the version up to date

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/FiligranHQ/xtm-hub/issues/919

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
In order to test it you need to need to use a XTM Hub platform.
Test need to be done with the master and the current branch in order to test the retrocompatibility of different OpenCTI version with the Hub

Related PR : https://github.com/FiligranHQ/xtm-hub/pull/927
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
