### PR TITLE
[backend] do not add dynamicFrom/dynamicTo if empty filter (#12350)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -563,10 +563,10 @@ export const filtersEntityIdsMappingResult = (inputFilters: FilterGroup, keysToR
 export const addDynamicFromAndToToFilters = (args: any): FilterGroup | undefined | null => {
   const { filters, dynamicFrom, dynamicTo } = args;
   let finalFilters = filters;
-  if (dynamicFrom) {
+  if (dynamicFrom && isFilterGroupNotEmpty(dynamicFrom)) {
     finalFilters = addFilter(finalFilters, RELATION_DYNAMIC_FROM_FILTER, dynamicFrom);
   }
-  if (dynamicTo) {
+  if (dynamicTo && isFilterGroupNotEmpty(dynamicTo)) {
     finalFilters = addFilter(finalFilters, RELATION_DYNAMIC_TO_FILTER, dynamicTo);
   }
   return finalFilters;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we missed something in previous fix: previous buildArgsFromDynamicFilters method didn't use dynamicFrom & dynamicTo if it was an empty filter. We now ignore dynamicFrom & dynamicTo if it is an empty filter
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12350
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
