### PR TITLE
[frontend] enable vertical scrolling for connector logs display (#7328)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -649,11 +649,12 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
 
   // Component for Logs content
   const ConnectorLogs = () => (
-    <Box sx={{ marginBottom: '20px' }}>
+    <Box sx={{ marginBottom: '20px', height: 'calc(100vh - 280px)' }}>
       <pre
         style={{
           height: '100%',
           overflowX: 'scroll',
+          overflowY: 'auto',
           paddingBottom: theme.spacing(2),
           backgroundColor: theme.palette.background.paper,
           padding: theme.spacing(2),

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -648,8 +648,10 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
   );
 
   // Component for Logs content
-  const ConnectorLogs = () => (
-    <Box sx={{ marginBottom: '20px', height: 'calc(100vh - 280px)' }}>
+  const ConnectorLogs = () => {
+    // calculating the full viewport height minus some space for elements above
+    const logsContainerHeight = 'calc(100vh - 280px)';
+    return (<Box sx={{ marginBottom: '20px', height: logsContainerHeight }}>
       <pre
         style={{
           height: '100%',
@@ -665,7 +667,8 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
         {connector.manager_connector_logs?.join('\n') || t_i18n('No logs available')}
       </pre>
     </Box>
-  );
+    );
+  };
 
   return (
     <>


### PR DESCRIPTION
### Proposed changes

* Fix connector logs display to enable proper vertical scrolling
* Set a fixed height for the logs container using viewport calculations (`calc(100vh - 280px)`)
* Add explicit `overflowY: 'auto'` to ensure vertical scrolling is enabled for long log outputs

### Related issues

* #7328

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is a straightforward UI fix that improves the user experience when viewing connector logs. The solution uses viewport-relative height calculations to ensure the log container fits properly within the available space while maintaining scrollability.