### PR TITLE
Align MinIO version in dev env with CI version

### DIFF
--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -96,7 +96,7 @@ services:
 
   opencti-dev-minio:
     container_name: opencti-dev-minio
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
     ports:
       - "9000:9000"
       - "9001:9001"


### PR DESCRIPTION
### Proposed changes

* Pin MinIO Docker image version to `RELEASE.2025-06-13T11-33-47Z` in the development docker-compose configuration
* Align development environment with CI pipeline configuration to ensure consistency

### Related issues

* No related issues

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This change ensures that developers use the same MinIO version as the CI pipeline, preventing potential version-related issues during local development. The CI environment (.drone.yml) already uses this specific version, and this change brings the development docker-compose.yml in sync with it.