### PR TITLE
[backend] Add telemetry for connector deployments via composer (#7328)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/connector.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector.ts
@@ -53,7 +53,7 @@ import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { extractEntityRepresentativeName } from '../database/entity-representative';
 import type { BasicStoreCommon } from '../types/store';
 import type { Connector } from '../connector/internalConnector';
-import { addWorkbenchDraftConvertionCount, addWorkbenchValidationCount } from '../manager/telemetryManager';
+import { addWorkbenchDraftConvertionCount, addWorkbenchValidationCount, addConnectorDeployedCount } from '../manager/telemetryManager';
 import { computeConnectorTargetContract, getSupportedContractsByImage } from '../modules/catalog/catalog-domain';
 import { getEntitiesMapFromCache } from '../database/cache';
 import { removeAuthenticationCredentials } from '../modules/ingestion/ingestion-common';
@@ -278,6 +278,8 @@ export const managedConnectorAdd = async (
     built_in: false
   };
   const createdConnector: any = await createEntity(context, user, connectorToCreate, ENTITY_TYPE_CONNECTOR);
+  // Increment telemetry for connector deployed via composer
+  await addConnectorDeployedCount();
   // Publish
   await publishUserAction({
     user,

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -58,6 +58,7 @@ export const TELEMETRY_GAUGE_ONBOARDING_EMAIL_SEND = 'onboardingEmailSendCount';
 export const TELEMETRY_BACKGROUND_TASK_USER = 'userBackgroundTaskCount';
 export const TELEMETRY_EMAIL_TEMPLATE_CREATED = 'emailTemplateCreatedCount';
 export const TELEMETRY_FORGOT_PASSWORD = 'forgotPasswordCount';
+export const TELEMETRY_CONNECTOR_DEPLOYED = 'connectorDeployedCount';
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -105,6 +106,10 @@ export const addEmailTemplateCreatedCount = async () => {
 };
 export const addForgotPasswordCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_FORGOT_PASSWORD, 1);
+};
+
+export const addConnectorDeployedCount = async () => {
+  await redisSetTelemetryAdd(TELEMETRY_CONNECTOR_DEPLOYED, 1);
 };
 
 // End Region user event counters
@@ -256,6 +261,8 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setEmailTemplateCreatedCount(emailTemplateCreatedCountInRedis);
     const forgotPasswordCountInRedis = await redisGetTelemetry(TELEMETRY_FORGOT_PASSWORD);
     manager.setForgotPasswordCount(forgotPasswordCountInRedis);
+    const connectorDeployedCountInRedis = await redisGetTelemetry(TELEMETRY_CONNECTOR_DEPLOYED);
+    manager.setConnectorDeployedCount(connectorDeployedCountInRedis);
     // end region Telemetry user events
 
     logApp.debug('[TELEMETRY] Fetching telemetry data successfully');

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -66,6 +66,9 @@ export class TelemetryMeterManager {
   // Number of PIR
   pirCount = 0;
 
+  // Number of connectors deployed
+  connectorDeployedCount = 0;
+
   constructor(meterProvider: MeterProvider) {
     this.meterProvider = meterProvider;
   }
@@ -162,6 +165,10 @@ export class TelemetryMeterManager {
     this.pirCount = n;
   }
 
+  setConnectorDeployedCount(n: number) {
+    this.connectorDeployedCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: { unit?: string, valueType?: ValueType } = {}) {
     const meter = this.meterProvider.getMeter(TELEMETRY_SERVICE_NAME);
     const gaugeOptions = { description, unit: opts.unit ?? 'count', valueType: opts.valueType ?? ValueType.INT };
@@ -198,5 +205,6 @@ export class TelemetryMeterManager {
     this.registerGauge('email_template_created_count', 'Number of email templates created', 'emailTemplateCreatedCount');
     this.registerGauge('forgot_password_count', 'Number of clicks on Forgot Password', 'forgotPasswordCount');
     this.registerGauge('pir_count', 'number of PIRs', 'pirCount');
+    this.registerGauge('connector_deployed_count', 'Number of connectors deployed via composer', 'connectorDeployedCount');
   }
 }


### PR DESCRIPTION
### Proposed changes

* Add telemetry counter to track connectors deployed through the managed connector API (composer)
* Implement `connectorDeployedCount` metric in the telemetry system
* Increment counter when a connector is created via `managedConnectorAdd` function

### Related issues

* #7328

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The metric is only incremented when connectors are deployed via the `managedConnectorAdd` function, not for manually configured connectors, providing clear insights into automated deployment usage.
