### PR TITLE
[frontend] fix right menu getting over the chatbot in fullsize (#11027)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -21,6 +21,7 @@ const StyledDrawer = styled(Drawer)(() => ({
     position: 'fixed',
     overflow: 'auto',
     padding: 0,
+    zIndex: 998,
   },
 }));
 


### PR DESCRIPTION
Bug description:
* go in a view with a right menu, like a malware Knowledge view
* open the chatbot
* extend it 
* the chatbot is below the right menu

This fix overwrite default MUI drawer zindex