### PR TITLE
Added config to front and back eslint to activate auto save with linter

### DIFF
--- a/opencti-platform/opencti-front/.eslintrc.js
+++ b/opencti-platform/opencti-front/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: [
     'airbnb-base',
     'airbnb-typescript/base',
@@ -48,10 +49,7 @@ module.exports = {
     'vitest.config.ts',
     'setup-vitest.ts',
   ],
-  plugins: [
-    'import-newlines',
-    'custom-rules',
-  ],
+  plugins: ['import-newlines', 'custom-rules'],
   rules: {
     'custom-rules/classes-rule': 1,
     'no-restricted-syntax': 0,
@@ -61,7 +59,10 @@ module.exports = {
     'object-curly-newline': 'off',
     'arrow-body-style': 'off',
     'max-len': [
-      'error', 180, 2, {
+      'error',
+      180,
+      2,
+      {
         ignoreUrls: true,
         ignoreComments: false,
         ignoreRegExpLiterals: true,
@@ -70,16 +71,19 @@ module.exports = {
       },
     ],
     '@typescript-eslint/lines-between-class-members': 'off',
-    '@typescript-eslint/naming-convention': ['error', {
-      selector: 'variable',
-      format: ['camelCase', 'UPPER_CASE'],
-      leadingUnderscore: 'allow',
-      trailingUnderscore: 'allow',
-      filter: {
-        regex: '/([^_]*)/',
-        match: true,
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow',
+        filter: {
+          regex: '/([^_]*)/',
+          match: true,
+        },
       },
-    }],
+    ],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/opencti-platform/opencti-graphql/.eslintrc.js
+++ b/opencti-platform/opencti-graphql/.eslintrc.js
@@ -1,24 +1,22 @@
 module.exports = {
-  plugins: [
-    '@typescript-eslint/eslint-plugin',
-    'import-newlines'
-  ],
+  root: true,
+  plugins: ['@typescript-eslint/eslint-plugin', 'import-newlines'],
   extends: [
     'airbnb-base',
     'airbnb-typescript/base',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended'
+    'plugin:@typescript-eslint/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,
     project: './tsconfig.json',
-    tsconfigRootDir: __dirname
+    tsconfigRootDir: __dirname,
   },
   env: {
-    jest: true
+    jest: true,
   },
   ignorePatterns: [
     '**/build/**',
@@ -33,7 +31,7 @@ module.exports = {
     'jest.config.js',
     'jest.setup.js',
     'jest.file.transform.js',
-    'jest.relay.transform.js'
+    'jest.relay.transform.js',
   ],
   rules: {
     'import/extensions': [
@@ -41,8 +39,8 @@ module.exports = {
       'ignorePackages',
       {
         js: 'never',
-        ts: 'never'
-      }
+        ts: 'never',
+      },
     ],
     'max-len': [
       'error',
@@ -53,8 +51,8 @@ module.exports = {
         ignoreComments: false,
         ignoreRegExpLiterals: true,
         ignoreStrings: true,
-        ignoreTemplateLiterals: true
-      }
+        ignoreTemplateLiterals: true,
+      },
     ],
     camelcase: 'off',
     'no-underscore-dangle': 'off',
@@ -72,22 +70,20 @@ module.exports = {
       {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
-        caughtErrorsIgnorePattern: '^_'
-      }
+        caughtErrorsIgnorePattern: '^_',
+      },
     ],
     'import-newlines/enforce': ['error', { items: 20, 'max-len': 180 }],
     '@typescript-eslint/no-floating-promises': ['error'],
   },
   overrides: [
     {
-      files: [
-        '*.js'
-      ],
+      files: ['*.js'],
       rules: {
         '@typescript-eslint/no-this-alias': 'off',
         '@typescript-eslint/return-await': 'off',
         '@typescript-eslint/no-use-before-define': 'off'
-      }
-    }
-  ]
+      },
+    },
+  ],
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added config to allow auto linter on save with vscode 
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
