### PR TITLE
[backend] prevents name and email from being updated for external users (#12174)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -807,6 +807,12 @@ export const userEditField = async (context, user, userId, rawInputs) => {
   }
   for (let index = 0; index < rawInputs.length; index += 1) {
     const input = rawInputs[index];
+    if (userToUpdate.external && input.key === 'name') {
+      throw FunctionalError('Name cannot be updated for external user');
+    }
+    if (userToUpdate.external && input.key === 'user_email') {
+      throw FunctionalError('Email cannot be updated for external user');
+    }
     if (input.key === 'password') {
       const userPassword = R.head(input.value).toString();
       await checkPasswordFromPolicy(context, userPassword);

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.ts
@@ -342,6 +342,46 @@ describe('User resolver standard behavior', () => {
     });
     expect(invalidQueryResult.errors?.[0].message).toEqual('The language you have provided is not valid');
   });
+  it('should not update Name field for internal user', async () => {
+    const UPDATE_QUERY = gql`
+      mutation UserEdit($id: ID!, $input: [EditInput]!) {
+        userEdit(id: $id) {
+          fieldPatch(input: $input) {
+            id
+          }
+        }
+      }
+    `;
+    const result = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: { id: ADMIN_USER.id, input: { key: 'name', value: ['new name'] } },
+    });
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBe(1);
+    if (result.errors) {
+      expect(result.errors[0].message).toBe('Name cannot be updated for external user');
+    }
+  });
+  it('should not update Email field for internal user', async () => {
+    const UPDATE_QUERY = gql`
+      mutation UserEdit($id: ID!, $input: [EditInput]!) {
+        userEdit(id: $id) {
+          fieldPatch(input: $input) {
+            id
+          }
+        }
+      }
+    `;
+    const result = await queryAsAdmin({
+      query: UPDATE_QUERY,
+      variables: { id: ADMIN_USER.id, input: { key: 'user_email', value: ['mail@mail.com'] } },
+    });
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBe(1);
+    if (result.errors) {
+      expect(result.errors[0].message).toBe('Email cannot be updated for external user');
+    }
+  });
   it('should Admin be able renew a user token', async () => {
     const queryUserBeforeRenew = await queryAsAdminWithSuccess({ query: READ_QUERY, variables: { id: userInternalId } });
     const tokenBeforeRenew = queryUserBeforeRenew.data?.user.api_token;


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* protect name and email from being updated trhough api
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/12174


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
