### PR TITLE
[backend] Fix stream fetch range for PIR (#11149)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -829,7 +829,7 @@ export const fetchStreamEventsRangeFromEventId = async (
     const streamResult = await client.call(
       'XRANGE',
       opts.streamName ?? REDIS_STREAM_NAME,
-      startTimestamp,
+      `(${startEventId}`, // ( prefix to exclude startEventId
       endTimestamp
     ) as any[];
     // Process the event results


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* exclude start time when fetching stream events for pir (otherwise the same last event is fetched again)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11149

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
