### PR TITLE
[frontend] Rework the query of ingestion monitoring to be smaller on …

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Connectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Connectors.jsx
@@ -3,19 +3,18 @@ import IngestionMenu from './IngestionMenu';
 import { useFormatter } from '../../../components/i18n';
 import { QueryRenderer } from '../../../relay/environment';
 import WorkersStatus, { workersStatusQuery } from './connectors/WorkersStatus';
-import ConnectorsStatus, { connectorsStatusQuery } from './connectors/ConnectorsStatus';
+import ConnectorsStatus from './connectors/ConnectorsStatus';
 import Loader, { LoaderVariant } from '../../../components/Loader';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import PageContainer from '../../../components/PageContainer';
-import useHelper from '../../../utils/hooks/useHelper';
 
 const Connectors = () => {
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
-  const { isFeatureEnable } = useHelper();
-  const enableComposerFeatureFlag = isFeatureEnable('COMPOSER');
+
   setTitle(t_i18n('Ingestion monitoring | Ingestion | Data'));
+
   return (
     <div data-testid="connectors-page">
       <IngestionMenu />
@@ -34,16 +33,17 @@ const Connectors = () => {
             return <Loader variant={LoaderVariant.container} />;
           }}
         />
-        <QueryRenderer
-          query={connectorsStatusQuery}
-          variables={{ enableComposerFeatureFlag }}
-          render={({ props }) => {
-            if (props) {
-              return <ConnectorsStatus data={props} />;
-            }
-            return <Loader variant={LoaderVariant.container} />;
-          }}
-        />
+        <ConnectorsStatus />
+        {/* <QueryRenderer */}
+        {/*  query={connectorsStatusQuery} */}
+        {/*  variables={{ enableComposerFeatureFlag }} */}
+        {/*  render={({ props }) => { */}
+        {/*    if (props) { */}
+        {/*      return <ConnectorsStatus data={props} />; */}
+        {/*    } */}
+        {/*    return <Loader variant={LoaderVariant.container} />; */}
+        {/*  }} */}
+        {/* /> */}
       </PageContainer>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/Connectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Connectors.jsx
@@ -34,16 +34,6 @@ const Connectors = () => {
           }}
         />
         <ConnectorsStatus />
-        {/* <QueryRenderer */}
-        {/*  query={connectorsStatusQuery} */}
-        {/*  variables={{ enableComposerFeatureFlag }} */}
-        {/*  render={({ props }) => { */}
-        {/*    if (props) { */}
-        {/*      return <ConnectorsStatus data={props} />; */}
-        {/*    } */}
-        {/*    return <Loader variant={LoaderVariant.container} />; */}
-        {/*  }} */}
-        {/* /> */}
       </PageContainer>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectors.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectors.tsx
@@ -1,0 +1,23 @@
+import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
+import { IngestionConnectorsQuery } from '@components/data/IngestionCatalog/__generated__/IngestionConnectorsQuery.graphql';
+import React from 'react';
+
+export const ingestionConnectorsQuery = graphql`
+  query IngestionConnectorsQuery {
+    connectors {
+      manager_contract_image
+    }
+  }
+`;
+
+interface IngestionConnectorsProps {
+  queryRef: PreloadedQuery<IngestionConnectorsQuery>;
+  children: ({ data }: { data: IngestionConnectorsQuery['response'] }) => React.ReactNode;
+}
+
+const IngestionConnectors: React.FC<IngestionConnectorsProps> = ({ queryRef, children }) => {
+  const data = usePreloadedQuery(ingestionConnectorsQuery, queryRef);
+  return children({ data });
+};
+
+export default IngestionConnectors;

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectorsCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectorsCatalog.tsx
@@ -1,0 +1,28 @@
+import { graphql, usePreloadedQuery } from 'react-relay';
+import type { PreloadedQuery } from 'react-relay';
+import React from 'react';
+import { IngestionConnectorsCatalogsQuery } from '@components/data/IngestionCatalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
+
+export const ingestionConnectorsCatalogsQuery = graphql`
+  query IngestionConnectorsCatalogsQuery($enableComposerFeatureFlag: Boolean!) {
+    catalogs @include(if: $enableComposerFeatureFlag) {
+      id
+      name
+      description
+      contracts
+    }
+  }
+`;
+
+interface IngestionConnectorsCatalogsProps {
+  queryRef: PreloadedQuery<IngestionConnectorsCatalogsQuery>;
+  children: ({ data }: { data: IngestionConnectorsCatalogsQuery['response'] }) => React.ReactNode;
+}
+
+const IngestionConnectorsCatalogs: React.FC<IngestionConnectorsCatalogsProps> = ({ queryRef, children }) => {
+  const data = usePreloadedQuery(ingestionConnectorsCatalogsQuery, queryRef);
+
+  return children({ data });
+};
+
+export default IngestionConnectorsCatalogs;

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useIngestionCatalogFilters.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useIngestionCatalogFilters.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { FilterState } from '@components/data/IngestionCatalog/IngestionCatalogFilters';
 import { IngestionConnector } from '@components/data/IngestionCatalog';
-import { IngestionCatalogQuery$data } from '@components/data/__generated__/IngestionCatalogQuery.graphql';
+import { IngestionConnectorsCatalogsQuery } from '@components/data/IngestionCatalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
 import { MESSAGING$ } from '../../../../../relay/environment';
 import { useFormatter } from '../../../../../components/i18n';
 
 type UseIngestionCatalogFiltersProps = {
-  catalogs: IngestionCatalogQuery$data['catalogs'];
+  catalogs: NonNullable<IngestionConnectorsCatalogsQuery['response']['catalogs']>;
   searchParams: URLSearchParams;
 };
 

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/createDeploymentCountMap.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/createDeploymentCountMap.ts
@@ -1,6 +1,6 @@
-import { IngestionCatalogQuery$data } from '@components/data/__generated__/IngestionCatalogQuery.graphql';
+import { IngestionConnectorsQuery$data } from '@components/data/IngestionCatalog/__generated__/IngestionConnectorsQuery.graphql';
 
-type Connector = NonNullable<IngestionCatalogQuery$data['connectors']>[number];
+type Connector = NonNullable<IngestionConnectorsQuery$data['connectors']>[number];
 
 const createDeploymentCountMap = (connectors: readonly Connector[]) => {
   const deploymentCountMap = new Map<string, number>();

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorStatusChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorStatusChip.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
+import { ConnectorsStateQuery$data } from '@components/data/connectors/__generated__/ConnectorsStateQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { computeConnectorStatus } from '../../../../utils/Connector';
 
 type ConnectorStatusChipProps = {
-  connector: Partial<ConnectorsStatus_data$data['connectors'][0]>
+  connector: Partial<ConnectorsStateQuery$data['connectors'][0]>
 };
 
 const ConnectorStatusChip: React.FC<ConnectorStatusChipProps> = ({ connector }) => {

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsList.tsx
@@ -1,0 +1,50 @@
+import { graphql, usePreloadedQuery } from 'react-relay';
+import type { PreloadedQuery } from 'react-relay';
+import React from 'react';
+import type { ConnectorsListQuery } from './__generated__/ConnectorsListQuery.graphql';
+
+export const connectorsListQuery = graphql`
+  query ConnectorsListQuery($enableComposerFeatureFlag: Boolean!) {
+    connectorManagers @include(if: $enableComposerFeatureFlag) {
+      id
+      name
+    }
+    connectors {
+      id
+      name
+      connector_type
+      connector_scope
+      is_managed @include(if: $enableComposerFeatureFlag)
+      manager_contract_image @include(if: $enableComposerFeatureFlag)
+      manager_contract_definition @include(if: $enableComposerFeatureFlag)
+      manager_contract_configuration @include(if: $enableComposerFeatureFlag) {
+        key
+        value
+      }
+      connector_user {
+        id
+        name
+      }
+      config {
+        listen
+        listen_exchange
+        push
+        push_exchange
+      }
+      built_in
+    }
+  }
+`;
+
+interface ConnectorsListProps {
+  queryRef: PreloadedQuery<ConnectorsListQuery>;
+  children: ({ data }: { data: ConnectorsListQuery['response'] }) => React.ReactNode;
+}
+
+const ConnectorsList: React.FC<ConnectorsListProps> = ({ queryRef, children }) => {
+  const data = usePreloadedQuery(connectorsListQuery, queryRef);
+
+  return children({ data });
+};
+
+export default ConnectorsList;

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsState.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsState.tsx
@@ -1,0 +1,52 @@
+import { graphql, usePreloadedQuery } from 'react-relay';
+import type { PreloadedQuery } from 'react-relay';
+import React from 'react';
+import type { ConnectorsStateQuery } from './__generated__/ConnectorsStateQuery.graphql';
+
+export const connectorsStateQuery = graphql`
+  query ConnectorsStateQuery($enableComposerFeatureFlag: Boolean!) {
+    connectors {
+      id
+      active
+      auto
+      connector_trigger_filters
+      manager_current_status @include(if: $enableComposerFeatureFlag)
+      manager_requested_status @include(if: $enableComposerFeatureFlag)
+      updated_at
+    }
+    connectorManagers @include(if: $enableComposerFeatureFlag) {
+      id
+      active
+      last_sync_execution
+    }
+    rabbitMQMetrics {
+      queues {
+        name
+        messages
+        messages_ready
+        messages_unacknowledged
+        consumers
+        idle_since
+        message_stats {
+          ack
+          ack_details {
+            rate
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface ConnectorsStateProps {
+  queryRef: PreloadedQuery<ConnectorsStateQuery>;
+  children: ({ data }: { data: ConnectorsStateQuery['response'] }) => React.ReactNode;
+}
+
+const ConnectorsState: React.FC<ConnectorsStateProps> = ({ queryRef, children }) => {
+  const data = usePreloadedQuery(connectorsStateQuery, queryRef);
+
+  return children({ data });
+};
+
+export default ConnectorsState;

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
@@ -19,7 +19,7 @@ import JsonFormArrayRenderer, { jsonFormArrayTester } from '@components/data/Ing
 import reconcileManagedConnectorContractDataWithSchema from '@components/data/connectors/utils/reconcileManagedConnectorContractDataWithSchema';
 import buildContractConfiguration from '@components/data/connectors/utils/buildContractConfiguration';
 import JsonFormUnsupportedType, { jsonFormUnsupportedTypeTester } from '@components/data/IngestionCatalog/utils/JsonFormUnsupportedType';
-import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
+import { ConnectorsListQuery$data } from '@components/data/connectors/__generated__/ConnectorsListQuery.graphql';
 import TextField from '../../../../components/TextField';
 import { type FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -56,7 +56,7 @@ const customRenderers = [
 ];
 
 type ManagedConnectorEditionProps = {
-  connector: ConnectorsStatus_data$data['connectors'][0]
+  connector: ConnectorsListQuery$data['connectors'][0]
   open: boolean;
   onClose: () => void
 };

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
@@ -7,7 +7,6 @@ import React, { useMemo } from 'react';
 import { useTheme } from '@mui/styles';
 import { graphql } from 'react-relay';
 import { FormikHelpers } from 'formik/dist/types';
-import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import { JsonForms } from '@jsonforms/react';
@@ -20,6 +19,7 @@ import JsonFormArrayRenderer, { jsonFormArrayTester } from '@components/data/Ing
 import reconcileManagedConnectorContractDataWithSchema from '@components/data/connectors/utils/reconcileManagedConnectorContractDataWithSchema';
 import buildContractConfiguration from '@components/data/connectors/utils/buildContractConfiguration';
 import JsonFormUnsupportedType, { jsonFormUnsupportedTypeTester } from '@components/data/IngestionCatalog/utils/JsonFormUnsupportedType';
+import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
 import TextField from '../../../../components/TextField';
 import { type FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/hooks/useConnectorsStatusFilters.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/hooks/useConnectorsStatusFilters.ts
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ConnectorsStatusFilterState } from '@components/data/connectors/ConnectorsStatusFilters';
-import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
 import { ManagerContractDefinition } from '@components/data/connectors/utils/managerContractDefinitionType';
+import { ConnectorsListQuery } from '@components/data/connectors/__generated__/ConnectorsListQuery.graphql';
+import { ConnectorsStateQuery } from '@components/data/connectors/__generated__/ConnectorsStateQuery.graphql';
 
-type Connector = NonNullable<ConnectorsStatus_data$data['connectors']>[number];
+type Connector =
+  NonNullable<ConnectorsListQuery['response']['connectors']>[number]
+  & Partial<NonNullable<ConnectorsStateQuery['response']['connectors']>[number]>;
 
 type UseConnectorsStatusFiltersProps = {
-  connectors: readonly Connector[]
+  connectors: Connector[]
   managerContractDefinitionMap: Map<string, ManagerContractDefinition>
   searchParams: URLSearchParams;
 };

--- a/opencti-platform/opencti-front/src/utils/Connector.tsx
+++ b/opencti-platform/opencti-front/src/utils/Connector.tsx
@@ -1,4 +1,4 @@
-import { ConnectorsStatus_data$data } from '@components/data/connectors/__generated__/ConnectorsStatus_data.graphql';
+import { ConnectorsStateQuery$data } from '@components/data/connectors/__generated__/ConnectorsStateQuery.graphql';
 import { stixFilters, useAvailableFilterKeysForEntityTypes } from './filters/filtersUtils';
 import useSchema from './hooks/useSchema';
 
@@ -67,7 +67,7 @@ export const computeConnectorStatus = ({
   manager_current_status,
   manager_requested_status,
   active,
-}: Partial<ConnectorsStatus_data$data['connectors'][0]>) => {
+}: Partial<ConnectorsStateQuery$data['connectors'][0]>) => {
   if (manager_requested_status) {
     // On connector created, manager_current_status is null
     const isTransitioning = (manager_current_status ?? '').slice(0, 5) !== manager_requested_status.slice(0, 5);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove catalogs from the query as it is unused in monitoring
* Split the queries, with connectorsList and connectorsState
* Only refetch connectors state intervally
* Should also improve the ingestion catalog -> load only once the catalog and use it from the cache

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7328 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
