### PR TITLE
[frontend] Empty fields display in entities lists and overview (#12441)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemAuthor.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemAuthor.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import * as PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Button from '@mui/material/Button';
 import { resolveLink } from '../utils/Entity';
 
-const ItemAuthor = (props) => {
-  const { createdBy } = props;
+interface ItemAuthorProps {
+  createdBy: {
+    id: string,
+    name: string,
+    entity_type: string,
+  } | null | undefined
+}
+
+const ItemAuthor = ({ createdBy }: ItemAuthorProps) => {
   return (
     <>
       {createdBy ? (
@@ -25,10 +31,6 @@ const ItemAuthor = (props) => {
       )}
     </>
   );
-};
-
-ItemAuthor.propTypes = {
-  createdBy: PropTypes.object,
 };
 
 export default ItemAuthor;

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDetails.tsx
@@ -69,7 +69,7 @@ const ExternalReferenceDetailsComponent = ({
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('External ID')}
             </Typography>
-            {externalReference.external_id}
+            {externalReference.external_id ?? '-'}
             <Typography
               variant="h3"
               gutterBottom={true}

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
@@ -15,7 +15,7 @@ import type { Theme } from '../../../../components/Theme';
 import { MalwareAnalysisDetails_malwareAnalysis$key } from './__generated__/MalwareAnalysisDetails_malwareAnalysis.graphql';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
-import { emptyFilled } from '../../../../utils/String';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -104,11 +104,13 @@ MalwareAnalysisDetailsProps
             >
               {t_i18n('Maliciousness')}
             </Typography>
-            <Chip
-              key={data.result}
-              classes={{ root: classes.chip }}
-              label={emptyFilled(data.result)}
-            />
+            <FieldOrEmpty source={data.result}>
+              <Chip
+                key={data.result}
+                classes={{ root: classes.chip }}
+                label={data.result}
+              />
+            </FieldOrEmpty>
             <Typography
               variant="h3"
               gutterBottom={true}

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDetails.tsx
@@ -179,16 +179,18 @@ MalwareAnalysisDetailsProps
         <Typography variant="h3" gutterBottom={true} style={{ marginTop: 20 }}>
           {t_i18n('Modules')}
         </Typography>
-        <List>
-          {(data.modules ?? []).map((module, index) => (
-            <ListItem key={`${index}:${module}`} dense={true} divider={true}>
-              <ListItemIcon>
-                <ViewModuleOutlined />
-              </ListItemIcon>
-              <ListItemText primary={module} />
-            </ListItem>
-          ))}
-        </List>
+        <FieldOrEmpty source={data.modules}>
+          <List>
+            {data.modules?.map((module, index) => (
+              <ListItem key={`${index}:${module}`} dense={true} divider={true}>
+                <ListItemIcon>
+                  <ViewModuleOutlined />
+                </ListItemIcon>
+                <ListItemText primary={module} />
+              </ListItem>
+            ))}
+          </List>
+        </FieldOrEmpty>
         <StixDomainObjectNestedEntities
           entityId={data.id}
           entityType="Malware-Analysis"

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
@@ -152,7 +152,7 @@ class AddNotesLinesContainer extends Component {
               <div style={{ marginRight: 50 }}>
                 <ItemMarkings
                   variant="inList"
-                  markingDefinitions={data.objectMarking ?? []}
+                  markingDefinitions={note.objectMarking ?? []}
                 />
               </div>
             </ListItemButton>
@@ -204,6 +204,10 @@ const AddNotesLines = createPaginationContainer(
                 definition
                 x_opencti_order
                 x_opencti_color
+              }
+              createdBy {
+                name
+                id
               }
             }
           }

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
@@ -147,7 +147,7 @@ class AddNotesLinesContainer extends Component {
                 secondary={truncate(note.content, 120)}
               />
               <div style={{ marginRight: 50 }}>
-                {R.pathOr('', ['createdBy', 'name'], note)}
+                {note.createdBy?.name ?? '-'}
               </div>
               <div style={{ marginRight: 50 }}>
                 <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDetails.jsx
@@ -10,6 +10,7 @@ import Chip from '@mui/material/Chip';
 import inject18n from '../../../../components/i18n';
 import ItemLikelihood from '../../../../components/ItemLikelihood';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const styles = (theme) => ({
   paper: {
@@ -63,14 +64,16 @@ class NoteDetailsComponent extends Component {
               <Typography variant="h3" gutterBottom={true}>
                 {t('Note types')}
               </Typography>
-              {note.note_types?.map((noteType) => (
-                <Chip
-                  key={noteType}
-                  classes={{ root: classes.chip }}
-                  label={noteType}
-                  color="primary"
-                />
-              ))}
+              <FieldOrEmpty source={note.note_types}>
+                {note.note_types?.map((noteType) => (
+                  <Chip
+                    key={noteType}
+                    classes={{ root: classes.chip }}
+                    label={noteType}
+                    color="primary"
+                  />
+                ))}
+              </FieldOrEmpty>
               <Typography
                 variant="h3"
                 gutterBottom={true}

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/AddOpinionsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/AddOpinionsLines.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { graphql, createPaginationContainer } from 'react-relay';
+import { createPaginationContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -140,7 +140,7 @@ class AddOpinionsLinesContainer extends Component {
                 secondary={truncate(opinion.explanation, 120)}
               />
               <div style={{ marginRight: 50 }}>
-                {R.pathOr('', ['createdBy', 'name'], opinion)}
+                {opinion.createdBy?.name ?? '-'}
               </div>
               <div style={{ marginRight: 50 }}>
                 <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsList.tsx
@@ -7,7 +7,6 @@ import DialogContent from '@mui/material/DialogContent';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import * as R from 'ramda';
 import { Link } from 'react-router-dom';
 import Tooltip from '@mui/material/Tooltip';
 import { ListItemButton } from '@mui/material';
@@ -115,7 +114,7 @@ const StixCoreObjectOpinionsList: FunctionComponent<StixCoreObjectOpinionsListPr
                       textOverflow: 'ellipsis',
                     }}
                   />
-                  <Tooltip title={R.pathOr('', ['createdBy', 'name'], opinion)}>
+                  <Tooltip title={opinion?.createdBy?.name ?? '-'}>
                     <div style={{
                       marginRight: 50,
                       width: '200px',
@@ -124,7 +123,7 @@ const StixCoreObjectOpinionsList: FunctionComponent<StixCoreObjectOpinionsListPr
                       textOverflow: 'ellipsis',
                     }}
                     >
-                      {R.pathOr('', ['createdBy', 'name'], opinion)}
+                      {opinion?.createdBy?.name ?? '-'}
                     </div>
                   </Tooltip>
                   <div style={{ marginRight: 50 }}>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDetails.jsx
@@ -9,6 +9,7 @@ import Grid from '@mui/material/Grid';
 import Chip from '@mui/material/Chip';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const styles = (theme) => ({
   paper: {
@@ -47,13 +48,15 @@ class ChannelDetailsComponent extends Component {
               <Typography variant="h3" gutterBottom={true}>
                 {t('Channel types')}
               </Typography>
-              {R.propOr(['-'], 'channel_types', channel).map((channelType) => (
-                <Chip
-                  key={channelType}
-                  classes={{ root: classes.chip }}
-                  label={channelType}
-                />
-              ))}
+              <FieldOrEmpty source={channel.channel_types}>
+                {channel.chanel_types?.map((channelType) => (
+                  <Chip
+                    key={channelType}
+                    classes={{ root: classes.chip }}
+                    label={channelType}
+                  />
+                ))}
+              </FieldOrEmpty>
             </Grid>
           </Grid>
         </Paper>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
@@ -19,6 +19,7 @@ import ItemBoolean from '../../../../components/ItemBoolean';
 import StixDomainObjectNestedEntities from '../../common/stix_domain_objects/StixDomainObjectNestedEntities';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import StixCoreObjectKillChainPhasesView from '../../common/stix_core_objects/StixCoreObjectKillChainPhasesView';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const styles = (theme) => ({
   paper: {
@@ -86,27 +87,29 @@ class MalwareDetailsComponent extends Component {
               >
                 {t('Architecture execution env.')}
               </Typography>
-              <List>
-                {architectureExecutionEnvs.map((architectureExecutionEnv) => (
-                  <ListItem
-                    key={architectureExecutionEnv}
-                    dense={true}
-                    divider={true}
-                  >
-                    <ListItemIcon>
-                      <AtomVariant />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={
-                        <ItemOpenVocab
-                          type="processor-architecture-ov"
-                          value={architectureExecutionEnv}
-                        />
-                      }
-                    />
-                  </ListItem>
-                ))}
-              </List>
+              <FieldOrEmpty source={architectureExecutionEnvs}>
+                <List>
+                  {architectureExecutionEnvs.map((architectureExecutionEnv) => (
+                    <ListItem
+                      key={architectureExecutionEnv}
+                      dense={true}
+                      divider={true}
+                    >
+                      <ListItemIcon>
+                        <AtomVariant />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          <ItemOpenVocab
+                            type="processor-architecture-ov"
+                            value={architectureExecutionEnv}
+                          />
+                        }
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </FieldOrEmpty>
               <Typography
                 variant="h3"
                 gutterBottom={true}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { graphql, createFragmentContainer } from 'react-relay';
-import * as R from 'ramda';
+import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -86,7 +85,7 @@ const ContainerAddStixCoreObjectsLineComponent = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.createdBy.width }}
             >
-              {R.pathOr('', ['createdBy', 'name'], node)}
+              {node.createdBy?.name ?? '-'}
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as R from 'ramda';
 import { Link } from 'react-router-dom';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
@@ -125,7 +124,7 @@ const ContainerStixCoreObjectLineComponent = (props) => {
                 className={classes.bodyItem}
                 style={{ width: dataColumns.createdBy.width }}
               >
-                {R.pathOr('', ['createdBy', 'name'], node)}
+                {node.createdBy?.name ?? '-'}
               </div>
               <div
                 className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservableLine.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as R from 'ramda';
 import { Link } from 'react-router-dom';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
@@ -175,7 +174,7 @@ const ContainerStixCyberObservableLineComponent = (props) => {
                 className={classes.bodyItem}
                 style={{ width: dataColumns.createdBy.width }}
               >
-                {R.pathOr('', ['createdBy', 'name'], node)}
+                {node.createdBy?.name ?? '-'}
               </div>
               <div
                 className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as R from 'ramda';
 import { Link } from 'react-router-dom';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
@@ -172,7 +171,7 @@ const ContainerStixDomainObjectLineComponent = (props) => {
                 className={classes.bodyItem}
                 style={{ width: dataColumns.createdBy.width }}
               >
-                {R.pathOr('', ['createdBy', 'name'], node)}
+                {node.createdBy?.name ?? '-'}
               </div>
               <div
                 className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
@@ -7,7 +7,6 @@ import ListItemText from '@mui/material/ListItemText';
 import { MoreVert } from '@mui/icons-material';
 import Skeleton from '@mui/material/Skeleton';
 import makeStyles from '@mui/styles/makeStyles';
-import * as R from 'ramda';
 import IconButton from '@mui/material/IconButton';
 import { ListItemButton } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
@@ -115,7 +114,7 @@ const ContainerStixObjectOrStixRelationshipLineComponent = ({
                 className={classes.bodyItem}
                 style={{ width: dataColumns.createdBy.width }}
               >
-                {R.pathOr('', ['createdBy', 'name'], node)}
+                {node.createdBy?.name ?? '-'}
               </div>
               <div
                 className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
@@ -373,7 +373,7 @@ const StixCoreObjectOrStixRelationshipLastContainers = (props) => {
                                     </div>
                                   </Tooltip>
                                   <div className={classes.bodyItem} style={{ width: '20%' }}>
-                                    {container.createdBy?.name ?? ''}
+                                    {container.createdBy?.name ?? '-'}
                                   </div>
                                   <div className={classes.bodyItem} style={{ width: '12%' }}>
                                     {fsd(container.created)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
@@ -157,7 +157,7 @@ class EntityStixCoreRelationshipLineAllComponent extends Component {
                   className={classes.bodyItem}
                   style={{ width: dataColumns.createdBy.width }}
                 >
-                  {R.pathOr('', ['createdBy', 'name'], node)}
+                  {node.createdBy?.name ?? '-'}
                 </div>
                 <div
                   className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
@@ -155,7 +155,7 @@ class EntityStixCoreRelationshipLineFromComponent extends Component {
                   className={classes.bodyItem}
                   style={{ width: dataColumns.createdBy.width }}
                 >
-                  {R.pathOr('', ['createdBy', 'name'], node)}
+                  {node.createdBy?.name ?? '-'}
                 </div>
                 <div
                   className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
@@ -153,7 +153,7 @@ class EntityStixCoreRelationshipLineToComponent extends Component {
                   className={classes.bodyItem}
                   style={{ width: dataColumns.createdBy.width }}
                 >
-                  {R.pathOr('', ['createdBy', 'name'], node)}
+                  {node.createdBy?.name ?? '-'}
                 </div>
                 <div
                   className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
-import * as R from 'ramda';
 import { graphql, PreloadedQuery } from 'react-relay';
 import { Link } from 'react-router-dom';
 import ListLines from '../../../../../components/list_lines/ListLines';
@@ -146,7 +145,7 @@ const EntityStixCoreRelationshipsContextualViewComponent: FunctionComponent<Enti
       label: 'Author',
       width: '10%',
       isSortable: isRuntimeSort ?? false,
-      render: (stixCoreObject: EntityStixCoreRelationshipsContextualViewLine_node$data) => R.pathOr('', ['createdBy', 'name'], stixCoreObject),
+      render: (stixCoreObject: EntityStixCoreRelationshipsContextualViewLine_node$data) => stixCoreObject.createdBy?.name ?? '-',
     },
     creator: {
       label: 'Creators',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
@@ -64,6 +64,10 @@ const contextualViewLineFragment = graphql`
       id
       name
     }
+    createdBy {
+      name
+      id
+    }
     ... on StixCoreObject {
       containers {
         edges {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';
-import * as R from 'ramda';
 import { KeyboardArrowRight } from '@mui/icons-material';
 import ListItem from '@mui/material/ListItem';
 import Skeleton from '@mui/material/Skeleton';
@@ -290,7 +289,7 @@ EntityStixCoreRelationshipsEntitiesLineProps
               className={classes.bodyItem}
               style={{ width: dataColumns.createdBy.width }}
             >
-              {R.pathOr('', ['createdBy', 'name'], stixCoreObject)}
+              {stixCoreObject.createdBy?.name ?? '-'}
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose, pathOr } from 'ramda';
+import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -57,11 +57,7 @@ class StixDomainObjectDetectDuplicate extends Component {
         })
           .toPromise()
           .then((data) => {
-            const potentialDuplicates = pathOr(
-              [],
-              ['stixDomainObjects', 'edges'],
-              data,
-            );
+            const potentialDuplicates = data.stixDomainObjects?.edges ?? [];
             this.setState({ potentialDuplicates });
           });
       } else {
@@ -152,11 +148,7 @@ class StixDomainObjectDetectDuplicate extends Component {
                         secondary={truncate(element.node.description, 60)}
                       />
                       <div style={{ marginRight: 50 }}>
-                        {pathOr(
-                          '',
-                          ['node', 'createdBy', 'node', 'name'],
-                          element,
-                        )}
+                        {element.node.createdBy?.name ?? '-'}
                       </div>
                       <div style={{ marginRight: 50 }}>
                         <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
@@ -430,8 +430,6 @@ const StixDomainObjectsLines = createPaginationContainer(
             node {
               id
               entity_type
-              id
-              entity_type
               ... on AttackPattern {
                 name
                 description

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntityLine.tsx
@@ -311,7 +311,7 @@ export const StixNestedRefRelationshipCreationFromEntityLine: FunctionComponent<
               className={classes.bodyItem}
               style={{ width: dataColumns.createdBy.width }}
             >
-              {data.createdBy?.name ?? ''}
+              {data.createdBy?.name ?? '-'}
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -61,7 +61,7 @@ import Alert from '@mui/material/Alert';
 import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
 import Avatar from '@mui/material/Avatar';
-import { Switch, FormControlLabel } from '@mui/material';
+import { FormControlLabel, Switch } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import UserEmailSend from '../settings/users/UserEmailSend';
@@ -2929,7 +2929,7 @@ class DataTableToolBar extends Component {
                           )}
                         />
                         <div style={{ marginRight: 50 }}>
-                          {R.pathOr('', ['createdBy', 'name'], element)}
+                          {element.createdBy?.name ?? '-'}
                         </div>
                         <div style={{ marginRight: 50 }}>
                           <ItemMarkings
@@ -2982,7 +2982,7 @@ class DataTableToolBar extends Component {
                       >
                         {t('Author')}
                       </Typography>
-                      {R.pathOr('', ['createdBy', 'name'], keptElement)}
+                      {keptElement?.createdBy?.name ?? '-'}
                     </>
                   )}
                   {noMarking !== true && (

--- a/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import * as R from 'ramda';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -106,7 +105,7 @@ const EntitiesStixDomainObjectLineComponent = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.createdBy.width }}
             >
-              {R.pathOr('', ['createdBy', 'name'], node)}
+              {node.createdBy?.name ?? '-'}
             </div>
             <div
               className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
@@ -1,15 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import { graphql, createFragmentContainer } from 'react-relay';
+import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import * as R from 'ramda';
 import inject18n from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const styles = (theme) => ({
   paper: {
@@ -41,11 +41,13 @@ class EventDetailsComponent extends Component {
               >
                 {t('Event types')}
               </Typography>
-              {R.propOr(['-'], 'event_types', event).map((eventType) => (
-                <div key={`event_type_ov_${eventType}`} style={{ marginBottom: 10 }}>
-                  <ItemOpenVocab key="type" small={true} type="event_type_ov" value={eventType}/>
-                </div>
-              ))}
+              <FieldOrEmpty source={event.event_types}>
+                {event.event_types?.map((eventType) => (
+                  <div key={`event_type_ov_${eventType}`} style={{ marginBottom: 10 }}>
+                    <ItemOpenVocab key="type" small={true} type="event_type_ov" value={eventType}/>
+                  </div>
+                ))}
+              </FieldOrEmpty>
             </Grid>
             <Grid item xs={6}>
               <Typography variant="h3" gutterBottom={true}>

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorTargetedOrganizations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorTargetedOrganizations.jsx
@@ -150,7 +150,7 @@ class SectorTargetedOrganizations extends Component {
                                 }
                               />
                               <div style={inlineStyles.itemAuthor}>
-                                {R.pathOr('', ['createdBy', 'name'], relation)}
+                                {relation.createdBy?.name ?? '-'}
                               </div>
                               <div style={inlineStyles.itemDate}>
                                 {fsd(relation.start_time)}

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/AddObservedDataLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/AddObservedDataLines.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { graphql, createPaginationContainer } from 'react-relay';
-import { map, filter, head, compose, pathOr } from 'ramda';
+import { createPaginationContainer, graphql } from 'react-relay';
+import { compose, filter, head, map } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -144,7 +144,7 @@ class AddObservedDataLinesContainer extends Component {
                 secondary={truncate(observedData.explanation, 120)}
               />
               <div style={{ marginRight: 50 }}>
-                {pathOr('', ['createdBy', 'name'], observedData)}
+                {observedData.createdBy?.name ?? '-'}
               </div>
               <div style={{ marginRight: 50 }}>
                 <ItemMarkings

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryOverview.tsx
@@ -2,7 +2,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { FunctionComponent } from 'react';
-import { propOr } from 'ramda';
 import { graphql, useFragment } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
@@ -66,7 +65,7 @@ const CountryOverviewComponent: FunctionComponent<CountryOverviewProps> = ({
         <Typography variant="h3" gutterBottom={true} style={{ marginTop: 20 }}>
           {t_i18n('Author')}
         </Typography>
-        <ItemAuthor createdBy={propOr(null, 'createdBy', country)} />
+        <ItemAuthor createdBy={country.createdBy} />
         <Typography variant="h3" gutterBottom={true} style={{ marginTop: 20 }}>
           {t_i18n('Description')}
         </Typography>

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDetails.tsx
@@ -13,6 +13,7 @@ import { PositionDetailsLocationRelationshipsLinesQueryLinesPaginationQuery } fr
 import usePreloadedFragment from '../../../../utils/hooks/usePreloadedFragment';
 import { PositionDetails_positionRelationships$key } from './__generated__/PositionDetails_positionRelationships.graphql';
 import { isNotEmptyField } from '../../../../utils/utils';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -172,94 +173,98 @@ const PositionDetails: FunctionComponent<PositionDetailsProps> = ({
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Latitude')}
             </Typography>
-            {position.latitude && (
+            <FieldOrEmpty source={position.latitude}>
               <ExpandableMarkdown
-                source={position.latitude.toString()}
+                source={position.latitude?.toString()}
                 limit={300}
               />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Longitude')}
             </Typography>
-            {position.longitude && (
+            <FieldOrEmpty source={position.longitude}>
               <ExpandableMarkdown
-                source={position.longitude.toString()}
+                source={position.longitude?.toString()}
                 limit={300}
               />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Street address')}
             </Typography>
-            {position.street_address && (
+            <FieldOrEmpty source={position.street_address}>
               <ExpandableMarkdown
                 source={position.street_address}
                 limit={300}
               />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Postal code')}
             </Typography>
-            {position.postal_code && (
+            <FieldOrEmpty source={position.postal_code}>
               <ExpandableMarkdown source={position.postal_code} limit={300} />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('City')}
             </Typography>
-            {cities
-              && cities.map((name) => (
+            <FieldOrEmpty source={cities}>
+              {cities?.map((name) => (
                 <Chip
                   key={name}
                   classes={{ root: classes.chip }}
                   label={name}
                 />
               ))}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Country')}
             </Typography>
-            {countries
-              && countries.map((name) => (
+            <FieldOrEmpty source={countries}>
+              {countries?.map((name) => (
                 <Chip
                   key={name}
                   classes={{ root: classes.chip }}
                   label={name}
                 />
               ))}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Region')}
             </Typography>
-            {regions
-              && regions.map((name) => (
+            <FieldOrEmpty source={regions}>
+              {regions?.map((name) => (
                 <Chip
                   key={name}
                   classes={{ root: classes.chip }}
                   label={name}
                 />
               ))}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('entity_Administrative-Area')}
             </Typography>
-            {areas
-              && areas.map((name) => (
+            <FieldOrEmpty source={areas}>
+              {areas?.map((name) => (
                 <Chip
                   key={name}
                   classes={{ root: classes.chip }}
                   label={name}
                 />
               ))}
+            </FieldOrEmpty>
           </Grid>
         </Grid>
       </Paper>

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionOverview.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose, propOr } from 'ramda';
+import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import Paper from '@mui/material/Paper';
@@ -45,7 +45,7 @@ class PositionOverviewComponent extends Component {
           >
             {t('Author')}
           </Typography>
-          <ItemAuthor createdBy={propOr(null, 'createdBy', position)} />
+          <ItemAuthor createdBy={position.createdBy} />
           <Typography
             variant="h3"
             gutterBottom={true}

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionOverview.tsx
@@ -2,7 +2,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { FunctionComponent } from 'react';
-import { propOr } from 'ramda';
 import { graphql, useFragment } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
@@ -66,7 +65,7 @@ const RegionOverview: FunctionComponent<RegionOverviewProps> = ({
         <Typography variant="h3" gutterBottom={true} style={{ marginTop: 20 }}>
           {t_i18n('Author')}
         </Typography>
-        <ItemAuthor createdBy={propOr(null, 'createdBy', region)} />
+        <ItemAuthor createdBy={region.createdBy} />
         <Typography variant="h3" gutterBottom={true} style={{ marginTop: 20 }}>
           {t_i18n('Description')}
         </Typography>

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -29,6 +29,7 @@ import StixCoreObjectKillChainPhasesView from '../../common/stix_core_objects/St
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import Transition from '../../../../components/Transition';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -148,13 +149,15 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
             >
               {t_i18n('Indicator types')}
             </Typography>
-            {indicator.indicator_types && indicator.indicator_types.map((indicatorType) => (
-              <Chip
-                key={indicatorType}
-                classes={{ root: classes.chip }}
-                label={indicatorType}
-              />
-            ))}
+            <FieldOrEmpty source={indicator.indicator_types}>
+              {indicator.indicator_types?.map((indicatorType) => (
+                <Chip
+                  key={indicatorType}
+                  classes={{ root: classes.chip }}
+                  label={indicatorType}
+                />
+              ))}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
@@ -183,17 +186,19 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
             >
               {t_i18n('Platforms')}
             </Typography>
-            <List>
-              { (indicator.x_mitre_platforms ?? []).map((platform) => (
-                platform
-                && <ListItem key={platform} dense={true} divider={true}>
-                  <ListItemIcon>
-                    <SettingsApplications />
-                  </ListItemIcon>
-                  <ListItemText primary={platform} />
-                </ListItem>
-              ))}
-            </List>
+            <FieldOrEmpty source={indicator.x_mitre_platforms}>
+              <List>
+                {indicator.x_mitre_platforms?.map((platform) => (
+                  platform
+                  && <ListItem key={platform} dense={true} divider={true}>
+                    <ListItemIcon>
+                      <SettingsApplications />
+                    </ListItemIcon>
+                    <ListItemText primary={platform} />
+                  </ListItem>
+                ))}
+              </List>
+            </FieldOrEmpty>
           </Grid>
         </Grid>
         <Divider />

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { compose } from 'ramda';
 import { Link } from 'react-router-dom';
 import { createFragmentContainer, graphql } from 'react-relay';
@@ -132,7 +131,7 @@ class IndicatorEntityLineComponent extends Component {
                   className={classes.bodyItem}
                   style={{ width: dataColumns.createdBy.width }}
                 >
-                  {R.pathOr('', ['createdBy', 'name'], node)}
+                  {node.createdBy?.name ?? '-'}
                 </div>
                 <div
                   className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -1,15 +1,15 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { interval } from 'rxjs';
-import { graphql, createPaginationContainer } from 'react-relay';
+import { createPaginationContainer, graphql } from 'react-relay';
 import { Link } from 'react-router-dom';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import * as R from 'ramda';
 import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Tooltip from '@mui/material/Tooltip';
-import * as R from 'ramda';
 import { AutoFix } from 'mdi-material-ui';
 import { ListItemButton } from '@mui/material';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -191,7 +191,7 @@ class StixCyberObservableEntitiesLinesComponent extends Component {
                           className={classes.bodyItem}
                           style={{ width: '12%' }}
                         >
-                          {R.pathOr('', ['createdBy', 'name'], node)}
+                          {node.createdBy?.name ?? '-'}
                         </div>
                         <div
                           className={classes.bodyItem}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { compose, propOr } from 'ramda';
+import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
@@ -151,7 +151,7 @@ class StixCyberObservableOverview extends Component {
                 {t('Author')}
               </Typography>
               <ItemAuthor
-                createdBy={propOr(null, 'createdBy', stixCyberObservable)}
+                createdBy={stixCyberObservable.createdBy}
               />
               <StixCoreObjectLabelsView
                 labels={stixCyberObservable.objectLabel}

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplates.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplates.tsx
@@ -12,6 +12,7 @@ import CaseTemplateLines, { caseTemplatesLinesQuery } from './CaseTemplateLines'
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 import useConnectedDocumentModifier from '../../../../utils/hooks/useConnectedDocumentModifier';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -51,7 +52,7 @@ const CaseTemplates = () => {
         label: 'Description',
         width: '50%',
         isSortable: false,
-        render: (data: CaseTemplateLine_node$data) => data.description,
+        render: (data: CaseTemplateLine_node$data) => (<FieldOrEmpty source={data.description}>{data.description}</FieldOrEmpty>),
       },
       tasks: {
         label: 'Tasks',

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessages.tsx
@@ -16,6 +16,7 @@ import SettingsMessageCreation from './SettingsMessageCreation';
 import SettingsMessagesLines from './SettingsMessagesLines';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import ColumnsLinesTitles from '../../../../components/ColumnsLinesTitles';
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -111,9 +112,11 @@ const SettingsMessages = ({
       width: '15%',
       isSortable: false,
       render: (data: SettingsMessagesLine_settingsMessage$data) => (
-        <Tooltip title={data.recipients?.map(({ name }) => name).join(', ')}>
-          <span>{data.recipients?.map(({ name }) => name).join(', ')}</span>
-        </Tooltip>
+        <FieldOrEmpty source={data.recipients}>
+          <Tooltip title={data.recipients?.map(({ name }) => name).join(', ')}>
+            <span>{data.recipients?.map(({ name }) => name).join(', ')}</span>
+          </Tooltip>
+        </FieldOrEmpty>
       ),
     },
   };

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDetails.tsx
@@ -3,23 +3,13 @@ import { graphql, useFragment } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import makeStyles from '@mui/styles/makeStyles';
+import { useTheme } from '@mui/material/styles';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import { DataComponentDetails_dataComponent$data, DataComponentDetails_dataComponent$key } from './__generated__/DataComponentDetails_dataComponent.graphql';
 import DataComponentDataSource from './DataComponentDataSource';
 import DataComponentAttackPatterns from './DataComponentAttackPatterns';
-import type { Theme } from '../../../../components/Theme';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: '15px',
-    borderRadius: 4,
-  },
-}));
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const DataComponentDetailsFragment = graphql`
   fragment DataComponentDetails_dataComponent on DataComponent {
@@ -43,7 +33,7 @@ const DataComponentDetails: FunctionComponent<DataComponentDetailsProps> = ({
   dataComponent,
 }) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme();
 
   const data: DataComponentDetails_dataComponent$data = useFragment(
     DataComponentDetailsFragment,
@@ -55,15 +45,23 @@ const DataComponentDetails: FunctionComponent<DataComponentDetailsProps> = ({
       <Typography variant="h4" gutterBottom={true}>
         {t_i18n('Details')}
       </Typography>
-      <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
+      <Paper
+        style={{
+          marginTop: theme.spacing(1),
+          padding: '15px',
+          borderRadius: 4,
+        }}
+        className={'paper-for-grid'}
+        variant="outlined"
+      >
         <Grid container={true} spacing={3}>
           <Grid item xs={12}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Description')}
             </Typography>
-            {data.description && (
+            <FieldOrEmpty source={data.description}>
               <ExpandableMarkdown source={data.description} limit={300} />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={12}>
             <DataComponentDataSource dataComponent={data} />

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
@@ -3,23 +3,13 @@ import { graphql, useFragment } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import makeStyles from '@mui/styles/makeStyles';
+import { useTheme } from '@mui/material/styles';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../../components/i18n';
 import { DataSourceDetails_dataSource$data, DataSourceDetails_dataSource$key } from './__generated__/DataSourceDetails_dataSource.graphql';
 import DataSourceDataComponents from './DataSourceDataComponents';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
-import type { Theme } from '../../../../components/Theme';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: '15px',
-    borderRadius: 4,
-  },
-}));
+import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 
 const DataSourceDetailsFragment = graphql`
   fragment DataSourceDetails_dataSource on DataSource {
@@ -45,7 +35,7 @@ const DataSourceDetailsComponent: FunctionComponent<DataSourceDetailsProps> = ({
   dataSource,
 }) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme();
 
   const data: DataSourceDetails_dataSource$data = useFragment(
     DataSourceDetailsFragment,
@@ -57,28 +47,38 @@ const DataSourceDetailsComponent: FunctionComponent<DataSourceDetailsProps> = ({
       <Typography variant="h4" gutterBottom={true}>
         {t_i18n('Details')}
       </Typography>
-      <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
+      <Paper
+        style={{
+          marginTop: theme.spacing(1),
+          padding: '15px',
+          borderRadius: 4,
+        }}
+        className={'paper-for-grid'}
+        variant="outlined"
+      >
         <Grid container={true} spacing={3}>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Description')}
             </Typography>
-            {data.description && (
+            <FieldOrEmpty source={data.description}>
               <ExpandableMarkdown source={data.description} limit={300} />
-            )}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Platforms')}
             </Typography>
-            {data.x_mitre_platforms?.map((platform) => (
-              <ItemOpenVocab
-                key={platform}
-                small={false}
-                type="platforms_ov"
-                value={platform}
-              />
-            ))}
+            <FieldOrEmpty source={data.x_mitre_platforms}>
+              {data.x_mitre_platforms?.map((platform) => (
+                <ItemOpenVocab
+                  key={platform}
+                  small={false}
+                  type="platforms_ov"
+                  value={platform}
+                />
+              ))}
+            </FieldOrEmpty>
             <Typography
               variant="h3"
               gutterBottom={true}
@@ -86,14 +86,16 @@ const DataSourceDetailsComponent: FunctionComponent<DataSourceDetailsProps> = ({
             >
               {t_i18n('Layers')}
             </Typography>
-            {data.collection_layers?.map((layer) => (
-              <ItemOpenVocab
-                key={layer}
-                small={false}
-                type="collection_layers_ov"
-                value={layer}
-              />
-            ))}
+            <FieldOrEmpty source={data.collection_layers}>
+              {data.collection_layers?.map((layer) => (
+                <ItemOpenVocab
+                  key={layer}
+                  small={false}
+                  type="collection_layers_ov"
+                  value={layer}
+                />
+              ))}
+            </FieldOrEmpty>
           </Grid>
           <Grid item xs={12}>
             <DataSourceDataComponents dataSource={data} />

--- a/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/navigation/navigation.spec.ts
@@ -168,7 +168,7 @@ const navigateMalwareAnalyses = async (page: Page) => {
   await page.getByLabel('relationships', { exact: true }).click();
   await expect(page.getByRole('link', { name: 'related to Malware Spelevo EK' })).toBeVisible();
   await page.getByLabel('entities', { exact: true }).click();
-  await expect(page.getByRole('link', { name: 'Malware Spelevo EK admin covid-19' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Malware Spelevo EK - admin covid-19' })).toBeVisible();
 
   // -- Content
   await malwareAnalysesDetailsPage.tabs.goToContentTab();


### PR DESCRIPTION
### Proposed changes
- In entities list, empty authors should be displayed as '-' instead of nothing
- In entities overview, empty fields should be displayed as '-'
- In Add Notes list panel, fix the display of markings and authors (None was always displayed even if there were markings)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/12441