### PR TITLE
[backend] improve inputResolveRefs perfs (#12455)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -803,7 +803,7 @@ const inputResolveRefs = async (context, user, input, type, entitySetting) => {
             const vocabularyId = idVocabulary(i, category);
             const vocabularyElement = { id: vocabularyId, destKey, multiple: isListing };
             if (fetchingIdsMap.has(vocabularyId)) {
-              fetchingIdsMap[vocabularyId].push(vocabularyElement);
+              fetchingIdsMap.get(vocabularyId).push(vocabularyElement);
             } else {
               fetchingIdsMap.set(vocabularyId, [vocabularyElement]);
             }
@@ -812,7 +812,7 @@ const inputResolveRefs = async (context, user, input, type, entitySetting) => {
           R.uniq(id).forEach((i) => {
             const listingElement = { id: i, destKey, multiple: true };
             if (fetchingIdsMap.has(i)) {
-              fetchingIdsMap[i].push(listingElement);
+              fetchingIdsMap.get(i).push(listingElement);
             } else {
               fetchingIdsMap.set(i, [listingElement]);
             }
@@ -826,7 +826,7 @@ const inputResolveRefs = async (context, user, input, type, entitySetting) => {
           } else {
             const singleElement = { id, destKey, multiple: false };
             if (fetchingIdsMap.has(id)) {
-              fetchingIdsMap[id].push(singleElement);
+              fetchingIdsMap.get(id).push(singleElement);
             } else {
               fetchingIdsMap.set(id, [singleElement]);
             }
@@ -861,7 +861,7 @@ const inputResolveRefs = async (context, user, input, type, entitySetting) => {
       instanceIds.forEach((instanceId) => {
         resolvedIds.add(instanceId);
         if (fetchingIdsMap.has(instanceId)) {
-          matchingConfigs.push(...fetchingIdsMap[instanceId]);
+          matchingConfigs.push(...fetchingIdsMap.get(instanceId));
         }
       });
       for (let configIndex = 0; configIndex < matchingConfigs.length; configIndex += 1) {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -793,8 +793,12 @@ const inputResolveRefs = async (context, user, input, type, entitySetting) => {
           R.uniq(id.map((label) => idLabel(label)))
             .forEach((labelId) => {
               const labelElement = { id: labelId, destKey, multiple: true };
+              if (fetchingIdsMap.has(labelId)) {
+                fetchingIdsMap.get(labelId).push(labelElement);
+              } else {
+                fetchingIdsMap.set(labelId, [labelElement]);
+              }
               expectedIds.push(labelId);
-              fetchingIdsMap.set(labelId, [labelElement]);
             });
         } else if (hasOpenVocab) {
           const ids = isListing ? id : [id];


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* inputResolveRefsFn was CPU inefficient: resolved elements were being identified in O(n²) in matchingConfigs computation. It is now O(n), and it now goes through instancesIds instead of going through the whole fetchingsIds for every resolvedElements
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12455
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
