### PR TITLE
[frontend] Fix widget data selection limit when changing widget types (#10463)

### DIFF
--- a/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
@@ -36,6 +36,7 @@ const CreateEntityControlledDial: FunctionComponent<CreateEntityControlledDialPr
       variant={variant}
       aria-label={buttonValue}
       title={buttonValue}
+      data-testid={`create-${entityType.toLowerCase()}-button`}
       sx={style ?? { marginLeft: theme.spacing(1) }}
     >
       {buttonValue}

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetConfigContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetConfigContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, Dispatch, ReactNode, useContext, useEffect, useSt
 import { FintelTemplateWidget } from '@components/settings/sub_types/fintel_templates/FintelTemplateWidgetsList';
 import type { Widget, WidgetContext, WidgetDataSelection, WidgetParameters, WidgetPerspective } from '../../../utils/widget/widget';
 import { emptyFilterGroup, SELF_ID } from '../../../utils/filters/filtersUtils';
+import { getCurrentDataSelectionLimit } from '../../../utils/widget/widgetUtils';
 
 export interface WidgetConfigType {
   fintelVariableName: string | null;
@@ -116,11 +117,26 @@ export const WidgetConfigProvider = ({
   }, [open]);
 
   const setConfigWidget = (widget: WidgetConfigType['widget']) => {
+    // Check if widget type is changing and validate dataSelection
+    let adjustedWidget = widget;
+
+    if (widget.type && widget.type !== conf.widget.type) {
+      const newLimit = getCurrentDataSelectionLimit(widget.type);
+
+      // If there's a limit and current dataSelection exceeds it
+      if (newLimit > 0 && conf.widget.dataSelection.length > newLimit) {
+        adjustedWidget = {
+          ...widget,
+          dataSelection: conf.widget.dataSelection.slice(0, newLimit),
+        };
+      }
+    }
+
     setConfig((oldConf) => ({
       ...oldConf,
       widget: {
         ...oldConf.widget,
-        ...widget,
+        ...adjustedWidget,
       },
     }));
   };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WorkspaceWidgetConfig.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WorkspaceWidgetConfig.tsx
@@ -61,6 +61,7 @@ const WorkspaceWidgetConfig = ({ widget, onComplete, closeMenu, handleImportWidg
                 disableElevation
                 sx={{ marginLeft: 1 }}
                 onClick={handleOpenWidgetConfig}
+                data-testid="create-widget-button"
               >
                 {t_i18n('Create Widget')}
               </Button>


### PR DESCRIPTION
### Proposed changes

* Implemented validation in `WidgetConfigContext` to enforce the maximum number of data selections allowed per widget type
* Added test data attributes (`data-testid`) to improve E2E test coverage for widget creation buttons

### Related issues
* #10463

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This fix addresses an issue where users could exceed the data selection limit when switching between widget types. For example, when changing from a "Line" chart (which supports up to 5 data selections) to a "Number" widget (which only supports 1 data selection), the system now automatically truncates the excess data selections to comply with the new widget type's constraints.