### PR TITLE
[backend](PIR) Increase stream batch size to 7500 (#11149)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -352,7 +352,7 @@
     "enabled": true,
     "lock_key": "pir_manager_lock",
     "interval": 30000,
-    "stream_batch_size": 1000,
+    "stream_batch_size": 7500,
     "max_concurrency": 5
   },
   "exclusion_list_cache_build_manager": {

--- a/opencti-platform/opencti-graphql/src/manager/pirManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/pirManager.ts
@@ -38,7 +38,7 @@ const PIR_MANAGER_LABEL = 'Pir Manager';
 const PIR_MANAGER_CONTEXT = 'pir_manager';
 
 const PIR_MANAGER_INTERVAL = conf.get('pir_manager:interval') ?? 10000;
-const PIR_MANAGER_STREAM_BATCH_SIZE = conf.get('pir_manager:stream_batch_size') ?? 1000;
+const PIR_MANAGER_STREAM_BATCH_SIZE = conf.get('pir_manager:stream_batch_size') ?? 7500;
 const PIR_MANAGER_LOCK_KEY = conf.get('pir_manager:lock_key');
 const PIR_MANAGER_ENABLED = booleanConf('pir_manager:enabled', false);
 const PIR_MANAGER_MAX_CONCURRENCY = conf.get('pir_manager:max_concurrency') ?? 5;

--- a/opencti-platform/opencti-graphql/src/modules/pir/pir-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/pir/pir-domain.ts
@@ -224,7 +224,7 @@ export const pirAdd = async (context: AuthContext, user: AuthUser, input: PirAdd
   });
   // create rabbit queue for pir
   await registerConnectorQueues(pirId, `Pir ${pirId} queue`, 'internal', 'pir');
-  // -- notify the Pir creation --
+  // notify the Pir creation
   return notify(BUS_TOPICS[ENTITY_TYPE_PIR].ADDED_TOPIC, created, user);
 };
 


### PR DESCRIPTION
## Proposed changes
Increase PIR stream batch size to 7 500 by default to make the rescan quicker