### PR TITLE
[backend] Fix pir relationship stix converter (#11149)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
@@ -1301,6 +1301,7 @@ const convertInPirRelToStix = (instance: StoreRelationPir): SRO.StixRelation => 
         target_ref_pir_refs: instance.to[RELATION_IN_PIR] ?? [],
         kill_chain_phases: [],
         pir_score: instance.pir_score,
+        pir_explanations: instance.pir_explanations,
       })
     }
   };


### PR DESCRIPTION
### Proposed changes
 Fix pir relationship stix converter

to avoid having these error in backend when modifying the author of a relationship having caused a flag : 

<img width="1817" height="491" alt="image" src="https://github.com/user-attachments/assets/c892f58a-fb47-4752-9673-04ec58d04c36" />
