### PR TITLE
[frontend/backend] Workspace creation capabilities (#12459)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -167,10 +167,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
                   rows="4"
                   style={{ marginTop: 20 }}
                 />
-                <div style={{
-                  marginTop: 20,
-                  textAlign: 'right',
-                }}>
+                <div style={{ marginTop: 20, textAlign: 'right' }}>
                   <Button
                     variant="contained"
                     onClick={handleReset}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -4,7 +4,6 @@ import Button from '@mui/material/Button';
 import * as Yup from 'yup';
 import { graphql } from 'react-relay';
 import { FileUploadOutlined } from '@mui/icons-material';
-import makeStyles from '@mui/styles/makeStyles';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/styles';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -21,18 +20,8 @@ import CreateEntityControlledDial from '../../../components/CreateEntityControll
 import { isNotEmptyField } from '../../../utils/utils';
 import GradientButton from '../../../components/GradientButton';
 import { UserContext } from '../../../utils/hooks/useAuth';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles((theme) => ({
-  buttons: {
-    marginTop: 20,
-    textAlign: 'right',
-  },
-  button: {
-    marginLeft: theme.spacing(2),
-  },
-}));
+import Security from '../../../utils/Security';
+import { EXPLORE_EXUPDATE, INVESTIGATION_INUPDATE } from '../../../utils/hooks/useGranted';
 
 const workspaceMutation = graphql`
   mutation WorkspaceCreationMutation($input: WorkspaceAddInput!) {
@@ -55,7 +44,6 @@ const workspaceValidation = (t_i18n) => Yup.object().shape({
 });
 
 const WorkspaceCreation = ({ paginationOptions, type }) => {
-  const classes = useStyles();
   const theme = useTheme();
   const { t_i18n } = useFormatter();
   const inputRef = useRef();
@@ -110,11 +98,13 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   };
 
   const createInvestigationButton = (props) => (
-    <CreateEntityControlledDial entityType='Investigation' {...props} />
+    <Security needs={[INVESTIGATION_INUPDATE]}>
+      <CreateEntityControlledDial entityType='Investigation' {...props} />
+    </Security>
   );
 
   const createDashboardButton = (props) => (
-    <>
+    <Security needs={[EXPLORE_EXUPDATE]}>
       <ToggleButton
         value="import"
         size="small"
@@ -137,7 +127,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
         </GradientButton>
       )}
       <CreateEntityControlledDial entityType='Dashboard' {...props} />
-    </>
+    </Security>
   );
 
   return (
@@ -177,12 +167,15 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
                   rows="4"
                   style={{ marginTop: 20 }}
                 />
-                <div className={classes.buttons}>
+                <div style={{
+                  marginTop: 20,
+                  textAlign: 'right',
+                }}>
                   <Button
                     variant="contained"
                     onClick={handleReset}
                     disabled={isSubmitting}
-                    classes={{ root: classes.button }}
+                    style={{ marginLeft: theme.spacing(2) }}
                   >
                     {t_i18n('Cancel')}
                   </Button>
@@ -191,7 +184,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
                     color="secondary"
                     onClick={submitForm}
                     disabled={isSubmitting}
-                    classes={{ root: classes.button }}
+                    style={{ marginLeft: theme.spacing(2) }}
                   >
                     {t_i18n('Create')}
                   </Button>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
@@ -52,12 +52,12 @@ interface WorkspaceCreationForm {
   description: string,
 }
 
-interface WorskpaceCreationProps {
+interface WorkspaceCreationProps {
   paginationOptions: WorkspacesLinesPaginationQuery$variables,
   type: string,
 }
 
-const WorkspaceCreation = ({ paginationOptions, type }: WorskpaceCreationProps) => {
+const WorkspaceCreation = ({ paginationOptions, type }: WorkspaceCreationProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from 'react';
+import React, { BaseSyntheticEvent, useContext, useRef } from 'react';
 import { Field, Form, Formik } from 'formik';
 import Button from '@mui/material/Button';
 import * as Yup from 'yup';
@@ -7,10 +7,13 @@ import { FileUploadOutlined } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/styles';
 import ToggleButton from '@mui/material/ToggleButton';
+import { FormikConfig } from 'formik/dist/types';
+import { WorkspacesLinesPaginationQuery$variables } from './__generated__/WorkspacesLinesPaginationQuery.graphql';
+import { WorkspaceCreationImportMutation } from './__generated__/WorkspaceCreationImportMutation.graphql';
 import VisuallyHiddenInput from '../common/VisuallyHiddenInput';
 import Drawer from '../common/drawer/Drawer';
 import { useFormatter } from '../../../components/i18n';
-import { handleError } from '../../../relay/environment';
+import { handleError, handleErrorInForm } from '../../../relay/environment';
 import TextField from '../../../components/TextField';
 import MarkdownField from '../../../components/fields/MarkdownField';
 import { resolveLink } from '../../../utils/Entity';
@@ -22,6 +25,7 @@ import GradientButton from '../../../components/GradientButton';
 import { UserContext } from '../../../utils/hooks/useAuth';
 import Security from '../../../utils/Security';
 import { EXPLORE_EXUPDATE, INVESTIGATION_INUPDATE } from '../../../utils/hooks/useGranted';
+import type { Theme } from '../../../components/Theme';
 
 const workspaceMutation = graphql`
   mutation WorkspaceCreationMutation($input: WorkspaceAddInput!) {
@@ -38,42 +42,52 @@ export const importMutation = graphql`
   }
 `;
 
-const workspaceValidation = (t_i18n) => Yup.object().shape({
+const workspaceValidation = (t_i18n: (s: string) => string) => Yup.object().shape({
   name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')).required(t_i18n('This field is required')),
   description: Yup.string().nullable(),
 });
 
-const WorkspaceCreation = ({ paginationOptions, type }) => {
-  const theme = useTheme();
+interface WorkspaceCreationForm {
+  name: string,
+  description: string,
+}
+
+interface WorskpaceCreationProps {
+  paginationOptions: WorkspacesLinesPaginationQuery$variables,
+  type: string,
+}
+
+const WorkspaceCreation = ({ paginationOptions, type }: WorskpaceCreationProps) => {
+  const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
-  const inputRef = useRef();
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
     ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?platform_id=${settings.id}`
     : '';
 
-  const [commitImportMutation] = useApiMutation(importMutation);
+  const [commitImportMutation] = useApiMutation<WorkspaceCreationImportMutation>(importMutation);
   const [commitCreationMutation] = useApiMutation(workspaceMutation);
   const navigate = useNavigate();
 
-  const handleImport = (event) => {
+  const handleImport = (event: BaseSyntheticEvent) => {
     const importedFile = event.target.files[0];
     commitImportMutation({
       variables: { file: importedFile },
       onCompleted: (data) => {
-        inputRef.current.value = null; // Reset the input uploader ref
+        if (inputRef.current) inputRef.current.value = ''; // Reset the input uploader ref
         navigate(
           `${resolveLink('Dashboard')}/${data.workspaceConfigurationImport}`,
         );
       },
       onError: (error) => {
-        inputRef.current.value = null; // Reset the input uploader ref
+        if (inputRef.current) inputRef.current.value = ''; // Reset the input uploader ref
         handleError(error);
       },
     });
   };
 
-  const onSubmit = (values, { setSubmitting, resetForm }) => {
+  const onSubmit: FormikConfig<WorkspaceCreationForm>['onSubmit'] = (values, { setSubmitting, resetForm, setErrors }) => {
     commitCreationMutation({
       variables: {
         input: {
@@ -89,7 +103,10 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
           'workspaceAdd',
         );
       },
-      setSubmitting,
+      onError: (error) => {
+        handleErrorInForm(error, setErrors);
+        setSubmitting(false);
+      },
       onCompleted: () => {
         setSubmitting(false);
         resetForm();
@@ -97,25 +114,26 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
     });
   };
 
-  const createInvestigationButton = (props) => (
+  const createInvestigationButton = (props: { onOpen: () => void }) => (
     <Security needs={[INVESTIGATION_INUPDATE]}>
       <CreateEntityControlledDial entityType='Investigation' {...props} />
     </Security>
   );
 
-  const createDashboardButton = (props) => (
+  const createDashboardButton = (props: { onOpen: () => void }) => (
     <Security needs={[EXPLORE_EXUPDATE]}>
-      <ToggleButton
-        value="import"
-        size="small"
-        onClick={() => inputRef.current?.click()}
-        sx={{ marginLeft: theme.spacing(1) }}
-        data-testid='ImportDashboard'
-        title={t_i18n('Import dashboard')}
-      >
-        <FileUploadOutlined fontSize="small" color={'primary'} />
-      </ToggleButton>
-      {isXTMHubAccessible && isNotEmptyField(importFromHubUrl) && (
+      <>
+        <ToggleButton
+          value="import"
+          size="small"
+          onClick={() => inputRef.current?.click()}
+          sx={{ marginLeft: theme.spacing(1) }}
+          data-testid='ImportDashboard'
+          title={t_i18n('Import dashboard')}
+        >
+          <FileUploadOutlined fontSize="small" color={'primary'} />
+        </ToggleButton>
+        {isXTMHubAccessible && isNotEmptyField(importFromHubUrl) && (
         <GradientButton
           size="small"
           sx={{ marginLeft: theme.spacing(1) }}
@@ -125,8 +143,9 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
         >
           {t_i18n('Import from Hub')}
         </GradientButton>
-      )}
-      <CreateEntityControlledDial entityType='Dashboard' {...props} />
+        )}
+        <CreateEntityControlledDial entityType='Dashboard' {...props} />
+      </>
     </Security>
   );
 

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
@@ -2,11 +2,22 @@ import * as R from 'ramda';
 import type { FileHandle } from 'fs/promises';
 import { v4 as uuidv4 } from 'uuid';
 import pjson from '../../../package.json';
-import { createEntity, deleteElementById, fullEntitiesOrRelationsConnection, pageEntitiesOrRelationsConnection, updateAttribute } from '../../database/middleware';
+import {
+  createEntity,
+  deleteElementById,
+  fullEntitiesOrRelationsConnection,
+  pageEntitiesOrRelationsConnection,
+  updateAttribute
+} from '../../database/middleware';
 import { fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import { BUS_TOPICS } from '../../config/conf';
 import { delEditContext, notify, setEditContext } from '../../database/redis';
-import { type BasicStoreEntityWorkspace, ENTITY_TYPE_WORKSPACE, type StoreEntityWorkspace, type WidgetConfiguration } from './workspace-types';
+import {
+  type BasicStoreEntityWorkspace,
+  ENTITY_TYPE_WORKSPACE,
+  type StoreEntityWorkspace,
+  type WidgetConfiguration
+} from './workspace-types';
 import { DatabaseError, ForbiddenAccess, FunctionalError } from '../../config/errors';
 import type { AuthContext, AuthUser } from '../../types/user';
 import type {
@@ -20,12 +31,18 @@ import type {
   WorkspaceDuplicateInput,
   WorkspaceObjectsArgs
 } from '../../generated/graphql';
-import { getUserAccessRight, isUserHasCapabilities, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../../utils/access';
+import { getUserAccessRight, isUserHasCapability, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../../utils/access';
 import { publishUserAction } from '../../listener/UserActionListener';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { elFindByIds, elRawDeleteByQuery } from '../../database/engine';
 import type { BasicStoreEntity } from '../../types/store';
-import { buildPagination, isEmptyField, isNotEmptyField, READ_DATA_INDICES_WITHOUT_INTERNAL, READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
+import {
+  buildPagination,
+  isEmptyField,
+  isNotEmptyField,
+  READ_DATA_INDICES_WITHOUT_INTERNAL,
+  READ_INDEX_INTERNAL_OBJECTS
+} from '../../database/utils';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { extractContentFrom } from '../../utils/fileToContent';
 import { isCompatibleVersionWithMinimal } from '../../utils/version';
@@ -165,9 +182,9 @@ export const addWorkspace = async (
   // check capabilities according to workspace type
   let hasCapa;
   if (input.type === 'investigation') {
-    hasCapa = isUserHasCapabilities(user, ['INVESTIGATION_INUPDATE']);
+    hasCapa = isUserHasCapability(user, 'INVESTIGATION_INUPDATE');
   } else if (input.type === 'dashboard') {
-    hasCapa = isUserHasCapabilities(user, ['EXPLORE_EXUPDATE']);
+    hasCapa = isUserHasCapability(user, 'EXPLORE_EXUPDATE');
   }
   if (!hasCapa) {
     throw ForbiddenAccess();

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
@@ -2,22 +2,11 @@ import * as R from 'ramda';
 import type { FileHandle } from 'fs/promises';
 import { v4 as uuidv4 } from 'uuid';
 import pjson from '../../../package.json';
-import {
-  createEntity,
-  deleteElementById,
-  fullEntitiesOrRelationsConnection,
-  pageEntitiesOrRelationsConnection,
-  updateAttribute
-} from '../../database/middleware';
+import { createEntity, deleteElementById, fullEntitiesOrRelationsConnection, pageEntitiesOrRelationsConnection, updateAttribute } from '../../database/middleware';
 import { fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import { BUS_TOPICS } from '../../config/conf';
 import { delEditContext, notify, setEditContext } from '../../database/redis';
-import {
-  type BasicStoreEntityWorkspace,
-  ENTITY_TYPE_WORKSPACE,
-  type StoreEntityWorkspace,
-  type WidgetConfiguration
-} from './workspace-types';
+import { type BasicStoreEntityWorkspace, ENTITY_TYPE_WORKSPACE, type StoreEntityWorkspace, type WidgetConfiguration } from './workspace-types';
 import { DatabaseError, ForbiddenAccess, FunctionalError } from '../../config/errors';
 import type { AuthContext, AuthUser } from '../../types/user';
 import type {
@@ -36,13 +25,7 @@ import { publishUserAction } from '../../listener/UserActionListener';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { elFindByIds, elRawDeleteByQuery } from '../../database/engine';
 import type { BasicStoreEntity } from '../../types/store';
-import {
-  buildPagination,
-  isEmptyField,
-  isNotEmptyField,
-  READ_DATA_INDICES_WITHOUT_INTERNAL,
-  READ_INDEX_INTERNAL_OBJECTS
-} from '../../database/utils';
+import { buildPagination, isEmptyField, isNotEmptyField, READ_DATA_INDICES_WITHOUT_INTERNAL, READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { extractContentFrom } from '../../utils/fileToContent';
 import { isCompatibleVersionWithMinimal } from '../../utils/version';

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -884,7 +884,7 @@ describe('Elasticsearch pagination', () => {
     data = await elPaginate(testContext, ADMIN_USER, READ_RELATIONSHIPS_INDICES, { connectionFormat: false });
     expect(data).not.toBeNull();
     const entityTypeMap = mapCountPerEntityType(data);
-    expect(entityTypeMap.get('has-capability')).toBe(56);
+    expect(entityTypeMap.get('has-capability')).toBe(57);
     expect(entityTypeMap.get('accesses-to')).toBe(28);
     expect(entityTypeMap.get('member-of')).toBe(13);
     expect(entityTypeMap.get('has-role')).toBe(9);
@@ -905,7 +905,7 @@ describe('Elasticsearch pagination', () => {
     expect(entityTypeMap.get('external-reference')).toBe(7);
     expect(entityTypeMap.get('operating-system')).toBe(1);
     expect(entityTypeMap.get('stix-sighting-relationship')).toBe(2);
-    expect(data.length).toEqual(265);
+    expect(data.length).toEqual(266);
     filterBaseTypes = R.uniq(R.map((e) => e.base_type, data));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -836,7 +836,7 @@ describe('Elasticsearch pagination', () => {
     const internalRelationships = groupByIndices[`${ES_INDEX_PREFIX}_internal_relationships-000001`].map((m) => m.node);
     const internalRelationshipsByType = R.groupBy((m) => m.entity_type, internalRelationships);
     expect(internalRelationshipsByType['accesses-to'].length).toEqual(28);
-    expect(internalRelationshipsByType['has-capability'].length).toEqual(56);
+    expect(internalRelationshipsByType['has-capability'].length).toEqual(57);
     expect(internalRelationshipsByType['has-role'].length).toEqual(9);
     expect(internalRelationshipsByType['member-of'].length).toEqual(13);
     expect(internalRelationshipsByType['participate-to'].length).toEqual(4);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/elasticSearch-test.js
@@ -875,7 +875,8 @@ describe('Elasticsearch pagination', () => {
     expect(metaByEntityType['object-marking'].length).toEqual(28);
     expect(metaByEntityType['kill-chain-phase'].length).toEqual(3);
     expect(metaByEntityType['operating-system'].length).toEqual(1);
-    expect(data.edges.length).toEqual(265);
+
+    expect(data.edges.length).toEqual(266);
     let filterBaseTypes = R.uniq(R.map((e) => e.node.base_type, data.edges));
     expect(filterBaseTypes.length).toEqual(1);
     expect(R.head(filterBaseTypes)).toEqual('RELATION');

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -130,7 +130,7 @@ export const ROLE_SECURITY: Role = {
   id: generateStandardId(ENTITY_TYPE_ROLE, { name: 'Access knowledge/exploration/settings and edit/delete' }),
   name: 'Access knowledge/exploration/settings and edit/delete',
   description: 'Knowledge/exploration/settings edit/delete',
-  capabilities: ['KNOWLEDGE_KNUPDATE_KNDELETE', 'EXPLORE_EXUPDATE_EXDELETE', 'SETTINGS_SETACCESSES', 'SETTINGS_SECURITYACTIVITY']
+  capabilities: ['KNOWLEDGE_KNUPDATE_KNDELETE', 'EXPLORE_EXUPDATE_EXDELETE', 'INVESTIGATION_INUPDATE_INDELETE', 'SETTINGS_SETACCESSES', 'SETTINGS_SECURITYACTIVITY']
 };
 TESTING_ROLES.push(ROLE_SECURITY);
 


### PR DESCRIPTION
### Proposed changes
- Investigations (resp. dashboards) creation is possible if the user has the capability create investigation (resp. dashboards) 
- WorkspaceCreation file turned to tsx
- backend tests: add a capa to a user that created an investigation in the tests whereas he hadn't the capa

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/12459