### PR TITLE
[frontend] warning message in Playbook component for author replacement (#12318)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3044,6 +3044,7 @@
   "Renew": "Erneuern",
   "REPLACE": "ERSETZEN",
   "Replace": "Ersetzen Sie",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "Die Operation \"Ersetzen\" ersetzt den Autor effektiv, wenn die Vertrauensstufe der Entität mit dem neuen Autor höher ist als die der Entität mit dem alten Autor.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "Die Operation \"Ersetzen\" ersetzt die im Kontext dieses Playbooks hinzugefügten Feldwerte, z. B. durch Anreicherung oder andere Wissensmanipulationen, aber nur dann, wenn die Werte bereits in die Plattform geschrieben wurden.",
   "Report": "Bericht",
   "Report actions": "Aktionen melden",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3044,6 +3044,7 @@
   "Renew": "Renew",
   "REPLACE": "REPLACE",
   "Replace": "Replace",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.",
   "Report": "Report",
   "Report actions": "Report actions",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3044,6 +3044,7 @@
   "Renew": "Renovar",
   "REPLACE": "REEMPLAZAR",
   "Replace": "Reemplazarr",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "La operación Reemplazar sustituirá efectivamente al autor si el nivel de confianza de la entidad con el nuevo autor es superior al de la entidad con el antiguo autor.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "La operación Reemplazar reemplazará efectivamente los valores de este campo añadidos en el contexto de este libro de jugadas como el enriquecimiento u otras manipulaciones del conocimiento pero sólo los añadirá si los valores ya están escritos en la plataforma.",
   "Report": "Informe",
   "Report actions": "Informar de las acciones",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3044,6 +3044,7 @@
   "Renew": "Renouveler",
   "REPLACE": "REMPLACER",
   "Replace": "Remplacer",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "L'opération de remplacement remplacera effectivement l'auteur si le niveau de confiance de l'entité avec le nouvel auteur est supérieur à celui de l'entité avec l'ancien auteur.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "L'opération de remplacement, ne remplacera effectivement que les valeurs de ce champ ajoutées dans le contexte de ce playbook tel que l'enrichissement ou d'autres manipulations de connaissances, mais elle ne les ajoutera que si les valeurs sont déjà écrites dans la plateforme.",
   "Report": "Report",
   "Report actions": "Rapport d'actions",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3044,6 +3044,7 @@
   "Renew": "Rinnova",
   "REPLACE": "SOSTITUIRE",
   "Replace": "Sostituisci",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "L'operazione Replace sostituisce effettivamente l'autore se il livello di confidenza dell'entità con il nuovo autore è superiore a quello dell'entità con il vecchio autore.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "Rimpiazzare l'operazione sostituirà effettivamente i valori di questo campo aggiunti nel contesto di questo playbook, come arricchimento o altre manipolazioni della conoscenza, ma li aggiungerà solo se i valori sono già scritti nella piattaforma.",
   "Report": "Report",
   "Report actions": "Azioni del report",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3044,6 +3044,7 @@
   "Renew": "更新",
   "REPLACE": "置き換える",
   "Replace": "置換",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "新しい著者を持つエンティティの信頼度が、古い著者を持つエンティティの信頼度よりも高ければ、置換操作は著者を効果的に置き換える。",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "置換操作は、エンリッチメントやその他の知識操作など、このプレイブックのコンテキストで追加されたフィールド値を効果的に置き換えますが、値がすでにプラットフォームに書き込まれている場合にのみ追加されます。",
   "Report": "レポート",
   "Report actions": "活動報告",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3044,6 +3044,7 @@
   "Renew": "갱신",
   "REPLACE": "REPLACE",
   "Replace": "교체",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "새 작성자가 있는 엔티티의 신뢰 수준이 이전 작성자가 있는 엔티티의 신뢰 수준보다 높으면 바꾸기 작업을 통해 작성자를 효과적으로 교체할 수 있습니다.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "바꾸기 작업은 보강 또는 기타 지식 조작과 같이 이 플레이북의 컨텍스트에서 추가된 이 필드 값을 효과적으로 바꾸지만 플랫폼에 값이 이미 작성된 경우에만 값을 추가합니다.",
   "Report": "보고서",
   "Report actions": "보고서 작업",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3044,6 +3044,7 @@
   "Renew": "Обновить",
   "REPLACE": "ЗАМЕНИТЬ",
   "Replace": "Заменить",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "Операция Replace эффективно заменит автора, если уровень доверия к сущности с новым автором выше, чем к сущности со старым автором.",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "Операция Replace эффективно заменит значения этого поля, добавленные в контексте данного плейбука, например, при обогащении или других манипуляциях со знаниями, но добавит их только в том случае, если значения уже записаны в платформе.",
   "Report": "Отчет",
   "Report actions": "Отчетные действия",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3044,6 +3044,7 @@
   "Renew": "更新",
   "REPLACE": "替换",
   "Replace": "替换",
+  "Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.": "如果新作者实体的置信度高于旧作者实体的置信度，则替换操作将有效替换作者。",
   "Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.": "替换（Replace）操作将有效地替换在此播放列表中添加的字段值，如充实或其他知识操作，但只有在值已写入平台的情况下才会附加这些值。",
   "Report": "报告",
   "Report actions": "报告行动",

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -761,6 +761,11 @@ const PlaybookAddComponentsContent = ({
                                   {t_i18n('Replace operation will effectively replace this field values added in the context of this playbook such as enrichment or other knowledge manipulations but it will only append them if values are already written in the platform.')}
                                 </Alert>
                               )}
+                              {(actionsInputs[i]?.op === 'replace' && actionsInputs[i]?.attribute === 'createdBy') && (
+                                <Alert severity="warning" style={{ marginBottom: 20 }}>
+                                  {t_i18n('Replace operation will effectively replace the author if the confidence level of the entity with the new author is superior to the one of the entity with the old author.')}
+                                </Alert>
+                              )}
                               {(actionsInputs[i]?.op === 'remove') && (
                                 <Alert severity="warning" style={{ marginBottom: 20 }}>
                                   {t_i18n('Remove operation will only apply on field values added in the context of this playbook such as enrichment or other knowledge manipulations but not if values are already written in the platform.')}


### PR DESCRIPTION
### Proposed changes
Add warning message in 'Manipulate knowledge' component of a playbook if the selected field is author and the selected operation is replace.

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/12318