### PR TITLE
[frontend] corrected margin in filter widget

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
@@ -100,7 +100,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
       </Box>
 
       <Box sx={{ paddingTop: 1 }}>
-        {isFilterGroupNotEmpty(filtersDynamicFrom) && (<div style={{ marginTop: 8, color: 'orange' }}>
+        {isFilterGroupNotEmpty(filtersDynamicFrom) && (<div style={{ marginTop: 8, color: 'orange', marginBottom: 4 }}>
           {t_i18n('Pre-query to get data to be used as source entity of the relationship (limited to 5000)')}
         </div>)}
         <FilterIconButton
@@ -117,7 +117,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
         />
 
         {isFilterGroupNotEmpty(filtersDynamicTo)
-          && (<div style={{ marginTop: 8, color: '#03A847' }}>
+          && (<div style={{ marginTop: 8, color: '#03A847', marginBottom: 4 }}>
             {t_i18n('Pre-query to get data to be used as target entity of the relationship (limited to 5000)')}
           </div>)
         }
@@ -135,7 +135,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
         />
 
         {isFilterGroupNotEmpty(filters) && perspective === 'relationships' && (
-          <div style={{ marginTop: 8 }}>
+          <div style={{ marginTop: 8, marginBottom: 4 }}>
             {t_i18n('Result: the relationships with source respecting the source pre-query, target respecting the target pre-query, and matching:')}
           </div>
         )}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Corrected margin in filter widget :  
<img width="879" height="476" alt="Capture d’écran 2025-09-25 à 11 49 34" src="https://github.com/user-attachments/assets/3cbb2011-589b-49da-90d2-693825a96ca6" />

(in dashboards > custom dashboard > dashboard > create widget > perspective Knowledge > steps until tab Filters )

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* after correction to this issue : https://github.com/OpenCTI-Platform/opencti/issues/12074 the margins were not good on filter widget
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
