### PR TITLE
[ci] correctly pass down current tag in env to build script (#7328)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           command: yarn install
       - run:
           working_directory: ~/opencti/opencti-platform/opencti-graphql
-          command: TAG_VERSION=${CIRCLE_TAG}; yarn build
+          command: TAG_VERSION=${CIRCLE_TAG} yarn build
       - slack/notify:
           event: fail
           template: basic_fail_1


### PR DESCRIPTION
Fix circle Ci env passing to yarn build, so the manifest fetched from connectors repo is the tagged version when we release a tagged version of octi.