### PR TITLE
[frontend] 'creators of related entity' filter values for Activity widgets (#11611)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -665,10 +665,13 @@ const useSearchEntities = ({
               });
           }
           if (!cacheEntities[filterKey]) {
-            // fetch only the identities listed as creator of at least 1 thing + myself
-            fetchQuery(identitySearchCreatorsSearchQuery, {
-              entityTypes: searchContext.entityTypes ?? [],
-            })
+            const entityTypesFromSearchContext = searchContext.entityTypes ?? [];
+            // for History and Activity, fetch the creators of all stix core objects
+            const entityTypes = entityTypesFromSearchContext.includes('History') || entityTypesFromSearchContext.includes('Activity')
+              ? ['Stix-Core-Object']
+              : entityTypesFromSearchContext;
+            // fetch only: myself + the identities listed as creator of at least 1 object of type in the searchContext.entityTypes
+            fetchQuery(identitySearchCreatorsSearchQuery, { entityTypes })
               .toPromise()
               .then((response) => {
                 const data = response as IdentitySearchCreatorsSearchQuery$data;

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -667,11 +667,10 @@ const useSearchEntities = ({
               });
           }
           if (!cacheEntities[filterKey]) {
-            const entityTypesFromSearchContext = searchContext.entityTypes ?? [];
             // for History and Activity, fetch the creators of all stix core objects
-            const entityTypes = entityTypesFromSearchContext.includes('History') || entityTypesFromSearchContext.includes('Activity')
+            const entityTypes = searchContext.entityTypes?.includes('History') || searchContext.entityTypes?.includes('Activity')
               ? []
-              : entityTypesFromSearchContext;
+              : searchContext.entityTypes;
             // fetch only: myself + the identities listed as creator of at least 1 object of type in the searchContext.entityTypes
             fetchQuery(identitySearchCreatorsSearchQuery, { entityTypes })
               .toPromise()

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -264,6 +264,8 @@ const groupsQuery = graphql`
 
 export type EntityValue = FilterOptionValue;
 
+const INTERNAL_TYPES_IN_ACTIVITY = ['User', 'Group', 'Workspace', 'Label', 'Marking-Definition', 'Pir', 'DisseminationList', 'ExclusionList', 'DecayRule', 'EmailTemplate', 'CsvMapper', 'JsonMapper', 'StatusTemplate', 'TaxiiCollection', 'StreamCollection', 'Feed', 'Notifier', 'FintelDesign', 'RetentionRule'];
+
 const useSearchEntities = ({
   availableEntityTypes,
   availableRelationshipTypes,
@@ -668,7 +670,7 @@ const useSearchEntities = ({
             const entityTypesFromSearchContext = searchContext.entityTypes ?? [];
             // for History and Activity, fetch the creators of all stix core objects
             const entityTypes = entityTypesFromSearchContext.includes('History') || entityTypesFromSearchContext.includes('Activity')
-              ? ['Stix-Core-Object']
+              ? []
               : entityTypesFromSearchContext;
             // fetch only: myself + the identities listed as creator of at least 1 object of type in the searchContext.entityTypes
             fetchQuery(identitySearchCreatorsSearchQuery, { entityTypes })
@@ -731,7 +733,7 @@ const useSearchEntities = ({
               value: n.label,
               type: n.label,
             })),
-            ...['User', 'Group', 'Workspace', 'Label', 'Marking-Definition', 'Pir', 'DisseminationList', 'ExclusionList', 'DecayRule', 'EmailTemplate', 'CsvMapper', 'JsonMapper', 'StatusTemplate', 'TaxiiCollection', 'StreamCollection', 'Feed', 'Notifier', 'FintelDesign', 'RetentionRule'].map((n) => ({
+            ...INTERNAL_TYPES_IN_ACTIVITY.map((n) => ({
               label: t_i18n(`entity_${n}`),
               value: n,
               type: n,


### PR DESCRIPTION
### Proposed changes
In Activity/History widgets, the 'creators of related entity' filter should contains the value of myself and all the creators (and not only myself and the current user value)

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11611