### PR TITLE
[backend/frontend] can enter free text for connector's name (#12572)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Anzeige von Daten im Zusammenhang mit dem Verlauf und der Aktivität.",
   "Display global knowledge with filters and criteria.": "Globales Wissen mit Filtern und Kriterien anzeigen.",
   "Display legend": "Legende anzeigen",
+  "Display name": "Name anzeigen",
   "Display name of the sender": "Anzeigename des Absenders",
   "Display nested relationships": "Geschachtelte Beziehungen anzeigen",
   "Display notes": "Notizen anzeigen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Display data related to the history and activity.",
   "Display global knowledge with filters and criteria.": "Display global knowledge with filters and criteria.",
   "Display legend": "Display legend",
+  "Display name": "Display name",
   "Display name of the sender": "Display name of the sender",
   "Display nested relationships": "Display nested relationships",
   "Display notes": "Display notes",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Mostrar datos relacionados con el historial y la actividad.",
   "Display global knowledge with filters and criteria.": "Muestra conocimiento global con filtros y criterios.",
   "Display legend": "Mostrar leyenda",
+  "Display name": "Mostrar nombre",
   "Display name of the sender": "Nombre para mostrar del remitente",
   "Display nested relationships": "Mostrar relaciones anidadas",
   "Display notes": "Mostrar las notas",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Afficher les données relatives à l'historique et à l'activité.",
   "Display global knowledge with filters and criteria.": "Afficher la connaissance globale avec des filtres et des critères.",
   "Display legend": "Afficher la légende",
+  "Display name": "Nom d'affichage",
   "Display name of the sender": "Nom d'affichage de l'expéditeur",
   "Display nested relationships": "Afficher les relations imbriquées",
   "Display notes": "Afficher les notes",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Visualizza i dati relativi alla storia e all'attività.",
   "Display global knowledge with filters and criteria.": "Visualizza la conoscenza globale con filtri e criteri.",
   "Display legend": "Visualizza la legenda",
+  "Display name": "Nome visualizzato",
   "Display name of the sender": "Nome visualizzato del mittente",
   "Display nested relationships": "Visualizza le relazioni nidificate",
   "Display notes": "Visualizza le note",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "履歴とアクティビティに関するデータを表示します。",
   "Display global knowledge with filters and criteria.": "フィルターと条件を使用してグローバルな知識を表示します。",
   "Display legend": "凡例の表示",
+  "Display name": "表示名",
   "Display name of the sender": "送信者の表示名",
   "Display nested relationships": "ネストされた関係の表示",
   "Display notes": "ノートを表示",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "기록 및 활동과 관련된 데이터 표시.",
   "Display global knowledge with filters and criteria.": "필터 및 기준으로 글로벌 지식 표시.",
   "Display legend": "범례 표시",
+  "Display name": "표시 이름",
   "Display name of the sender": "발신자의 표시 이름",
   "Display nested relationships": "중첩된 관계 표시",
   "Display notes": "노트 표시",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "Отображение данных, связанных с историей и активностью.",
   "Display global knowledge with filters and criteria.": "Отображение глобальных знаний с помощью фильтров и критериев.",
   "Display legend": "Показать легенду",
+  "Display name": "Отображаемое имя",
   "Display name of the sender": "Отображаемое имя отправителя",
   "Display nested relationships": "Отображение вложенных отношений",
   "Display notes": "Показывать заметки",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1022,6 +1022,7 @@
   "Display data related to the history and activity.": "显示与历史和活动相关的数据。",
   "Display global knowledge with filters and criteria.": "使用过滤器和标准显示全局知识。",
   "Display legend": "显示图例",
+  "Display name": "显示名称",
   "Display name of the sender": "发件人的显示名称",
   "Display nested relationships": "显示嵌套关系",
   "Display notes": "显示注释",

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -301,7 +301,6 @@ const IngestionCatalogConnectorCreation = ({
         <Formik<ManagedConnectorValues>
           onReset={onClose}
           validationSchema={Yup.object().shape({
-            name: k8sNameSchema(t_i18n),
             user_id: Yup.object().required(),
           })}
           initialValues={{

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -76,15 +76,6 @@ const sanitizeContainerName = (label: string): string => {
   return sanitized;
 };
 
-// Validate K8s name format
-const k8sNameSchema = (t_i18n: (key: string) => string) => Yup.string()
-  .required(t_i18n('This field is required'))
-  .min(2, t_i18n('Name must be at least 2 characters'))
-  .max(63, t_i18n('Name must be at most 63 characters'))
-  .matches(/^\S+$/, t_i18n('Name cannot contain whitespace'))
-  .matches(/^[a-z0-9-]+$/, t_i18n('Only lowercase letters, numbers and hyphens are allowed'))
-  .matches(/^[a-z0-9].*[a-z0-9]$/, t_i18n('Name cannot start or end with a hyphen'));
-
 const customRenderers = [
   ...materialRenderers,
   { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
@@ -104,6 +95,7 @@ interface IngestionCatalogConnectorCreationProps {
 
 export interface ManagedConnectorValues extends BasicUserHandlingValues {
   name: string;
+  display_name: string;
   user_id: string | FieldOption;
   automatic_user?: boolean;
   confidence_level?: string;
@@ -130,7 +122,7 @@ const IngestionCatalogConnectorCreation = ({
     resetForm,
   }: Partial<FormikHelpers<ManagedConnectorValues>>) => {
     const input = {
-      name: values.name,
+      name: values.display_name,
       catalog_id: catalogId,
       user_id: typeof values.user_id === 'string' ? values.user_id : values.user_id?.value,
       automatic_user: values.automatic_user ?? true,
@@ -192,8 +184,7 @@ const IngestionCatalogConnectorCreation = ({
     Object.entries(connector.config_schema.properties).forEach(([key, value]) => {
       if (key === 'CONNECTOR_NAME') {
         if (value.default !== undefined) {
-          // Apply sanitization to the default connector name
-          const baseName = sanitizeContainerName(value.default.toString());
+          const baseName = value.default.toString();
           defaultConnectorName = deploymentCount > 0
             ? `${baseName}-${deploymentCount + 1}`
             : baseName;
@@ -304,7 +295,8 @@ const IngestionCatalogConnectorCreation = ({
             user_id: Yup.object().required(),
           })}
           initialValues={{
-            name: connectorName,
+            display_name: connectorName,
+            name: sanitizeContainerName(connectorName),
             confidence_level: connector.max_confidence_level.toString(),
             user_id: { label: '', value: '' },
             automatic_user: true,
@@ -312,7 +304,7 @@ const IngestionCatalogConnectorCreation = ({
           }}
           onSubmit={() => {}}
         >
-          {({ values, isSubmitting, setSubmitting, resetForm, isValid, setValues }) => {
+          {({ values, isSubmitting, setSubmitting, resetForm, isValid, setValues, setFieldValue }) => {
             const errors = compiledValidator?.validate(values)?.errors;
 
             const disableCreate = !isValid || isSubmitting || !!errors?.[0];
@@ -331,11 +323,23 @@ const IngestionCatalogConnectorCreation = ({
                     component={TextField}
                     style={fieldSpacingContainerStyle}
                     variant="standard"
-                    name="name"
-                    label={t_i18n('Instance name')}
+                    name="display_name"
+                    label={t_i18n('Display name')}
                     required
                     fullWidth={true}
-                    helperText={t_i18n('Only lowercase letters, numbers and hyphens')}
+                    onChange={(_: string, value: string) => {
+                      setFieldValue('name', sanitizeContainerName(value));
+                    }}
+                  />
+
+                  <Field
+                    component={TextField}
+                    style={fieldSpacingContainerStyle}
+                    variant="standard"
+                    name="name"
+                    label={t_i18n('Instance name')}
+                    fullWidth={true}
+                    disabled
                   />
 
                   <IngestionCreationUserHandling

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -791,6 +791,7 @@ export const connectorQuery = graphql`
     connector(id: $id) {
       id
       name
+      title
       ...Connector_connector
     }
   }

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsList.tsx
@@ -8,6 +8,7 @@ export const connectorsListQuery = graphql`
     connectors {
       id
       name
+      title
       connector_type
       is_managed
       built_in

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -405,7 +405,7 @@ const ConnectorsStatusContent: FunctionComponent<ConnectorsStatusContentProps> =
                                 gridTemplateColumns: gridColumns,
                               }}
                             >
-                              <Tooltip title={connector.name} placement={'top'}>
+                              <Tooltip title={connector.title} placement={'top'}>
                                 <div className={classes.bodyItem}>
                                   {
                                     connector.is_managed ? connector.manager_contract_excerpt?.title : connector.name

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
@@ -25,7 +25,7 @@ class RootConnector extends Component {
             if (props.connector) {
               return (
                 <>
-                  <Breadcrumbs elements={[{ label: t('Data') }, { label: t('Ingestion') }, { label: t('Ingestion monitoring'), link: '/dashboard/data/ingestion/connectors' }, { label: props.connector.name, current: true }]} />
+                  <Breadcrumbs elements={[{ label: t('Data') }, { label: t('Ingestion') }, { label: t('Ingestion monitoring'), link: '/dashboard/data/ingestion/connectors' }, { label: props.connector.title, current: true }]} />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2275,6 +2275,7 @@ type Connector implements BasicObject & InternalObject {
   entity_type: String!
   parent_types: [String]!
   name: String!
+  title: String!
   active: Boolean
   auto: Boolean
   only_contextual: Boolean

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2180,6 +2180,7 @@ type Connector implements BasicObject & InternalObject {
   parent_types: [String]!
   # Connector
   name: String!
+  title: String!
   active: Boolean
   auto: Boolean
   only_contextual: Boolean

--- a/opencti-platform/opencti-graphql/src/database/repository.js
+++ b/opencti-platform/opencti-graphql/src/database/repository.js
@@ -18,6 +18,7 @@ import { logApp } from '../config/conf';
 export const completeConnector = (connector) => {
   if (connector) {
     const completed = { ...connector };
+    completed.title = connector.title ? connector.title : connector.name;
     completed.is_managed = isNotEmptyField(connector.catalog_id);
     completed.connector_scope = connector.connector_scope ? connector.connector_scope.split(',') : [];
     completed.config = connectorConfig(connector.id, connector.listen_callback_uri);

--- a/opencti-platform/opencti-graphql/src/domain/connector.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector.ts
@@ -267,6 +267,7 @@ export const managedConnectorAdd = async (
 
   // Create connector
   const connectorToCreate: any = {
+    title: input.name,
     name: sanitizedName,
     connector_type: targetContract.container_type,
     catalog_id: input.catalog_id,
@@ -277,6 +278,7 @@ export const managedConnectorAdd = async (
     connector_state_timestamp: now(),
     built_in: false
   };
+
   const createdConnector: any = await createEntity(context, user, connectorToCreate, ENTITY_TYPE_CONNECTOR);
   // Increment telemetry for connector deployed via composer
   await addConnectorDeployedCount();

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3950,6 +3950,7 @@ export type Connector = BasicObject & InternalObject & {
   parent_types: Array<Maybe<Scalars['String']['output']>>;
   playbook_compatible?: Maybe<Scalars['Boolean']['output']>;
   standard_id: Scalars['String']['output'];
+  title: Scalars['String']['output'];
   updated_at?: Maybe<Scalars['DateTime']['output']>;
   works?: Maybe<Array<Maybe<Work>>>;
 };
@@ -36814,6 +36815,7 @@ export type ConnectorResolvers<ContextType = any, ParentType extends ResolversPa
   parent_types?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   playbook_compatible?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updated_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   works?: Resolver<Maybe<Array<Maybe<ResolversTypes['Work']>>>, ParentType, ContextType, Partial<ConnectorWorksArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -387,6 +387,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
   [ENTITY_TYPE_CONNECTOR]: [
     { ...updatedAt, update: true }, // Allow change of updated_at for connector ping
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'title', label: 'Title', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'active', label: 'Status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'auto', label: 'Auto', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'built_in', label: 'Built-in', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add new attribute in connector object: title
* Now connector's display name uses title and has no k8s name constraints

https://github.com/user-attachments/assets/7996ff9d-f16d-44dd-9711-4e6f9db9f325




### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12572 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
