### PR TITLE
[backend] Add more log when query fails in test

### DIFF
--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -86,7 +86,7 @@ export const queryAsUserWithSuccess = async (client: AxiosInstance, request: { q
   const requestResult = await executeInternalQuery(client, print(request.query), request.variables);
   expect(requestResult, `Something is wrong with this query: ${request.query}`).toBeDefined();
   if (requestResult.errors) {
-    logApp.info('Unexpected error; requestResult:', { requestResult });
+    logApp.error('Unexpected error; request:', { request, requestResult });
   }
   expect(requestResult.errors, `This errors should not be there: ${JSON.stringify(requestResult.errors)}`).toBeUndefined();
   return requestResult;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
