### PR TITLE
[backend/worker] handle too large items (#12816)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2226,6 +2226,7 @@ type ConnectorConfig {
   push: String!
   push_routing: String!
   push_exchange: String!
+  dead_letter_routing: String!
 }
 
 type ConnectorMetadata {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2131,6 +2131,7 @@ type ConnectorConfig {
   push: String!
   push_routing: String!
   push_exchange: String!
+  dead_letter_routing: String!
 }
 
 type ConnectorMetadata {

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -264,10 +264,11 @@ const CONNECTOR_QUEUE_PLAYBOOK = { id: 'playbook', name: 'Internal playbook mana
 const CONNECTOR_QUEUE_SYNC = { id: 'sync', name: 'Internal sync manager', type: 'internal', scope: 'sync' };
 /** @deprecated [>=6.3 & <6.6]. Remove and add migration to remove the queues. */
 const DEPRECATED_INTERNAL_QUEUES = [CONNECTOR_QUEUE_PLAYBOOK, CONNECTOR_QUEUE_SYNC];
+const CONNECTOR_QUEUE_BUNDLES_TOO_LARGE = { id: 'too-large-bundle', name: 'Bundle too large for ingestion', type: 'internal', scope: 'dead letter' };
 // endregion
 export const getInternalQueues = () => {
   const backgroundTaskConnectorQueues = getInternalBackgroundTaskQueues();
-  return [...DEPRECATED_INTERNAL_QUEUES, ...backgroundTaskConnectorQueues];
+  return [CONNECTOR_QUEUE_BUNDLES_TOO_LARGE, ...DEPRECATED_INTERNAL_QUEUES, ...backgroundTaskConnectorQueues];
 };
 
 export const initializeInternalQueues = async () => {

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -210,6 +210,7 @@ export const connectorConfig = (id, listen_callback_uri = undefined) => ({
   listen_routing: listenRouting(id),
   listen_exchange: CONNECTOR_EXCHANGE,
   listen_callback_uri,
+  dead_letter_routing: listenRouting(CONNECTOR_QUEUE_BUNDLES_TOO_LARGE.id),
 });
 
 export const listenRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}listen_routing_${connectorId}`;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3963,6 +3963,7 @@ export type ConnectorWorksArgs = {
 export type ConnectorConfig = {
   __typename?: 'ConnectorConfig';
   connection: RabbitMqConnection;
+  dead_letter_routing: Scalars['String']['output'];
   listen: Scalars['String']['output'];
   listen_callback_uri?: Maybe<Scalars['String']['output']>;
   listen_exchange: Scalars['String']['output'];
@@ -36824,6 +36825,7 @@ export type ConnectorResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type ConnectorConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['ConnectorConfig'] = ResolversParentTypes['ConnectorConfig']> = ResolversObject<{
   connection?: Resolver<ResolversTypes['RabbitMQConnection'], ParentType, ContextType>;
+  dead_letter_routing?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   listen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   listen_callback_uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   listen_exchange?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/rabbitmq-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/rabbitmq-test.js
@@ -20,7 +20,7 @@ describe('Rabbit connector management', () => {
   });
   it('should connector queues available', async () => {
     const data = await metrics(testContext, ADMIN_USER);
-    expect(data.queues.length).toEqual(18);
+    expect(data.queues.length).toEqual(20);
     const aggregationMap = new Map(data.queues.map((q) => [q.name, q]));
     expect(aggregationMap.get(`${RABBIT_QUEUE_PREFIX}listen_${testConnectorId}`)).toBeDefined();
     expect(aggregationMap.get(`${RABBIT_QUEUE_PREFIX}push_${testConnectorId}`)).toBeDefined();

--- a/opencti-worker/src/config.yml.sample
+++ b/opencti-worker/src/config.yml.sample
@@ -7,4 +7,4 @@ opencti:
 worker:
   log_level: 'info'
   telemetry_enabled: false
-  objects_max_deps: 0
+  objects_max_refs: 0

--- a/opencti-worker/src/config.yml.sample
+++ b/opencti-worker/src/config.yml.sample
@@ -7,3 +7,4 @@ opencti:
 worker:
   log_level: 'info'
   telemetry_enabled: false
+  objects_max_deps: 0

--- a/opencti-worker/src/listen_handler.py
+++ b/opencti-worker/src/listen_handler.py
@@ -10,6 +10,7 @@ from requests import RequestException, Timeout
 ERROR_TYPE_BAD_GATEWAY = "Bad Gateway"
 ERROR_TYPE_TIMEOUT = "Request timed out"
 
+
 @dataclass(unsafe_hash=True)
 class ListenHandler:
     logger: Any
@@ -50,9 +51,7 @@ class ListenHandler:
             return "requeue"
         except Exception as ex:
             # Technical unmanaged exception
-            self.logger.error(
-                "Error executing listen handling", {"reason": str(ex)}
-            )
+            self.logger.error("Error executing listen handling", {"reason": str(ex)})
             error_msg = traceback.format_exc()
             if ERROR_TYPE_BAD_GATEWAY in error_msg or ERROR_TYPE_TIMEOUT in error_msg:
                 # Nack the message and requeue

--- a/opencti-worker/src/message_queue_consumer.py
+++ b/opencti-worker/src/message_queue_consumer.py
@@ -75,7 +75,7 @@ class MessageQueueConsumer:  # pylint: disable=too-many-instance-attributes
                     {
                         "consumer_type": self.consumer_type,
                         "queue": self.queue_name,
-                        "tag": method.delivery_tag
+                        "tag": method.delivery_tag,
                     },
                 )
                 task_future = self.execution_pool.submit(

--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -119,8 +119,13 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                         except Exception as err:  # pylint: disable=broad-except
                             self.logger.warning(str(err))
                         for too_large_item_bundle in too_large_items_bundles:
+                            too_large_item_bundle["original_connector_id"] = self.connector_id
                             self.logger.warning(
                                 "Detected a bundle too large, sending it to dead letter queue...",
+                                {
+                                    "bundle_id": too_large_item_bundle["id"],
+                                    "connector_id": self.connector_id
+                                }
                             )
                             self.send_bundle_to_specific_queue(
                                 push_channel,
@@ -153,8 +158,13 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                                 self.api.work.add_expectations(work_id, expectations)
                                 # For each bundle too large, send it to the too large queue
                             for too_large_elements_bundle in too_large_elements_bundles:
+                                too_large_elements_bundle["original_connector_id"] = self.connector_id
                                 self.logger.warning(
                                     "Detected a bundle too large, sending it to dead letter queue...",
+                                    {
+                                        "bundle_id": too_large_elements_bundle["id"],
+                                        "connector_id": self.connector_id
+                                    }
                                 )
                                 self.send_bundle_to_specific_queue(
                                     push_channel,

--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Union, Literal
 
 import pika
+from pika.adapters.blocking_connection import BlockingChannel
+
 from pycti import OpenCTIApiClient, OpenCTIStix2Splitter
 
 
@@ -16,11 +18,14 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
     opencti_url: str
     opencti_token: str
     ssl_verify: Union[bool, str]
+    connector_id: str
     push_exchange: str
+    listen_exchange: str
     push_routing: str
     pika_parameters: pika.ConnectionParameters
     bundles_global_counter: Any
     bundles_processing_time_gauge: Any
+    objects_max_refs: int
 
     def __post_init__(self) -> None:
         self.api = OpenCTIApiClient(
@@ -30,10 +35,36 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
             json_logging=self.json_logging,
             ssl_verify=self.ssl_verify,
         )
+        # Small hack to handle any rabbit prefix that could have been configured
+        self.listen_too_large_routing = self.push_routing.replace(
+            "push_routing", "listen_routing"
+        ).replace(self.connector_id, "too-large-bundle")
+
+    def send_bundle_to_specific_queue(
+        self,
+        push_channel: BlockingChannel,
+        exchange: str,
+        routing_key: str,
+        data: Any,
+        bundle: Any,
+    ):
+        text_bundle = json.dumps(bundle)
+        data["content"] = base64.b64encode(
+            text_bundle.encode("utf-8", "escape")
+        ).decode("utf-8")
+        push_channel.basic_publish(
+            exchange=exchange,
+            routing_key=routing_key,
+            body=json.dumps(data),
+            properties=pika.BasicProperties(
+                delivery_mode=2,
+                content_encoding="utf-8",  # make message persistent
+            ),
+        )
 
     def handle_message(
-            self,
-            body: str,
+        self,
+        body: str,
     ) -> Literal["ack", "nack", "requeue"]:
         try:
             data: Dict[str, Any] = json.loads(body)
@@ -73,13 +104,37 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                     raise ValueError("JSON data type is not a STIX2 bundle")
                 if len(content["objects"]) == 1 or data.get("no_split", False):
                     update = data.get("update", False)
-                    imported_items = self.api.stix2.import_bundle_from_json(
-                        raw_content, update, types, work_id
+                    imported_items, too_large_items_bundles = (
+                        self.api.stix2.import_bundle_from_json(
+                            raw_content, update, types, work_id, self.objects_max_refs
+                        )
                     )
+                    if len(too_large_items_bundles) > 0:
+                        push_pika_connection = pika.BlockingConnection(
+                            self.pika_parameters
+                        )
+                        push_channel = push_pika_connection.channel()
+                        try:
+                            push_channel.confirm_delivery()
+                        except Exception as err:  # pylint: disable=broad-except
+                            self.logger.warning(str(err))
+                        for too_large_item_bundle in too_large_items_bundles:
+                            self.logger.warning(
+                                "Detected a bundle too large, sending it to dead letter queue...",
+                            )
+                            self.send_bundle_to_specific_queue(
+                                push_channel,
+                                self.listen_exchange,
+                                self.listen_too_large_routing,
+                                data,
+                                too_large_item_bundle,
+                            )
                 else:
                     # As bundle is received as complete, split and requeue
                     # Create a specific channel to push the split bundles
-                    with pika.BlockingConnection(self.pika_parameters) as push_pika_connection:
+                    with pika.BlockingConnection(
+                        self.pika_parameters
+                    ) as push_pika_connection:
                         with push_pika_connection.channel() as push_channel:
                             try:
                                 push_channel.confirm_delivery()
@@ -87,8 +142,8 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                                 self.logger.warning(str(err))
                             # Instance spliter and split the big bundle
                             event_version = content.get("x_opencti_event_version")
-                            stix2_splitter = OpenCTIStix2Splitter()
-                            expectations, _, bundles = (
+                            stix2_splitter = OpenCTIStix2Splitter(self.objects_max_refs)
+                            expectations, _, bundles, too_large_elements_bundles = (
                                 stix2_splitter.split_bundle_with_expectations(
                                     content, False, event_version
                                 )
@@ -96,20 +151,26 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             # Add expectations to the work
                             if work_id is not None:
                                 self.api.work.add_expectations(work_id, expectations)
+                                # For each bundle too large, send it to the too large queue
+                            for too_large_elements_bundle in too_large_elements_bundles:
+                                self.logger.warning(
+                                    "Detected a bundle too large, sending it to dead letter queue...",
+                                )
+                                self.send_bundle_to_specific_queue(
+                                    push_channel,
+                                    self.listen_exchange,
+                                    self.listen_too_large_routing,
+                                    data,
+                                    too_large_elements_bundle,
+                                )
                             # For each split bundle, send it to the same queue
                             for bundle in bundles:
-                                text_bundle = json.dumps(bundle)
-                                data["content"] = base64.b64encode(
-                                    text_bundle.encode("utf-8", "escape")
-                                ).decode("utf-8")
-                                push_channel.basic_publish(
-                                    exchange=self.push_exchange,
-                                    routing_key=self.push_routing,
-                                    body=json.dumps(data),
-                                    properties=pika.BasicProperties(
-                                        delivery_mode=2,
-                                        content_encoding="utf-8",  # make message persistent
-                                    ),
+                                self.send_bundle_to_specific_queue(
+                                    push_channel,
+                                    self.push_exchange,
+                                    self.push_routing,
+                                    data,
+                                    bundle,
                                 )
             # Event type event
             # Specific OpenCTI event operation with specific operation
@@ -147,17 +208,17 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                         )
                     # All standard operations
                     case (
-                    "delete"  # Standard delete
-                    | "restore"  # Restore an operation from trash
-                    | "delete_force"  # Delete with no trash
-                    | "share"  # Share an element
-                    | "unshare"  # Unshare an element
-                    | "rule_apply"  # Applying a rule (start engine)
-                    | "rule_clear"  # Clearing a rule (stop engine)
-                    | "rules_rescan"  # Rescan a rule (massive operation in UI)
-                    | "enrichment"  # Ask for enrichment (massive operation in UI)
-                    | "clear_access_restriction"  # Clear access members (massive operation in UI)
-                    | "revert_draft"  # Cancel draft modification (massive operation in UI)
+                        "delete"  # Standard delete
+                        | "restore"  # Restore an operation from trash
+                        | "delete_force"  # Delete with no trash
+                        | "share"  # Share an element
+                        | "unshare"  # Unshare an element
+                        | "rule_apply"  # Applying a rule (start engine)
+                        | "rule_clear"  # Clearing a rule (stop engine)
+                        | "rules_rescan"  # Rescan a rule (massive operation in UI)
+                        | "enrichment"  # Ask for enrichment (massive operation in UI)
+                        | "clear_access_restriction"  # Clear access members (massive operation in UI)
+                        | "revert_draft"  # Cancel draft modification (massive operation in UI)
                     ):
                         data_object = content["data"]
                         data_object["opencti_operation"] = event_type
@@ -178,14 +239,10 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
             return "ack"
         except Exception as ex:
             # Technical unmanaged exception
-            self.logger.error(
-                "Error executing data handling", {"reason": str(ex)}
-            )
+            self.logger.error("Error executing data handling", {"reason": str(ex)})
             # Nack message and discard
             return "nack"
         finally:
             self.bundles_global_counter.add(len(imported_items))
             processing_delta = datetime.datetime.now() - start_processing
             self.bundles_processing_time_gauge.record(processing_delta.seconds)
-
-

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -244,6 +244,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             connector_config["push_exchange"],
                             connector_config["listen_exchange"],
                             connector_config["push_routing"],
+                            connector_config["dead_letter_routing"],
                             pika_parameters,
                             bundles_global_counter,
                             bundles_processing_time_gauge,

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -139,7 +139,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             False,
             "0.0.0.0",
         )
-        self.stix_object_max_refs = get_config_variable(
+        self.stix_objects_max_refs = get_config_variable(
             "WORKER_OBJECTS_MAX_REFS",
             ["worker", "objects_max_refs"],
             config,
@@ -247,7 +247,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             pika_parameters,
                             bundles_global_counter,
                             bundles_processing_time_gauge,
-                            self.stix_object_max_refs,
+                            self.stix_objects_max_refs,
                         )
                         self.consumers[push_queue] = MessageQueueConsumer(
                             self.worker_logger,

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -139,7 +139,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             False,
             "0.0.0.0",
         )
-        self.stix_objects_max_refs = get_config_variable(
+        self.objects_max_refs = get_config_variable(
             "WORKER_OBJECTS_MAX_REFS",
             ["worker", "objects_max_refs"],
             config,
@@ -247,7 +247,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             pika_parameters,
                             bundles_global_counter,
                             bundles_processing_time_gauge,
-                            self.stix_objects_max_refs,
+                            self.objects_max_refs,
                         )
                         self.consumers[push_queue] = MessageQueueConsumer(
                             self.worker_logger,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add new internal queue `too-large-bundle`
* add `objects_max_refs` config to worker.py
* in worker, if item has too many dependencies, it is sent to the `too-large-bundle` queue instead of being ingested

client PR: https://github.com/OpenCTI-Platform/client-python/pull/982
doc PR: https://github.com/OpenCTI-Platform/docs/pull/360

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12816
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
