### PR TITLE
[worker] add 'info' default value to worker log level (#11216)

### DIFF
--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -576,7 +576,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
         )
         # Load worker config
         self.log_level = get_config_variable(
-            "WORKER_LOG_LEVEL", ["worker", "log_level"], config
+            "WORKER_LOG_LEVEL", ["worker", "log_level"], config, default="info"
         )
         self.listen_api_ssl_verify = get_config_variable(
             "WORKER_LISTEN_API_SSL_VERIFY",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add 'info' default value to worker log level
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11216 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
