### PR TITLE
[backend/client] handle file markings input as standard ids in file upload (#11643)

### DIFF
--- a/client-python/pycti/entities/indicator/opencti_indicator_properties.py
+++ b/client-python/pycti/entities/indicator/opencti_indicator_properties.py
@@ -266,6 +266,17 @@ INDICATOR_PROPERTIES_WITH_FILES = """
                     mimetype
                     version
                 }
+                objectMarking {
+                    id
+                    standard_id
+                    entity_type
+                    definition_type
+                    definition
+                    created
+                    modified
+                    x_opencti_order
+                    x_opencti_color
+                }
             }
         }
     }

--- a/client-python/pycti/entities/opencti_attack_pattern.py
+++ b/client-python/pycti/entities/opencti_attack_pattern.py
@@ -254,6 +254,17 @@ class AttackPattern:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_campaign.py
+++ b/client-python/pycti/entities/opencti_campaign.py
@@ -232,6 +232,17 @@ class Campaign:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_case_incident.py
+++ b/client-python/pycti/entities/opencti_case_incident.py
@@ -475,6 +475,17 @@ class CaseIncident:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_case_rfi.py
+++ b/client-python/pycti/entities/opencti_case_rfi.py
@@ -473,6 +473,17 @@ class CaseRfi:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_case_rft.py
+++ b/client-python/pycti/entities/opencti_case_rft.py
@@ -473,6 +473,17 @@ class CaseRft:
                                 mimetype
                                 version
                             }
+                            objectMarking {
+                                id
+                                standard_id
+                                entity_type
+                                definition_type
+                                definition
+                                created
+                                modified
+                                x_opencti_order
+                                x_opencti_color
+                            }
                         }
                     }
                 }

--- a/client-python/pycti/entities/opencti_channel.py
+++ b/client-python/pycti/entities/opencti_channel.py
@@ -212,6 +212,17 @@ class Channel:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_course_of_action.py
+++ b/client-python/pycti/entities/opencti_course_of_action.py
@@ -228,6 +228,17 @@ class CourseOfAction:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_data_component.py
+++ b/client-python/pycti/entities/opencti_data_component.py
@@ -244,6 +244,17 @@ class DataComponent:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_data_source.py
+++ b/client-python/pycti/entities/opencti_data_source.py
@@ -230,6 +230,17 @@ class DataSource:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_event.py
+++ b/client-python/pycti/entities/opencti_event.py
@@ -232,6 +232,17 @@ class Event:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_external_reference.py
+++ b/client-python/pycti/entities/opencti_external_reference.py
@@ -63,6 +63,17 @@ class ExternalReference:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_feedback.py
+++ b/client-python/pycti/entities/opencti_feedback.py
@@ -435,6 +435,17 @@ class Feedback:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_grouping.py
+++ b/client-python/pycti/entities/opencti_grouping.py
@@ -419,6 +419,17 @@ class Grouping:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_identity.py
+++ b/client-python/pycti/entities/opencti_identity.py
@@ -264,6 +264,17 @@ class Identity:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_incident.py
+++ b/client-python/pycti/entities/opencti_incident.py
@@ -239,6 +239,17 @@ class Incident:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_infrastructure.py
+++ b/client-python/pycti/entities/opencti_infrastructure.py
@@ -250,6 +250,17 @@ class Infrastructure:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_intrusion_set.py
+++ b/client-python/pycti/entities/opencti_intrusion_set.py
@@ -238,6 +238,17 @@ class IntrusionSet:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_language.py
+++ b/client-python/pycti/entities/opencti_language.py
@@ -134,6 +134,17 @@ class Language:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }
@@ -249,6 +260,17 @@ class Language:
                         metaData {
                             mimetype
                             version
+                        }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
                         }
                     }
                 }

--- a/client-python/pycti/entities/opencti_location.py
+++ b/client-python/pycti/entities/opencti_location.py
@@ -232,6 +232,17 @@ class Location:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_malware.py
+++ b/client-python/pycti/entities/opencti_malware.py
@@ -266,6 +266,17 @@ class Malware:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_malware_analysis.py
+++ b/client-python/pycti/entities/opencti_malware_analysis.py
@@ -242,6 +242,17 @@ class MalwareAnalysis:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_narrative.py
+++ b/client-python/pycti/entities/opencti_narrative.py
@@ -228,6 +228,17 @@ class Narrative:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_note.py
+++ b/client-python/pycti/entities/opencti_note.py
@@ -463,6 +463,17 @@ class Note:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_observed_data.py
+++ b/client-python/pycti/entities/opencti_observed_data.py
@@ -456,6 +456,17 @@ class ObservedData:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_opinion.py
+++ b/client-python/pycti/entities/opencti_opinion.py
@@ -234,6 +234,17 @@ class Opinion:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_report.py
+++ b/client-python/pycti/entities/opencti_report.py
@@ -465,6 +465,17 @@ class Report:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_stix_core_object.py
+++ b/client-python/pycti/entities/opencti_stix_core_object.py
@@ -811,6 +811,17 @@ class StixCoreObject:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_stix_domain_object.py
+++ b/client-python/pycti/entities/opencti_stix_domain_object.py
@@ -1094,6 +1094,17 @@ class StixDomainObject:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_task.py
+++ b/client-python/pycti/entities/opencti_task.py
@@ -240,6 +240,17 @@ class Task:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_threat_actor.py
+++ b/client-python/pycti/entities/opencti_threat_actor.py
@@ -143,6 +143,17 @@ class ThreatActor:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_threat_actor_group.py
+++ b/client-python/pycti/entities/opencti_threat_actor_group.py
@@ -146,6 +146,17 @@ class ThreatActorGroup:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_threat_actor_individual.py
+++ b/client-python/pycti/entities/opencti_threat_actor_individual.py
@@ -146,6 +146,17 @@ class ThreatActorIndividual:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_tool.py
+++ b/client-python/pycti/entities/opencti_tool.py
@@ -147,6 +147,17 @@ class Tool:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/opencti_vulnerability.py
+++ b/client-python/pycti/entities/opencti_vulnerability.py
@@ -183,6 +183,17 @@ class Vulnerability:
                             mimetype
                             version
                         }
+                        objectMarking {
+                            id
+                            standard_id
+                            entity_type
+                            definition_type
+                            definition
+                            created
+                            modified
+                            x_opencti_order
+                            x_opencti_color
+                        }
                     }
                 }
             }

--- a/client-python/pycti/entities/stix_cyber_observable/opencti_stix_cyber_observable_properties.py
+++ b/client-python/pycti/entities/stix_cyber_observable/opencti_stix_cyber_observable_properties.py
@@ -664,6 +664,17 @@ SCO_PROPERTIES_WITH_FILES = """
                     mimetype
                     version
                 }
+                objectMarking {
+                    id
+                    standard_id
+                    entity_type
+                    definition_type
+                    definition
+                    created
+                    modified
+                    x_opencti_order
+                    x_opencti_color
+                }
             }
         }
     }

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2238,14 +2238,39 @@ class OpenCTIStix2:
                     self.opencti.api_url.replace("graphql", "storage/get/") + file["id"]
                 )
                 data = self.opencti.fetch_opencti_file(url, binary=True, serialize=True)
-                entity["x_opencti_files"].append(
-                    {
-                        "name": file["name"],
-                        "data": data,
-                        "mime_type": file["metaData"]["mimetype"],
-                        "version": file["metaData"].get("version", None),
+                x_opencti_file = {
+                    "name": file["name"],
+                    "data": data,
+                    "mime_type": file["metaData"]["mimetype"],
+                    "version": file["metaData"].get("version", None),
+                    "object_marking_refs": [],
+                }
+                for file_marking_definition in file["objectMarking"]:
+                    if file_marking_definition["definition_type"] == "TLP":
+                        created = "2017-01-20T00:00:00.000Z"
+                    else:
+                        created = file_marking_definition["created"]
+                    marking_definition = {
+                        "type": "marking-definition",
+                        "spec_version": SPEC_VERSION,
+                        "id": file_marking_definition["standard_id"],
+                        "created": created,
+                        "definition_type": file_marking_definition[
+                            "definition_type"
+                        ].lower(),
+                        "name": file_marking_definition["definition"],
+                        "definition": {
+                            file_marking_definition["definition_type"]
+                            .lower(): file_marking_definition["definition"]
+                            .lower()
+                            .replace("tlp:", "")
+                        },
                     }
-                )
+                    result.append(marking_definition)
+                    x_opencti_file["object_marking_refs"].append(
+                        marking_definition["id"]
+                    )
+                entity["x_opencti_files"].append(x_opencti_file)
             del entity["importFiles"]
             del entity["importFilesIds"]
 

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -571,7 +571,7 @@ export const upload = async (
   const markings = await getEntitiesMapFromCache<BasicStoreObject>(context, SYSTEM_USER, ENTITY_TYPE_MARKING_DEFINITION);
   const normalized_file_markings = file_markings?.map((m) => {
     const marking = markings.get(m);
-    return marking ? markings.get(m)?.internal_id : m;
+    return marking ? marking.internal_id : m;
   }) ?? [];
   const filtered_markings = normalized_file_markings.filter((id) => id) as string[];
   // Verify markings

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -569,7 +569,10 @@ export const upload = async (
 ): Promise<{ upload: LoadedFile; untouched: boolean }> => {
   const { entity, meta = {}, noTriggerImport = false, errorOnExisting = false, file_markings = [], importContextEntities = [] } = opts;
   const markings = await getEntitiesMapFromCache<BasicStoreObject>(context, SYSTEM_USER, ENTITY_TYPE_MARKING_DEFINITION);
-  const normalized_file_markings = file_markings?.map((m) => (markings.get(m) ? markings.get(m)?.internal_id : m)) ?? [];
+  const normalized_file_markings = file_markings?.map((m) => {
+    const marking = markings.get(m);
+    return marking ? markings.get(m)?.internal_id : m;
+  }) ?? [];
   const filtered_markings = normalized_file_markings.filter((id) => id) as string[];
   // Verify markings
   for (let index = 0; index < (filtered_markings ?? []).length; index += 1) {

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -29,7 +29,7 @@ import {
   SUPPORT_STORAGE_PATH,
 } from '../modules/internal/document/document-domain';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
-import { isUserHasCapability, KNOWLEDGE, KNOWLEDGE_KNASKIMPORT, SETTINGS_SUPPORT, validateMarking } from '../utils/access';
+import { isUserHasCapability, KNOWLEDGE, KNOWLEDGE_KNASKIMPORT, SETTINGS_SUPPORT, SYSTEM_USER, validateMarking } from '../utils/access';
 import { internalLoadById } from './middleware-loader';
 import { getDraftContext } from '../utils/draftContext';
 import { isModuleActivated } from './cluster-module';
@@ -38,6 +38,8 @@ import { deleteFileFromStorage, getFileSize, rawCopyFile, rawListObjects, rawUpl
 import { promiseMap } from '../utils/promiseUtils';
 import { ENTITY_TYPE_SUPPORT_PACKAGE } from '../modules/support/support-types';
 import { pushAll } from '../utils/arrayUtil';
+import { getEntitiesMapFromCache } from './cache';
+import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 
 // Minio configuration
 const excludedFiles = conf.get('minio:excluded_files') || ['.DS_Store'];
@@ -566,10 +568,13 @@ export const upload = async (
   opts: FileUploadOpts,
 ): Promise<{ upload: LoadedFile; untouched: boolean }> => {
   const { entity, meta = {}, noTriggerImport = false, errorOnExisting = false, file_markings = [], importContextEntities = [] } = opts;
+  const markings = await getEntitiesMapFromCache<BasicStoreObject>(context, SYSTEM_USER, ENTITY_TYPE_MARKING_DEFINITION);
+  const normalized_file_markings = file_markings?.map((m) => (markings.get(m) ? markings.get(m)?.internal_id : m)) ?? [];
+  const filtered_markings = normalized_file_markings.filter((id) => id) as string[];
   // Verify markings
-  for (let index = 0; index < (file_markings ?? []).length; index += 1) {
-    const markingId = file_markings[index];
-    await validateMarking(context, user, markingId);
+  for (let index = 0; index < (filtered_markings ?? []).length; index += 1) {
+    const markingId = filtered_markings[index];
+    await validateMarking(context, user, markingId, markings);
   }
   const metadata: FileMetadata = { ...meta };
   if (!metadata.version) {
@@ -622,7 +627,7 @@ export const upload = async (
     information: '',
     lastModified: new Date(),
     lastModifiedSinceMin: sinceNowInMinutes(new Date()),
-    metaData: { ...fullMetadata, messages: [], errors: [], file_markings },
+    metaData: { ...fullMetadata, messages: [], errors: [], file_markings: filtered_markings },
     uploadStatus: 'complete',
   };
   await indexFileToDocument(context, file);

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -26,7 +26,7 @@ import { isFilterGroupNotEmpty } from './filtering/filtering-utils';
 import type { BasicStoreSettings } from '../types/settings';
 import type { StixObject } from '../types/stix-2-1-common';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
-import type { BasicConnection, BasicStoreCommon, BasicStoreEntity, BasicStoreRelation } from '../types/store';
+import type { BasicConnection, BasicStoreIdentifier, BasicStoreCommon, BasicStoreEntity, BasicStoreRelation } from '../types/store';
 import type { AuthContext, AuthUser, UserRole } from '../types/user';
 import { ID_SUBFILTER, INSTANCE_REGARDING_OF, RELATION_INFERRED_SUBFILTER, RELATION_TYPE_SUBFILTER } from './filtering/filtering-constants';
 import { pushAll } from './arrayUtil';
@@ -948,12 +948,13 @@ export const controlUserRestrictDeleteAgainstElement = <T extends ObjectWithCrea
  * @param context
  * @param user
  * @param markingId
+ * @param markingsMap
  */
-export const validateMarking = async (context: AuthContext, user: AuthUser, markingId: string) => {
+export const validateMarking = async (context: AuthContext, user: AuthUser, markingId: string, markingsMap?: Map<string, BasicStoreIdentifier | StixObject>) => {
   if (isBypassUser(user)) {
     return;
   }
-  const markings = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_MARKING_DEFINITION);
+  const markings = markingsMap ?? await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_MARKING_DEFINITION);
   const userMarking = (user.allowed_marking || []).map((m) => markings.get(m.internal_id)).filter((m) => isNotEmptyField(m)) as BasicStoreCommon[];
   const userMarkingIds = userMarking.map((marking) => extractIdsFromStoreObject(marking)).flat();
   if (!userMarkingIds.includes(markingId)) {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-helper-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-helper-test.ts
@@ -4,6 +4,8 @@ import type { AuthContext } from '../../../src/types/user';
 import { ADMIN_USER } from '../../utils/testQuery';
 import { MARKING_TLP_CLEAR } from '../../../src/schema/identifier';
 import { findById as findDocumentById, SUPPORT_STORAGE_PATH } from '../../../src/modules/internal/document/document-domain';
+import { storeLoadById } from '../../../src/database/middleware-loader';
+import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 
 const adminContext: AuthContext = {
   user: ADMIN_USER,
@@ -23,8 +25,9 @@ describe('File storage upload with marking', () => {
     const document = await findDocumentById(adminContext, ADMIN_USER, uploadedFileWithMarking.upload.id);
     expect(document.metaData.file_markings).toBeDefined();
     expect(document.metaData.file_markings?.length, 'One marking MARKING_TLP_CLEAR is expected on this document.').toBe(1);
+    const tlpClearMarking = await storeLoadById(adminContext, ADMIN_USER, MARKING_TLP_CLEAR, ENTITY_TYPE_MARKING_DEFINITION);
     if (document.metaData.file_markings) {
-      expect(document.metaData.file_markings[0]).toBe(MARKING_TLP_CLEAR);
+      expect(document.metaData.file_markings[0]).toBe(tlpClearMarking.internal_id);
     }
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-test.js
@@ -8,6 +8,8 @@ import { elLoadById } from '../../../src/database/engine';
 import { allFilesForPaths, paginatedForPathWithEnrichment } from '../../../src/modules/internal/document/document-domain';
 import { utcDate } from '../../../src/utils/format';
 import { MARKING_TLP_AMBER_STRICT } from '../../../src/schema/identifier';
+import { storeLoadById } from '../../../src/database/middleware-loader';
+import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObject';
 
 const exportFileName = '(ExportFileStix)_Malware-Paradise Ransomware_all.json';
 const exportFileId = (malware) => `export/Malware/${malware.id}/${exportFileName.toLowerCase()}`;
@@ -33,7 +35,8 @@ describe('File storage file listing', () => {
     expect(file.name).toEqual(exportFileName);
     expect(file.size).toEqual(FILE_SIZE);
     expect(file.metaData).not.toBeNull();
-    expect(file.metaData.file_markings[0]).toEqual(MARKING_TLP_AMBER_STRICT);
+    const tlpAmberMarking = await storeLoadById(testContext, ADMIN_USER, MARKING_TLP_AMBER_STRICT, ENTITY_TYPE_MARKING_DEFINITION);
+    expect(file.metaData.file_markings[0]).toEqual(tlpAmberMarking.internal_id);
     expect(file.metaData.encoding).toEqual('7bit');
     expect(file.metaData.filename).toEqual(exportFileName.replace(/\s/g, '%20'));
     expect(file.metaData.mimetype).toEqual('application/json');


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* handle file markings input as standard ids in file upload
* add file markings in all entities fragment in pycti to have it available during export
* add file markings handling during export in opencti_stix2

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11643

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
